### PR TITLE
Fix AnnotationFacotry#annotate() to avoid adding to a unmodifiableList

### DIFF
--- a/src/main/java/spoon/reflect/factory/AnnotationFactory.java
+++ b/src/main/java/spoon/reflect/factory/AnnotationFactory.java
@@ -126,7 +126,7 @@ public class AnnotationFactory extends TypeFactory {
 			annotation = factory.Core().createAnnotation();
 			annotation.setAnnotationType(factory.Type().createReference(
 					annotationType));
-			element.getAnnotations().add(annotation);
+			element.addAnnotation(annotation);
 		}
 		boolean isArray;
 
@@ -199,7 +199,7 @@ public class AnnotationFactory extends TypeFactory {
 			annotation = factory.Core().createAnnotation();
 			annotation.setAnnotationType(factory.Type().createReference(
 					annotationType));
-			element.getAnnotations().add(annotation);
+			element.addAnnotation(annotation);
 		}
 		return annotation;
 	}


### PR DESCRIPTION
The AnnotationFacotry#annotate() add an annotation by "element.getAnnotations().add(annotation)", but element.getAnnotations() method returns an unmodifiedList, which will then cause Exception. Changed version use element.addAnnotation(annotation) instead.
