### PR TITLE
Reworked the maven project to allow a Maven Central Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.sonatype.oss</groupId>
+    <artifactId>oss-parent</artifactId>
+    <version>7</version>
+  </parent>
+
   <groupId>fr.inria.gforge.spoon</groupId>
   <artifactId>spoon-core</artifactId>
   <packaging>jar</packaging>
@@ -8,6 +15,7 @@
   <description>Spoon is a tool for meta-programming, analysis and transformation of Java programs.</description>
   <url>http://spoon.gforge.inria.fr/</url>
   <inceptionYear>2007</inceptionYear>
+
   <licenses>
     <license>
       <name>CeCILL-C</name>
@@ -16,10 +24,17 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <organization>
+    <name>Inria</name>
+    <url>http://www.inria.fr</url>
+  </organization>
+
   <issueManagement>
-    <system>gforge</system>
-    <url>http://gforge.inria.fr/tracker/?group_id=73</url>
+    <system>GitHub</system>
+    <url>https://github.com/INRIA/spoon/issues</url>
   </issueManagement>
+
   <mailingLists>
     <mailingList>
       <name>spoon-discuss</name>
@@ -28,15 +43,94 @@
       <archive>http://lists.gforge.inria.fr/pipermail/spoon-discuss/</archive>
     </mailingList>
   </mailingLists>
+
+  <developers>
+    <developer>
+      <name>Benoit Cornu</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Favio DeMarco</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Christophe Dufour</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Matias Martinez</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Martin Monperrus</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Carlos Noguera</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Renaud Pawlak</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Nicolas Petitprez</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+    <developer>
+      <name>Lionel Seinturier</name>
+      <roles>
+        <role>Contributor</role>
+      </roles>
+    </developer>
+  </developers>
+
   <scm>
-    <connection>scm:svn:svn://scm.gforge.inria.fr/svnroot/spoon/trunk</connection>
     <url>https://gforge.inria.fr/scm/viewvc.php/?root=spoon</url>
+    <connection>scm:svn:svn://scm.gforge.inria.fr/svnroot/spoon/trunk</connection>
     <developerConnection>scm:svn:svn+ssh://scm.gforge.inria.fr/svnroot/spoon/trunk</developerConnection>
   </scm>
+
   <properties>
     <java.src.version>1.7</java.src.version>
     <runtime.log>target/velocity.log</runtime.log>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>gforge.inria.fr-release</id>
+      <name>inria</name>
+      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/repositories/releases</url>
+    </repository>
+    <snapshotRepository>
+      <id>gforge.inria.fr-snapshot</id>
+      <name>inria-snapshots</name>
+      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>gforge.inria.fr-site</id>
+      <name>inria</name>
+      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/mvnsites</url>
+    </site>
+  </distributionManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>
@@ -66,27 +160,55 @@
       <version>1.2.17</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>
   </dependencies>
+
   <build>
+    <defaultGoal>clean install</defaultGoal>
+
     <resources>
-      <resource><directory>src/main/resources</directory><filtering>true</filtering></resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
     </resources>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
           <source>${java.src.version}</source>
           <target>${java.src.version}</target>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>2.8.1</version>
+      </plugin>
+
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.2</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>2.5</version>
         <configuration>
           <archive>
             <manifest>
@@ -96,6 +218,7 @@
           </archive>
         </configuration>
       </plugin>
+
       <!-- clean coverage data before collecting -->
       <plugin>
         <artifactId>cobertura-maven-plugin</artifactId>
@@ -109,8 +232,11 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
         <dependencies>
           <dependency>
             <groupId>sun.jdk</groupId>
@@ -123,13 +249,13 @@
         <executions>
           <execution>
             <phase>test</phase>
-
             <goals>
               <goal>run</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -150,9 +276,11 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.4</version>
         <configuration>
           <archive>
             <manifest>
@@ -175,36 +303,21 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5</version>
         <configuration>
-          <minmemory>128m</minmemory>
-          <maxmemory>512</maxmemory>
-          <excludePackageNames>spoon.support.*</excludePackageNames>
+          <autoVersionSubmodules>true</autoVersionSubmodules>
+          <useReleaseProfile>false</useReleaseProfile>
+          <releaseProfiles>release</releaseProfiles>
+          <goals>deploy</goals>
         </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
+
     </plugins>
 
-    
     <pluginManagement>
       <plugins>
         <!--This plugin's configuration is used to store Eclipse m2e settings 
@@ -244,15 +357,20 @@
       </plugins>
     </pluginManagement>
   </build>
+
   <reporting>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.7</version>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.1</version>
         <configuration>
-          <linkXref>true</linkXref>
+          <linkXRef>true</linkXRef>
           <sourceEncoding>utf-8</sourceEncoding>
           <minimumTokens>100</minimumTokens>
           <targetJdk>${java.src.version}</targetJdk>
@@ -267,33 +385,9 @@
         </reportSets>
       </plugin>
       <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <excludePackageNames>spoon.support.*</excludePackageNames>
-          <minmemory>128m</minmemory>
-          <maxmemory>512m</maxmemory>
-          <encoding>UTF-8</encoding>
-          <docencoding>UTF-8</docencoding>
-          <charset>UTF-8</charset>
-        </configuration>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jxr-plugin</artifactId>
-      </plugin>
-<!--      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.0</version>
-        <configuration>
-          <formats>
-            <format>xml</format>
-            <format>html</format>
-          </formats>
-        </configuration>
-      </plugin>-->
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>taglist-maven-plugin</artifactId>
+        <version>2.4</version>
         <configuration>
           <tags>
             <tag>TODO</tag>
@@ -305,35 +399,56 @@
       </plugin>
     </plugins>
   </reporting>
-  <repositories>
-    <repository>
-      <id>gforge.inria.fr</id>
-      <name>Maven Repository for Spoon Projects</name>
-      <url>http://spoon.gforge.inria.fr/repositories/releases</url>
-      <releases />
-    </repository>
-  </repositories>
 
-  <distributionManagement>
-    <repository>
-      <id>gforge.inria.fr-release</id>
-      <name>inria</name>
-      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/repositories/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>gforge.inria.fr-snapshot</id>
-      <name>inria-snapshots</name>
-      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/repositories/snapshots</url>
-    </snapshotRepository>
-    <site>
-      <id>gforge.inria.fr-site</id>
-      <name>inria</name>
-      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/mvnsites</url>
-    </site>
-  </distributionManagement>
-  
-  <organization>
-    <name>Inria</name>
-    <url>http://www.inria.fr</url>
-  </organization>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.3</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.9.1</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This is a pull request for issue #12. The problem is described over at the issue page.

What this PR changes:
1. reformatted the the pom to have a more common order of the tags and added spacing for readability.
2. removed all warning by maven due to missing plugin versions and source encoding.
3. changed the information to confirm to the sonatype-release requirements:
   - added the developers tag: the names were taken from the README and the role is Contributer
   - added the sonatype-oss parent as per requirement
   - added a profile called "release" that configures both the gpg plugin for code signing (sonatype requirement) and the release plugin for releases.
