### PR TITLE
Fixed javadoc problems

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -99,6 +99,10 @@ public class Launcher {
 	/**
 	 * A default program entry point (instantiates a launcher with the given
 	 * arguments and calls {@link #run()}).
+	 *
+	 * @param args The command line arguments
+	 *
+	 * @throws java.lang.Exception if the argument handling fails
 	 */
 	public static void main(String[] args) throws Exception {
 		Launcher launcher = new Launcher();
@@ -116,6 +120,8 @@ public class Launcher {
 
 	/**
 	 * Print the usage for this command-line launcher.
+	 *
+	 * @throws java.lang.Exception if the argument handling fails
 	 */
 	public void printUsage() throws Exception {
 		this.args = new String[] { "--help" };
@@ -124,6 +130,8 @@ public class Launcher {
 
 	/**
 	 * Constructor with no arguments.
+	 *
+	 * @throws com.martiansoftware.jsap.JSAPException if defining the ocmmon arguments fails
 	 */
 	public Launcher() throws JSAPException {
 		jsapArgs = defineArgs();
@@ -131,6 +139,8 @@ public class Launcher {
 
 	/**
 	 * Adds an input resource to be processed by Spoon.
+	 *
+	 * @param resource the input resource to add
 	 */
 	public void addInputResource(SpoonResource resource) {
 		inputResources.add(resource);
@@ -138,6 +148,8 @@ public class Launcher {
 
 	/**
 	 * Adds a processor.
+	 *
+	 * @param name the name of the processor
 	 */
 	public void addProcessor(String name) {
 		processors.add(name);
@@ -145,6 +157,8 @@ public class Launcher {
 
 	/**
 	 * Adds a resource that contains a template (usually a source File).
+	 *
+	 * @param resource the resource to add
 	 */
 	public void addTemplateResource(SpoonResource resource) {
 		templateResources.add(resource);
@@ -367,6 +381,10 @@ public class Launcher {
 
 	/**
 	 * Returns the command-line given launching arguments in JSAP format.
+	 *
+	 * @return the JSAP result
+	 *
+	 * @throws java.lang.Exception if parsing the arguments fails
 	 */
 	protected final JSAPResult getArguments() throws Exception {
 		return parseArgs();
@@ -374,6 +392,10 @@ public class Launcher {
 
 	/**
 	 * Processes the arguments.
+	 *
+	 * @param factory a factory implementation
+	 *
+	 * @throws java.lang.Exception if the argument handling fails
 	 */
 	protected void processArguments(Factory factory) throws Exception {
 
@@ -431,6 +453,8 @@ public class Launcher {
 	/**
 	 * Gets the list of input sources as files. This method can be overriden to
 	 * customize this list.
+	 *
+	 * @return A List of input sources
 	 */
 	protected java.util.List<SpoonResource> getInputSources() {
 		return inputResources;
@@ -439,6 +463,8 @@ public class Launcher {
 	/**
 	 * Gets the list of processor types to be initially applied during the
 	 * processing (-p option).
+	 *
+	 * @return a List of processor types
 	 */
 	protected java.util.List<String> getProcessorTypes() {
 		return processors;
@@ -446,6 +472,8 @@ public class Launcher {
 
 	/**
 	 * Gets the list of template sources as files.
+	 *
+	 * @return A List of template sources
 	 */
 	protected List<SpoonResource> getTemplateSources() {
 		return templateResources;
@@ -453,6 +481,9 @@ public class Launcher {
 
 	/**
 	 * Load content of spoonlet file (template and processor list).
+	 *
+	 * @param factory the factory to use
+	 * @param spoonletFile the file of the spoonlet to load
 	 */
 	protected void loadSpoonlet(Factory factory, File spoonletFile) {
 		Environment env = factory.getEnvironment();
@@ -503,9 +534,7 @@ public class Launcher {
 
 	/**
 	 * Parses the arguments given by the command line.
-	 * 
-	 * @param args
-	 *            the command-line arguments as a string array
+	 *
 	 * @return the JSAP-presented arguments
 	 * @throws JSAPException
 	 *             when an error occurs in the argument parsing
@@ -546,6 +575,8 @@ public class Launcher {
 	 * 
 	 * @param factory
 	 *            the factory this compiler works on
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler(Factory factory) {
 		return new JDTBasedSpoonCompiler(factory);
@@ -559,6 +590,8 @@ public class Launcher {
 	 *            the factory this compiler works on
 	 * @param inputSources
 	 *            the sources to be processed and/or compiled
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler(Factory factory,
 			List<SpoonResource> inputSources) {
@@ -570,6 +603,12 @@ public class Launcher {
 	/**
 	 * Creates a new Spoon Java compiler in order to process and compile Java
 	 * source code.
+	 *
+	 * @param factory the factory to use
+	 * @param inputSources the input sources to use
+	 * @param templateSources the template sources to use
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler(Factory factory,
 			List<SpoonResource> inputSources,
@@ -584,6 +623,8 @@ public class Launcher {
 	 * Creates a new Spoon Java compiler with a default factory in order to
 	 * process and compile Java source code. The compiler's factory can be
 	 * accessed with the {@link SpoonCompiler#getFactory()}.
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler() {
 		return createCompiler(factory);
@@ -592,6 +633,10 @@ public class Launcher {
 	/**
 	 * Creates a new Spoon Java compiler with a default factory and a list of
 	 * input sources.
+	 *
+	 * @param inputSources the input soures to use
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler(List<SpoonResource> inputSources) {
 		SpoonCompiler c = createCompiler(factory);
@@ -602,6 +647,11 @@ public class Launcher {
 	/**
 	 * Creates a new Spoon Java compiler with a default factory and a list of
 	 * input and template sources.
+	 *
+	 * @param inputSources the input sources to use
+	 * @param templateSources the template sources to use
+	 *
+	 * @return a new spoon compiler
 	 */
 	public SpoonCompiler createCompiler(
 			List<SpoonResource> inputSources,
@@ -616,6 +666,8 @@ public class Launcher {
 	 * Creates a default Spoon factory, which holds the Java model (AST)
 	 * compiled from the source files and which can be processed by Spoon
 	 * processors.
+	 *
+	 * @return a new Factory instance
 	 */
 	public Factory createFactory() {
 		return createFactory(new StandardEnvironment());
@@ -634,6 +686,8 @@ public class Launcher {
 
 	/**
 	 * Creates a new default environment.
+	 *
+	 * @return a new Environment instance
 	 */
 	public Environment createEnvironment() {
 		return new StandardEnvironment();
@@ -651,6 +705,7 @@ public class Launcher {
 	 * @param debug
 	 *            tells Spoon to print out the detailed traces
 	 * @param properties
+	 *            tells Spoon where the processor configuration files are loaded from
 	 * @param autoImports
 	 *            tells Spoon to automatically generate the imports when
 	 *            printing out the source code
@@ -667,7 +722,6 @@ public class Launcher {
 	 * @param sourceOutputDir
 	 *            sets the Spoon output directory where to generate the printed
 	 *            source code
-	 * @return a properly initialized environment
 	 */
 	public void initEnvironment(Environment environment,
 			int complianceLevel, boolean verbose, boolean debug,
@@ -723,7 +777,7 @@ public class Launcher {
 	 * {@link SpoonCompiler#generateProcessedSourceFiles(OutputType)}.</li>
 	 * <li>Processed source code compilation (optional):
 	 * {@link SpoonCompiler#compile()}.</li>
-	 * <ol>
+	 * </ol>
 	 * 
 	 * @param compiler
 	 *            the compiler to be used, with a properly initialized factory
@@ -746,9 +800,9 @@ public class Launcher {
 	 *            the destination directory of the compiled bytecode
 	 * @param buildOnlyOutdatedFiles
 	 *            build and compile the files that has been modified since the
-	 *            last build/compilation (requires <code>!nooutput</code> and
-	 *            <code>compile</code> with a correctly set
-	 *            <code>detinatioDirectory</code>)
+	 *            last build/compilation (requires {@code !nooutput} and
+	 *            {@code compile} with a correctly set
+	 *            {@code destinationDirectory})
 	 * @param sourceClasspath
 	 *            the classpath to build and compile the input sources, given as
 	 *            a string
@@ -884,6 +938,8 @@ public class Launcher {
 
 	/**
 	 * Starts the Spoon processing.
+	 *
+	 * @throws java.lang.Exception if the argument handling fails
 	 */
 	public void run() throws Exception {
 

--- a/src/main/java/spoon/SpoonTask.java
+++ b/src/main/java/spoon/SpoonTask.java
@@ -59,6 +59,8 @@ public class SpoonTask extends Java {
 
 		/**
 		 * Gets the processor type.
+		 *
+		 * @return the qualified name if the processor name
 		 */
 		public String getType() {
 			return type;
@@ -67,6 +69,8 @@ public class SpoonTask extends Java {
 		/**
 		 * Sets the processor's type as a string representing the Java qualified
 		 * name.
+		 *
+		 * @param type the qualified name of the processors type
 		 */
 		public void setType(String type) {
 			this.type = type;
@@ -128,6 +132,8 @@ public class SpoonTask extends Java {
 	/**
 	 * Adds a new processor type to be instantiated and used by Spoon when
 	 * processing the code.
+	 *
+	 * @param processorType the processor type to add
 	 */
 	public void addProcessor(ProcessorType processorType) {
 		processorTypes.add(processorType);
@@ -135,6 +141,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Adds a source set.
+	 *
+	 * @param set the files to set
 	 */
 	public void addSourceSet(FileSet set) {
 		sourcefilesets.addElement(set);
@@ -142,6 +150,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Adds a template source set.
+	 *
+	 * @param set the files to set
 	 */
 	public void addTemplateSet(FileSet set) {
 		templatefilesets.addElement(set);
@@ -347,6 +357,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets the name of the laucher to be used.
+	 *
+	 * @param classname the class name to set
 	 */
 	public void setClassName(String classname) {
 		this.classname = classname;
@@ -372,7 +384,9 @@ public class SpoonTask extends Java {
 	}
 
 	/**
-	 * Sets the java14 property (to be able to parse java 1.4 source files).
+	 * Sets the compliance level (JDK version 1.X where X would be the parameter for this method).
+	 *
+	 * @param javaCompliance the compliance level to set
 	 */
 	public void setJavaCompliance(int javaCompliance) {
 		this.javaCompliance = javaCompliance;
@@ -380,6 +394,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Tells Spoon not to generate any source files.
+	 *
+	 * @param nooutput true to not generate any source files
 	 */
 	public void setNoOutput(boolean nooutput) {
 		this.nooutput = nooutput;
@@ -387,6 +403,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Tells Spoon to generate class files (bytecode).
+	 *
+	 * @param compile true to enable class file generation
 	 */
 	public void setCompile(boolean compile) {
 		this.compile = compile;
@@ -394,6 +412,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets the output directory for generated sources.
+	 *
+	 * @param output the output directory as a {@link java.io.File}
 	 */
 	@Override
 	public void setOutput(File output) {
@@ -402,6 +422,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets the destination directory for compiled classes (bytecode).
+	 *
+	 * @param destination the destination directory as a {@link java.io.File}
 	 */
 	public void setDestination(File destination) {
 		this.destination = destination;
@@ -410,6 +432,8 @@ public class SpoonTask extends Java {
 	/**
 	 * Sets the root directory where the processors' properties XML
 	 * configuration files are located.
+	 *
+	 * @param properties the property file to set
 	 */
 	public void setProperties(File properties) {
 		this.properties = properties;
@@ -417,6 +441,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Enables/disable printing out statistics on Spoon execution time.
+	 *
+	 * @param stats true to enable statistic output
 	 */
 	public void setStats(boolean stats) {
 		this.stats = stats;
@@ -425,6 +451,8 @@ public class SpoonTask extends Java {
 	/**
 	 * Sets a file or a directory to be processed (only templates, see
 	 * {@link #setInput(File)}).
+	 *
+	 * @param template sets the template file
 	 */
 	public void setTemplate(File template) {
 		this.template = template;
@@ -432,6 +460,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets Spoon to be in verbose mode.
+	 *
+	 * @param verbose true to enable verbose mode
 	 */
 	public void setVerbose(boolean verbose) {
 		this.verbose = verbose;
@@ -439,6 +469,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets Spoon to be in debug mode.
+	 *
+	 * @param debug true to enable debugging
 	 */
 	public void setDebug(boolean debug) {
 		this.debug = debug;
@@ -448,6 +480,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets Spoon to use tabulations instead of spaces when printing source.
+	 *
+	 * @param tabs true to use tabs instead of spaces
 	 */
 	public void setTabs(boolean tabs) {
 		this.tabs = tabs;
@@ -458,6 +492,8 @@ public class SpoonTask extends Java {
 	/**
 	 * Sets Spoon to use source code fragment driven generation technique
 	 * (preserves original formatting).
+	 *
+	 * @param fragments true to use fragment driven generation
 	 */
 	public void setFragments(boolean fragments) {
 		this.fragments = fragments;
@@ -467,6 +503,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Sets the tabulation size (default is 4 spaces).
+	 *
+	 * @param tabSize the tab size
 	 */
 	public void setTabSize(int tabSize) {
 		this.tabSize = tabSize;
@@ -474,6 +512,8 @@ public class SpoonTask extends Java {
 
 	/**
 	 * Tells if Spoon should precompile the input files before processing.
+	 *
+	 * @param precompile true to pre compile the input files
 	 */
 	public void setPrecompile(boolean precompile) {
 		this.precompile = precompile;
@@ -541,20 +581,26 @@ public class SpoonTask extends Java {
 	/**
 	 * Sets Spoon to build only the outdated source files (gives better
 	 * performances). This option will be ignored if the noouput option is on.
+	 *
+	 * @param buildOnlyOutdatedFiles true to only build outdated files
 	 */
 	public void setBuildOnlyOutdatedFiles(boolean buildOnlyOutdatedFiles) {
 		this.buildOnlyOutdatedFiles = buildOnlyOutdatedFiles;
 	}
 
 	/**
-	 * Sets the output type (none, classes, or compilationunits).
+	 * Sets the output type ({@code none}, {@code classes}, or {@code compilationunits}).
+	 *
+	 * @param outputType the output type string
 	 */
-	public void setOutputType(String ouputType) {
-		this.outputType = ouputType;
+	public void setOutputType(String outputType) {
+		this.outputType = outputType;
 	}
 
 	/**
 	 * Sets the encoding to be used by the compiler.
+	 *
+	 * @param encoding the encoding used by the compiler
 	 */
 	public void setEncoding(String encoding) {
 		this.encoding = encoding;
@@ -563,6 +609,8 @@ public class SpoonTask extends Java {
 	/**
 	 * Tells if Spoon should try to preserve the original line numbers when
 	 * generating the source code (may lead to human-unfriendly formatting).
+	 *
+	 * @param lines true to enable line preservation
 	 */
 	public void setLines(boolean lines) {
 		this.lines = lines;

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -36,49 +36,72 @@ public interface Environment {
 
 	/**
 	 * Gets the Java version compliance level.
+	 *
+	 * @return the level
 	 */
 	public int getComplianceLevel();
 
 	/**
 	 * Sets the Java version compliance level.
+	 *
+	 * @param level the level to set
 	 */
 	public void setComplianceLevel(int level);
 
 	/**
 	 * This method should be called to print out a message with a source
 	 * position link during the processing.
+	 *
+	 * @param message The message to report
 	 */
 	public void debugMessage(String message);
 
 	/**
 	 * Returns the default file generator for this environment (gives the
 	 * default output directory for the created files).
+	 *
+	 * @return the default file generator
 	 */
 	public FileGenerator<? extends CtElement> getDefaultFileGenerator();
 
 	/**
 	 * Gets the processing manager.
+	 *
+	 * @return the processing manager
 	 */
 	ProcessingManager getManager();
 
 	/**
 	 * Returns the properties for a given processor.
+	 *
+	 * @param processorName the name of the processor to get the properties for
+	 *
+	 * @return the properties of the processor
+	 *
+	 * @throws java.lang.Exception in case the configuration can not be processed
 	 */
 	ProcessorProperties getProcessorProperties(String processorName)
 			throws Exception;
 
 	/**
 	 * Sets the properties for a given processor.
+	 *
+	 * @param processorName the name of the processor to set the properties for
+	 * @param prop the properties to set
 	 */
 	void setProcessorProperties(String processorName, ProcessorProperties prop);
 
 	/**
 	 * Returns true if Spoon is in debug mode.
+	 *
+	 * @return true if debugging is enabled
 	 */
 	public boolean isDebug();
 
 	/**
 	 * Returns true is we let Spoon handle imports
+	 *
+	 * @return true if auto imports is enabled
 	 */
 	public boolean isAutoImports();
 
@@ -86,11 +109,15 @@ public interface Environment {
 	 * Tells if the processing is stopped, generally because one of the
 	 * processors called {@link #setProcessingStopped(boolean)} after reporting
 	 * an error.
+	 *
+	 * @return true if the processing is stopped
 	 */
 	public boolean isProcessingStopped();
 
 	/**
 	 * Returns true if Spoon is in verbose mode.
+	 *
+	 * @return true if spoon is in verbose mode
 	 */
 	public boolean isVerbose();
 
@@ -155,101 +182,139 @@ public interface Environment {
 	 * processing. On contrary to regular messages, progress messages are not
 	 * meant to remain in the message logs and just indicate to the user some
 	 * task progression information.
+	 *
+	 * @param message The message to report
 	 */
 	public void reportProgressMessage(String message);
 
 	/**
 	 * Sets the debug mode.
+	 *
+	 * @param debug true to enable debugging, false to disable
 	 */
 	public void setDebug(boolean debug);
 
 	/**
 	 * Sets the default file generator for this environment.
+	 *
+	 * @param generator the file generator to set as default
 	 */
 	void setDefaultFileGenerator(FileGenerator<? extends CtElement> generator);
 
 	/**
 	 * Sets the processing manager of this environment.
+	 *
+	 * @param manager the processing manager to set
 	 */
 	void setManager(ProcessingManager manager);
 
 	/**
 	 * This method can be called to stop the processing and all the remaining
 	 * tasks. In general, a processor calls it after reporting a fatal error.
+	 *
+	 * @param processingStopped the new state
 	 */
 	void setProcessingStopped(boolean processingStopped);
 
 	/**
 	 * Sets/unsets the verbose mode.
+	 *
+	 * @param verbose true to enable verbose mode, false to disable it
 	 */
 	void setVerbose(boolean verbose);
 
 	/**
 	 * Tells if the code generation use code fragments.
+	 *
+	 * @return true if source code fragments are used
 	 */
 	boolean isUsingSourceCodeFragments();
 
 	/**
 	 * Sets the code generation to use code fragments.
+	 *
+	 * @param b true to enable source code fragments
 	 */
 	void useSourceCodeFragments(boolean b);
 
 	/**
 	 * Gets the size of the tabulations in the generated source code.
+	 *
+	 * @return the tab size
 	 */
 	int getTabulationSize();
 
 	/**
 	 * Sets the size of the tabulations in the generated source code.
+	 *
+	 * @param size the tab size to set
 	 */
 	void setTabulationSize(int size);
 
 	/**
 	 * Tells if Spoon uses tabulations in the source code.
+	 *
+	 * @return true if tabs are used
 	 */
 	boolean isUsingTabulations();
 
 	/**
 	 * Sets Spoon to use tabulations in the source code.
+	 *
+	 * @param b true to enable tabs
 	 */
 	void useTabulations(boolean b);
 
 	/**
 	 * Gets the current input path
+	 *
+	 * @return the source path as a string
 	 */
 	String getSourcePath();
 
 	/**
 	 * Tell to the Java printer to automatically generate imports and use simple
 	 * names instead of fully-qualified name.
+	 *
+	 * @param autoImports true to enable auto imports
 	 */
 	void setAutoImports(boolean autoImports);
 
 	/**
 	 * Sets the root folder where the processors' XML configuration files are
 	 * located.
+	 *
+	 * @param xmlRootFolder the folder where processor configs are located
 	 */
 	void setXmlRootFolder(File xmlRootFolder);
 
 	/**
 	 * Gets the error count from building, processing, and compiling within this
 	 * environment.
+	 *
+	 * @return the number of errors
 	 */
 	int getErrorCount();
 
 	/**
 	 * Gets the warning count from building, processing, and compiling within
 	 * this environment.
+	 *
+	 * @return the number of warnings
 	 */
 	int getWarningCount();
 
 	/**
 	 * Gets the class loader used to compile/process the input source code.
+	 *
+	 * @return the classloader
 	 */
 	ClassLoader getInputClassLoader();
 
 	/**
 	 * Sets the class loader used to compile/process the input source code.
+	 *
+	 * @param classLoader the classloader to use
 	 */
 	void setInputClassLoader(ClassLoader classLoader);
 
@@ -257,11 +322,15 @@ public interface Environment {
 	 * When set, the generated source code will try to generate code that
 	 * preserves the line numbers of the original source code. This option may
 	 * lead to difficult-to-read indentation and formatting.
+	 *
+	 * @param preserveLineNumbers true to preserve line numbers
 	 */
 	void setPreserveLineNumbers(boolean preserveLineNumbers);
 
 	/**
 	 * Tells if the source generator will try to preserve the original line numbers.
+	 *
+	 * @return true if line numbers are preserved
 	 */
 	boolean isPreserveLineNumbers();
 	

--- a/src/main/java/spoon/compiler/SpoonCompiler.java
+++ b/src/main/java/spoon/compiler/SpoonCompiler.java
@@ -31,14 +31,14 @@ import spoon.reflect.factory.Factory;
  * 
  * <p>
  * The Spoon model (see {@link Factory} is built from input sources given as
- * files. Use {@link #build(Factory))} and {@link #build(Factory, List)))} to
- * create the Spoon model. Once the model is built and stored in the factory, it
+ * files. Use {@link #build()} to create the Spoon model.
+ * Once the model is built and stored in the factory, it
  * can be processed by using a {@link spoon.processing.ProcessingManager}.
  * </p>
  * 
  * <p>
  * Create an instance of the default implementation of the Spoon compiler by
- * using {@link Spoon#createCompiler()}. For example:
+ * using {@link spoon.Launcher#createCompiler()}. For example:
  * </p>
  * 
  * <pre>
@@ -48,7 +48,7 @@ import spoon.reflect.factory.Factory;
  * compiler.build(factory, files);
  * </pre>
  * 
- * @see Spoon#createCompiler()
+ * @see spoon.Launcher#createCompiler()
  */
 public interface SpoonCompiler extends FactoryAccessor {
 
@@ -58,6 +58,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @param source
 	 *            file or directory to add
+	 *
+	 * @throws java.io.IOException if the file is invalid
 	 */
 	void addInputSource(File source) throws IOException;
 
@@ -66,11 +68,15 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @param destinationDirectory
 	 *            destination directory
+	 *
+	 * @throws java.io.IOException if the destination directory was not found
 	 */
 	void setDestinationDirectory(File destinationDirectory) throws IOException;
 
 	/**
 	 * Gets the output directory of this compiler.
+	 *
+	 * @return the output directory as a File
 	 */
 	File getDestinationDirectory();
 
@@ -79,11 +85,15 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @param outputDirectory
 	 *            output directory
+	 *
+	 * @throws java.io.IOException if the directory is invalid
 	 */
 	void setOutputDirectory(File outputDirectory) throws IOException;
 
 	/**
 	 * Gets the output directory of this compiler.
+	 *
+	 * @return the output directory as a File
 	 */
 	File getOutputDirectory();
 
@@ -100,6 +110,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	/**
 	 * Gets all the files/directories given as input sources to this builder
 	 * (see {@link #addInputSource(File)}).
+	 *
+	 * @return a Set of input files
 	 */
 	Set<File> getInputSources();
 
@@ -112,6 +124,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @param source
 	 *            file or directory to add
+	 *
+	 * @throws java.io.IOException in case the file is not found
 	 */
 	void addTemplateSource(File source) throws IOException;
 
@@ -131,6 +145,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	/**
 	 * Gets all the files/directories given as template sources to this builder
 	 * (see {@link #addTemplateSource(File)}).
+	 *
+	 * @return a Set of template sources
 	 */
 	Set<File> getTemplateSources();
 
@@ -142,15 +158,15 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * Builds the program's model with this compiler's factory and stores the
 	 * result into this factory. Note that this method should only be used once
 	 * on a given factory.
+	 *
+	 * @see #getSourceClasspath
+	 * @see #getTemplateClasspath
 	 * 
 	 * @return true if the Java was successfully compiled with the core Java
 	 *         compiler, false if some errors were encountered while compiling
 	 * 
-	 * @exception Exception
+	 * @throws  java.lang.Exception
 	 *                when a building problem occurs
-	 * 
-	 * @see #getSourceClasspath()
-	 * @see #getTemplateClasspath()
 	 */
 	boolean build() throws Exception;
 
@@ -161,6 +177,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @param outputType
 	 *            the output method
+	 *
+	 * @throws java.lang.Exception in case the generation fails
 	 */
 	void generateProcessedSourceFiles(OutputType outputType) throws Exception;
 
@@ -170,6 +188,8 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * {@link #getDestinationDirectory()}.
 	 * 
 	 * @see #getSourceClasspath()
+	 *
+	 * @return true on success
 	 */
 	boolean compile();
 
@@ -177,11 +197,11 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * Generates the bytecode by compiling the input sources. The bytecode is
 	 * generated in the directory given by {@link #getDestinationDirectory()}.
 	 * 
-	 * @param addDestinationDirectoryToClasspath
-	 *            set this flag to true to automatically add the bytecode
-	 *            destination directory to the classpath
-	 * 
 	 * @see #getSourceClasspath()
+	 *
+	 * @return true if no problems occur
+	 *
+	 * @throws java.lang.Exception if compilation files
 	 */
 	boolean compileInputSources() throws Exception;
 
@@ -190,32 +210,40 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * 
 	 * @see #compileInputSources()
 	 * @see #build()
-	 * @see #build(List)
 	 * @see #compile()
+	 *
+	 * @return the source classpath
 	 */
 	String getSourceClasspath();
 
 	/**
 	 * Sets the classpath that is used to build/compile the input sources.
-	 * 
+	 *
+	 * @param classpath the source classpath to set
 	 */
 	void setSourceClasspath(String classpath);
 
 	/**
 	 * Gets the classpath that is used to build the template sources.
 	 * 
-	 * @see #buildTemplates(List)
+	 * @see #build
+	 *
+	 * @return the template classpath
 	 */
 	String getTemplateClasspath();
 
 	/**
 	 * Sets the classpath that is used to build the template sources.
+	 *
+	 * @param classpath the template classpath to set
 	 */
 	void setTemplateClasspath(String classpath);
 
 	/**
 	 * Sets this compiler to optimize the model building process by ignoring
 	 * files that has not be modified since the latest source code generation.
+	 *
+	 * @param buildOnlyOutdatedFiles true to only build outdated files
 	 */
 	void setBuildOnlyOutdatedFiles(boolean buildOnlyOutdatedFiles);
 
@@ -224,22 +252,30 @@ public interface SpoonCompiler extends FactoryAccessor {
 	 * to the forced-to-be-built list. All the files added here will be build
 	 * even if no changes are detected on the file system. This list has no
 	 * impacts if @link #setBuildOnlyOutdatedFiles(boolean)} is false.
+	 *
+	 * @param source the source to build
 	 */
 	void forceBuild(SpoonResource source);
 
 	/**
 	 * Sets the encoding to use when different from the system encoding.
+	 *
+	 * @param encoding the encoding to use
 	 */
 	void setEncoding(String encoding);
 
 	/**
 	 * Gets the encoding used by this compiler. Null means that it uses the
 	 * system encoding.
+	 *
+	 * @return the current encoding
 	 */
 	String getEncoding();
 
 	/**
 	 * Processes the Java model with the given processors.
+	 *
+	 * @param processorTypes the processor types as a List
 	 */
 	void process(List<String> processorTypes);
 

--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -27,11 +27,15 @@ public interface SpoonFile extends SpoonResource {
 
 	/**
 	 * Gets the file content as a stream.
+	 *
+	 * @return an InputStream to get the content
 	 */
 	InputStream getContent();
 
 	/**
 	 * True if a Java source code file.
+	 *
+	 * @return true if this is a java source file
 	 */
 	boolean isJava();
 
@@ -39,7 +43,7 @@ public interface SpoonFile extends SpoonResource {
 	 * Tells if this file is an actual file (not a virtual file that holds
 	 * in-memory contents).
 	 * 
-	 * @return
+	 * @return true if it is an actual file in the file system
 	 */
 	boolean isActualFile();
 

--- a/src/main/java/spoon/compiler/SpoonFolder.java
+++ b/src/main/java/spoon/compiler/SpoonFolder.java
@@ -26,21 +26,29 @@ public interface SpoonFolder extends SpoonResource {
 
 	/**
 	 * Gets all the files (excluding folders) in the folder.
+	 *
+	 * @return a List of all files but no folders
 	 */
 	List<SpoonFile> getFiles();
 
 	/**
 	 * Gets all the files (including folders) in the folder.
+	 *
+	 * @return a List of all files
 	 */
 	List<SpoonFile> getAllFiles();
 
 	/**
 	 * Gets all the Java source files in the folder.
+	 *
+	 * @return a List of all java source files
 	 */
 	List<SpoonFile> getAllJavaFiles();
 
 	/**
 	 * Gets the subfolders in this folder.
+	 *
+	 * @return the List of sub folders
 	 */
 	List<SpoonFolder> getSubFolders();
 

--- a/src/main/java/spoon/compiler/SpoonResource.java
+++ b/src/main/java/spoon/compiler/SpoonResource.java
@@ -27,37 +27,51 @@ public interface SpoonResource {
 
 	/**
 	 * Gets the folder that contains this resource.
+	 *
+	 * @return The parent spoon folder of this resource
 	 */
 	SpoonFolder getParent();
 
 	/**
 	 * Gets the name of this resource.
+	 *
+	 * @return the name of this resource
 	 */
 	String getName();
 
 	/**
 	 * Tells if this resource is a file.
+	 *
+	 * @return true if this file is an actual file on the filesystem
 	 */
 	boolean isFile();
 
 	/**
 	 * Tells if this resource is an archive.
+	 *
+	 * @return true if this is resource is an archive
 	 */
 	boolean isArchive();
 
 	/**
 	 * Gets this resource path.
+	 *
+	 * @return the path of this resource as a string
 	 */
 	String getPath();
 
 	/**
 	 * Gets the parent of this resource on the file system.
+	 *
+	 * @return a File instance for this resource' parent
 	 */
 	File getFileSystemParent();
 
 	/**
 	 * Gets the corresponding file if possible (returns null if this resource
 	 * does not correspond to any file on the filesystem).
+	 *
+	 * @return a File instance for this resource
 	 */
 	File toFile();
 

--- a/src/main/java/spoon/compiler/SpoonResourceHelper.java
+++ b/src/main/java/spoon/compiler/SpoonResourceHelper.java
@@ -38,6 +38,10 @@ public abstract class SpoonResourceHelper {
 
 	/**
 	 * Tells if the given file is an archive file.
+	 *
+	 * @param f the file to check
+	 *
+	 * @return true if the filename ends with ".jar" or ".zip", otherwise false
 	 */
 	public static boolean isArchive(File f) {
 		return f.getName().endsWith(".jar") || f.getName().endsWith(".zip");
@@ -45,6 +49,10 @@ public abstract class SpoonResourceHelper {
 
 	/**
 	 * Tells if the given file is file (files are not archives).
+	 *
+	 * @param f the file to check
+	 *
+	 * @return true if the file is an actual file (no link, no folder) and is not an archive, otherwise false
 	 */
 	public static boolean isFile(File f) {
 		return f.isFile() && !isArchive(f);
@@ -53,6 +61,12 @@ public abstract class SpoonResourceHelper {
 	/**
 	 * Creates the list of {@link SpoonResource} corresponding to the given
 	 * paths (files, folders, archives).
+	 *
+	 * @param paths the paths to wrap into spoon resources
+	 *
+	 * @return a List of the resources
+	 *
+	 * @throws java.io.FileNotFoundException if one of the paths doesn't point to a file
 	 */
 	public static List<SpoonResource> resources(String... paths)
 			throws FileNotFoundException {
@@ -65,6 +79,12 @@ public abstract class SpoonResourceHelper {
 
 	/**
 	 * Creates the {@link SpoonFile} corresponding to the given file.
+	 *
+	 * @param f the file to wrap
+	 *
+	 * @return a spoon file object
+	 *
+	 * @throws java.io.FileNotFoundException if the file was not found
 	 */
 	public static SpoonFile createFile(File f) throws FileNotFoundException {
 		if (!f.exists()) {
@@ -75,6 +95,12 @@ public abstract class SpoonResourceHelper {
 
 	/**
 	 * Creates the {@link SpoonResource} corresponding to the given file.
+	 *
+	 * @param f The file to create a resource for
+	 *
+	 * @return the created spoon resource
+	 *
+	 * @throws java.io.FileNotFoundException of the file was not found
 	 */
 	public static SpoonResource createResource(File f)
 			throws FileNotFoundException {
@@ -86,6 +112,12 @@ public abstract class SpoonResourceHelper {
 
 	/**
 	 * Creates the {@link SpoonFolder} corresponding to the given file.
+	 *
+	 * @param f the folder to create
+	 *
+	 * @return a spoon folder object
+	 *
+	 * @throws java.io.FileNotFoundException if the folder was not found
 	 */
 	public static SpoonFolder createFolder(File f) throws FileNotFoundException {
 		if (!f.exists()) {

--- a/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
@@ -73,6 +73,8 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	 * Adds a consumed annotation type (to be used in subclasses constructors).
 	 * A consumed annotation type is also part of the processed annotation
 	 * types.
+	 *
+	 * @param annotationType the annotation type to consume
 	 */
 	final protected void addConsumedAnnotationType(
 			Class<? extends A> annotationType) {
@@ -82,6 +84,8 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 
 	/**
 	 * Adds a processed annotation type (to be used in subclasses constructors).
+	 *
+	 * @param annotationType the annotation type to process
 	 */
 	final protected void addProcessedAnnotationType(
 			Class<? extends A> annotationType) {
@@ -90,6 +94,8 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 
 	/**
 	 * Removes a processed annotation type.
+	 *
+	 * @param annotationType the annotation type to not process anymore
 	 */
 	final protected void removeProcessedAnnotationType(
 			Class<? extends A> annotationType) {
@@ -111,7 +117,9 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	}
 
 	/**
-	 * Removes a processed annotation type.
+	 * Removes a consumed annotation type.
+	 *
+	 * @param annotationType the annotation type to not consume anymore
 	 */
 	final protected void removeConsumedAnnotationType(
 			Class<? extends A> annotationType) {

--- a/src/main/java/spoon/processing/AbstractManualProcessor.java
+++ b/src/main/java/spoon/processing/AbstractManualProcessor.java
@@ -40,6 +40,8 @@ public abstract class AbstractManualProcessor implements Processor<CtElement> {
 
 	/**
 	 * Invalid method in this context.
+	 *
+	 * @param elementType the {@link java.lang.Class} of the element
 	 */
 	protected void addProcessedElementType(
 			Class<? extends CtElement> elementType) {
@@ -72,6 +74,8 @@ public abstract class AbstractManualProcessor implements Processor<CtElement> {
 
 	/**
 	 * Invalid method in this context.
+	 *
+	 * @return true if privileged
 	 */
 	public final boolean isPrivileged() {
 		return false;

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -64,6 +64,8 @@ public abstract class AbstractProcessor<E extends CtElement> implements
 	/**
 	 * Adds a processed element type. This method is typically invoked in
 	 * subclasses' constructors.
+	 *
+	 * @param elementType the {@link java.lang.Class} of the element
 	 */
 	protected void addProcessedElementType(
 			Class<? extends CtElement> elementType) {
@@ -92,6 +94,10 @@ public abstract class AbstractProcessor<E extends CtElement> implements
 	/**
 	 * Helper method to load the properties of the given processor (uses
 	 * {@link Environment#getProcessorProperties(String)}).
+	 *
+	 * @param p the processor t load the properties for
+	 *
+	 * @return the processor properties
 	 */
 	public static ProcessorProperties loadProperties(Processor<?> p) {
 		ProcessorProperties props = null;
@@ -143,6 +149,9 @@ public abstract class AbstractProcessor<E extends CtElement> implements
 
 	/**
 	 * Helper method to initialize the properties of a given processor.
+	 *
+	 * @param p the processor
+	 * @param properties the processor properties
 	 */
 	public static void initProperties(Processor<?> p,
 			ProcessorProperties properties) {
@@ -185,6 +194,8 @@ public abstract class AbstractProcessor<E extends CtElement> implements
 
 	/**
 	 * Removes a processed element type.
+	 *
+	 * @param elementType the {@link java.lang.Class} of the element
 	 */
 	protected void removeProcessedElementType(
 			Class<? extends CtElement> elementType) {

--- a/src/main/java/spoon/processing/AnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AnnotationProcessor.java
@@ -67,10 +67,17 @@ public interface AnnotationProcessor<A extends Annotation, E extends CtElement>
 	/**
 	 * Returns true (default) if the processor automatically infers the consumed
 	 * annotation type to the <code>A</code> actual type.
+	 *
+	 * @return true if annotations are automatically inferred
 	 */
 	boolean inferConsumedAnnotationType();
 	
-	/** Returns true if this annotation should be removed from the processed code.
+	/**
+	 * Returns true if this annotation should be removed from the processed code.
+	 *
+	 * @param annotation the annotation to check for
+	 *
+	 * @return true of the given annotation should be consumed
 	 */
 	boolean shoudBeConsumed(CtAnnotation<? extends Annotation> annotation);
 

--- a/src/main/java/spoon/processing/FactoryAccessor.java
+++ b/src/main/java/spoon/processing/FactoryAccessor.java
@@ -26,11 +26,15 @@ public interface FactoryAccessor {
 
 	/**
 	 * Gets the factory of this object.
+	 *
+	 * @return the factory
 	 */
 	Factory getFactory();
 
 	/**
 	 * Sets the factory object.
+	 *
+	 * @param factory the factory to set
 	 */
 	void setFactory(Factory factory);
 

--- a/src/main/java/spoon/processing/FileGenerator.java
+++ b/src/main/java/spoon/processing/FileGenerator.java
@@ -34,16 +34,22 @@ public interface FileGenerator<T extends CtElement> extends Processor<T> {
 
 	/**
 	 * Sets the root directory where files should be created.
+	 *
+	 * @param directory the output directory as a {@link java.io.File} to add
 	 */
 	public void setOutputDirectory(File directory);
 
 	/**
 	 * Gets the root directory where files are created.
+	 *
+	 * @return the output directory as a {@link java.io.File}
 	 */
 	public File getOutputDirectory();
 
 	/**
 	 * Gets the created files.
+	 *
+	 * @return a {@link java.util.List} of created files
 	 */
 	public List<File> getCreatedFiles();
 

--- a/src/main/java/spoon/processing/ProblemFixer.java
+++ b/src/main/java/spoon/processing/ProblemFixer.java
@@ -33,11 +33,15 @@ public interface ProblemFixer<T extends CtElement> extends FactoryAccessor {
 
 	/**
 	 * Returns the description of this fixer
+	 *
+	 * @return a description
 	 */
 	public abstract String getDescription();
 
 	/**
 	 * Returns a short String that represent this fixer.
+	 *
+	 * @return a label
 	 */
 	public abstract String getLabel();
 
@@ -47,7 +51,7 @@ public interface ProblemFixer<T extends CtElement> extends FactoryAccessor {
 	 * 
 	 * @param element
 	 *            the element marked by a problem
-	 * @return List of modified elements
+	 * @return List of modified elements as a {@link spoon.reflect.Changes} object
 	 */
 	public abstract Changes run(T element);
 }

--- a/src/main/java/spoon/processing/ProcessingManager.java
+++ b/src/main/java/spoon/processing/ProcessingManager.java
@@ -28,7 +28,7 @@ import spoon.reflect.declaration.CtElement;
  * {@link spoon.compiler.SpoonCompiler#build()}. To use, add processors to
  * the manager, and then call the {@code process} method. The processors will be
  * removed from the manager once applied. Also, the method
- * {@link spoon.processing.Processor#processingDone()} is upcalled.
+ * {@link spoon.processing.Processor#processingDone()} is up called.
  * 
  * @see spoon.compiler.Environment#getManager()
  */
@@ -37,24 +37,30 @@ public interface ProcessingManager extends FactoryAccessor {
 	 * Adds a processor by instantiating its type (a class that must define an
 	 * empty constructor).
 	 * 
-	 * @see #getProcessors().
+	 * @see #getProcessors()
+	 *
+	 * @param type the {@link java.lang.Class} of the processor to add
 	 */
 	void addProcessor(Class<? extends Processor<?>> type);
 
 	/**
 	 * Adds a processor.
 	 * 
-	 * @see #getProcessors().
+	 * @see #getProcessors()
+	 *
+	 * @param p the processor to add
+	 *
+	 * @return true if the processor has been added
 	 */
 	boolean addProcessor(Processor<?> p);
 
 	/**
 	 * Adds a processor by instantiating its type (a class that must define an
-	 * empty constructor and implement {@link Processor}).
+	 * empty constructor and implement {@link spoon.processing.Processor}.
 	 * 
 	 * @param qualifiedName
 	 *            the qualified name of the processor's type
-	 * @see #getProcessors().
+	 * @see #getProcessors()
 	 */
 	void addProcessor(String qualifiedName);
 
@@ -66,6 +72,10 @@ public interface ProcessingManager extends FactoryAccessor {
 	 * 
 	 * @see #process(Collection)
 	 * @see #process()
+	 *
+	 * @param type the type of the processor
+	 *
+	 * @return true if the processor is to be applied
 	 */
 	boolean isToBeApplied(Class<? extends Processor<?>> type);
 
@@ -75,6 +85,8 @@ public interface ProcessingManager extends FactoryAccessor {
 	 * 
 	 * @see #process(Collection)
 	 * @see #process()
+	 *
+	 * @return a {@link java.util.Collection} of processors
 	 */
 	Collection<Processor<?>> getProcessors();
 
@@ -86,6 +98,8 @@ public interface ProcessingManager extends FactoryAccessor {
 	 * <code>process</code> method (non-blocking implementation). Processors
 	 * that have been applied are removed from the manager and
 	 * {@link #getProcessors()} does not contain them anymore.
+	 *
+	 * @param elements a {@link java.util.Collection} of elements to process
 	 */
 	void process(Collection<? extends CtElement> elements);
 
@@ -96,6 +110,8 @@ public interface ProcessingManager extends FactoryAccessor {
 	 * another call to a <code>process</code> method (non-blocking
 	 * implementation). Processors that have been applied are removed from the
 	 * manager and {@link #getProcessors()} does not contain them anymore.
+	 *
+	 * @param element the element to process
 	 */
 	void process(CtElement element);
 
@@ -112,6 +128,8 @@ public interface ProcessingManager extends FactoryAccessor {
 	/**
 	 * Gets the processor which is currently achieving the processing task if
 	 * any.
+	 *
+	 * @return the current processor
 	 */
 	Processor<?> getCurrentProcessor();
 }

--- a/src/main/java/spoon/processing/Processor.java
+++ b/src/main/java/spoon/processing/Processor.java
@@ -34,11 +34,15 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	 * Gets the model's traversal strategy for this processor (default is
 	 * {@link TraversalStrategy#POST_ORDER}). Programmers should override this
 	 * method to return another strategy if needed.
+	 *
+	 * @return the traversal strategy
 	 */
 	TraversalStrategy getTraversalStrategy();
 
 	/**
 	 * Gets the environment of this processor.
+	 *
+	 * @return the environment of this processor
 	 */
 	Environment getEnvironment();
 
@@ -92,6 +96,8 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 
 	/**
 	 * Gets all the element types than need to be processed.
+	 *
+	 * @return a {@link java.util.Set} of the processed element types
 	 */
 	Set<Class<? extends CtElement>> getProcessedElementTypes();
 
@@ -120,6 +126,8 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	 * environment.
 	 * 
 	 * @see Environment#getProcessorProperties(String)
+	 *
+	 * @param properties the processor properties
 	 */
 	void initProperties(ProcessorProperties properties);
 

--- a/src/main/java/spoon/processing/ProcessorProperties.java
+++ b/src/main/java/spoon/processing/ProcessorProperties.java
@@ -24,11 +24,19 @@ public interface ProcessorProperties {
 
 	/**
 	 * Gets the property converted in given type or null (can be an array).
+	 *
+	 * @param <T> the type of the property
+	 * @param type the {@link java.lang.Class} of the type
+	 * @param name the name of the property
+	 *
+	 * @return the property
 	 */
 	<T> T get(Class<T> type, String name);
 
 	/**
 	 * Gets the corresponding processor name.
+	 *
+	 * @return name of the processor
 	 */
 	String getProcessorName();
 

--- a/src/main/java/spoon/processing/Property.java
+++ b/src/main/java/spoon/processing/Property.java
@@ -31,6 +31,8 @@ import java.lang.annotation.Target;
 public @interface Property {
 	/**
 	 * An optional text that describes the property.
+	 *
+	 * @return a description
 	 */
 	String value() default "";
 }

--- a/src/main/java/spoon/reflect/Changes.java
+++ b/src/main/java/spoon/reflect/Changes.java
@@ -42,6 +42,8 @@ public class Changes {
 	
 	/**
 	 * Gets the list of elements added in the model.
+	 *
+	 * @return the List of added elements
 	 */
 	public List<CtElement> getAdded() {
 		if (added == null) {
@@ -52,6 +54,8 @@ public class Changes {
 
 	/**
 	 * Gets the list of elements removed from the model.
+	 *
+	 * @return the List of removed elements
 	 */
 	public List<CtElement> getRemoved() {
 		if (removed == null) {
@@ -62,6 +66,8 @@ public class Changes {
 
 	/**
 	 * Gets the list of updated elements.
+	 *
+	 * @return the List of modified elements
 	 */
 	public List<CtElement> getModified() {
 		if (modified == null) {
@@ -72,6 +78,8 @@ public class Changes {
 
 	/**
 	 * Returns true if elements are added.
+	 *
+	 * @return true if elements are added
 	 */
 	public boolean hasAdded() {
 		return added != null && !added.isEmpty();
@@ -79,6 +87,8 @@ public class Changes {
 
 	/**
 	 * Returns true if elements are modified.
+	 *
+	 * @return true if elements are modified
 	 */
 	public boolean hasModified() {
 		return modified != null && !modified.isEmpty();
@@ -86,6 +96,8 @@ public class Changes {
 
 	/**
 	 * Returns true if elements are removed.
+	 *
+	 * @return true if elements are removed
 	 */
 	public boolean hasRemoved() {
 		return removed != null && !removed.isEmpty();

--- a/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
@@ -39,26 +39,36 @@ public interface CtAbstractInvocation<T> extends CtElement {
 
 	/**
 	 * Adds an argument expression to the invocation.
+	 *
+	 * @param argument the argument expression to set
 	 */
 	void addArgument(CtExpression<?> argument);
 
 	/**
 	 * Removes an argument expression from the invocation.
+	 *
+	 * @param argument the argument expression to remove
 	 */
 	void removeArgument(CtExpression<?> argument);
 
 	/**
 	 * Returns the invoked executable.
+	 *
+	 * @return the executable reference
 	 */
 	CtExecutableReference<T> getExecutable();
 
 	/**
 	 * Sets the invocation's arguments.
+	 *
+	 * @param arguments a List of argument expressions to set
 	 */
 	void setArguments(List<CtExpression<?>> arguments);
 
 	/**
 	 * Sets the invoked executable.
+	 *
+	 * @param executable the executable reference to set
 	 */
 	void setExecutable(CtExecutableReference<T> executable);
 }

--- a/src/main/java/spoon/reflect/code/CtArrayAccess.java
+++ b/src/main/java/spoon/reflect/code/CtArrayAccess.java
@@ -32,11 +32,15 @@ public interface CtArrayAccess<T, E extends CtExpression<?>> extends
 		CtTargetedExpression<T, E> {
 	/**
 	 * Sets the expression that defines the index.
+	 *
+	 * @param expression the index expression to set
 	 */
 	void setIndexExpression(CtExpression<Integer> expression);
 
 	/**
 	 * Returns the expression that defines the index.
+	 *
+	 * @return the index expression
 	 */
 	CtExpression<Integer> getIndexExpression();
 }

--- a/src/main/java/spoon/reflect/code/CtAssert.java
+++ b/src/main/java/spoon/reflect/code/CtAssert.java
@@ -23,21 +23,29 @@ package spoon.reflect.code;
 public interface CtAssert<T> extends CtStatement {
 	/**
 	 * Gets the assert expression.
+	 *
+	 * @return the assertion expression
 	 */
 	CtExpression<Boolean> getAssertExpression();
 
 	/**
 	 * Sets the assert expression.
+	 *
+	 * @param asserted the assertion expression to set
 	 */
 	void setAssertExpression(CtExpression<Boolean> asserted);
 
 	/**
 	 * Gets the expression of the assertion if defined.
+	 *
+	 * @return the expression
 	 */
 	CtExpression<T> getExpression();
 
 	/**
 	 * Sets the expression of the assertion.
+	 *
+	 * @param expression the expression to set
 	 */
 	void setExpression(CtExpression<T> expression);
 }

--- a/src/main/java/spoon/reflect/code/CtAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtAssignment.java
@@ -23,28 +23,36 @@ package spoon.reflect.code;
  * @param <T>
  *            type of assigned expression
  * @param <A>
- *            type of expression to assign, it should extends <T>
+ *            type of expression to assign, it should extends &lt;T&gt;
  */
 public interface CtAssignment<T, A extends T> extends CtStatement,
 		CtExpression<T> {
 
 	/**
 	 * Returns the assigned expression (a variable, an array access...).
+	 *
+	 * @return the expression that gets assigned
 	 */
 	CtExpression<T> getAssigned();
 
 	/**
 	 * Returns the assignment that is set to the assigned expression.
+	 *
+	 * @return the assignment expression itself
 	 */
 	CtExpression<A> getAssignment();
 
 	/**
 	 * Sets the assigned expression.
+	 *
+	 * @param assigned the expression to assign
 	 */
 	void setAssigned(CtExpression<T> assigned);
 
 	/**
 	 * Sets the expression that is set to the assigned expression.
+	 *
+	 * @param assignment the assignment expression
 	 */
 	void setAssignment(CtExpression<A> assignment);
 

--- a/src/main/java/spoon/reflect/code/CtBinaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtBinaryOperator.java
@@ -27,31 +27,43 @@ public interface CtBinaryOperator<T> extends CtExpression<T> {
 
 	/**
 	 * Returns the left-hand operand.
+	 *
+	 * @return the expression from the left hand side
 	 */
 	CtExpression<?> getLeftHandOperand();
 
 	/**
 	 * Returns the right-hand operand.
+	 *
+	 * @return the expression from the right hand side
 	 */
 	CtExpression<?> getRightHandOperand();
 
 	/**
 	 * Sets the left-hand operand.
+	 *
+	 * @param expression the expression to set
 	 */
 	void setLeftHandOperand(CtExpression<?> expression);
 
 	/**
 	 * Sets the right-hand operand.
+	 *
+	 * @param expression the expression to set
 	 */
 	void setRightHandOperand(CtExpression<?> expression);
 
 	/**
 	 * Sets the kind of this binary operator.
+	 *
+	 * @param kind the kind of binary operator to set
 	 */
 	void setKind(BinaryOperatorKind kind);
 
 	/**
 	 * Gets the kind of this binary operator.
+	 *
+	 * @return the kinf of binary operator
 	 */
 	BinaryOperatorKind getKind();
 

--- a/src/main/java/spoon/reflect/code/CtBlock.java
+++ b/src/main/java/spoon/reflect/code/CtBlock.java
@@ -30,27 +30,38 @@ public interface CtBlock<R> extends CtStatement, CtStatementList, TemplateParame
 
 	/**
 	 * Inserts the given statement at the begining of the block.
+	 *
+	 * @param statement the statement to insert
 	 */
 	void insertBegin(CtStatement statement);
 
 	/**
 	 * Inserts the given statement list at the begining of the block.
+	 *
+	 * @param statements a List of statements to insert
 	 */
 	void insertBegin(CtStatementList statements);
 
 	/**
 	 * Inserts the given statement at the end of the block.
+	 *
+	 * @param statement the statement to insert
 	 */
 	void insertEnd(CtStatement statement);
 
 	/**
 	 * Inserts the given statements at the end of the block.
+	 *
+	 * @param statements a {@link spoon.reflect.code.CtStatementList} to insert
 	 */
 	void insertEnd(CtStatementList statements);
 
 	/**
 	 * Inserts the given statement before a set of insertion points given by a
 	 * filter.
+	 *
+	 * @param insertionPoints a {@link spoon.reflect.visitor.Filter} to find insertion points
+	 * @param statement the statement to insert
 	 */
 	void insertBefore(Filter<? extends CtStatement> insertionPoints,
 			CtStatement statement);
@@ -58,6 +69,9 @@ public interface CtBlock<R> extends CtStatement, CtStatementList, TemplateParame
 	/**
 	 * Inserts the given statement list before a set of insertion points given
 	 * by a filter.
+	 *
+	 * @param insertionPoints a {@link spoon.reflect.visitor.Filter} to find insertion points
+	 * @param statements a {@link spoon.reflect.code.CtStatementList} to insert
 	 */
 	void insertBefore(Filter<? extends CtStatement> insertionPoints,
 			CtStatementList statements);
@@ -65,6 +79,9 @@ public interface CtBlock<R> extends CtStatement, CtStatementList, TemplateParame
 	/**
 	 * Inserts the given statement after a set of insertion points given by a
 	 * filter.
+	 *
+	 * @param insertionPoints a {@link spoon.reflect.visitor.Filter} to find insertion points
+	 * @param statement the statement to insert
 	 */
 	void insertAfter(Filter<? extends CtStatement> insertionPoints,
 			CtStatement statement);
@@ -72,27 +89,43 @@ public interface CtBlock<R> extends CtStatement, CtStatementList, TemplateParame
 	/**
 	 * Inserts the given statement list after a set of insertion points given by
 	 * a filter.
+	 *
+	 * @param insertionPoints a {@link spoon.reflect.visitor.Filter} to find insertion points
+	 * @param statements a List of statements to insert
 	 */
 	void insertAfter(Filter<? extends CtStatement> insertionPoints,
 			CtStatementList statements);
 
 	/**
 	 * Gets the ith statement of this block.
+	 *
+	 * @param <T> the statement's type
+	 * @param i the index of the statement to get
+	 *
+	 * @return the statement at index i
 	 */
 	<T extends CtStatement> T getStatement(int i);
 
 	/**
 	 * Gets the last statement of this block.
+	 *
+	 * @param <T> the statement's type
+	 *
+	 * @return the last statement
 	 */
 	<T extends CtStatement> T getLastStatement();
 
 	/**
 	 * Adds a statement to this block.
+	 *
+	 * @param statement the statement to add
 	 */
 	void addStatement(CtStatement statement);
 
 	/**
 	 * Removes a statement from this block.
+	 *
+	 * @param statement the statement to remove
 	 */
 	void removeStatement(CtStatement statement);
 

--- a/src/main/java/spoon/reflect/code/CtBreak.java
+++ b/src/main/java/spoon/reflect/code/CtBreak.java
@@ -24,12 +24,16 @@ public interface CtBreak extends CtCFlowBreak {
 	/**
 	 * Gets the label from which the control flow breaks (null if no label
 	 * defined).
+	 *
+	 * @return the target label name or null if none set
 	 */
 	String getTargetLabel();
 
 	/**
 	 * Sets the label from which the control flow breaks (null if no label
 	 * defined).
+	 *
+	 * @param targetLabel the target label name or null
 	 */
 	void setTargetLabel(String targetLabel);
 }

--- a/src/main/java/spoon/reflect/code/CtCase.java
+++ b/src/main/java/spoon/reflect/code/CtCase.java
@@ -28,11 +28,15 @@ package spoon.reflect.code;
 public interface CtCase<S> extends CtStatement, CtStatementList {
 	/**
 	 * Gets the case expression.
+	 *
+	 * @return the case expression
 	 */
 	CtExpression<S> getCaseExpression();
 
 	/**
 	 * Sets the case expression.
+	 *
+	 * @param caseExpression the case expression to set
 	 */
 	void setCaseExpression(CtExpression<S> caseExpression);
 }

--- a/src/main/java/spoon/reflect/code/CtCatch.java
+++ b/src/main/java/spoon/reflect/code/CtCatch.java
@@ -26,21 +26,29 @@ public interface CtCatch extends CtCodeElement {
 
 	/**
 	 * Gets the catch's parameter (a throwable).
+	 *
+	 * @return the throwable declaration
 	 */
 	CtLocalVariable<? extends Throwable> getParameter();
 
 	/**
 	 * Sets the catch's parameter (a throwable).
+	 *
+	 * @param parameter the throwable declaration to set
 	 */
 	void setParameter(CtLocalVariable<? extends Throwable> parameter);
 
 	/**
 	 * Gets the catch's body.
+	 *
+	 * @return the catch body block
 	 */
 	CtBlock<?> getBody();
 
 	/**
 	 * Sets the catch's body.
+	 *
+	 * @param body the catch body block to set
 	 */
 	void setBody(CtBlock<?> body);
 }

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
@@ -13,8 +13,12 @@ public interface CtCodeSnippetExpression<T> extends CtCodeSnippet,
 
 	/**
 	 * Compiles this expression snippet to produce the corresponding AST expression.
-	 * 
-	 * @throws SnippetCompilationError
+	 *
+	 * @param <E> the expression's type
+	 *
+	 * @return the compiled expression
+	 *
+	 * @throws spoon.support.compiler.SnippetCompilationError
 	 *             when the current snippet is not valid Java code expression
 	 */
 	<E extends CtExpression<T>> E compile() throws SnippetCompilationError;

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
@@ -14,7 +14,8 @@ public interface CtCodeSnippetStatement extends CtCodeSnippet, CtStatement {
 	/**
 	 * Compiles this statement code snippet to produce the corresponding AST
 	 * statement.
-	 * 
+	 *
+	 * @param <S> the statement's type
 	 * @return a statement
 	 * @throws SnippetCompilationError
 	 *             when the current snippet is not valid Java code

--- a/src/main/java/spoon/reflect/code/CtConditional.java
+++ b/src/main/java/spoon/reflect/code/CtConditional.java
@@ -24,31 +24,43 @@ public interface CtConditional<T> extends CtExpression<T> {
 
 	/**
 	 * Gets the "false" expression.
+	 *
+	 * @return the expression of the false section
 	 */
 	CtExpression<T> getElseExpression();
 
 	/**
 	 * Gets the "true" expression.
+	 *
+	 * @return the expression of the true section
 	 */
 	CtExpression<T> getThenExpression();
 
 	/**
 	 * Gets the condition expression.
+	 *
+	 * @return the condition expression
 	 */
 	CtExpression<Boolean> getCondition();
 
 	/**
 	 * Sets the "false" expression.
+	 *
+	 * @param elseExpression the expression for the else section
 	 */
 	void setElseExpression(CtExpression<T> elseExpression);
 
 	/**
 	 * Sets the "true" expression.
+	 *
+	 * @param thenExpression the expression for the true section
 	 */
 	void setThenExpression(CtExpression<T> thenExpression);
 
 	/**
 	 * Sets the condition expression.
+	 *
+	 * @param condition the condition expression
 	 */
 	void setCondition(CtExpression<Boolean> condition);
 

--- a/src/main/java/spoon/reflect/code/CtContinue.java
+++ b/src/main/java/spoon/reflect/code/CtContinue.java
@@ -24,24 +24,32 @@ public interface CtContinue extends CtCFlowBreak {
 	/**
 	 * Gets the statement where the control flow continues (null if no label
 	 * defined).
+	 *
+	 * @return the labelled statement
 	 */
 	CtStatement getLabelledStatement();
 
 	/**
 	 * Sets the statement where the control flow continues (null if no label
 	 * defined).
+	 *
+	 * @param labelledStatement the labelled statement
 	 */
 	void setLabelledStatement(CtStatement labelledStatement);
 	
 	/**
 	 * Gets the label from which the control flow breaks (null if no label
 	 * defined).
+	 *
+	 * @return the target label name
 	 */
 	String getTargetLabel();
 
 	/**
 	 * Sets the label from which the control flow breaks (null if no label
 	 * defined).
+	 *
+	 * @param targetLabel the target label name to set
 	 */
 	void setTargetLabel(String targetLabel);
 }

--- a/src/main/java/spoon/reflect/code/CtDo.java
+++ b/src/main/java/spoon/reflect/code/CtDo.java
@@ -23,11 +23,15 @@ package spoon.reflect.code;
 public interface CtDo extends CtLoop {
 	/**
 	 * Returns the looping test as a boolean expression.
+	 *
+	 * @return condition expression
 	 */
 	CtExpression<Boolean> getLoopingExpression();
 
 	/**
 	 * Sets the looping test as a boolean expression.
+	 *
+	 * @param expression the condition expression to set
 	 */
 	void setLoopingExpression(CtExpression<Boolean> expression);
 }

--- a/src/main/java/spoon/reflect/code/CtExpression.java
+++ b/src/main/java/spoon/reflect/code/CtExpression.java
@@ -34,16 +34,22 @@ public interface CtExpression<T> extends CtCodeElement, CtTypedElement<T>,
 
 	/**
 	 * Returns the type casts if any.
+	 *
+	 * @return the List of type references
 	 */
 	List<CtTypeReference<?>> getTypeCasts();
 
 	/**
 	 * Sets the type casts.
+	 *
+	 * @param types a List of type references to set
 	 */
 	void setTypeCasts(List<CtTypeReference<?>> types);
 
 	/**
 	 * Adds a type cast.
+	 *
+	 * @param type a type reference to add
 	 */
 	void addTypeCast(CtTypeReference<?> type);
 	

--- a/src/main/java/spoon/reflect/code/CtFor.java
+++ b/src/main/java/spoon/reflect/code/CtFor.java
@@ -26,51 +26,79 @@ public interface CtFor extends CtLoop {
 
 	/**
 	 * Gets the end-loop test expression.
+	 *
+	 * @return the expression of the condition
 	 */
 	CtExpression<Boolean> getExpression();
 
 	/**
 	 * Gets the <i>init</i> statements.
+	 *
+	 * @return the initialization statement
 	 */
 	List<CtStatement> getForInit();
 
 	/**
 	 * Adds an <i>init</i> statement.
+	 *
+	 * @param statement the statement to add
+	 *
+	 * @return true if the statement has been added
 	 */
 	boolean addForInit(CtStatement statement);
 
 	/**
 	 * Removes an <i>init</i> statement.
+	 *
+	 * @param statement the statement to remove
+	 *
+	 * @return true if the statement has een removed
 	 */
 	boolean removeForInit(CtStatement statement);
 
 	/**
 	 * Gets the <i>update</i> statements.
+	 *
+	 * @return the List of update statements
 	 */
 	List<CtStatement> getForUpdate();
 
 	/**
 	 * Sets the end-loop test expression.
+	 *
+	 * @param expression the expression to set for the condition
 	 */
 	void setExpression(CtExpression<Boolean> expression);
 
 	/**
 	 * Sets the <i>init</i> statements.
+	 *
+	 * @param forInit the List of initialization statements to set
 	 */
 	void setForInit(List<CtStatement> forInit);
 
 	/**
 	 * Sets the <i>update</i> statements.
+	 *
+	 * @param forUpdate the List if update statements to set
 	 */
 	void setForUpdate(List<CtStatement> forUpdate);
 
 	/**
 	 * Adds an <i>update</i> statement.
+	 *
+	 * @param statement the statement to add
+	 *
+	 * @return true if the update statement has been added
 	 */
 	boolean addForUpdate(CtStatement statement);
 
 	/**
 	 * Removes an <i>update</i> statement.
+	 *
+	 * @param statement the statement to remove
+	 *
+	 * @return true of the statement has been removed
 	 */
 	boolean removeForUpdate(CtStatement statement);
 

--- a/src/main/java/spoon/reflect/code/CtForEach.java
+++ b/src/main/java/spoon/reflect/code/CtForEach.java
@@ -21,25 +21,32 @@ package spoon.reflect.code;
  * This code element defines a <code>foreach</code> loop (enhanced
  * <code>for</code>).
  */
-
 public interface CtForEach extends CtLoop {
 	/**
 	 * Gets the iterated expression (an iterable of an array).
+	 *
+	 * @return the expression
 	 */
 	CtExpression<?> getExpression();
 
 	/**
 	 * Gets the variable that references the currently iterated element.
+	 *
+	 * @return the local variable
 	 */
 	CtLocalVariable<?> getVariable();
 
 	/**
 	 * Sets the iterated expression (an iterable of an array).
+	 *
+	 * @param expression the iterated expression
 	 */
 	void setExpression(CtExpression<?> expression);
 
 	/**
 	 * Sets the variable that references the currently iterated element.
+	 *
+	 * @param variable the local variable
 	 */
 	void setVariable(CtLocalVariable<?> variable);
 }

--- a/src/main/java/spoon/reflect/code/CtIf.java
+++ b/src/main/java/spoon/reflect/code/CtIf.java
@@ -27,32 +27,48 @@ public interface CtIf extends CtStatement, TemplateParameter<Void> {
 	/**
 	 * Gets the boolean expression that represents the <code>if</code>'s
 	 * condition.
+	 *
+	 * @return the boolean expression
 	 */
 	CtExpression<Boolean> getCondition();
 
 	/**
 	 * Gets the statement executed when the condition is false.
+	 *
+	 * @param <S> the statement's type
+	 *
+	 * @return the {@code else} statement
 	 */
 	<S extends CtStatement> S getElseStatement();
 
 	/**
 	 * Gets the statement executed when the condition is true.
+	 *
+	 * @param <S> the statement's type
+	 *
+	 * @return the {@code then} statement
 	 */
 	<S extends CtStatement> S getThenStatement();
 
 	/**
 	 * Sets the boolean expression that represents the <code>if</code>'s
 	 * condition.
+	 *
+	 * @param expression the boolean expression to set as the condition
 	 */
 	void setCondition(CtExpression<Boolean> expression);
 
 	/**
 	 * Sets the statement executed when the condition is false.
+	 *
+	 * @param elseStatement the else statement to set
 	 */
 	void setElseStatement(CtStatement elseStatement);
 
 	/**
 	 * Sets the statement executed when the condition is true.
+	 *
+	 * @param thenStatement the then statement to set
 	 */
 	void setThenStatement(CtStatement thenStatement);
 

--- a/src/main/java/spoon/reflect/code/CtLiteral.java
+++ b/src/main/java/spoon/reflect/code/CtLiteral.java
@@ -27,11 +27,15 @@ public interface CtLiteral<T> extends CtExpression<T> {
 
 	/**
 	 * Gets the actual value of the literal (statically known).
+	 *
+	 * @return the literal value
 	 */
 	T getValue();
 
 	/**
 	 * Sets the actual value of the literal.
+	 *
+	 * @param value the literal value to set
 	 */
 	void setValue(T value);
 

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -26,11 +26,15 @@ public interface CtLoop extends CtStatement, TemplateParameter<Void> {
 
 	/**
 	 * Gets the body of this loop.
+	 *
+	 * @return the body statement of the loop
 	 */
 	CtStatement getBody();
 
 	/**
 	 * Sets the body of this loop.
+	 *
+	 * @param body the body statement to set
 	 */
 	void setBody(CtStatement body);
 }

--- a/src/main/java/spoon/reflect/code/CtNewArray.java
+++ b/src/main/java/spoon/reflect/code/CtNewArray.java
@@ -29,41 +29,65 @@ public interface CtNewArray<T> extends CtExpression<T> {
 
 	/**
 	 * Gets the expressions that define the array's dimensions.
+	 *
+	 * @return the List of the dimension expressions
 	 */
 	List<CtExpression<Integer>> getDimensionExpressions();
 
 	/**
 	 * Sets the expressions that define the array's dimensions.
+	 *
+	 * @param dimensions the List of expressions to set
 	 */
 	void setDimensionExpressions(List<CtExpression<Integer>> dimensions);
 
 	/**
 	 * Adds a dimension expression.
+	 *
+	 * @param dimension the expression to be added
+	 *
+	 * @return true if the expression has been added
 	 */
 	boolean addDimensionExpression(CtExpression<Integer> dimension);
 
 	/**
 	 * Removes a dimension expression.
+	 *
+	 * @param dimension the expression to be removed
+	 *
+	 * @return true if the expression has been removed
 	 */
 	boolean removeDimensionExpression(CtExpression<Integer> dimension);
 
 	/**
 	 * Gets the initialization expressions.
+	 *
+	 * @return the List of initialization expressions
 	 */
 	List<CtExpression<?>> getElements();
 
 	/**
 	 * Sets the initialization expressions.
+	 *
+	 * @param expression a List of expressions to add
 	 */
 	void setElements(List<CtExpression<?>> expression);
 
 	/**
 	 * Adds an element.
+	 *
+	 * @param expression the expression to add
+	 *
+	 * @return true if the expression has been added
 	 */
 	boolean addElement(CtExpression<?> expression);
 
 	/**
 	 * Removes an element.
+	 *
+	 * @param expression the expression to remove
+	 *
+	 * @return true if the expression has been removed
 	 */
 	boolean removeElement(CtExpression<?> expression);
 

--- a/src/main/java/spoon/reflect/code/CtNewClass.java
+++ b/src/main/java/spoon/reflect/code/CtNewClass.java
@@ -31,11 +31,15 @@ public interface CtNewClass<T> extends
 
 	/**
 	 * Gets the created class.
+	 *
+	 * @return the anonymous class
 	 */
 	CtClass<?> getAnonymousClass();
 
 	/**
 	 * Sets the created class.
+	 *
+	 * @param anonymousClass the anonymous class
 	 */
 	void setAnonymousClass(CtClass<?> anonymousClass);
 

--- a/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
@@ -24,11 +24,15 @@ public interface CtOperatorAssignment<T, A extends T> extends
 		CtAssignment<T, A> {
 	/**
 	 * Sets the operator kind.
+	 *
+	 * @param kind the kind of the binary operator
 	 */
 	void setKind(BinaryOperatorKind kind);
 
 	/**
 	 * Gets the operator kind.
+	 *
+	 * @return the kind of the binary operator
 	 */
 	BinaryOperatorKind getKind();
 }

--- a/src/main/java/spoon/reflect/code/CtReturn.java
+++ b/src/main/java/spoon/reflect/code/CtReturn.java
@@ -26,11 +26,15 @@ public interface CtReturn<R> extends CtCFlowBreak, TemplateParameter<Void> {
 
 	/**
 	 * Gets the returned expression.
+	 *
+	 * @return the returned expression
 	 */
 	CtExpression<R> getReturnedExpression();
 
 	/**
 	 * Sets the returned expression.
+	 *
+	 * @param returnedExpression the expression to return
 	 */
 	void setReturnedExpression(CtExpression<R> returnedExpression);
 

--- a/src/main/java/spoon/reflect/code/CtStatement.java
+++ b/src/main/java/spoon/reflect/code/CtStatement.java
@@ -29,12 +29,20 @@ public interface CtStatement extends CtCodeElement {
 
 	/**
 	 * Inserts a statement after the current statement.
+	 *
+	 * @param statement the statement to insert
+	 *
+	 * @throws spoon.reflect.declaration.ParentNotInitializedException if the parent is not initialized
 	 */
 	void insertAfter(CtStatement statement)
 			throws ParentNotInitializedException;
 
 	/**
 	 * Inserts a statement list before the current statement.
+	 *
+	 * @param statements a List of statements to insert
+	 *
+	 * @throws spoon.reflect.declaration.ParentNotInitializedException if the parent is not initialized
 	 */
 	void insertAfter(CtStatementList statements)
 			throws ParentNotInitializedException;
@@ -42,12 +50,20 @@ public interface CtStatement extends CtCodeElement {
 	/**
 	 * Inserts a statement given as parameter before the current statement
 	 * (this).
+	 *
+	 * @param statement the statement to insert
+	 *
+	 * @throws spoon.reflect.declaration.ParentNotInitializedException if the parent is not initialized
 	 */
 	void insertBefore(CtStatement statement)
 			throws ParentNotInitializedException;
 
 	/**
 	 * Inserts a statement list before the current statement.
+	 *
+	 * @param statements a List of statements to insert
+	 *
+	 * @throws spoon.reflect.declaration.ParentNotInitializedException if the parent is not initialized
 	 */
 	void insertBefore(CtStatementList statements)
 			throws ParentNotInitializedException;
@@ -61,6 +77,8 @@ public interface CtStatement extends CtCodeElement {
 
 	/**
 	 * Sets the label of this statement.
+	 *
+	 * @param label the label to set
 	 */
 	void setLabel(String label);
 

--- a/src/main/java/spoon/reflect/code/CtStatementList.java
+++ b/src/main/java/spoon/reflect/code/CtStatementList.java
@@ -28,21 +28,29 @@ public interface CtStatementList extends CtCodeElement, Iterable<CtStatement> {
 
 	/**
 	 * Returns the statement list.
+	 *
+	 * @return the List if statements
 	 */
 	List<CtStatement> getStatements();
 
 	/**
 	 * Sets the statement list.
+	 *
+	 * @param statements the List of statements to set
 	 */
 	void setStatements(List<CtStatement> statements);
 
 	/**
 	 * Adds a statement at the end of the list.
+	 *
+	 * @param statement the statement to add
 	 */
 	void addStatement(CtStatement statement);
 
 	/**
 	 * Removes a statement.
+	 *
+	 * @param statement the statement to remove
 	 */
 	void removeStatement(CtStatement statement);
 

--- a/src/main/java/spoon/reflect/code/CtSwitch.java
+++ b/src/main/java/spoon/reflect/code/CtSwitch.java
@@ -34,6 +34,8 @@ public interface CtSwitch<S> extends CtStatement {
 	 * <code>byte</code>, <code>short</code>, <code>int</code>,
 	 * <code>Character</code>, <code>Byte</code>, <code>Short</code>,
 	 * <code>Integer</code>, or an <code>enum</code> type
+	 *
+	 * @return the selector expression
 	 */
 	CtExpression<S> getSelector();
 
@@ -42,26 +44,40 @@ public interface CtSwitch<S> extends CtStatement {
 	 * <code>byte</code>, <code>short</code>, <code>int</code>,
 	 * <code>Character</code>, <code>Byte</code>, <code>Short</code>,
 	 * <code>Integer</code>, or an <code>enum</code> type
+	 *
+	 * @param selector the selector expression to set
 	 */
 	void setSelector(CtExpression<S> selector);
 
 	/**
 	 * Gets the list of cases defined for this switch.
+	 *
+	 * @return the List of cases
 	 */
 	List<CtCase<? super S>> getCases();
 
 	/**
 	 * Sets the list of cases defined for this switch.
+	 *
+	 * @param cases the List of cases to set
 	 */
 	void setCases(List<CtCase<? super S>> cases);
 
 	/**
 	 * Adds a case;
+	 *
+	 * @param c the case to add
+	 *
+	 * @return true if the case has been added
 	 */
 	boolean addCase(CtCase<? super S> c);
 
 	/**
 	 * Removes a case;
+	 *
+	 * @param c the case to remove
+	 *
+	 * @return true if the case has been removed
 	 */
 	boolean removeCase(CtCase<? super S> c);
 

--- a/src/main/java/spoon/reflect/code/CtSynchronized.java
+++ b/src/main/java/spoon/reflect/code/CtSynchronized.java
@@ -30,16 +30,22 @@ public interface CtSynchronized extends CtStatement {
 
 	/**
 	 * Sets the expression that defines the monitored.
+	 *
+	 * @param expression the expression to monitor
 	 */
 	void setExpression(CtExpression<?> expression);
 
 	/**
 	 * Gets the synchronized block.
+	 *
+	 * @return the synchronized block
 	 */
 	CtBlock<?> getBlock();
 
 	/**
 	 * Sets the synchronized block.
+	 *
+	 * @param block the synchronized block
 	 */
 	void setBlock(CtBlock<?> block);
 }

--- a/src/main/java/spoon/reflect/code/CtTargetedExpression.java
+++ b/src/main/java/spoon/reflect/code/CtTargetedExpression.java
@@ -32,11 +32,15 @@ public interface CtTargetedExpression<T, E extends CtExpression<?>> extends
 
 	/**
 	 * Gets the target expression.
+	 *
+	 * @return the target
 	 */
 	E getTarget();
 
 	/**
 	 * Sets the target expression.
+	 *
+	 * @param target the target to set
 	 */
 	void setTarget(E target);
 

--- a/src/main/java/spoon/reflect/code/CtThisAccess.java
+++ b/src/main/java/spoon/reflect/code/CtThisAccess.java
@@ -27,11 +27,15 @@ public interface CtThisAccess<T> extends CtExpression<T> {
 
 	/**
 	 * Tells if this access must be qualified by the class it refers to.
+	 *
+	 * @return true if this {@code this} access must be qualified
 	 */
 	boolean isQualified();
 
 	/**
 	 * Sets this access to be qualified by the class it refers to.
+	 *
+	 * @param qualified true to require a qualified access
 	 */
 	void setQualified(boolean qualified);
 

--- a/src/main/java/spoon/reflect/code/CtThrow.java
+++ b/src/main/java/spoon/reflect/code/CtThrow.java
@@ -26,11 +26,15 @@ public interface CtThrow extends CtCFlowBreak, TemplateParameter<Void> {
 
 	/**
 	 * Returns the thrown expression (must be a throwable).
+	 *
+	 * @return the thrown expression
 	 */
 	CtExpression<? extends Throwable> getThrownExpression();
 
 	/**
 	 * Sets the thrown expression (must be a throwable).
+	 *
+	 * @param thrownExpression the expression to be thrown
 	 */
 	void setThrownExpression(CtExpression<? extends Throwable> thrownExpression);
 

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -29,64 +29,96 @@ public interface CtTry extends CtStatement, TemplateParameter<Void> {
 	/**
 	 * Gets the auto-closeable resources of this <code>try</code>. Available
 	 * from Java 7 with the <i>try-with-resource</i> statement.
+	 *
+	 * @return the List of resources
 	 */
 	List<CtLocalVariable<? extends AutoCloseable>> getResources();
 
 	/**
 	 * Sets the auto-closeable resources of this <code>try</code>. Available
 	 * from Java 7 with the <i>try-with-resource</i> statement.
+	 *
+	 * @param resources the List of resources to set
 	 */
 	void setResources(List<CtLocalVariable<? extends AutoCloseable>> resources);
 
 	/**
 	 * Adds a resource.
+	 *
+	 * @param resource the resource to add
+	 *
+	 * @return true if the resource has been added
 	 */
 	boolean addResource(CtLocalVariable<? extends AutoCloseable> resource);
 
 	/**
 	 * Removes a resource.
+	 *
+	 * @param resource the resource to remove
+	 *
+	 * @return true if the resource has been removed
 	 */
 	boolean removeResource(CtLocalVariable<? extends AutoCloseable> resource);
 
 	/**
 	 * Gets the <i>catchers</i> of this <code>try</code>.
+	 *
+	 * @return the List of catch blocks
 	 */
 	List<CtCatch> getCatchers();
 
 	/**
 	 * Sets the <i>catchers</i> of this <code>try</code>.
+	 *
+	 * @param catchers the List of catch blocks to set
 	 */
 	void setCatchers(List<CtCatch> catchers);
 
 	/**
 	 * Adds a catch block.
+	 *
+	 * @param catcher the catch block to add
+	 *
+	 * @return true if the catch block as been added
 	 */
 	boolean addCatcher(CtCatch catcher);
 
 	/**
 	 * Removes a catch block.
+	 *
+	 * @param catcher the catch block to remove
+	 *
+	 * @return true if the catch block as been removed
 	 */
 	boolean removeCatcher(CtCatch catcher);
 
 	/**
 	 * Sets the tried body.
+	 *
+	 * @return the body
 	 */
 	CtBlock<?> getBody();
 
 	/**
 	 * Sets the tried body.
+	 *
+	 * @param body the body
 	 */
 	void setBody(CtBlock<?> body);
 
 	/**
 	 * Gets the <i>finalizer</i> block of this <code>try</code> (
 	 * <code>finally</code> part).
+	 *
+	 * @return the finally block
 	 */
 	CtBlock<?> getFinalizer();
 
 	/**
 	 * Sets the <i>finalizer</i> block of this <code>try</code> (
 	 * <code>finally</code> part).
+	 *
+	 * @param finalizer the finally block to set
 	 */
 	void setFinalizer(CtBlock<?> finalizer);
 }

--- a/src/main/java/spoon/reflect/code/CtUnaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtUnaryOperator.java
@@ -28,21 +28,29 @@ public interface CtUnaryOperator<T> extends CtExpression<T>, CtStatement {
 
 	/**
 	 * Gets the expression to which the operator is applied.
+	 *
+	 * @return the expression this operator is applied to
 	 */
 	CtExpression<T> getOperand();
 
 	/**
 	 * Sets the expression to which the operator is applied.
+	 *
+	 * @param expression the expression this operator gets applied
 	 */
 	void setOperand(CtExpression<T> expression);
 
 	/**
 	 * Sets the kind of this operator.
+	 *
+	 * @param kind the kind of the unary operator to set
 	 */
 	void setKind(UnaryOperatorKind kind);
 
 	/**
 	 * Gets the kind of this operator.
+	 *
+	 * @return the kind of this unary operator
 	 */
 	UnaryOperatorKind getKind();
 

--- a/src/main/java/spoon/reflect/code/CtVariableAccess.java
+++ b/src/main/java/spoon/reflect/code/CtVariableAccess.java
@@ -28,11 +28,15 @@ import spoon.reflect.reference.CtVariableReference;
 public interface CtVariableAccess<T> extends CtExpression<T> {
 	/**
 	 * Gets the reference to the accessed variable.
+	 *
+	 * @return the variable reference
 	 */
 	CtVariableReference<T> getVariable();
 
 	/**
 	 * Sets the reference to the accessed variable.
+	 *
+	 * @param variable the variable reference to set
 	 */
 	void setVariable(CtVariableReference<T> variable);
 }

--- a/src/main/java/spoon/reflect/code/CtWhile.java
+++ b/src/main/java/spoon/reflect/code/CtWhile.java
@@ -23,11 +23,15 @@ package spoon.reflect.code;
 public interface CtWhile extends CtLoop {
 	/**
 	 * Gets the looping boolean test expression.
+	 *
+	 * @return the condition expression
 	 */
 	CtExpression<Boolean> getLoopingExpression();
 
 	/**
 	 * Sets the looping boolean test expression.
+	 *
+	 * @param expression the condition expression
 	 */
 	void setLoopingExpression(CtExpression<Boolean> expression);
 }

--- a/src/main/java/spoon/reflect/cu/CompilationUnit.java
+++ b/src/main/java/spoon/reflect/cu/CompilationUnit.java
@@ -15,42 +15,58 @@ public interface CompilationUnit extends FactoryAccessor {
 	/**
 	 * Gets the file that corresponds to this compilation unit if any (contains
 	 * the source code).
+	 *
+	 * @return the source file
 	 */
 	File getFile();
 
 	/**
 	 * Sets the file that corresponds to this compilation unit.
+	 *
+	 * @param file the source file to set
 	 */
 	void setFile(File file);
 
 	/**
 	 * Gets all the types declared in this compilation unit.
+	 *
+	 * @return the List of declared types
 	 */
 	List<CtSimpleType<?>> getDeclaredTypes();
 
 	/**
 	 * Sets the types declared in this compilation unit.
+	 *
+	 * @param types the List if declared types to set
 	 */
 	void setDeclaredTypes(List<CtSimpleType<?>> types);
 
 	/**
 	 * Searches and returns the main type (the type which has the same name as
 	 * the file).
+	 *
+	 * @return the main type
 	 */
 	CtSimpleType<?> getMainType();
 
 	/**
 	 * Add a source code fragment to this compilation unit.
+	 *
+	 * @param fragment the source code fragment to add
 	 */
 	void addSourceCodeFragment(SourceCodeFragment fragment);
 
 	/**
 	 * Gets the source code fragments for this compilation unit.
+	 *
+	 * @return the List of source code fragments
 	 */
 	List<SourceCodeFragment> getSourceCodeFraments();
 
 	/**
 	 * Gets the original source code as a string.
+	 *
+	 * @return the original source code as a string
 	 */
 	String getOriginalSourceCode();
 

--- a/src/main/java/spoon/reflect/cu/Import.java
+++ b/src/main/java/spoon/reflect/cu/Import.java
@@ -7,11 +7,9 @@ import spoon.reflect.reference.CtReference;
  * of the AST and are generated automatically. However, when the auto-import
  * feature of a compilation unit is turned off, the programmer can manually
  * specify the imports to be done.
- * 
- * @see CompilationUnit#isAutoImport()
- * @see CompilationUnit#setAutoImport(boolean)
- * @see CompilationUnit#getManualImports()
- * @see CompilationUnit#setManualImports(java.util.Set)
+ *
+ * @see spoon.compiler.Environment#isAutoImports()
+ * @see spoon.compiler.Environment#setAutoImports(boolean)
  */
 public interface Import {
 	
@@ -22,6 +20,8 @@ public interface Import {
 
 	/**
 	 * Gets the reference of the element that is imported.
+	 *
+	 * @return the reference
 	 */
 	CtReference getReference();
 

--- a/src/main/java/spoon/reflect/cu/SourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/SourcePosition.java
@@ -29,28 +29,38 @@ public interface SourcePosition {
 	/**
 	 * Returns a string representation of this position in the form
 	 * "sourcefile:line", or "sourcefile" if no line number is available.
+	 *
+	 * @return a String representation
 	 */
 	String toString();
 
 	/**
 	 * Gets the file for this position.
+	 *
+	 * @return the file
 	 */
 	File getFile();
 
 	/**
 	 * Gets the compilation unit for this position.
+	 *
+	 * @return the compilation unit
 	 */
 	CompilationUnit getCompilationUnit();
 
 	/**
 	 * Gets the line in the source file (1 indexed). Prefer using
 	 * {@link #getSourceStart()}}.
+	 *
+	 * @return the line (beginning with 1)
 	 */
 	int getLine();
 
 	/**
 	 * Gets the end line in the source file (1 indexed). Prefer using
 	 * {@link #getSourceEnd()}}.
+	 *
+	 * @return the end line (beginning with 1)
 	 */
 	int getEndLine();
 
@@ -59,6 +69,8 @@ public interface SourcePosition {
 	 * because it has to calculate the column number depending on
 	 * {@link Environment#getTabulationSize()} and
 	 * {@link CompilationUnit#getOriginalSourceCode()}. Prefer {@link #getSourceStart()}.
+	 *
+	 * @return the column (beginning with 1)
 	 */
 	int getColumn();
 
@@ -67,16 +79,22 @@ public interface SourcePosition {
 	 * because it has to calculate the column number depending on
 	 * {@link Environment#getTabulationSize()} and
 	 * {@link CompilationUnit#getOriginalSourceCode()}. Prefer {@link #getSourceEnd()}.
+	 *
+	 * @return the end column (beginning with 1)
 	 */
 	int getEndColumn();
 
 	/**
 	 * Gets the index at which the position ends in the source file.
+	 *
+	 * @return the end index
 	 */
 	int getSourceEnd();
 
 	/**
 	 * Gets the index at which the position starts in the source file.
+	 *
+	 * @return the the start index
 	 */
 	int getSourceStart();
 

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -37,12 +37,14 @@ public interface CtAnnotation<A extends Annotation> extends CtElement {
 	 * NOTE: before using an annotation proxy, you have to make sure that all
 	 * the types referenced by the annotation have been compiled and are in the
 	 * classpath so that accessed values can be converted into the actual types ({@link #getElementValue(String)}).
+	 *
+	 * @return the actual annotation instance
 	 */
 	A getActualAnnotation();
 
 	/**
 	 * Returns the annotation type of this annotation.
-	 * 
+	 *
 	 * @return a reference to the type of this annotation
 	 */
 	CtTypeReference<A> getAnnotationType();
@@ -54,7 +56,8 @@ public interface CtAnnotation<A extends Annotation> extends CtElement {
 	 * NOTE: in case of a type, the value is converted to the actual type. To
 	 * access the type as a reference, use {@link #getElementValues()}, which
 	 * returns a map containing the raw (unconverted) values.
-	 * 
+	 *
+	 * @param <T> the type of the value
 	 * @param key
 	 *            name of searched value
 	 * @return the value or null if not found
@@ -89,6 +92,8 @@ public interface CtAnnotation<A extends Annotation> extends CtElement {
 	 * form of a map that associates element names with their corresponding
 	 * values. Note that type values are stored as
 	 * {@link spoon.reflect.reference.CtTypeReference}.
+	 *
+	 * @param values a Map of annotation values
 	 */
 	void setElementValues(Map<String, Object> values);
 

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -32,22 +32,32 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 
 	/**
 	 * Gets the fields defined by this class.
+	 *
+	 * @return A List of all fields
 	 */
 	List<CtField<?>> getFields();
 
 	/**
 	 * Returns the anonymous blocks of this class.
+	 *
+	 * @return a List of anonymous executables
 	 */
 	List<CtAnonymousExecutable> getAnonymousExecutables();
 
 	/**
 	 * Returns the constructor of the class that takes the given argument types.
+	 *
+	 * @param parameterTypes the type references of the constructor parameters
+	 *
+	 * @return The constructor with a matching signature
 	 */
 	CtConstructor<T> getConstructor(CtTypeReference<?>... parameterTypes);
 
 	/**
 	 * Returns the constructors of this class. This includes the default
 	 * constructor if this class has no constructors explicitly declared.
+	 *
+	 * @return a Set of constructors
 	 */
 	Set<CtConstructor<T>> getConstructors();
 
@@ -61,13 +71,16 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 
 	/**
 	 * Sets the anonymous blocks of this class.
+	 *
+	 * @param e the Set of  anonymous executables to set
 	 */
 	void setAnonymousExecutables(List<CtAnonymousExecutable> e);
 
 	/**
 	 * Add an anonymous block to this class.
 	 * 
-	 * @param e
+	 * @param e an anonymous executable to add
+	 *
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addAnonymousExecutable(CtAnonymousExecutable e);
@@ -75,28 +88,37 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	/**
 	 * Remove an anonymous block to this class.
 	 * 
-	 * @param e
+	 * @param e an anonymous executable to remove
+	 *
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeAnonymousExecutable(CtAnonymousExecutable e);
 
 	/**
 	 * Sets the constructors for this class.
+	 *
+	 * @param constructors the Set of constructors for this class
 	 */
 	void setConstructors(Set<CtConstructor<T>> constructors);
 
 	/**
 	 * Adds a constructor to this class.
+	 *
+	 * @param constructor the constructor to add
 	 */
 	void addConstructor(CtConstructor<T> constructor);
 
 	/**
 	 * Removes a constructor from this class.
+	 *
+	 * @param constructor the constructor to remove
 	 */
 	void removeConstructor(CtConstructor<T> constructor);
 
 	/**
 	 * Sets the superclass type.
+	 *
+	 * @param classType the type reference to set
 	 */
 	void setSuperclass(CtTypeReference<?> classType);
 

--- a/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
+++ b/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
@@ -15,11 +15,15 @@ public interface CtCodeSnippet {
 
 	/**
 	 * Sets the textual value of the code.
+	 *
+	 * @param value the code as a string
 	 */
 	void setValue(String value);
 
 	/**
 	 * Gets the textual value of the code.
+	 *
+	 * @return the code as a string
 	 */
 	String getValue();
 

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -64,7 +64,8 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 
 	/**
 	 * Gets the annotation element for a given annotation type.
-	 * 
+	 *
+	 * @param <A> the type of the annotation
 	 * @param annotationType
 	 *            the annotation type
 	 * @return the annotation if this element is annotated by one annotation of
@@ -77,12 +78,16 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	 * Returns the annotations that are present on this element.
 	 * 
 	 * For sake of encapsulation, the returned list is unmodifiable.
+	 *
+	 * @return a List of annotations
 	 */
 	List<CtAnnotation<? extends Annotation>> getAnnotations();
 
 	/**
 	 * Returns the text of the documentation ("javadoc") comment of this
 	 * element.
+	 *
+	 * @return the documentation string
 	 */
 	String getDocComment();
 
@@ -91,6 +96,8 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	 * manually added to the tree may have a null parent if not manually set.
 	 * Note that the parents of an entire tree of elements can be automatically
 	 * set by using the {@link #updateAllParentsBelow()}.
+	 *
+	 * @return the parent element
 	 * 
 	 * @throws ParentNotInitializedException
 	 *             when the parent of this element is not initialized
@@ -99,6 +106,8 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 
 	/**
 	 * Tells if this parent has been initialized.
+	 *
+	 * @return true if the parent is initialized
 	 */
 	boolean isParentInitialized();
 
@@ -107,27 +116,44 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	 * parent, which is different from being not initialized). When an element
 	 * is a root element, {@link #getParent()} will return null without throwing
 	 * an exception.
+	 *
+	 * @return true if this element is a root element
 	 */
 	boolean isRootElement();
 
 	/**
 	 * Sets the root element flag to this element.
+	 *
+	 * @param rootElement true to set this element as a root element
 	 */
 	void setRootElement(boolean rootElement);
 
 	/**
 	 * Gets the signature of the element.
+	 *
+	 * @return the signature of the element as a string
 	 */
 	String getSignature();
 
 	/**
 	 * Gets the first parent that matches the given type.
+	 *
+	 * @param <P> the type of element
+	 * @param parentType  the type of parent
+	 *
+	 * @return the element
 	 */
 	<P extends CtElement> P getParent(Class<P> parentType)
 			throws ParentNotInitializedException;
 
 	/**
 	 * Tells if the given element is a direct or indirect parent.
+	 *
+	 * @param candidate the element to check
+	 *
+	 * @return true if the given element has a parent
+	 *
+	 * @throws spoon.reflect.declaration.ParentNotInitializedException if the parent is not initialized
 	 */
 	boolean hasParent(CtElement candidate) throws ParentNotInitializedException;
 
@@ -140,13 +166,15 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 
 	/**
 	 * Replaces this element by another one.
+	 *
+	 * @param element the element to replace
 	 */
 	void replace(CtElement element);
 
 	/**
 	 * Add an annotation for this element
 	 * 
-	 * @param annotation
+	 * @param annotation the annotation to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addAnnotation(CtAnnotation<? extends Annotation> annotation);
@@ -154,7 +182,7 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	/**
 	 * Remove an anntation for this element
 	 * 
-	 * @param annotation
+	 * @param annotation the annotation to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeAnnotation(CtAnnotation<? extends Annotation> annotation);
@@ -162,6 +190,8 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	/**
 	 * Sets the text of the documentation ("javadoc") comment of this
 	 * declaration.
+	 *
+	 * @param docComment the comment string to set
 	 */
 	void setDocComment(String docComment);
 
@@ -208,29 +238,37 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 	/**
 	 * Returns true if this element is implicit and automatically added by the
 	 * Java compiler.
+	 *
+	 * @return true if this element is implicit
 	 */
 	boolean isImplicit();
 
 	/**
 	 * Sets this element to be implicit (will not be printed).
+	 *
+	 * @param b true to set this element implicit
 	 */
 	void setImplicit(boolean b);
 
 	/**
 	 * Calculates and returns the set of all the types referenced by this
 	 * element (and sub-elements in the AST).
+	 *
+	 * @return a Set of type references
 	 */
 	Set<CtTypeReference<?>> getReferencedTypes();
 
 	/**
-	 * @param filter
-	 * @return
+	 * @param <E> the type of element
+	 * @param filter the filter to apply
+	 * @return the elements
 	 */
 	<E extends CtElement> List<E> getElements(Filter<E> filter);
 
 	/**
-	 * @param filter
-	 * @return
+	 * @param <T> the reference type
+	 * @param filter the reference filter to apply
+	 * @return the reference
 	 */
 	<T extends CtReference> List<T> getReferences(ReferenceFilter<T> filter);
 
@@ -246,6 +284,8 @@ public interface CtElement extends FactoryAccessor, Comparable<CtElement> {
 
 	/**
 	 * Sets the annotations for this element.
+	 *
+	 * @param annotation the annotations to set as a List
 	 */
 	void setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
 

--- a/src/main/java/spoon/reflect/declaration/CtEnum.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnum.java
@@ -25,7 +25,11 @@ import java.util.List;
  */
 public interface CtEnum<T extends Enum<?>> extends CtClass<T> {
 
-	/** Returns the set of predefined constant values of this enum */
+	/**
+	 * Returns the set of predefined constant values of this enum
+	 *
+	 * @return the List of enum fields
+	 */
 	public List<CtField<?>> getValues();
 	
 }

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -38,16 +38,24 @@ public interface CtExecutable<R> extends CtNamedElement, CtGenericElement,
 
 	/**
 	 * Gets the body expression.
+	 *
+	 * @param <B> the body's type
+	 *
+	 * @return the body
 	 */
 	<B extends R> CtBlock<B> getBody();
 
 	/**
 	 * Gets the declaring type
+	 *
+	 * @return the declaring type
 	 */
 	CtType<?> getDeclaringType();
 
 	/**
 	 * Gets the parameters list.
+	 *
+	 * @return the List of parameters
 	 */
 	List<CtParameter<?>> getParameters();
 
@@ -61,23 +69,30 @@ public interface CtExecutable<R> extends CtNamedElement, CtGenericElement,
 	/**
 	 * Returns the exceptions and other throwables listed in this method or
 	 * constructor's <tt>throws</tt> clause.
+	 *
+	 * @return the Set of thrown types
 	 */
 	Set<CtTypeReference<? extends Throwable>> getThrownTypes();
 
 	/**
 	 * Sets the body expression.
+	 *
+	 * @param <B> the body's type
+	 * @param body the body to set
 	 */
 	<B extends R> void setBody(CtBlock<B> body);
 
 	/**
 	 * Sets the parameters.
+	 *
+	 * @param parameters the Set of parameters to set
 	 */
 	void setParameters(List<CtParameter<?>> parameters);
 
 	/**
 	 * Add a parameter for this executable
 	 * 
-	 * @param parameter
+	 * @param parameter the parameter to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addParameter(CtParameter<?> parameter);
@@ -85,20 +100,22 @@ public interface CtExecutable<R> extends CtNamedElement, CtGenericElement,
 	/**
 	 * Remove a parameter for this executable
 	 * 
-	 * @param parameter
+	 * @param parameter the parameter to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeParameter(CtParameter<?> parameter);
 
 	/**
 	 * Sets the thrown types.
+	 *
+	 * @param thrownTypes the Set of throwable types to set
 	 */
 	void setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 
 	/**
 	 * add a thrown type.
 	 * 
-	 * @param throwType
+	 * @param throwType the thrown type to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addThrownType(CtTypeReference<? extends Throwable> throwType);
@@ -106,7 +123,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtGenericElement,
 	/**
 	 * remove a thrown type.
 	 * 
-	 * @param throwType
+	 * @param throwType the thrown type to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeThrownType(CtTypeReference<? extends Throwable> throwType);

--- a/src/main/java/spoon/reflect/declaration/CtField.java
+++ b/src/main/java/spoon/reflect/declaration/CtField.java
@@ -31,6 +31,8 @@ public interface CtField<T> extends CtNamedElement, CtVariable<T> {
 
 	/**
 	 * Gets the type that declares this field.
+	 *
+	 * @return the declaring type
 	 */
 	CtSimpleType<?> getDeclaringType();
 

--- a/src/main/java/spoon/reflect/declaration/CtGenericElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtGenericElement.java
@@ -28,18 +28,22 @@ import spoon.reflect.reference.CtTypeReference;
 public interface CtGenericElement extends CtElement {
 	/**
 	 * Returns the formal type parameters of this generic element.
+	 *
+	 * @return the List of type parameters
 	 */
 	List<CtTypeReference<?>> getFormalTypeParameters();
 
 	/**
 	 * Sets the type parameters of this generic element.
+	 *
+	 * @param formalTypeParameters the List of type parameters
 	 */
 	void setFormalTypeParameters(List<CtTypeReference<?>> formalTypeParameters);
 
 	/**
 	 * Add a type parameter to this generic element.
 	 * 
-	 * @param formalTypeParameter
+	 * @param formalTypeParameter the type parameter to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addFormalTypeParameter(CtTypeReference<?> formalTypeParameter);
@@ -47,7 +51,7 @@ public interface CtGenericElement extends CtElement {
 	/**
 	 * Removes a type parameters from this generic element.
 	 * 
-	 * @param formalTypeParameter
+	 * @param formalTypeParameter the type parameter to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeFormalTypeParameter(CtTypeReference<?> formalTypeParameter);

--- a/src/main/java/spoon/reflect/declaration/CtModifiable.java
+++ b/src/main/java/spoon/reflect/declaration/CtModifiable.java
@@ -46,13 +46,15 @@ public interface CtModifiable extends CtElement, FactoryAccessor {
 
 	/**
 	 * Sets the modifiers.
+	 *
+	 * @param modifiers The Set of modifiers to set
 	 */
 	void setModifiers(Set<ModifierKind> modifiers);
 
 	/**
 	 * add a modifier
 	 * 
-	 * @param modifier
+	 * @param modifier the modifier to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addModifier(ModifierKind modifier);
@@ -60,18 +62,22 @@ public interface CtModifiable extends CtElement, FactoryAccessor {
 	/**
 	 * remove a modifier
 	 * 
-	 * @param modifier
+	 * @param modifier the modifier to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeModifier(ModifierKind modifier);
 
 	/**
 	 * Sets the visibility of this modifiable element (replaces old visibility).
+	 *
+	 * @param visibility the visibility modifier
 	 */
 	void setVisibility(ModifierKind visibility);
 
 	/**
 	 * Gets the visibility of this modifiable element.
+	 *
+	 * @return the kind of modifier
 	 */
 	ModifierKind getVisibility();
 }

--- a/src/main/java/spoon/reflect/declaration/CtNamedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtNamedElement.java
@@ -26,16 +26,22 @@ public interface CtNamedElement extends CtElement, CtModifiable {
 
 	/**
 	 * Returns the simple (unqualified) name of this element.
+	 *
+	 * @return the simple name
 	 */
 	String getSimpleName();
 
 	/**
 	 * Sets the simple (unqualified) name of this element.
+	 *
+	 * @param simpleName the simple name to set
 	 */
 	void setSimpleName(String simpleName);
 
 	/**
 	 * Returns the corresponding reference.
+	 *
+	 * @return the reference
 	 */
 	CtReference getReference();
 

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -39,6 +39,8 @@ public interface CtPackage extends CtNamedElement {
 
 	/**
 	 * Gets the declaring package of the current one.
+	 *
+	 * @return the declaring package
 	 */
 	CtPackage getDeclaringPackage();
 
@@ -53,6 +55,8 @@ public interface CtPackage extends CtNamedElement {
 
 	/**
 	 * Gets the set of included child packages.
+	 *
+	 * @return the Set of included child packages
 	 */
 	Set<CtPackage> getPackages();
 
@@ -74,6 +78,9 @@ public interface CtPackage extends CtNamedElement {
 
 	/**
 	 * Finds a top-level type by name.
+	 *
+	 * @param <T> the type's concrete type
+	 * @param simpleName the simple name of the type
 	 * 
 	 * @return the found type or null
 	 */
@@ -81,16 +88,22 @@ public interface CtPackage extends CtNamedElement {
 
 	/**
 	 * Returns the set of the top-level types in this package.
+	 *
+	 * @return the Set of top level types
 	 */
 	Set<CtSimpleType<?>> getTypes();
 
 	/**
 	 * Adds a type to this package.
+	 *
+	 * @param type the type to add
 	 */
 	void addType(CtSimpleType<?> type);
 
 	/**
 	 * Removes a type from this package.
+	 *
+	 * @param type the type to remove
 	 */
 	void removeType(CtSimpleType<?> type);
 
@@ -103,17 +116,17 @@ public interface CtPackage extends CtNamedElement {
 	void setPackages(Set<CtPackage> pack);
 
 	/**
-	 * add a subpackage
+	 * Adds a sub package
 	 * 
-	 * @param pack
+	 * @param pack the sub package to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean addPackage(CtPackage pack);
 
 	/**
-	 * remove a subpackage
+	 * Removes a sub package
 	 * 
-	 * @param pack
+	 * @param pack the sub package to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removePackage(CtPackage pack);

--- a/src/main/java/spoon/reflect/declaration/CtParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtParameter.java
@@ -29,6 +29,8 @@ public interface CtParameter<T> extends CtNamedElement, CtVariable<T> {
 	/**
 	 * Gets the executable that is the parent declaration of this parameter
 	 * declaration.
+	 *
+	 * @return the declaring executable
 	 */
 	CtExecutable<?> getParent();
 
@@ -36,11 +38,15 @@ public interface CtParameter<T> extends CtNamedElement, CtVariable<T> {
 	 * Returns <tt>true</tt> if this parameter accepts a variable number of
 	 * arguments (must be the last parameter of
 	 * {@link CtExecutable#getParameters()}).
+	 *
+	 * @return true for a vararg
 	 */
 	boolean isVarArgs();
 
 	/**
 	 * Sets this parameter to have varargs.
+	 *
+	 * @param varArgs true to set this parameter to varargs
 	 */
 	void setVarArgs(boolean varArgs);
 

--- a/src/main/java/spoon/reflect/declaration/CtSimpleType.java
+++ b/src/main/java/spoon/reflect/declaration/CtSimpleType.java
@@ -39,6 +39,8 @@ public interface CtSimpleType<T> extends CtNamedElement {
 	 * @param includeSamePackage
 	 *            set to true if the method should return also the types located
 	 *            in the same package as the current type
+	 *
+	 * @return a Set of type references
 	 */
 	Set<CtTypeReference<?>> getUsedTypes(boolean includeSamePackage);
 
@@ -55,11 +57,6 @@ public interface CtSimpleType<T> extends CtNamedElement {
 	Class<T> getActualClass();
 
 	/**
-	 * Returns the fields that are directly declared by this class or interface.
-	 * Includes enum constants.
-	 */
-	// List<CtField<?>> getAllFields();
-	/**
 	 * Gets the type where this one is declared. If a declaring type is set, the
 	 * package corresponds to the declaring type's package.
 	 * 
@@ -69,6 +66,8 @@ public interface CtSimpleType<T> extends CtNamedElement {
 
 	/**
 	 * Gets a field from its name.
+	 *
+	 * @param name the name of the field
 	 * 
 	 * @return null if does not exit
 	 */
@@ -77,27 +76,40 @@ public interface CtSimpleType<T> extends CtNamedElement {
 	/**
 	 * Returns the fields that are directly declared by this class or interface.
 	 * Includes enum constants.
+	 *
+	 * @return the List of fields
 	 */
 	List<CtField<?>> getFields();
 
 	/**
 	 * Gets a nested type from its name.
+	 *
+	 * @param <N> the type's name
+	 * @param name the type's name
+	 *
+	 * @return the nested type
 	 */
 	<N extends CtSimpleType<?>> N getNestedType(String name);
 
 	/**
 	 * Returns the declarations of the nested classes and interfaces that are
 	 * directly declared by this class or interface.
+	 *
+	 * @return a Set of simple types
 	 */
 	Set<CtSimpleType<?>> getNestedTypes();
 
 	/**
 	 * Gets the package where this type is declared.
+	 *
+	 * @return the declaring package
 	 */
 	CtPackage getPackage();
 
 	/**
 	 * Returns the fully qualified name of this type declaration.
+	 *
+	 * @return the qualified name as a string
 	 */
 	String getQualifiedName();
 
@@ -106,11 +118,15 @@ public interface CtSimpleType<T> extends CtNamedElement {
 	/**
 	 * Returns true if this type is top-level (declared as the main type in a
 	 * file).
+	 *
+	 * @return true if this is a top-level type
 	 */
 	boolean isTopLevel();
 
 	/**
 	 * Sets the type's fields.
+	 *
+	 * @param fields the List of fields to set
 	 * 
 	 * @deprecated use {@link #addField(CtField)} and
 	 *             {@link #removeField(CtField)} instead
@@ -119,23 +135,27 @@ public interface CtSimpleType<T> extends CtNamedElement {
 	void setFields(List<CtField<?>> fields);
 
 	/**
-	 * add a Field
-	 * 
-	 * @param field
+	 * Adds a field
+	 *
+	 * @param <F> the field's type
+	 * @param field the field to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<F> boolean addField(CtField<F> field);
 
 	/**
-	 * remove a Field
-	 * 
-	 * @param field
+	 * Removes a field
+	 *
+	 * @param <F> the field's type
+	 * @param field the field to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<F> boolean removeField(CtField<F> field);
 
 	/**
 	 * Sets some nested types.
+	 *
+	 * @param nestedTypes the Set of nested types to set
 	 * 
 	 * @deprecated use {@link #addNestedType(CtSimpleType)} and
 	 *             {@link #removeNestedType(CtSimpleType)} instead
@@ -145,16 +165,18 @@ public interface CtSimpleType<T> extends CtNamedElement {
 
 	/**
 	 * remove a nested type
-	 * 
-	 * @param nestedType
+	 *
+	 * @param <N> type type's generic type
+	 * @param nestedType the nested type to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<N> boolean addNestedType(CtSimpleType<N> nestedType);
 
 	/**
 	 * add a nested type
-	 * 
-	 * @param nestedType
+	 *
+	 * @param <N> type type's generic type
+	 * @param nestedType the nested type to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<N> boolean removeNestedType(CtSimpleType<N> nestedType);

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -31,11 +31,18 @@ public interface CtType<T> extends CtSimpleType<T>, CtGenericElement {
 	/**
 	 * Return all the accessible methods for this type (the recursion stops when
 	 * the super-type is not in the model).
+	 *
+	 * @return a List of all methods
 	 */
 	Set<CtMethod<?>> getAllMethods();
 
 	/**
 	 * Gets a method from its return type, name, and parameter types.
+	 *
+	 * @param <R> the method's return type
+	 * @param name the name of the method
+	 * @param returnType the return type reference
+	 * @param parameterTypes the type references of the parameters
 	 * 
 	 * @return null if does not exit
 	 */
@@ -44,6 +51,10 @@ public interface CtType<T> extends CtSimpleType<T>, CtGenericElement {
 
 	/**
 	 * Gets a method from its name and parameter types.
+	 *
+	 * @param <R> the method's return type
+	 * @param name the name of the method
+	 * @param parameterTypes the types of the parameters
 	 * 
 	 * @return null if does not exit
 	 */
@@ -52,63 +63,97 @@ public interface CtType<T> extends CtSimpleType<T>, CtGenericElement {
 	/**
 	 * Returns the methods that are directly declared by this class or
 	 * interface.
+	 *
+	 * @return the Set of methods directly declared by this type
 	 */
 	Set<CtMethod<?>> getMethods();
 
 	/**
 	 * Returns the methods that are directly declared by this class or
 	 * interface and annotated with one of the given annotations.
+	 *
+	 * @param annotationTypes annotations to search for
+	 *
+	 * @return the Set of methods annotated by the given annotations
 	 */
 	Set<CtMethod<?>> getMethodsAnnotatedWith(CtTypeReference<?>... annotationTypes);
 
 	/**
 	 * Returns the methods that are directly declared by this class or
 	 * interface and that have the given name.
+	 *
+	 * @param name the name to search for
+	 *
+	 * @return the List of methods matching the given name
 	 */
 	List<CtMethod<?>> getMethodsByName(String name);
 	
 	/**
 	 * Returns the interface types directly implemented by this class or
 	 * extended by this interface.
+	 *
+	 * @return the Set of super interface type references
 	 */
 	Set<CtTypeReference<?>> getSuperInterfaces();
 
 	/**
 	 * Sets the methods of this type.
+	 *
+	 * @param methods The Set of methods to set
 	 */
 	void setMethods(Set<CtMethod<?>> methods);
 
 	/**
 	 * Adds a method to this type.
+	 *
+	 * @param <M> the method's type
+	 * @param method the method to add
+	 *
+	 * @return true if the method has been added
 	 */
 	<M> boolean addMethod(CtMethod<M> method);
 
 	/**
 	 * Removes a method from this type.
+	 *
+	 * @param <M> the method's type
+	 * @param method the method to remove
+	 *
+	 * @return true of the method has been removed
 	 */
 	<M> boolean removeMethod(CtMethod<M> method);
 
 	/**
 	 * Sets the super interfaces of this type.
+	 *
+	 * @param interfaces A Set of interface type references to set
 	 */
 	void setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
 
 	/**
-	 * 
-	 * @param interfac
+	 * Adds a super interface to this type
+	 *
+	 * @param <S> the type reference' type
+	 * @param interfac the super interface type reference to add
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<S> boolean addSuperInterface(CtTypeReference<S> interfac);
 
 	/**
-	 * 
-	 * @param interfac
+	 * Removes a super interface from this type.
+	 *
+	 * @param <S> the type reference' type
+	 * @param interfac the super interface type reference to remove
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	<S> boolean removeSuperInterface(CtTypeReference<S> interfac);
 
 	/**
 	 * Tells if this type is a subtype of the given type.
+	 *
+	 * @param type the type to check against
+	 *
+	 * @return true if this type is a sub type of the given type
 	 */
 	boolean isSubtypeOf(CtTypeReference<?> type);
 

--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -30,35 +30,45 @@ public interface CtTypeParameter extends CtElement {
 	 * Returns the bounds of this type parameter. These are the types given by
 	 * the <i>extends</i> clause. If there is no explicit <i>extends</i> clause,
 	 * then <tt>java.lang.Object</tt> is considered to be the sole bound.
+	 *
+	 * @return the List of bounds
 	 */
 	List<CtTypeReference<?>> getBounds();
 
 	/**
 	 * Returns the name of this type parameter.
+	 *
+	 * @return the name of this parameter
 	 */
 	String getName();
 
 	/**
 	 * Sets the bounds of this type parameter.
+	 *
+	 * @param bounds the Set of bounds to set
 	 */
 	void setBounds(List<CtTypeReference<?>> bounds);
 
 	/**
+	 * Adds a bound
 	 * 
-	 * @param bounds
-	 * @return
+	 * @param bound the bound to add
+	 * @return true if the bound was added
 	 */
-	boolean addBound(CtTypeReference<?> bounds);
+	boolean addBound(CtTypeReference<?> bound);
 
 	/**
+	 * Removes a bound
 	 * 
-	 * @param bounds
-	 * @return
+	 * @param bound the bound to remove
+	 * @return true if the bound was removed
 	 */
-	boolean removeBound(CtTypeReference<?> bounds);
+	boolean removeBound(CtTypeReference<?> bound);
 
 	/**
 	 * Sets the name of this type parameter.
+	 *
+	 * @param name the new name
 	 */
 	void setName(String name);
 

--- a/src/main/java/spoon/reflect/declaration/CtTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypedElement.java
@@ -26,11 +26,15 @@ import spoon.reflect.reference.CtTypeReference;
 public interface CtTypedElement<T> extends CtElement, FactoryAccessor {
 	/**
 	 * Gets this element's type.
+	 *
+	 * @return the type reference
 	 */
 	CtTypeReference<T> getType();
 
 	/**
 	 * Sets this element's type.
+	 *
+	 * @param type the type reference to set
 	 */
 	void setType(CtTypeReference<T> type);
 }

--- a/src/main/java/spoon/reflect/declaration/CtVariable.java
+++ b/src/main/java/spoon/reflect/declaration/CtVariable.java
@@ -28,6 +28,8 @@ public interface CtVariable<T> extends CtNamedElement, CtTypedElement<T> {
 	/**
 	 * Gets the initialization expression assigned to the variable (also known
 	 * as the initializer), when declared.
+	 *
+	 * @return the default expression
 	 */
 	CtExpression<T> getDefaultExpression();
 
@@ -41,6 +43,8 @@ public interface CtVariable<T> extends CtNamedElement, CtTypedElement<T> {
 	/**
 	 * Sets the initialization expression assigned to the variable, when
 	 * declared.
+	 *
+	 * @param assignedExpression the assigned expression to set
 	 */
 	void setDefaultExpression(CtExpression<T> assignedExpression);
 }

--- a/src/main/java/spoon/reflect/eval/SymbolicEvaluationPath.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicEvaluationPath.java
@@ -36,6 +36,8 @@ public class SymbolicEvaluationPath {
 
 	/**
 	 * Adds a step to this path.
+	 *
+	 * @param step the evaluation step to add
 	 * 
 	 * @return the just added SymbolicEvaluationStep
 	 */
@@ -45,7 +47,11 @@ public class SymbolicEvaluationPath {
 	}
 
 	/**
-	 * Gets the ith step.
+	 * Gets the {@code i}-th step.
+	 *
+	 * @param i the index of the steop
+	 *
+	 * @return the evaluation step
 	 */
 	public SymbolicEvaluationStep getStep(int i) {
 		return steps.get(i);
@@ -53,6 +59,8 @@ public class SymbolicEvaluationPath {
 
 	/**
 	 * Returns the evaluation steps list.
+	 *
+	 * @return the List of evaluation steps
 	 */
 	public List<SymbolicEvaluationStep> getSteps() {
 		return steps;
@@ -60,6 +68,8 @@ public class SymbolicEvaluationPath {
 
 	/**
 	 * Gets the number of steps in this path.
+	 *
+	 * @return the number of steps
 	 */
 	public int getStepCount() {
 		return steps.size();
@@ -93,6 +103,8 @@ public class SymbolicEvaluationPath {
 	/**
 	 * Returns a new symbolic evaluation path that only contains the
 	 * {@link StepKind#ENTER} steps of this current path.
+	 *
+	 * @return the symbolic evaluation path
 	 */
 	public SymbolicEvaluationPath getEnterSteps() {
 		SymbolicEvaluationPath res = new SymbolicEvaluationPath();
@@ -107,6 +119,8 @@ public class SymbolicEvaluationPath {
 	/**
 	 * Returns a new symbolic evaluation path that only contains the
 	 * {@link StepKind#EXIT} steps of this current path.
+	 *
+	 * @return the symbolic evaluation path
 	 */
 	public SymbolicEvaluationPath getExitSteps() {
 		SymbolicEvaluationPath res = new SymbolicEvaluationPath();

--- a/src/main/java/spoon/reflect/eval/SymbolicEvaluationStack.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicEvaluationStack.java
@@ -44,6 +44,8 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Constructs and returns the calling stack for this evaluation stack.
+	 *
+	 * @return the calling stack
 	 */
 	public Stack<CtAbstractInvocation<?>> getCallingStack() {
 		Stack<CtAbstractInvocation<?>> s = new Stack<CtAbstractInvocation<?>>();
@@ -64,6 +66,8 @@ public class SymbolicEvaluationStack {
 	 *            {@link #getThis()})
 	 * @param executable
 	 *            the entered executable
+	 * @param arguments
+	 *            the executable arguments
 	 * @param variables
 	 *            the variables accessible from the frame (invocation's
 	 *            parameters)
@@ -86,6 +90,8 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Gets the this value of the top frame.
+	 *
+	 * @return {@code this} from the top stack frame
 	 */
 	public SymbolicInstance<?> getThis() {
 		return frameStack.peek().getThis();
@@ -93,6 +99,10 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Gets the symbolic value of a variable within the top frame.
+	 *
+	 * @param vref the variable to get the value for
+	 *
+	 * @return the symbolic instance for the value
 	 */
 	public SymbolicInstance<?> getVariableValue(CtVariableReference<?> vref) {
 		if (frameStack.peek().getVariables().containsKey(vref)) {
@@ -103,6 +113,9 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Sets the symbolic value of a variable within the top frame.
+	 *
+	 * @param vref the variable to set the value for
+	 * @param value the value to set
 	 */
 	public void setVariableValue(CtVariableReference<?> vref,
 			SymbolicInstance<?> value) {
@@ -115,6 +128,8 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Creates a copy of the given stack.
+	 *
+	 * @param stack the symbolic stack to copy
 	 */
 	public SymbolicEvaluationStack(SymbolicEvaluationStack stack) {
 		for (SymbolicStackFrame f : stack.frameStack) {
@@ -151,6 +166,8 @@ public class SymbolicEvaluationStack {
 	/**
 	 * Gets the current result (returned value) for the top stack frame of this
 	 * stack.
+	 *
+	 * @return the result
 	 */
 	public SymbolicInstance<?> getResult() {
 		return frameStack.peek().getResult();
@@ -159,6 +176,8 @@ public class SymbolicEvaluationStack {
 	/**
 	 * Sets the current result (returned value) for the top stack frame of this
 	 * stack.
+	 *
+	 * @param result the result to set
 	 */
 	public void setResult(SymbolicInstance<?> result) {
 		frameStack.peek().setResult(result);
@@ -166,6 +185,8 @@ public class SymbolicEvaluationStack {
 
 	/**
 	 * Gets the frames as a stack.
+	 *
+	 * @return the Stack of frames
 	 */
 	public Stack<SymbolicStackFrame> getFrameStack() {
 		return frameStack;

--- a/src/main/java/spoon/reflect/eval/SymbolicEvaluationStep.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicEvaluationStep.java
@@ -50,6 +50,8 @@ public class SymbolicEvaluationStep {
 
 	/**
 	 * Gets the stack frame that corresponds to this state.
+	 *
+	 * @return the symbolic stack frame
 	 */
 	public SymbolicStackFrame getFrame() {
 		return frame;
@@ -57,6 +59,8 @@ public class SymbolicEvaluationStep {
 
 	/**
 	 * Gets the heap that corresponds to this state.
+	 *
+	 * @return the symbolic heap
 	 */
 	public SymbolicHeap getHeap() {
 		return heap;
@@ -73,6 +77,8 @@ public class SymbolicEvaluationStep {
 
 	/**
 	 * Gets the step kind.
+	 *
+	 * @return the kind of this step
 	 */
 	public StepKind getKind() {
 		return kind;
@@ -80,6 +86,8 @@ public class SymbolicEvaluationStep {
 
 	/**
 	 * Gets a symbolic instance from its id at the current evaluation step.
+	 *
+	 * @param id the string ID of the symbolic instance
 	 * 
 	 * @return null if not found
 	 */

--- a/src/main/java/spoon/reflect/eval/SymbolicEvaluator.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicEvaluator.java
@@ -30,8 +30,10 @@ import spoon.reflect.reference.CtTypeReference;
 public interface SymbolicEvaluator {
 
 	/**
-	 * Returns the list of external classes that should be handled as statefull
+	 * Returns the list of external classes that should be handled as stateful
 	 * beans.
+	 *
+	 * @return the List of stateful externals
 	 */
 	List<CtTypeReference<?>> getStatefullExternals();
 
@@ -83,25 +85,38 @@ public interface SymbolicEvaluator {
 
 	/**
 	 * Gets the heap of the current symbolic evaluation step.
+	 *
+	 * @return the symbolic heap
 	 */
 	SymbolicHeap getHeap();
 
 	/**
 	 * Gets the stack of the symbolic abstract evaluation step.
+	 *
+	 * @return the evaluation stack
 	 */
 	SymbolicEvaluationStack getStack();
 
 	/**
 	 * Evaluates the given meta-model element in the current context of the
 	 * evaluator.
+	 *
+	 * @param element the element to evaluate
+	 *
+	 * @return the result of the evaluation of the given element
 	 */
 	SymbolicInstance<?> evaluate(CtElement element);
 
 	/**
 	 * Evaluates the given meta-model expression in the current context of the
 	 * evaluator.
+	 *
+	 * @param <T> the value's type
+	 * @param expression the expression to evaluate
+	 *
+	 * @return result of the symbolid evaluation of the given expression
 	 */
-	<T> SymbolicInstance<T> evaluate(CtExpression<T> expresion);
+	<T> SymbolicInstance<T> evaluate(CtExpression<T> expression);
 
 	/**
 	 * Adds an evaluation observer.

--- a/src/main/java/spoon/reflect/eval/SymbolicHeap.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicHeap.java
@@ -36,6 +36,8 @@ public class SymbolicHeap {
 
 	/**
 	 * Copies the given heap.
+	 *
+	 * @param heap the heap to copy
 	 */
 	@SuppressWarnings("unchecked")
 	public SymbolicHeap(SymbolicHeap heap) {
@@ -77,6 +79,8 @@ public class SymbolicHeap {
 	 * 
 	 * @param <T>
 	 *            the actual type if known
+	 * @param evaluator
+	 *            the symbolic avulator
 	 * @param concreteType
 	 *            the type reference
 	 * @return the symbolic value for the type
@@ -94,6 +98,8 @@ public class SymbolicHeap {
 
 	/**
 	 * Stores the given symbolic instance in the heap.
+	 *
+	 * @param instance the symbolic instance to store
 	 */
 	public void store(SymbolicInstance<?> instance) {
 		if (instance.isStateful()) {
@@ -105,6 +111,11 @@ public class SymbolicHeap {
 
 	/**
 	 * Gets an existing symbolic instance from its id.
+	 *
+	 * @param <T> the value's type
+	 * @param id the ID
+	 *
+	 * @return the symbolic instance for the given ID
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> SymbolicInstance<T> get(String id) {

--- a/src/main/java/spoon/reflect/eval/SymbolicInstance.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicInstance.java
@@ -78,6 +78,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Creates a literal symbolic instance.
+	 *
+	 * @param literal the name
 	 */
 	public SymbolicInstance(String literal) {
 		this.literal = literal;
@@ -89,6 +91,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Gets the next id to be attributed to the created instance.
+	 *
+	 * @return the next ID
 	 */
 	private static long getNextId() {
 		return id++;
@@ -123,6 +127,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Gets the unique Id of this abstract instance.
+	 *
+	 * @return the ID of this instance as a string
 	 */
 	public String getId() {
 		if (literal != null) {
@@ -151,6 +157,10 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Tests the equality by reference.
+	 *
+	 * @param obj the object to test against
+	 *
+	 * @return true if the given object equals this instance
 	 */
 	public boolean equalsRef(Object obj) {
 		if (this == obj) {
@@ -247,6 +257,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Tells if this logical value is stateful or not.
+	 *
+	 * @return true if this instance is stateful
 	 */
 	public boolean isStateful() {
 		return !fields.isEmpty();
@@ -262,6 +274,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Gets the type of the abstract instance.
+	 *
+	 * @return the concrete type
 	 */
 	public CtTypeReference<T> getConcreteType() {
 		return concreteType;
@@ -270,6 +284,8 @@ public class SymbolicInstance<T> {
 	/**
 	 * Gets the value of a field belonging to this instance, as an abstract
 	 * instance id.
+	 *
+	 * @param fref a reference to the field
 	 *
 	 * @return null if non-existing field
 	 */
@@ -280,6 +296,8 @@ public class SymbolicInstance<T> {
 	/**
 	 * Gets the value of a field belonging to this instance and identified by
 	 * its name, as an abstract instance id.
+	 *
+	 * @param fname the name of the field
 	 *
 	 * @return null if non-existing field
 	 */
@@ -316,6 +334,10 @@ public class SymbolicInstance<T> {
 	/**
 	 * Sets the value of a field belonging to this instance, and stores the
 	 * instance on the heap.
+	 *
+	 * @param heap the heap to set the field value in
+	 * @param fref the field to set the value for
+	 * @param value the value to set
 	 */
 	public void setFieldValue(SymbolicHeap heap, CtVariableReference<?> fref,
 			SymbolicInstance<?> value) {
@@ -332,6 +354,8 @@ public class SymbolicInstance<T> {
 	/**
 	 * Tells if this instance is a wrapper for an instance external from the
 	 * evaluator (regular Java object).
+	 *
+	 * @return true if this instance is a wrapper for an external instance
 	 */
 	public boolean isExternal() {
 		return isExternal;
@@ -351,6 +375,8 @@ public class SymbolicInstance<T> {
 	/**
 	 * Gets a copy of this instance (if the instance is stateless, returns
 	 * this).
+	 *
+	 * @return a clone of this instance
 	 */
 	public SymbolicInstance<T> getClone() {
 		if (!isStateful()) {
@@ -361,6 +387,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Creates a copy of the given instance.
+	 *
+	 * @param i the instance to copy
 	 */
 	public SymbolicInstance(SymbolicInstance<T> i) {
 		concreteType = i.concreteType;
@@ -371,6 +399,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Gets the name of this symbolic instance.
+	 *
+	 * @return the symbol name
 	 */
 	public String getSymbolName() {
 		return symbolName;
@@ -378,6 +408,8 @@ public class SymbolicInstance<T> {
 
 	/**
 	 * Gets the fields for this instance.
+	 *
+	 * @return the fields of this instance
 	 */
 	public Map<CtVariableReference<?>, String> getFields() {
 		return fields;

--- a/src/main/java/spoon/reflect/eval/SymbolicStackFrame.java
+++ b/src/main/java/spoon/reflect/eval/SymbolicStackFrame.java
@@ -35,6 +35,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Copies a frame from a given one (does not clone stateless info).
+	 *
+	 * @param frame the frame to copy
 	 */
 	public SymbolicStackFrame(SymbolicStackFrame frame) {
 		for (Entry<CtVariableReference<?>, SymbolicInstance<?>> e : frame.variables
@@ -79,6 +81,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the parent invocation of this frame.
+	 *
+	 * @return the parent invocation
 	 */
 	public CtAbstractInvocation<?> getInvocation() {
 		return invocation;
@@ -86,6 +90,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the <code>this</code> value.
+	 *
+	 * @return {@code this} from this stack frame
 	 */
 	public SymbolicInstance<?> getThis() {
 		return target;
@@ -93,6 +99,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the calling instance if applicable.
+	 *
+	 * @return the calling instance
 	 */
 	public SymbolicInstance<?> getCaller() {
 		return caller;
@@ -100,6 +108,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the local variables defined for this frame.
+	 *
+	 * @return a Map of the local variables of the frame
 	 */
 	public Map<CtVariableReference<?>, SymbolicInstance<?>> getVariables() {
 		return variables;
@@ -109,6 +119,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Return the arguments (also present in the variables).
+	 *
+	 * @return the List of arguments of from current stack frame
 	 */
 	public List<SymbolicInstance<?>> getArguments() {
 		return arguments;
@@ -125,6 +137,8 @@ public class SymbolicStackFrame {
 	 *            the target (this) of the frame ({@link #getThis()})
 	 * @param executable
 	 *            the executable that corresponds to this frame
+	 * @param arguments
+	 *            the arguments for the given executable
 	 * @param variables
 	 *            the local variables defined within this frame (should be a
 	 *            copy)
@@ -155,6 +169,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the executable of the frame.
+	 *
+	 * @return the executable of this frame
 	 */
 	public CtExecutableReference<?> getExecutable() {
 		return executable;
@@ -164,6 +180,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Gets the result of this frame execution.
+	 *
+	 * @return the result
 	 */
 	public SymbolicInstance<?> getResult() {
 		return result;
@@ -171,6 +189,8 @@ public class SymbolicStackFrame {
 
 	/**
 	 * Sets the result of this frame execution.
+	 *
+	 * @param result the result to set
 	 */
 	public void setResult(SymbolicInstance<?> result) {
 		this.result = result;

--- a/src/main/java/spoon/reflect/factory/AnnotationFactory.java
+++ b/src/main/java/spoon/reflect/factory/AnnotationFactory.java
@@ -51,11 +51,15 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Creates an annotation type.
-	 * 
+	 *
+	 * @param <T>
+	 *            the annotation's type
 	 * @param owner
 	 *            the package of the annotation type
 	 * @param simpleName
 	 *            the name of annotation
+	 *
+	 * @return a new annotation type
 	 */
 	public <T extends Annotation> CtAnnotationType<?> create(CtPackage owner,
 			String simpleName) {
@@ -70,6 +74,8 @@ public class AnnotationFactory extends TypeFactory {
 	 * 
 	 * @param qualifiedName
 	 *            the fully qualified name of the annotation type.
+	 *
+	 * @return a new annotation type
 	 */
 	public CtAnnotationType<?> create(String qualifiedName) {
 		return create(
@@ -79,6 +85,11 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Gets a annotation type from its name.
+	 *
+	 * @param <T> the annotation's type
+	 * @param qualifiedName the qualified name of the annotation
+	 *
+	 * @return the type of the annotation
 	 */
 	public <T extends Annotation> CtSimpleType<T> getAnnotationType(
 			String qualifiedName) {
@@ -87,7 +98,9 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Creates/updates an element's annotation value.
-	 * 
+	 *
+	 * @param <A>
+	 *            the annotation's type
 	 * @param element
 	 *            the program element to annotate
 	 * @param annotationType
@@ -107,7 +120,9 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Creates/updates an element's annotation value.
-	 * 
+	 *
+	 * @param <A>
+	 *            the annotation's type
 	 * @param element
 	 *            the program element to annotate
 	 * @param annotationType
@@ -170,7 +185,9 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Adds an annotation to an element.
-	 * 
+	 *
+	 * @param <A>
+	 *            the annotation's type
 	 * @param element
 	 *            the program element to annotate
 	 * @param annotationType
@@ -184,7 +201,9 @@ public class AnnotationFactory extends TypeFactory {
 
 	/**
 	 * Adds an annotation to an element.
-	 * 
+	 *
+	 * @param <A>
+	 *            the annotation's type
 	 * @param element
 	 *            the program element to annotate
 	 * @param annotationType

--- a/src/main/java/spoon/reflect/factory/ClassFactory.java
+++ b/src/main/java/spoon/reflect/factory/ClassFactory.java
@@ -40,10 +40,14 @@ public class ClassFactory extends TypeFactory {
 	/**
 	 * Creates an inner class.
 	 *
+	 * @param <T>
+	 *            the class' type
 	 * @param declaringClass
 	 *            declaring class
 	 * @param simpleName
 	 *            simple name of inner class (without . or $)
+	 *
+	 * @return the new class
 	 */
 	public <T> CtClass<T> create(CtClass<?> declaringClass, String simpleName) {
 		CtClass<T> c = factory.Core().createClass();
@@ -54,10 +58,14 @@ public class ClassFactory extends TypeFactory {
 	/**
 	 * Creates a top-level class.
 	 *
+	 * @param <T>
+	 *            the class' type
 	 * @param owner
 	 *            the declaring package
 	 * @param simpleName
 	 *            the simple name
+	 *
+	 * @return the new class
 	 */
 	public <T> CtClass<T> create(CtPackage owner, String simpleName) {
 		CtClass<T> c = factory.Core().createClass();
@@ -78,6 +86,7 @@ public class ClassFactory extends TypeFactory {
 	 * @param qualifiedName
 	 *            full name of class to create. Name can contain . or $ for
 	 *            inner types
+	 * @return the new class
 	 */
 	public <T> CtClass<T> create(String qualifiedName) {
 		if (hasInnerType(qualifiedName) > 0) {
@@ -94,7 +103,7 @@ public class ClassFactory extends TypeFactory {
 	 * @param <T>
 	 *            type of created class
 	 * @param cl
-	 *            the java class: note that this class should be Class<T> but
+	 *            the java class: note that this class should be Class&lt;T&gt; but
 	 *            it then poses problem when T is a generic type itself
 	 */
 	@Override

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -58,6 +58,8 @@ public class CodeFactory extends SubFactory {
 
 	/**
 	 * Creates a {@link spoon.reflect.code.CtCodeElement} sub-factory.
+	 *
+	 * @param factory the parent factory
 	 */
 	public CodeFactory(Factory factory) {
 		super(factory);
@@ -171,6 +173,11 @@ public class CodeFactory extends SubFactory {
 
 	/**
 	 * Creates a one-dimension array that must only contain literals.
+	 *
+	 * @param <T> the array's type
+	 * @param value the literal array value
+	 *
+	 * @return the new array
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtNewArray<T[]> createLiteralArray(T[] value) {
@@ -215,6 +222,11 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a local variable reference that points to an existing local
 	 * variable (strong referencing).
+	 *
+	 * @param <T> the local variable's type
+	 * @param localVariable the local variable to reference
+	 *
+	 * @return the new local variable reference
 	 */
 	public <T> CtLocalVariableReference<T> createLocalVariableReference(
 			CtLocalVariable<T> localVariable) {
@@ -229,6 +241,12 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a local variable reference with its name an type (weak
 	 * referencing).
+	 *
+	 * @param <T> the local variable's type
+	 * @param type the type of the accessed variable
+	 * @param name the name of the variable
+	 *
+	 * @return the new local variable reference
 	 */
 	public <T> CtLocalVariableReference<T> createLocalVariableReference(
 			CtTypeReference<T> type, String name) {
@@ -241,6 +259,11 @@ public class CodeFactory extends SubFactory {
 
 	/**
 	 * Creates a new statement list from an existing block.
+	 *
+	 * @param <R> the block's type
+	 * @param block the backing block
+	 *
+	 * @return the new statement list
 	 */
 	public <R> CtStatementList createStatementList(CtBlock<R> block) {
 		CtStatementList l = factory.Core().createStatementList();
@@ -269,6 +292,12 @@ public class CodeFactory extends SubFactory {
 
 	/**
 	 * Creates a variable access.
+	 *
+	 * @param <T> the variable's type
+	 * @param variable the variable to access
+	 * @param isStatic true if the variable is static
+	 *
+	 * @return the new variable access
 	 */
 	public <T> CtVariableAccess<T> createVariableAccess(
 			CtVariableReference<T> variable, boolean isStatic) {
@@ -295,6 +324,8 @@ public class CodeFactory extends SubFactory {
 	 * 
 	 * @param variables
 	 *            the variables to be accessed
+	 *
+	 * @return the List of variable access expressions
 	 */
 	public List<CtExpression<?>> createVariableAccesses(
 			List<? extends CtVariable<?>> variables) {
@@ -308,9 +339,11 @@ public class CodeFactory extends SubFactory {
 
 	/**
 	 * Creates a variable assignment (can be an expression or a statement).
-	 * 
+	 *
+	 * @param <A>
+	 *            the type of the variable being assigned
 	 * @param <T>
-	 *            the type of the assigned variable
+	 *            the type of the assigned expression
 	 * @param variable
 	 *            a reference to the assigned variable
 	 * @param isStatic
@@ -332,7 +365,8 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a list of statements that contains the assignments of a set of
 	 * variables.
-	 * 
+	 *
+	 * @param <T> the type of the variables and expressions
 	 * @param variables
 	 *            the variables to be assigned
 	 * @param expressions

--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -37,6 +37,8 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates the evaluation factory.
+	 *
+	 * @param factory the factory
 	 */
 	public CompilationUnitFactory(Factory factory) {
 		super(factory);
@@ -47,7 +49,7 @@ public class CompilationUnitFactory extends SubFactory {
 	/**
 	 * Gets the compilation unit map.
 	 * 
-	 * @return a map (path -> {@link CompilationUnit})
+	 * @return a map (path -&gt; {@link CompilationUnit})
 	 */
 	public Map<String, CompilationUnit> getMap() {
 		return compilationUnits;
@@ -55,6 +57,8 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates a compilation unit with no associated files.
+	 *
+	 * @return the new {@link spoon.reflect.cu.CompilationUnit}
 	 */
 	public CompilationUnit create() {
 		CompilationUnit cu = factory.Core().createCompilationUnit();
@@ -63,6 +67,10 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates or gets a compilation unit for a given file path.
+	 *
+	 * @param filePath the file path as a string
+	 *
+	 * @return the new {@link spoon.reflect.cu.CompilationUnit}
 	 */
 	public CompilationUnit create(String filePath) {
 		CompilationUnit cu = compilationUnits.get(filePath);
@@ -80,6 +88,10 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates an import for the given type.
+	 *
+	 * @param type a type reference to create the import from
+	 *
+	 * @return the new import
 	 */
 	public Import createImport(CtTypeReference<?> type) {
 		return new ImportImpl(type);
@@ -87,6 +99,10 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates an import for the given type.
+	 *
+	 * @param type the type to create the import for
+	 *
+	 * @return the new import
 	 */
 	public Import createImport(Class<?> type) {
 		return new ImportImpl(factory.Type().createReference(type));
@@ -94,6 +110,10 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates an import for the given field.
+	 *
+	 * @param field a field reference to create the import for
+	 *
+	 * @return the new import
 	 */
 	public Import createImport(CtFieldReference<?> field) {
 		return new ImportImpl(field);
@@ -101,6 +121,10 @@ public class CompilationUnitFactory extends SubFactory {
 
 	/**
 	 * Creates an import for the given package.
+	 *
+	 * @param pack a package reference
+	 *
+	 * @return the new import
 	 */
 	public Import createImport(CtPackageReference pack) {
 		return new ImportImpl(pack);

--- a/src/main/java/spoon/reflect/factory/ConstructorFactory.java
+++ b/src/main/java/spoon/reflect/factory/ConstructorFactory.java
@@ -50,7 +50,9 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Copies a constructor into a target class.
-	 * 
+	 *
+	 * @param <T>
+	 *            the constructor's type
 	 * @param target
 	 *            the target class
 	 * @param source
@@ -69,7 +71,9 @@ public class ConstructorFactory extends ExecutableFactory {
 	/**
 	 * Creates a constructor into a target class by copying it from a source
 	 * method.
-	 * 
+	 *
+	 * @param <T>
+	 *            the constructor's type
 	 * @param target
 	 *            the target class
 	 * @param source
@@ -93,13 +97,19 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Creates an empty constructor.
-	 * 
+	 *
+	 * @param <T>
+	 *            the constructor's type
+	 * @param target
+	 *            the target class
 	 * @param modifiers
 	 *            the modifiers
 	 * @param parameters
 	 *            the parameters
 	 * @param thrownTypes
 	 *            the thrown types
+	 *
+	 * @return the new constructor
 	 */
 	public <T> CtConstructor<T> create(CtClass<T> target,
 			Set<ModifierKind> modifiers, List<CtParameter<?>> parameters,
@@ -114,7 +124,9 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Create the default empty constructor.
-	 * 
+	 *
+	 * @param <T>
+	 *            the constructor's type
 	 * @param target
 	 *            the class to insert the constructor into
 	 * @return the created constructor
@@ -128,7 +140,11 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a constructor.
-	 * 
+	 *
+	 * @param <T>
+	 *            the constructor's type
+	 * @param target
+	 *            the target class
 	 * @param modifiers
 	 *            the modifiers
 	 * @param parameters
@@ -137,6 +153,8 @@ public class ConstructorFactory extends ExecutableFactory {
 	 *            the thrown types
 	 * @param body
 	 *            the body
+	 *
+	 * @return a new constructor
 	 */
 	public <T> CtConstructor<T> create(CtClass<T> target,
 			Set<ModifierKind> modifiers, List<CtParameter<?>> parameters,
@@ -150,6 +168,11 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a constructor reference from an existing constructor.
+	 *
+	 * @param <T> the executable's type
+	 * @param c a constructor
+	 *
+	 * @return the new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(CtConstructor<T> c) {
 		return factory.Executable().createReference(c);
@@ -157,6 +180,11 @@ public class ConstructorFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a constructor reference from an actual constructor.
+	 *
+	 * @param <T> the constructor's type
+	 * @param constructor the constructor
+	 *
+	 * @return the new constructor reference
 	 */
 	public <T> CtExecutableReference<T> createReference(
 			Constructor<T> constructor) {

--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -103,305 +103,507 @@ public interface CoreFactory {
 
 	/**
 	 * Creates an annotation.
+	 *
+	 * @param <A> the type of the annotation
+	 *
+	 * @return a new annotation
 	 */
 	<A extends Annotation> CtAnnotation<A> createAnnotation();
 
 	/**
 	 * Creates an annotation type.
+	 *
+	 * @param <T> the type of the actual annotation
+	 *
+	 * @return a new annotation type
 	 */
 	<T extends Annotation> CtAnnotationType<T> createAnnotationType();
 
 	/**
 	 * Creates an anonymous executable.
+	 *
+	 * @return a new anonymous executable
 	 */
 	CtAnonymousExecutable createAnonymousExecutable();
 
 	/**
 	 * Creates an array access expression.
+	 *
+	 * @param <T> the return type of the access
+	 * @param <E> the type of the target expression
+	 *
+	 * @return a new array access
 	 */
 	<T, E extends CtExpression<?>> CtArrayAccess<T, E> createArrayAccess();
 
 	/**
 	 * Creates an array type reference.
+	 *
+	 * @param <T> the type of the referenced array
+	 *
+	 * @return a new array type reference
 	 */
 	<T> CtArrayTypeReference<T> createArrayTypeReference();
 
 	/**
 	 * Creates an <code>assert</code> statement.
+	 *
+	 * @param <T> the type of the asserted expression
+	 *
+	 * @return a new {@code assert}
 	 */
 	<T> CtAssert<T> createAssert();
 
 	/**
 	 * Creates an assignment expression.
+	 *
+	 * @param <T> the type of the variable
+	 * @param <A> the type of the assigned expression
+	 *
+	 * @return a new assignment
 	 */
 	<T, A extends T> CtAssignment<T, A> createAssignment();
 
 	/**
 	 * Creates a binary operator.
+	 *
+	 * @param <T> the return type of the operator
+	 *
+	 * @return a new binary operator
 	 */
 	<T> CtBinaryOperator<T> createBinaryOperator();
 
 	/**
 	 * Creates a block.
+	 *
+	 * @param <R> the return type of the block
+	 *
+	 * @return a new block
 	 */
 	<R> CtBlock<R> createBlock();
 
 	/**
 	 * Creates a <code>break</code> statement.
+	 *
+	 * @return a new {@code break}
 	 */
 	CtBreak createBreak();
 
 	/**
 	 * Creates a <code>case</code> clause.
+	 *
+	 * @param <S> the type of the switch selector expression
+	 *
+	 * @return a new case
 	 */
 	<S> CtCase<S> createCase();
 
 	/**
 	 * Creates a <code>catch</code> clause.
+	 *
+	 * @return a new {@code catch}
 	 */
 	CtCatch createCatch();
 
 	/**
 	 * Creates a class.
+	 *
+	 * @param <T> the actual runtime type of the class
+	 *
+	 * @return a new class
 	 */
 	<T> CtClass<T> createClass();
 
 	/**
 	 * Creates a conditional expression (<code>boolExpr?ifTrue:ifFalse</code>).
+	 *
+	 * @param <T> the return type of the expression
+	 *
+	 * @return a new conditional expression
 	 */
 	<T> CtConditional<T> createConditional();
 
 	/**
 	 * Creates a constructor.
+	 *
+	 * @param <T> the type of the constructor's class
+	 *
+	 * @return a new constructor
 	 */
 	<T> CtConstructor<T> createConstructor();
 
 	/**
 	 * Creates a <code>continue</code> statement.
+	 *
+	 * @return a new {@code continue}
 	 */
 	CtContinue createContinue();
 
 	/**
 	 * Creates a <code>do</code> loop.
+	 *
+	 * @return a new {@code do}
 	 */
 	CtDo createDo();
 
 	/**
 	 * Creates an enum.
+	 *
+	 * @param <T> the actual runtime type of the enum
+	 *
+	 * @return a new enum
 	 */
 	<T extends Enum<?>> CtEnum<T> createEnum();
 
 	/**
 	 * Creates an executable reference.
+	 *
+	 * @param <T> the return type of the executable
+	 *
+	 * @return a new executable reference
 	 */
 	<T> CtExecutableReference<T> createExecutableReference();
 
 	/**
 	 * Creates a field.
+	 *
+	 * @param <T> the type of the field
+	 *
+	 * @return a new field
 	 */
 	<T> CtField<T> createField();
 
 	/**
 	 * Creates a field access expression.
+	 *
+	 * @param <T> the type of the field
+	 *
+	 * @return a new field access
 	 */
 	<T> CtFieldAccess<T> createFieldAccess();
 	
 
 	/**
 	 * Creates an access expression to this.
+	 *
+	 * @param <T> the runtime type of {@code this}
+	 *
+	 * @return a new {@code this} access
 	 */
 	<T> CtThisAccess<T> createThisAccess();
 	
 	/**
 	 * Creates an access expression to super.
+	 *
+	 * @param <T> the type of the super class
+	 *
+	 * @return a new super access
 	 */
 	<T> CtSuperAccess<T> createSuperAccess();
 
 	/**
 	 * Creates a field reference.
+	 *
+	 * @param <T> the type of the field
+	 *
+	 * @return a new field reference
 	 */
 	<T> CtFieldReference<T> createFieldReference();
 
 	/**
 	 * Creates a <code>for</code> loop.
+	 *
+	 * @return a new for
 	 */
 	CtFor createFor();
 
 	/**
 	 * Creates a <code>foreach</code> loop.
+	 *
+	 * @return a new foreach
 	 */
 	CtForEach createForEach();
 
 	/**
 	 * Creates an <code>if</code> statement.
+	 *
+	 * @return a new if
 	 */
 	CtIf createIf();
 
 	/**
 	 * Creates an interface.
+	 *
+	 * @param <T> the actual runtime type of the interface
+	 *
+	 * @return a new interface
 	 */
 	<T> CtInterface<T> createInterface();
 
 	/**
 	 * Creates an invocation expression.
+	 *
+	 * @param <T> the return type of the invocation
+	 *
+	 * @return a new invocation
 	 */
 	<T> CtInvocation<T> createInvocation();
 
 	/**
 	 * Creates a literal expression.
+	 *
+	 * @param <T> the type of the literal
+	 *
+	 * @return a new literal
 	 */
 	<T> CtLiteral<T> createLiteral();
 
 	/**
 	 * Creates a local variable declaration statement.
+	 *
+	 * @param <T> the type of the local variable
+	 *
+	 * @return a new local variable declaration
 	 */
 	<T> CtLocalVariable<T> createLocalVariable();
 
 	/**
 	 * Creates a local variable reference.
+	 *
+	 * @param <T> the local variable's type
+	 *
+	 * @return a new local variable reference
 	 */
 	<T> CtLocalVariableReference<T> createLocalVariableReference();
 
 	/**
 	 * Creates a method.
+	 *
+	 * @param <T> the method's return type
+	 *
+	 * @return a new method
 	 */
 	<T> CtMethod<T> createMethod();
 
 	/**
 	 * Creates a new array expression.
+	 *
+	 * @param <T> the array's type
+	 *
+	 * @return a new array creation
 	 */
 	<T> CtNewArray<T> createNewArray();
 
 	/**
 	 * Creates a new anonymous class expression.
+	 *
+	 * @param <T> the type of the class
+	 *
+	 * @return a new anonymous class creation
 	 */
 	<T> CtNewClass<T> createNewClass();
 
 	/**
-	 * Creates a new operator assignement (like +=).
+	 * Creates a new operator assignment (like +=).
+	 *
+	 * @param <T> the variable type
+	 * @param <A> the type of the expression to assign
+	 *
+	 * @return a new operator assignment
 	 */
 	<T, A extends T> CtOperatorAssignment<T, A> createOperatorAssignment();
 
 	/**
 	 * Creates a package.
+	 *
+	 * @return a new package
 	 */
 	CtPackage createPackage();
 
 	/**
 	 * Creates a package reference.
+	 *
+	 * @return  a new package reference
 	 */
 	CtPackageReference createPackageReference();
 
 	/**
 	 * Creates a parameter.
+	 *
+	 * @param <T> the parameter's type
+	 *
+	 * @return a new parameter
 	 */
 	<T> CtParameter<T> createParameter();
 
 	/**
 	 * Creates a parameter reference.
+	 *
+	 * @param <T> the referenced parameter's type
+	 *
+	 * @return a new parameter reference
 	 */
 	<T> CtParameterReference<T> createParameterReference();
 
 	/**
 	 * Creates a <code>return</code> statement.
+	 *
+	 * @param <R> the return expression's type
+	 *
+	 * @return a new return statement
 	 */
 	<R> CtReturn<R> createReturn();
 
 	/**
 	 * Creates a source position.
+	 *
+	 * @param compilationUnit the compilation unit
+	 * @param start the start position
+	 * @param end the end position
+	 * @param lineSeparatorPositions an array of line separator positions
+	 *
+	 * @return a new source position
 	 */
 	SourcePosition createSourcePosition(CompilationUnit compilationUnit,
 			int start, int end, int[] lineSeparatorPositions);
 
 	/**
 	 * Creates a statement list.
+	 *
+	 * @param <R> the statement list's type
+	 *
+	 * @return a new statement list
 	 */
 	<R> CtStatementList createStatementList();
 
 	/**
 	 * Creates a <code>switch</code> statement.
+	 *
+	 * @param <S> the selector expression's type
+	 *
+	 * @return a new switch statement
 	 */
 	<S> CtSwitch<S> createSwitch();
 
 	/**
 	 * Creates a <code>synchronized</code> statement.
+	 *
+	 * @return a new synchronized statement
 	 */
 	CtSynchronized createSynchronized();
 
 	/**
 	 * Creates a <code>throw</code> statement.
+	 *
+	 * @return a new throw block
 	 */
 	CtThrow createThrow();
 
 	/**
 	 * Creates a <code>try</code> block.
+	 *
+	 * @return a new try block
 	 */
 	CtTry createTry();
 
 	/**
 	 * Creates a type parameter.
+	 *
+	 * @return a new type parameter
 	 */
 	CtTypeParameter createTypeParameter();
 
 	/**
 	 * Creates a type parameter reference.
+	 *
+	 * @return a new type parameter reference
 	 */
 	CtTypeParameterReference createTypeParameterReference();
 
 	/**
 	 * Creates a type reference.
+	 *
+	 * @param <T> the referenced type
+	 *
+	 * @return a new type reference
 	 */
 	<T> CtTypeReference<T> createTypeReference();
 
 	/**
 	 * Creates a unary operator expression.
+	 *
+	 * @param <T> the return type of the operator
+	 *
+	 * @return a new unary operator
 	 */
 	<T> CtUnaryOperator<T> createUnaryOperator();
 
 	/**
 	 * Creates a variable access expression.
+	 *
+	 * @param <T> the variable type
+	 *
+	 * @return a new variable access
 	 */
 	<T> CtVariableAccess<T> createVariableAccess();
 
 	/**
 	 * Creates a <code>while</code> loop.
+	 *
+	 * @return a new while
 	 */
 	CtWhile createWhile();
 
 	/**
 	 * Creates a code snippet expression.
+	 *
+	 * @param <T> the return type of the expression
+	 *
+	 * @return a new code snippet expression
 	 */
 	<T> CtCodeSnippetExpression<T> createCodeSnippetExpression();
 
 	/**
 	 * Creates a code snippet statement.
+	 *
+	 * @return a new code snippet statement
 	 */
 	CtCodeSnippetStatement createCodeSnippetStatement();
 
 	/**
 	 * Gets the main factory of that core factory (cannot be <code>null</code>).
+	 *
+	 * @return the current main factory
 	 */
 	Factory getMainFactory();
 
 	/**
 	 * Sets the main factory of that core factory.
+	 *
+	 * @param mainFactory the main factory
 	 */
 	void setMainFactory(Factory mainFactory);
 
 	/**
 	 * Creates a compilation unit.
+	 *
+	 * @return a new compilation unit
 	 */
 	CompilationUnit createCompilationUnit();
 
 	/**
 	 * Creates a virtual compilation unit.
+	 *
+	 * @return a new virtual compilation unit
 	 */
 	CompilationUnit createVirtualCompilationUnit();
 
 	/**
 	 * Create an access to annotation value
+	 *
+	 * @param <T> the type of the field
 	 * 
-	 * @return
+	 * @return an annotation field access
 	 */
 	<T> CtAnnotationFieldAccess<T> createAnnotationFieldAccess();
 

--- a/src/main/java/spoon/reflect/factory/EnumFactory.java
+++ b/src/main/java/spoon/reflect/factory/EnumFactory.java
@@ -45,6 +45,8 @@ public class EnumFactory extends TypeFactory {
 	 *            package
 	 * @param simpleName
 	 *            the simple name
+	 *
+	 * @return a new enum
 	 */
 	public CtEnum<?> create(CtPackage owner, String simpleName) {
 		CtEnum<?> e = factory.Core().createEnum();
@@ -55,6 +57,10 @@ public class EnumFactory extends TypeFactory {
 
 	/**
 	 * Creates an enum from its qualified name.
+	 *
+	 * @param qualifiedName the qualified name of the enum
+	 *
+	 * @return a new enum
 	 */
 	public CtEnum<?> create(String qualifiedName) {
 		return create(
@@ -82,8 +88,10 @@ public class EnumFactory extends TypeFactory {
 	 * @param <T>
 	 *            type of created class
 	 * @param cl
-	 *            the java class: note that this class should be Class<T> but it
+	 *            the java class: note that this class should be Class&lt;T&gt; but it
 	 *            then poses problem when T is a generic type itself
+	 *
+	 * @return a new enum
 	 */
 	public <T extends Enum<?>> CtEnum<T> getEnum(Class<T> cl) {
 		try {

--- a/src/main/java/spoon/reflect/factory/EvalFactory.java
+++ b/src/main/java/spoon/reflect/factory/EvalFactory.java
@@ -41,6 +41,8 @@ public class EvalFactory extends SubFactory {
 
 	/**
 	 * Creates the evaluation factory.
+	 *
+	 * @param factory the parent factory
 	 */
 	public EvalFactory(Factory factory) {
 		super(factory);
@@ -48,6 +50,8 @@ public class EvalFactory extends SubFactory {
 
 	/**
 	 * Creates a partial evaluator on the Spoon meta-model.
+	 *
+	 * @return a new partial evaluator
 	 */
 	public PartialEvaluator createPartialEvaluator() {
 		return new VisitorPartialEvaluator();
@@ -58,6 +62,8 @@ public class EvalFactory extends SubFactory {
 	 * 
 	 * @param observers
 	 *            the observers to be notified of the the evaluation progress
+	 *
+	 * @return a new symbolic evaluator
 	 */
 	public SymbolicEvaluator createSymbolicEvaluator(
 			SymbolicEvaluatorObserver... observers) {
@@ -66,13 +72,17 @@ public class EvalFactory extends SubFactory {
 
 	/**
 	 * Creates a new symbolic instance.
-	 * 
+	 *
+	 * @param <T>
+	 *            the type of the symbolic instance
 	 * @param evaluator
 	 *            the evaluator
 	 * @param concreteType
 	 *            the type of the instance
 	 * @param isType
 	 *            tells if it is a type instance or a regular instance
+	 *
+	 * @return a new symbolic instance
 	 */
 	public <T> SymbolicInstance<T> createSymbolicInstance(
 			SymbolicEvaluator evaluator, CtTypeReference<T> concreteType,

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -51,6 +51,11 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an anonymous executable (initializer block) in a target class).
+	 *
+	 * @param target the target class
+	 * @param body the body
+	 *
+	 * @return the new anonymous executable
 	 */
 	public CtAnonymousExecutable createAnonymous(CtClass<?> target,
 			CtBlock<?> body) {
@@ -62,6 +67,13 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates a new parameter.
+	 *
+	 * @param <T> the parameter's type
+	 * @param parent the declaring executable
+	 * @param type the type of the parameter
+	 * @param name the name of the parameter
+	 *
+	 * @return the new parameter
 	 */
 	public <T> CtParameter<T> createParameter(CtExecutable<?> parent,
 			CtTypeReference<T> type, String name) {
@@ -81,6 +93,8 @@ public class ExecutableFactory extends SubFactory {
 	 *            the parameter's type
 	 * @param parameter
 	 *            the parameter
+	 *
+	 * @return the new parameter reference
 	 */
 	public <T> CtParameterReference<T> createParameterReference(
 			CtParameter<T> parameter) {
@@ -96,6 +110,11 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an executable reference from an existing executable.
+	 *
+	 * @param <T> the executable's type
+	 * @param e the executable
+	 *
+	 * @return the new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(CtExecutable<T> e) {
 		CtTypeReference<?> refs[] = new CtTypeReference[e.getParameters()
@@ -115,7 +134,9 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an executable reference.
-	 * 
+	 *
+	 * @param <T>
+	 *            the return type of the referenced executable
 	 * @param declaringType
 	 *            reference to the declaring type
 	 * @param type
@@ -124,6 +145,8 @@ public class ExecutableFactory extends SubFactory {
 	 *            simple name
 	 * @param parameterTypes
 	 *            list of parameter's types
+	 *
+	 * @return a new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(
 			CtTypeReference<?> declaringType, CtTypeReference<T> type,
@@ -143,7 +166,9 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an executable reference.
-	 * 
+	 *
+	 * @param <T>
+	 *            the return type of the referenced executable
 	 * @param declaringType
 	 *            reference to the declaring type
 	 * @param isStatic
@@ -154,6 +179,8 @@ public class ExecutableFactory extends SubFactory {
 	 *            simple name
 	 * @param parameterTypes
 	 *            list of parameter's types
+	 *
+	 * @return a new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(
 			CtTypeReference<?> declaringType, boolean isStatic,
@@ -175,7 +202,9 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an executable reference.
-	 * 
+	 *
+	 * @param <T>
+	 *            the return type of the referenced executable
 	 * @param declaringType
 	 *            reference to the declaring type
 	 * @param isStatic
@@ -186,6 +215,8 @@ public class ExecutableFactory extends SubFactory {
 	 *            simple name
 	 * @param parameterTypes
 	 *            list of parameter's types
+	 *
+	 * @return a new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(
 			CtTypeReference<?> declaringType, boolean isStatic,
@@ -207,7 +238,9 @@ public class ExecutableFactory extends SubFactory {
 
 	/**
 	 * Creates an executable reference.
-	 * 
+	 *
+	 * @param <T>
+	 *            the return type of the referenced executable
 	 * @param declaringType
 	 *            reference to the declaring type
 	 * @param type
@@ -216,6 +249,8 @@ public class ExecutableFactory extends SubFactory {
 	 *            simple name
 	 * @param parameterTypes
 	 *            list of parameter's types
+	 *
+	 * @return a new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(
 			CtTypeReference<?> declaringType, CtTypeReference<T> type,
@@ -236,6 +271,12 @@ public class ExecutableFactory extends SubFactory {
 	/**
 	 * Creates an executable reference from its signature, as defined by the
 	 * executable reference's toString.
+	 *
+	 * @param <T>
+	 *            the return type of the referenced executable
+	 * @param signature the executable signature as a string
+	 *
+	 * @return a new executable reference
 	 */
 	public <T> CtExecutableReference<T> createReference(String signature) {
 		CtExecutableReference<T> executableRef = factory.Core()

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -7,33 +7,98 @@ import spoon.compiler.Environment;
  * 
  * Most classes provides a method getFactory() that returns the current factory.
  * 
- * Otherwise FactoryImpl is a default implementation.
+ * Otherwise {@link spoon.reflect.factory.FactoryImpl} is a default implementation.
  */
 public interface Factory {
 
+	/**
+	 * The core factory.
+	 *
+	 * @return a core factory
+	 */
 	CoreFactory Core(); // used 238 times
 
+	/**
+	 * The {@link spoon.reflect.declaration.CtType} sub-factory.
+	 *
+	 * @return a type factory
+	 */
 	TypeFactory Type(); // used 107 times
-	
+
+	/**
+	 * Gets the Spoon environment that encloses this factory.
+	 *
+	 * @return a environment
+	 */
 	Environment getEnvironment(); // used 71 times
 
+	/**
+	 * The {@link spoon.reflect.declaration.CtPackage} sub-factory.
+	 *
+	 * @return a package factory
+	 */
 	PackageFactory Package(); // used 30 times
-	
+
+	/**
+	 * The {@link spoon.reflect.code.CtCodeElement} sub-factory.
+	 *
+	 * @return a code factory
+	 */
 	CodeFactory Code(); // used 28 times
-	
+
+	/**
+	 * The {@link spoon.reflect.declaration.CtClass} sub-factory.
+	 *
+	 * @return a class factory
+	 */
 	ClassFactory Class(); // used 27 times
 
+	/**
+	 * The {@link spoon.reflect.declaration.CtField} sub-factory.
+	 *
+	 * @return a field factory
+	 */
 	FieldFactory Field(); // used 9 times
-	
+
+	/**
+	 * The {@link spoon.reflect.declaration.CtExecutable} sub-factory.
+	 *
+	 * @return a executable factory
+	 */
 	ExecutableFactory Executable(); // used 8 times
 
+	/**
+	 * The {@link spoon.reflect.cu.CompilationUnit} sub-factory.
+	 *
+	 * @return a compilation unit factory
+	 */
 	CompilationUnitFactory CompilationUnit(); // used 7 times
-	
+
+	/**
+	 * The {@link spoon.reflect.declaration.CtMethod} sub-factory.
+	 *
+	 * @return a method factory
+	 */
 	MethodFactory Method(); // used 5 times
-	
+
+	/**
+	 * The {@link spoon.reflect.declaration.CtAnnotationType} sub-factory.
+	 *
+	 * @return an annotation factory
+	 */
 	AnnotationFactory Annotation(); // used 4 times
 
+	/**
+	 * The evaluators sub-factory.
+	 *
+	 * @return an eval factory
+	 */
 	EvalFactory Eval(); // used 4 times
 
+	/**
+	 * The {@link spoon.reflect.declaration.CtConstructor} sub-factory.
+	 *
+	 * @return a constractor factory
+	 */
 	ConstructorFactory Constructor(); // used 3 times
 }

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -47,6 +47,8 @@ public class FactoryImpl implements Factory, Serializable {
 	 * Returns the parent of this factory. When an element is not found in a
 	 * factory, it can be looked up in its parent factory using a delegation
 	 * model.
+	 *
+	 * @return the parent factory
 	 */
 	public Factory getParentFactory() {
 		return parentFactory;
@@ -54,9 +56,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient AnnotationFactory Annotation;
 
-	/**
-	 * The {@link CtAnnotationType} sub-factory.
-	 */
 	public AnnotationFactory Annotation() {
 		if (Annotation == null) {
 			Annotation = new AnnotationFactory(this);
@@ -66,9 +65,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient ClassFactory Class;
 
-	/**
-	 * The {@link CtClass} sub-factory.
-	 */
 	public ClassFactory Class() {
 		if (Class == null) {
 			Class = new ClassFactory(this);
@@ -78,9 +74,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient CodeFactory Code;
 
-	/**
-	 * The {@link spoon.reflect.code.CtCodeElement} sub-factory.
-	 */
 	public CodeFactory Code() {
 		if (Code == null) {
 			Code = new CodeFactory(this);
@@ -90,9 +83,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient ConstructorFactory Constructor;
 
-	/**
-	 * The {@link CtConstructor} sub-factory.
-	 */
 	public ConstructorFactory Constructor() {
 		if (Constructor == null) {
 			Constructor = new ConstructorFactory(this);
@@ -102,9 +92,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient CoreFactory Core;
 
-	/**
-	 * The core factory.
-	 */
 	public CoreFactory Core() {
 		if (Core == null) {
 			Core = new DefaultCoreFactory();
@@ -116,6 +103,8 @@ public class FactoryImpl implements Factory, Serializable {
 
 	/**
 	 * The {@link CtEnum} sub-factory.
+	 *
+	 * @return the singleton enum factory
 	 */
 	public EnumFactory Enum() {
 		if (Enum == null) {
@@ -126,9 +115,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient Environment Environment;
 
-	/**
-	 * Gets the Spoon environment that encloses this factory.
-	 */
 	public Environment getEnvironment() {
 		if (Environment == null) {
 			Environment = new StandardEnvironment();
@@ -138,9 +124,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient ExecutableFactory Executable;
 
-	/**
-	 * The {@link CtExecutable} sub-factory.
-	 */
 	public ExecutableFactory Executable() {
 		if (Executable == null) {
 			Executable = new ExecutableFactory(this);
@@ -150,9 +133,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient EvalFactory Eval;
 
-	/**
-	 * The evaluators sub-factory.
-	 */
 	public EvalFactory Eval() {
 		if (Eval == null) {
 			Eval = new EvalFactory(this);
@@ -162,9 +142,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient FieldFactory Field;
 
-	/**
-	 * The {@link CtField} sub-factory.
-	 */
 	public FieldFactory Field() {
 		if (Field == null) {
 			Field = new FieldFactory(this);
@@ -179,6 +156,8 @@ public class FactoryImpl implements Factory, Serializable {
 
 	/**
 	 * The {@link CtInterface} sub-factory.
+	 *
+	 * @return the singleton interface factory
 	 */
 	public InterfaceFactory Interface() {
 		if (Interface == null) {
@@ -189,9 +168,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient MethodFactory Method;
 
-	/**
-	 * The {@link CtMethod} sub-factory.
-	 */
 	public MethodFactory Method() {
 		if (Method == null) {
 			Method = new MethodFactory(this);
@@ -201,9 +177,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private PackageFactory Package;
 
-	/**
-	 * The {@link CtPackage} sub-factory.
-	 */
 	public PackageFactory Package() {
 		if (Package == null) {
 			Package = new PackageFactory(this);
@@ -213,9 +186,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private CompilationUnitFactory CompilationUnit;
 
-	/**
-	 * The {@link CompilationUnit} sub-factory.
-	 */
 	public CompilationUnitFactory CompilationUnit() {
 		if (CompilationUnit == null) {
 			CompilationUnit = new CompilationUnitFactory(this);
@@ -227,9 +197,6 @@ public class FactoryImpl implements Factory, Serializable {
 
 	private transient TypeFactory Type;
 
-	/**
-	 * The {@link CtType} sub-factory.
-	 */
 	public TypeFactory Type() {
 		if (Type == null) {
 			Type = new TypeFactory(this);
@@ -250,6 +217,8 @@ public class FactoryImpl implements Factory, Serializable {
 	 * contructed for the first time. Any subsequent constructions will not
 	 * affect the launching factory and references to other factories have to be
 	 * handled manually, if ever needed.
+	 *
+	 * @return the launching factory
 	 */
 	public static Factory getLauchingFactory() {
 		return launchingFactory;
@@ -257,6 +226,10 @@ public class FactoryImpl implements Factory, Serializable {
 
 	/**
 	 * A constructor that takes the parent factory
+	 *
+	 * @param coreFactory the core factory
+	 * @param environment the environment
+	 * @param parentFactory the parent factory
 	 */
 	public FactoryImpl(CoreFactory coreFactory, Environment environment,
 			Factory parentFactory) {
@@ -269,6 +242,9 @@ public class FactoryImpl implements Factory, Serializable {
 
 	/**
 	 * The constructor.
+	 *
+	 * @param coreFactory the core factory
+	 * @param environment the environment
 	 */
 	public FactoryImpl(CoreFactory coreFactory, Environment environment) {
 		this(coreFactory, environment, null);

--- a/src/main/java/spoon/reflect/factory/FieldFactory.java
+++ b/src/main/java/spoon/reflect/factory/FieldFactory.java
@@ -47,7 +47,9 @@ public class FieldFactory extends SubFactory {
 
 	/**
 	 * Creates a field.
-	 * 
+	 *
+	 * @param <T>
+	 *            the type of the field
 	 * @param target
 	 *            the target type to which the field is added
 	 * @param modifiers
@@ -56,6 +58,8 @@ public class FieldFactory extends SubFactory {
 	 *            the field's type
 	 * @param name
 	 *            the field's name
+	 *
+	 * @return a new field
 	 */
 	public <T> CtField<T> create(CtSimpleType<?> target,
 			Set<ModifierKind> modifiers, CtTypeReference<T> type, String name) {
@@ -70,7 +74,9 @@ public class FieldFactory extends SubFactory {
 
 	/**
 	 * Creates a field.
-	 * 
+	 *
+	 * @param <T>
+	 *            the type of the field
 	 * @param target
 	 *            the target type to which the field is added
 	 * @param modifiers
@@ -81,6 +87,8 @@ public class FieldFactory extends SubFactory {
 	 *            the field's name
 	 * @param defaultExpression
 	 *            the initializing expression
+	 *
+	 *  @return a new field
 	 */
 	public <T> CtField<T> create(CtSimpleType<?> target,
 			Set<ModifierKind> modifiers, CtTypeReference<T> type, String name,
@@ -99,6 +107,7 @@ public class FieldFactory extends SubFactory {
 	 *            the target type where the new field has to be inserted to
 	 * @param source
 	 *            the source field to be copied
+	 *
 	 * @return the newly created field
 	 */
 	public <T> CtField<T> create(CtType<?> target, CtField<T> source) {
@@ -110,6 +119,11 @@ public class FieldFactory extends SubFactory {
 
 	/**
 	 * Creates a field reference from an existing field.
+	 *
+	 * @param <T> the type of the referenced field
+	 * @param field the field to reference
+	 *
+	 * @return a new field reference
 	 */
 	public <T> CtFieldReference<T> createReference(CtField<T> field) {
 		return createReference(
@@ -119,6 +133,13 @@ public class FieldFactory extends SubFactory {
 
 	/**
 	 * Creates a field reference.
+	 *
+	 * @param <T> the actual type of the referenced field
+	 * @param declaringType the type that declares the referenced field
+	 * @param type the type of the referenced field
+	 * @param fieldName the name of the new field
+	 *
+	 * @return a new field reference
 	 */
 	public <T> CtFieldReference<T> createReference(
 			CtTypeReference<?> declaringType, CtTypeReference<T> type,
@@ -132,6 +153,11 @@ public class FieldFactory extends SubFactory {
 
 	/**
 	 * Creates a field reference from a <code>java.lang.reflect</code> field.
+	 *
+	 * @param <T> the type of the referenced field
+	 * @param field the field to reference
+	 *
+	 * @return a new field reference
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtFieldReference<T> createReference(Field field) {
@@ -148,6 +174,11 @@ public class FieldFactory extends SubFactory {
 	/**
 	 * Creates a field reference from its signature, as defined by the field
 	 * reference's toString.
+	 *
+	 * @param <T> the type of the referenced field
+	 * @param signature the signature of the field as a string
+	 *
+	 * @return a new field reference
 	 */
 	public <T> CtFieldReference<T> createReference(String signature) {
 		CtFieldReference<T> fieldRef = factory.Core().createFieldReference();

--- a/src/main/java/spoon/reflect/factory/InterfaceFactory.java
+++ b/src/main/java/spoon/reflect/factory/InterfaceFactory.java
@@ -40,6 +40,12 @@ public class InterfaceFactory extends TypeFactory {
 
 	/**
 	 * Creates an interface.
+	 *
+	 * @param <T> the actual type of the interface
+	 * @param owner the package the interface will belong to
+	 * @param simpleName the simple name of the interface
+	 *
+	 * @return a new interface
 	 */
 	public <T> CtInterface<T> create(CtPackage owner, String simpleName) {
 		CtInterface<T> i = factory.Core().createInterface();
@@ -50,6 +56,12 @@ public class InterfaceFactory extends TypeFactory {
 
 	/**
 	 * Creates an inner interface
+	 *
+	 * @param <T> the actual type of the interface
+	 * @param owner the type the interface will belong to
+	 * @param simpleName the simple name of the interface
+	 *
+	 * @return a new interface
 	 */
 	public <T> CtInterface<T> create(CtType<T> owner, String simpleName) {
 		CtInterface<T> i = factory.Core().createInterface();
@@ -60,6 +72,11 @@ public class InterfaceFactory extends TypeFactory {
 
 	/**
 	 * Creates an interface.
+	 *
+	 * @param <T> the actual type of the interface
+	 * @param qualifiedName the qualified name of the interface
+	 *
+	 * @return a new interface
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtInterface<T> create(String qualifiedName) {
@@ -74,6 +91,8 @@ public class InterfaceFactory extends TypeFactory {
 
 	/**
 	 * Gets a created interface
+	 *
+	 * @param qualifiedName the qualified name to look for
 	 *
 	 * @return the interface or null if does not exist
 	 */
@@ -93,8 +112,10 @@ public class InterfaceFactory extends TypeFactory {
 	 * @param <T>
 	 *            type of created class
 	 * @param cl
-	 *            the java class: note that this class should be Class<T> but
+	 *            the java class: note that this class should be Class&lt;T&gt; but
 	 *            it then poses problem when T is a generic type itself
+	 *
+	 * @return the interface or null if does not exist
 	 */
 	@Override
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/reflect/factory/MethodFactory.java
+++ b/src/main/java/spoon/reflect/factory/MethodFactory.java
@@ -54,7 +54,11 @@ public class MethodFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a method.
-	 * 
+	 *
+	 * @param <R>
+	 *            the return type of the method
+	 * @param <B>
+	 *            the return type of the method body
 	 * @param target
 	 *            the class where the method is inserted
 	 * @param modifiers
@@ -69,6 +73,8 @@ public class MethodFactory extends ExecutableFactory {
 	 *            the thrown types
 	 * @param body
 	 *            the method's body
+	 *
+	 * @return a new method
 	 */
 	public <R, B extends R> CtMethod<R> create(CtClass<?> target,
 			Set<ModifierKind> modifiers, CtTypeReference<R> returnType,
@@ -94,6 +100,7 @@ public class MethodFactory extends ExecutableFactory {
 	 *            tells if all the references to the owning type of the source
 	 *            method should be redirected to the target type (true is
 	 *            recommended for most uses)
+	 *
 	 * @return the newly created method
 	 */
 	public <T> CtMethod<T> create(CtType<?> target, CtMethod<T> source,
@@ -109,7 +116,9 @@ public class MethodFactory extends ExecutableFactory {
 
 	/**
 	 * Creates an empty method.
-	 * 
+	 *
+	 * @param <T>
+	 *            the type of the method
 	 * @param target
 	 *            the class where the method is inserted
 	 * @param modifiers
@@ -122,6 +131,8 @@ public class MethodFactory extends ExecutableFactory {
 	 *            the parameters
 	 * @param thrownTypes
 	 *            the thrown types
+	 *
+	 * @return the newly created method
 	 */
 	public <T> CtMethod<T> create(CtType<?> target,
 			Set<ModifierKind> modifiers, CtTypeReference<T> returnType,
@@ -145,6 +156,11 @@ public class MethodFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a method reference.
+	 *
+	 * @param <T> the return type of the referenced method
+	 * @param m the method to reference
+	 *
+	 * @return a new method reference
 	 */
 	public <T> CtExecutableReference<T> createReference(CtMethod<T> m) {
 		return factory.Executable().createReference(m);
@@ -152,6 +168,11 @@ public class MethodFactory extends ExecutableFactory {
 
 	/**
 	 * Creates a method reference from an actual method.
+	 *
+	 * @param <T> the returned type of the referenced method
+	 * @param method the method to reference
+	 *
+	 * @return a new executable reference
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtExecutableReference<T> createReference(Method method) {
@@ -168,6 +189,8 @@ public class MethodFactory extends ExecutableFactory {
 
 	/**
 	 * Gets all the main methods stored in this factory.
+	 *
+	 * @return the Collection of all main methods
 	 */
 	public Collection<CtMethod<Void>> getMainMethods() {
 		Collection<CtMethod<Void>> methods = new ArrayList<CtMethod<Void>>();

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -52,6 +52,12 @@ public class PackageFactory extends SubFactory implements Serializable {
 
 	/**
 	 * Creates a reference to an existing package.
+	 *
+	 * @param pack the pakcage to reference
+	 *
+	 * @return a new package reference
+	 *
+	 * @throws java.lang.IllegalArgumentException if the given package is null
 	 */
 	public CtPackageReference createReference(CtPackage pack) {
 		if (pack==null) { 
@@ -66,6 +72,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * 
 	 * @param pack
 	 *            a runtime package
+	 *
 	 * @return reference to the package
 	 */
 	public CtPackageReference createReference(Package pack) {
@@ -76,6 +83,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 	
 	/**
 	 * Returns a reference on the top level package.
+	 *
+	 * @return the top level package referenc
 	 */
 	public CtPackageReference topLevel() {
 		if(topLevel==null) {
@@ -89,6 +98,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * 
 	 * @param name
 	 *            full name of the package to reference
+	 *
+	 * @return a new package reference
 	 */
 	public CtPackageReference createReference(String name) {	  
 		CtPackageReference ref = factory.Core().createPackageReference();
@@ -103,6 +114,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 *            the parent package (can be null)
 	 * @param simpleName
 	 *            the package's simple name (no dots)
+	 *
 	 * @return the newly created package
 	 */
 	public CtPackage create(CtPackage parent, String simpleName) {
@@ -115,6 +127,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * 
 	 * @param qualifiedName
 	 *            the full name of the package
+	 *
+	 * @return a new package or the existing one
 	 */
 	public CtPackage getOrCreate(String qualifiedName) {
 		StringTokenizer token = new StringTokenizer(qualifiedName,
@@ -155,7 +169,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * 
 	 * @param qualifiedName
 	 *            the package to search
-	 * @return a found package or null
+	 *
+	 * @return a found package or null of not found
 	 */
 	public CtPackage get(String qualifiedName) {
 		if (qualifiedName.contains(CtType.INNERTTYPE_SEPARATOR)) {
@@ -178,6 +193,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 	/**
 	 * Gets the list of all created packages. It includes all the top-level
 	 * packages and their sub-packages.
+	 *
+	 * @return the Collection of all packages
 	 */
 	public Collection<CtPackage> getAll() {
 		Collection<CtPackage> packs = new ArrayList<CtPackage>();
@@ -189,6 +206,8 @@ public class PackageFactory extends SubFactory implements Serializable {
 
 	/**
 	 * Gets the list of all created root packages
+	 *
+	 * @return a Collection of all root packages
 	 */
 	public Collection<CtPackage> getAllRoots() {
 		return packages.values();
@@ -205,13 +224,15 @@ public class PackageFactory extends SubFactory implements Serializable {
 
 	/**
 	 * Registers a top-level package.
+	 *
+	 * @param pack the package to register
 	 */
-	public void register(CtPackage pck) {
-		if (packages.containsKey(pck.getQualifiedName())) {
-			throw new RuntimeException("package " + pck.getQualifiedName()
+	public void register(CtPackage pack) {
+		if (packages.containsKey(pack.getQualifiedName())) {
+			throw new RuntimeException("package " + pack.getQualifiedName()
 					+ " already created");
 		}
-		packages.put(pck.getQualifiedName(), pck);
+		packages.put(pack.getQualifiedName(), pack);
 	}
 
 }

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -30,6 +30,8 @@ public abstract class SubFactory  {
 
 	/**
 	 * The sub-factory constructor takes an instance of the parent factory.
+	 *
+	 * @param factory the parent factory
 	 */
 	public SubFactory(Factory factory) {
 		super();

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -61,6 +61,8 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Returns a reference on the null type (type of null).
+	 *
+	 * @return a new null type
 	 */
 	public CtTypeReference<?> nullType() {
 		if (nullType == null) {
@@ -86,6 +88,8 @@ public class TypeFactory extends SubFactory {
 	 *            type of array
 	 * @param type
 	 *            type of array values
+	 *
+	 * @return a new array reference
 	 */
 	public <T> CtArrayTypeReference<T[]> createArrayReference(
 			CtSimpleType<T> type) {
@@ -97,6 +101,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Creates a reference to a one-dimension array of given type.
+	 *
+	 * @param <T> the array's type
+	 * @param reference the type of the new array
+	 *
+	 * @return a new array reference
 	 */
 	public <T> CtArrayTypeReference<T[]> createArrayReference(
 			CtTypeReference<T> reference) {
@@ -108,6 +117,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Creates a reference to an n-dimension array of given type.
+	 *
+	 * @param reference the type of the array
+	 * @param n the number of dimensions
+	 *
+	 * @return a new array reference
 	 */
 	public CtArrayTypeReference<?> createArrayReference(
 			CtTypeReference<?> reference, int n) {
@@ -124,6 +138,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Creates a reference to an array of given type.
+	 *
+	 * @param <T> the array's type
+	 * @param qualifiedName the qualified name of the array type
+	 *
+	 * @return the new array type reference
 	 */
 	public <T> CtArrayTypeReference<T> createArrayReference(String qualifiedName) {
 		CtArrayTypeReference<T> array = factory.Core()
@@ -134,6 +153,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Creates a reference to a simple type
+	 *
+	 * @param <T> the reference' type
+	 * @param type the class to reference
+	 *
+	 * @return the new type reference
 	 */
 	public <T> CtTypeReference<T> createReference(Class<T> type) {
 		if (type.isArray()) {
@@ -147,6 +171,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Create a reference to a simple type
+	 *
+	 * @param <T> the reference' type
+	 * @param type the simple type to reference
+	 *
+	 * @return the new type reference
 	 */
 	public <T> CtTypeReference<T> createReference(CtSimpleType<T> type) {
 		CtTypeReference<T> ref = factory.Core().createTypeReference();
@@ -165,6 +194,11 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Create a reference to a simple type
+	 *
+	 * @param <T> the reference' type
+	 * @param qualifiedName the qualified name of the type
+	 *
+	 * @return the new type reference
 	 */
 	public <T> CtTypeReference<T> createReference(String qualifiedName) {
 		if (qualifiedName.endsWith("[]")) {
@@ -184,6 +218,9 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets a created type from its qualified name.
+	 *
+	 * @param <T> the type's actual type
+	 * @param qualifiedName the qualified name of the type
 	 * 
 	 * @return a found type or null if does not exist
 	 */
@@ -220,6 +257,8 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets the list of all top-level created types.
+	 *
+	 * @return the List of all top level types
 	 */
 	public List<CtSimpleType<?>> getAll() {
 		List<CtSimpleType<?>> types = new ArrayList<CtSimpleType<?>>();
@@ -231,6 +270,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets the list of all created types.
+	 *
+	 * @param includeNestedTypes true to include nested types as well
+	 *
+	 * @return the List of all created types
 	 */
 	public List<CtSimpleType<?>> getAll(boolean includeNestedTypes) {
 		if (!includeNestedTypes) {
@@ -258,8 +301,10 @@ public class TypeFactory extends SubFactory {
 	 * @param <T>
 	 *            actual type of the class
 	 * @param cl
-	 *            the java class: note that this class should be Class<T> but it
+	 *            the java class: note that this class should be Class&lt;T&gt; but it
 	 *            then poses problem when T is a generic type itself
+	 *
+	 * @return the simple type of a class
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtSimpleType<T> get(Class<?> cl) {
@@ -268,6 +313,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets the declaring type name for a given Java qualified name.
+	 *
+	 * @param qualifiedName the qualified name
+	 *
+	 * @return the declaring type name
 	 */
 	protected String getDeclaringTypeName(String qualifiedName) {
 		return qualifiedName.substring(0, hasInnerType(qualifiedName));
@@ -275,6 +324,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Creates a collection of type references from a collection of classes.
+	 *
+	 * @param classes the List if classes to create references for
+	 *
+	 * @return the List of references to the given classes
 	 */
 	public List<CtTypeReference<?>> createReferences(List<Class<?>> classes) {
 		List<CtTypeReference<?>> refs = new ArrayList<CtTypeReference<?>>();
@@ -286,6 +339,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets the package name for a given Java qualified name.
+	 *
+	 * @param qualifiedName the qualified name
+	 *
+	 * @return the package name from the give
 	 */
 	protected String getPackageName(String qualifiedName) {
 		if (hasPackage(qualifiedName) >= 0) {
@@ -296,6 +353,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Gets the simple name for a given Java qualified name.
+	 *
+	 * @param qualifiedName the qualified name
+	 *
+	 * @return the simple name from the given qualified name
 	 */
 	protected String getSimpleName(String qualifiedName) {
 		if (hasInnerType(qualifiedName) > 0) {
@@ -309,6 +370,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Tells if a given Java qualified name is that of an inner type.
+	 *
+	 * @param qualifiedName the qualified name the qualified name to check
+	 *
+	 * @return if not -1 the given name has an inner type
 	 */
 	protected int hasInnerType(String qualifiedName) {
 		int ret = qualifiedName.lastIndexOf(CtSimpleType.INNERTTYPE_SEPARATOR);
@@ -327,6 +392,10 @@ public class TypeFactory extends SubFactory {
 
 	/**
 	 * Tells if a given Java qualified name contains a package name.
+	 *
+	 * @param qualifiedName the qualified name to check
+	 *
+	 * @return if not -1 the qualified name contains the package name
 	 */
 	protected int hasPackage(String qualifiedName) {
 		return qualifiedName.lastIndexOf(CtPackage.PACKAGE_SEPARATOR);
@@ -339,6 +408,8 @@ public class TypeFactory extends SubFactory {
 	 *            the owning declaration
 	 * @param name
 	 *            the name of the formal parameter
+	 *
+	 * @return the new type parameter
 	 */
 	public CtTypeParameter createTypeParameter(CtElement owner, String name) {
 		CtTypeParameter typeParam = factory.Core().createTypeParameter();
@@ -355,6 +426,8 @@ public class TypeFactory extends SubFactory {
 	 *            the name of the formal parameter
 	 * @param bounds
 	 *            the bounds
+	 *
+	 * @return the new type parameter
 	 */
 	public CtTypeParameter createTypeParameter(CtElement owner, String name,
 			List<CtTypeReference<?>> bounds) {
@@ -369,6 +442,8 @@ public class TypeFactory extends SubFactory {
 	 * 
 	 * @param name
 	 *            the name of the formal parameter
+	 *
+	 * @return the new type parameter reference
 	 */
 	public CtTypeParameterReference createTypeParameterReference(String name) {
 		CtTypeParameterReference typeParam = factory.Core()
@@ -384,6 +459,8 @@ public class TypeFactory extends SubFactory {
 	 *            the name of the formal parameter
 	 * @param bounds
 	 *            the bounds
+	 *
+	 * @return the new type parameter reference
 	 */
 	public CtTypeParameterReference createTypeParameterReference(String name,
 			List<CtTypeReference<?>> bounds) {

--- a/src/main/java/spoon/reflect/package.html
+++ b/src/main/java/spoon/reflect/package.html
@@ -6,8 +6,8 @@
 	<p>This package defines the Spoon's compile-time meta-model of Java programs.
 
     <p>The meta-model defines a read/write compile-time meta-representation of Java 5 programs.
-    The programmers should instantiate or resolve the meta-elements by using {@link spoon.reflect.Factory}'s sub-factories because it ensures 
-    the model consistency. The {@link spoon.reflect.CoreFactory} is the raw factory for program elements and is the 
+    The programmers should instantiate or resolve the meta-elements by using {@link spoon.reflect.factory.Factory}'s sub-factories because it ensures
+    the model consistency. The {@link spoon.reflect.factory.CoreFactory} is the raw factory for program elements and is the
     only factory to be implemented when wanting to provide an alternative implementation of the Spoon meta-model.
 
 <h2>Related Documentation</h2>

--- a/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
@@ -24,11 +24,15 @@ public interface CtArrayTypeReference<T> extends CtTypeReference<T> {
 
 	/**
 	 * Gets the type of the elements contained in this array.
+	 *
+	 * @return the type of this array
 	 */
 	CtTypeReference<?> getComponentType();
 
 	/**
 	 * Sets the type of the elements contained in this array.
+	 *
+	 * @param componentType the type of this array
 	 */
 	void setComponentType(CtTypeReference<?> componentType);
 
@@ -36,18 +40,24 @@ public interface CtArrayTypeReference<T> extends CtTypeReference<T> {
 	 * Returns the number of dimensions of this array type. This corresponds to
 	 * the number of array types recursively embedded into the current one (see
 	 * {@link #getComponentType()}).
+	 *
+	 * @return the number of dimensions
 	 */
 	int getDimensionCount();
 
 	/**
 	 * Returns the simple name of the array type core component type (with no
 	 * []s). Use toString() to get the full array type including []s.
+	 *
+	 * @return the array type's simple name
 	 */
 	String getSimpleName();
 
 	/**
 	 * Sets the the simple name of the array type core component type (with no
 	 * []s).
+	 *
+	 * @param simpleName the simple name of the array's type
 	 */
 	void setSimpleName(String simpleName);
 

--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -85,11 +85,17 @@ public interface CtExecutableReference<T> extends CtReference,
 	/**
 	 * Returns <code>true</code> if this executable overrides the given
 	 * executable.
+	 *
+	 * @param executable the executable to check
+	 *
+	 * @return true if the given executable is overridden by this executable
 	 */
 	boolean isOverriding(CtExecutableReference<?> executable);
 
 	/**
-	 * Returns the executable overriden by this one, if exists (null otherwise).
+	 * Returns the executable overridden by this one, if exists (null otherwise).
+	 *
+	 * @return the overriding executable
 	 */
 	CtExecutableReference<?> getOverridingExecutable();
 
@@ -110,31 +116,43 @@ public interface CtExecutableReference<T> extends CtReference,
 
 	/**
 	 * Tells if the referenced executable is static.
+	 *
+	 * @return true if this executable is static
 	 */
 	boolean isStatic();
 
 	/**
 	 * Sets the declaring type.
+	 *
+	 * @param declaringType the type that declares this executable
 	 */
 	void setDeclaringType(CtTypeReference<?> declaringType);
 
 	/**
 	 * Sets the list of the executable's parameters types.
+	 *
+	 * @param parameterTypes the List of parameters
 	 */
 	void setParameterTypes(List<CtTypeReference<?>> parameterTypes);
 
 	/**
 	 * Sets this executable reference to be static or not.
+	 *
+	 * @param b true to make this executable static
 	 */
 	void setStatic(boolean b);
 
 	/**
 	 * Sets the type of the variable.
+	 *
+	 * @param type the variable type
 	 */
 	void setType(CtTypeReference<T> type);
 
 	/**
 	 * Tells if the referenced executable is final.
+	 *
+	 * @return true if this executable is final
 	 */
 	boolean isFinal();
 }

--- a/src/main/java/spoon/reflect/reference/CtFieldReference.java
+++ b/src/main/java/spoon/reflect/reference/CtFieldReference.java
@@ -37,36 +37,50 @@ public interface CtFieldReference<T> extends CtVariableReference<T> {
 
 	/**
 	 * Gets the type in which the field is declared.
+	 *
+	 * @return the type that declares this field
 	 */
 	CtTypeReference<?> getDeclaringType();
 
 	/**
 	 * Gets the qualified name of the field.
+	 *
+	 * The qualified name of the field
 	 */
 	String getQualifiedName();
 
 	/**
 	 * Tells if the referenced field is final.
+	 *
+	 * @return true if this field is final
 	 */
 	boolean isFinal();
 
 	/**
 	 * Tells if the referenced field is static.
+	 *
+	 * @return true if this field is static
 	 */
 	boolean isStatic();
 
 	/**
 	 * Sets the type in which the field is declared.
+	 *
+	 * @param declaringType the type that declares this field
 	 */
 	void setDeclaringType(CtTypeReference<?> declaringType);
 
 	/**
 	 * Forces a reference to a final element.
+	 *
+	 * @param b true to make this field final
 	 */
 	void setFinal(boolean b);
 
 	/**
 	 * Forces a reference to a static element.
+	 *
+	 * @param b true to make this field static
 	 */
 	void setStatic(boolean b);
 }

--- a/src/main/java/spoon/reflect/reference/CtGenericElementReference.java
+++ b/src/main/java/spoon/reflect/reference/CtGenericElementReference.java
@@ -26,21 +26,33 @@ import java.util.List;
 public interface CtGenericElementReference {
 	/**
 	 * Gets the type arguments.
+	 *
+	 * @return the List of type arguments
 	 */
 	List<CtTypeReference<?>> getActualTypeArguments();
 
 	/**
 	 * Sets the type arguments.
+	 *
+	 * @param actualTypeArguments the List of actual type parameters to set
 	 */
 	void setActualTypeArguments(List<CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Adds a type argument.
+	 *
+	 * @param actualTypeArgument the type argument to add
+	 *
+	 * @return true if the actual type argument has been added
 	 */
 	boolean addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 
 	/**
 	 * Removes a type argument.
+	 *
+	 * @param actualTypeArgument the type argument to remove
+	 *
+	 * @return true if the actual type argument has been removed
 	 */
 	boolean removeActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 

--- a/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
@@ -29,6 +29,8 @@ public interface CtLocalVariableReference<T> extends CtVariableReference<T> {
 	/**
 	 * Sets the local variable declaration that corresponds to this local
 	 * variable reference.
+	 *
+	 * @param declaration the declaration of the referenced local variable
 	 */
 	void setDeclaration(CtLocalVariable<T> declaration);
 }

--- a/src/main/java/spoon/reflect/reference/CtPackageReference.java
+++ b/src/main/java/spoon/reflect/reference/CtPackageReference.java
@@ -26,11 +26,15 @@ import spoon.reflect.declaration.CtPackage;
 public interface CtPackageReference extends CtReference {
 	/**
 	 * Gets the package element when available in the source code.
+	 *
+	 * @return the package
 	 */
 	CtPackage getDeclaration();
 
 	/**
 	 * Gets the package element when available in the class path.
+	 *
+	 * @return the actual package
 	 */
 	Package getActualPackage();
 }

--- a/src/main/java/spoon/reflect/reference/CtParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtParameterReference.java
@@ -27,11 +27,15 @@ public interface CtParameterReference<T> extends CtVariableReference<T> {
 
 	/**
 	 * Gets the declaring executable of the referenced parameter.
+	 *
+	 * @return the executable declaring the referenced parameter
 	 */
 	CtExecutableReference<?> getDeclaringExecutable();
 
 	/**
 	 * Sets the declaring executable of the referenced parameter.
+	 *
+	 * @param executable the executable to declare the referenced parameter
 	 */
 	void setDeclaringExecutable(CtExecutableReference<?> executable);
 

--- a/src/main/java/spoon/reflect/reference/CtReference.java
+++ b/src/main/java/spoon/reflect/reference/CtReference.java
@@ -40,11 +40,15 @@ public interface CtReference extends FactoryAccessor, Comparable<CtReference> {
 
 	/**
 	 * Gets the simple name of referenced element.
+	 *
+	 * @return the simple name
 	 */
 	String getSimpleName();
 
 	/**
 	 * Sets the name of referenced element.
+	 *
+	 * @param simpleName the simple name to set
 	 */
 	void setSimpleName(String simpleName);
 
@@ -57,6 +61,8 @@ public interface CtReference extends FactoryAccessor, Comparable<CtReference> {
 
 	/**
 	 * Accepts a visitor
+	 *
+	 * @param visitor a visitor
 	 */
 	void accept(CtVisitor visitor);
 
@@ -80,7 +86,8 @@ public interface CtReference extends FactoryAccessor, Comparable<CtReference> {
 
 	/**
 	 * Gets the annotation element for a given annotation type.
-	 * 
+	 *
+	 * @param <A> the type of the annotation
 	 * @param annotationType
 	 *            the annotation type
 	 * @return the annotation if this element is annotated by one annotation of
@@ -91,6 +98,8 @@ public interface CtReference extends FactoryAccessor, Comparable<CtReference> {
 
 	/**
 	 * Returns the annotations that are present on this element.
+	 *
+	 * @return the List of annotations
 	 */
 	List<Annotation> getAnnotations();
 

--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -27,31 +27,47 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 
 	/**
 	 * Gets the bounds (aka generics) of the referenced parameter.
+	 *
+	 * @return the List of bounds
 	 */
 	List<CtTypeReference<?>> getBounds();
 
 	/**
 	 * Returns {@code true} if the bounds are upper bounds.
+	 *
+	 * @return if this is an upper bound
 	 */
 	boolean isUpper();
 
 	/**
 	 * Sets the bounds (aka generics) of the referenced parameter.
+	 *
+	 * @param bounds the List of bounds to set
 	 */
 	void setBounds(List<CtTypeReference<?>> bounds);
 
 	/**
 	 * Set to {@code true} if the bounds are upper bounds.
+	 *
+	 * @param upper true to make this an upper bound
 	 */
 	void setUpper(boolean upper);
 
 	/**
 	 * Adds a bound.
+	 *
+	 * @param bound the bound to add
+	 *
+	 * @return true if the bound has been added
 	 */
 	boolean addBound(CtTypeReference<?> bound);
 
 	/**
 	 * Removes a bound.
+	 *
+	 * @param bound the bound to remove
+	 *
+	 * @return true if the bound has been removed
 	 */
 	boolean removeBound(CtTypeReference<?> bound);
 

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -42,6 +42,11 @@ public interface CtTypeReference<T> extends CtReference,
 	 */
 	Class<T> getActualClass();
 
+	/**
+	 * Returns the declaration of this type
+	 *
+	 * @return the declaration
+	 */
 	CtSimpleType<T> getDeclaration();
 
 	/**
@@ -69,92 +74,130 @@ public interface CtTypeReference<T> extends CtReference,
 	/**
 	 * Returns <code>true</code> if this referenced type is assignable from an
 	 * instance of the given type.
+	 *
+	 * @param type the type to check
+	 *
+	 * @return true if this type is assignable from the given type
 	 */
 	boolean isAssignableFrom(CtTypeReference<?> type);
 
 	/**
 	 * Return {@code true} if the referenced type is a primitive type (int,
 	 * double, boolean...).
+	 *
+	 * @return true if this is a primitive type
 	 */
 	boolean isPrimitive();
 
 	/**
 	 * Return {@code true} if the referenced type is a anonymous type
+	 *
+	 * @return true of this is an anonymous type
 	 */
 	boolean isAnonymous();
 
 	/**
 	 * Returns the corresponding non-primitive type for a primitive type (the
-	 * same type otherwhise).
+	 * same type otherwise).
+	 *
+	 * @return a boxed primitive if applicable
 	 */
 	CtTypeReference<?> box();
 
 	/**
 	 * Returns the primitive type for a boxing type (unchanged if the type does
 	 * not correspond to a boxing type).
+	 *
+	 * @return unboxes the primitive type of applicable
 	 */
 	CtTypeReference<?> unbox();
 
 	/**
 	 * Returns true if the referenced type is a sub-type of the given type.
+	 *
+	 * @param type the type to check against
+	 *
+	 * @return true of this type is a sub type of the given type
 	 */
 	boolean isSubtypeOf(CtTypeReference<?> type);
 
 	/**
 	 * Sets the reference to the declaring type. Should be set to null if the
 	 * referenced type is not a inner type.
+	 *
+	 * @param type the declaring type to set or null if this type is not a inner type
 	 */
 	void setDeclaringType(CtTypeReference<?> type);
 
 	/**
 	 * Sets the reference to the declaring package.
+	 *
+	 * @param pack the package to set
 	 */
 	void setPackage(CtPackageReference pack);
 
 	/**
 	 * Gets the fields declared by this type.
+	 *
+	 * @return the Collection of fields declared by this type
 	 */
 	Collection<CtFieldReference<?>> getDeclaredFields();
 
 	/**
 	 * Gets the fields declared by this type and by all its supertypes if
 	 * applicable.
+	 *
+	 * @return the Collection of all fields
 	 */
 	Collection<CtFieldReference<?>> getAllFields();
 
 	/**
 	 * Gets the executables declared by this type if applicable.
+	 *
+	 * @return the Collection of executables declared by this type
 	 */
 	Collection<CtExecutableReference<?>> getDeclaredExecutables();
 
 	/**
 	 * Gets the executables declared by this type and by all its supertypes if
 	 * applicable.
+	 *
+	 * @return the Collections of executables from this type
 	 */
 	Collection<CtExecutableReference<?>> getAllExecutables();
 
 	/**
 	 * Gets the superclass of this type if applicable (only for classes).
+	 *
+	 * @return a type reference of the super class
 	 */
 	CtTypeReference<?> getSuperclass();
 
 	/**
 	 * Gets the super interfaces of this type.
+	 *
+	 * @return the Set of super interfaces
 	 */
 	Set<CtTypeReference<?>> getSuperInterfaces();
 
 	/**
 	 * Returns true if the reference refers to the super implementation
+	 *
+	 * @return true if referring to the super implementation
 	 */
 	boolean isSuperReference();
 
 	/**
 	 * Says that this reference refers to the super implementation
+	 *
+	 * @param b true to refer to the super imeplementation
 	 */
 	void setSuperReference(boolean b);
 
 	/**
 	 * Returns true if this type is an interface.
+	 *
+	 * @return true if this type is an interface
 	 */
 	boolean isInterface();
 	

--- a/src/main/java/spoon/reflect/reference/CtVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtVariableReference.java
@@ -27,11 +27,15 @@ public interface CtVariableReference<T> extends CtReference {
 
 	/**
 	 * Gets the type of the variable.
+	 *
+	 * @return the type of the variable
 	 */
 	CtTypeReference<T> getType();
 
 	/**
 	 * Sets the type of the variable.
+	 *
+	 * @param type the type of this variable
 	 */
 	void setType(CtTypeReference<T> type);
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -686,22 +686,22 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (e.getTypeCasts().size() != 0) {
 			return true;
 		}
-        try {
-            if ((e.getParent() instanceof CtBinaryOperator)
-                    || (e.getParent() instanceof CtUnaryOperator)) {
-                return (e instanceof CtTargetedExpression)
-                        || (e instanceof CtAssignment)
-                        || (e instanceof CtConditional)
-                        || (e instanceof CtUnaryOperator);
-            }
-            if (e.getParent() instanceof CtTargetedExpression) {
-                return (e instanceof CtBinaryOperator)
-                        || (e instanceof CtAssignment)
-                        || (e instanceof CtConditional);
-            }
-        } catch (ParentNotInitializedException ex) {
-            // nothing we accept not to have a parent
-        }
+		try {
+			if ((e.getParent() instanceof CtBinaryOperator)
+					|| (e.getParent() instanceof CtUnaryOperator)) {
+				return (e instanceof CtTargetedExpression)
+						|| (e instanceof CtAssignment)
+						|| (e instanceof CtConditional)
+						|| (e instanceof CtUnaryOperator);
+			}
+			if (e.getParent() instanceof CtTargetedExpression) {
+				return (e instanceof CtBinaryOperator)
+						|| (e instanceof CtAssignment)
+						|| (e instanceof CtConditional);
+			}
+		} catch (ParentNotInitializedException ex) {
+			// nothing we accept not to have a parent
+		}
 		return false;
 	}
 
@@ -797,11 +797,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public <T> void visitCtBinaryOperator(CtBinaryOperator<T> operator) {
 		enterCtExpression(operator);
 		boolean paren = false;
-        try { paren = (operator.getParent() instanceof CtBinaryOperator)
+		try { paren = (operator.getParent() instanceof CtBinaryOperator)
 				|| (operator.getParent() instanceof CtUnaryOperator);
-        } catch (ParentNotInitializedException ex) {
-            // nothing if we have no parent
-        }
+		} catch (ParentNotInitializedException ex) {
+			// nothing if we have no parent
+		}
 		if (paren) {
 			write("(");
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
@@ -41,13 +41,13 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements
 	CtTypeReference<T> type;
 
 	public boolean addModifier(ModifierKind modifier) {
-        setMutable();
-        return modifiers.add(modifier);
+		setMutable();
+		return modifiers.add(modifier);
 	}
 
 	public boolean removeModifier(ModifierKind modifier) {
-        setMutable();
-        return modifiers.remove(modifier);
+		setMutable();
+		return modifiers.remove(modifier);
 	}
 
 	public void accept(CtVisitor visitor) {
@@ -107,14 +107,14 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements
 		this.type = type;
 	}
 
-    private void setMutable() {
-        if (modifiers == CtElementImpl.<ModifierKind> EMPTY_SET()) {
-            modifiers = new TreeSet<ModifierKind>();
-        }
-    }
+	private void setMutable() {
+		if (modifiers == CtElementImpl.<ModifierKind> EMPTY_SET()) {
+			modifiers = new TreeSet<ModifierKind>();
+		}
+	}
 
 	public void setVisibility(ModifierKind visibility) {
-        setMutable();
+		setMutable();
 		getModifiers().remove(ModifierKind.PUBLIC);
 		getModifiers().remove(ModifierKind.PROTECTED);
 		getModifiers().remove(ModifierKind.PRIVATE);

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ParentNotInitializedException;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public abstract class CtStatementImpl extends CtCodeElementImpl implements
 		CtStatement {
@@ -90,8 +89,8 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements
 				throw new IllegalArgumentException("should not happen");
 			}
 			if (stat instanceof CtBlock) {
-                ((CtBlock<?>) stat).insertBegin(statementsToBeInserted);
-                return;
+				((CtBlock<?>) stat).insertBegin(statementsToBeInserted);
+				return;
 			} else {
 				CtBlock<?> block = target.getFactory().Core().createBlock();
 				block.addStatement(stat);
@@ -102,30 +101,29 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements
 				parentBlock = block;
 			}
 		} else if (targetParent instanceof CtSwitch) {
-            for (CtStatement s : statementsToBeInserted) {
-                if (! (s instanceof CtCase)) {
-                    throw new RuntimeException(
-                            "cannot insert something that is not case in a switch");
-                }
-            }
-            int i=0;
-            for (CtStatement s : ((CtSwitch<?>) targetParent).getCases()) {
-                if (s == target) {
-                    break;
-                }
-                i++;
-            }
-            for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
-                CtStatement s = statementsToBeInserted.getStatements().get(j);
-                ((CtSwitch<?>) targetParent).getCases().add(i, (CtCase)s);
-            }
-            return;
-        } else if (targetParent instanceof CtLoop) {
+			for (CtStatement s : statementsToBeInserted) {
+				if (! (s instanceof CtCase)) {
+					throw new RuntimeException("cannot insert something that is not case in a switch");
+				}
+			}
+			int i=0;
+			for (CtStatement s : ((CtSwitch<?>) targetParent).getCases()) {
+				if (s == target) {
+					break;
+				}
+				i++;
+			}
+			for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
+				CtStatement s = statementsToBeInserted.getStatements().get(j);
+				((CtSwitch<?>) targetParent).getCases().add(i, (CtCase)s);
+			}
+			return;
+		} else if (targetParent instanceof CtLoop) {
 			CtStatement stat = ((CtLoop) targetParent).getBody();
 			if (stat instanceof CtBlock) {
 				parentBlock = (CtBlock<?>) stat;
-                ((CtBlock<?>) stat).insertBegin(statementsToBeInserted);
-                return;
+				((CtBlock<?>) stat).insertBegin(statementsToBeInserted);
+				return;
 			} else {
 				CtBlock<?> block = target.getFactory().Core().createBlock();
 				block.getStatements().add(stat);
@@ -133,27 +131,27 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements
 				parentBlock = block;
 			}
 		} else if (targetParent instanceof CtCase) {
-            int i=0;
-            for (CtStatement s : ((CtCase<?>) targetParent).getStatements()) {
-                if (s == target) {
-                    break;
-                }
-                i++;
-            }
-            for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
-                CtStatement s = statementsToBeInserted.getStatements().get(j);
-                ((CtCase<?>) targetParent).getStatements().add(i, s);
-            }
-            return;
-        } else {
+			int i=0;
+			for (CtStatement s : ((CtCase<?>) targetParent).getStatements()) {
+				if (s == target) {
+					break;
+				}
+				i++;
+			}
+			for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
+				CtStatement s = statementsToBeInserted.getStatements().get(j);
+				((CtCase<?>) targetParent).getStatements().add(i, s);
+			}
+			return;
+		} else {
 			parentBlock = (CtBlock<?>) targetParent;// BCUTAG bad cast
 		}
 
-        if (!(parentBlock instanceof CtBlock)) {
-            throw new RuntimeException("can not add a statement that is not in a block");
-        }
+		if (!(parentBlock instanceof CtBlock)) {
+			throw new RuntimeException("can not add a statement that is not in a block");
+		}
 
-        int indexOfTargetElement = 0;
+		int indexOfTargetElement = 0;
 		for (CtStatement s : parentBlock.getStatements()) {
 			if (s == target) {
 				break;

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -77,8 +77,8 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements
 		this.statements.remove(statement);
 	}
 
-    @Override
-    public Iterator<CtStatement> iterator() {
-        return statements.iterator();
-    }
+	@Override
+	public Iterator<CtStatement> iterator() {
+		return statements.iterator();
+	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -178,9 +178,9 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	public CtElement getParent() throws ParentNotInitializedException {
 		if (parent == null) {
-            String exceptionMsg ="";
+			String exceptionMsg ="";
 			if (this instanceof CtNamedElement) {
-                exceptionMsg =(
+				exceptionMsg =(
 						"parent not initialized for "
 								+ ((CtNamedElement) this).getSimpleName()
 								+ (getPosition() != null ? " " + getPosition()
@@ -192,7 +192,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 								+ (getPosition() != null ? " " + getPosition()
 										: " (?)"));
 			}
-            throw new ParentNotInitializedException(exceptionMsg);
+			throw new ParentNotInitializedException(exceptionMsg);
 		}
 		if (parent == ROOT_ELEMENT) {
 			return null;

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -47,7 +47,7 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements
 		v.visitCtParameter(this);
 	}
 
-    @Override
+	@Override
 	public CtExpression<T> getDefaultExpression() {
 		return defaultExpression;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -55,7 +55,7 @@ public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T>
 
 	@Override
 	public String getQualifiedName() {
-                 return Array.class.getCanonicalName();
+				 return Array.class.getCanonicalName();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -27,7 +27,7 @@ import spoon.reflect.declaration.CtSimpleType;
  * 
  * <p>
  * To define a new statement list template parameter, you must subclass this
- * class and implement the {@link #statements()} method, which actually defines
+ * class and implement the {@link #statement()} method, which actually defines
  * the Java statements. It corresponds to a
  * {@link spoon.reflect.code.CtStatementList}.
  */

--- a/src/main/java/spoon/template/TemplateParameter.java
+++ b/src/main/java/spoon/template/TemplateParameter.java
@@ -34,6 +34,8 @@ public interface TemplateParameter<T> {
 	 * marker in a template code. When generating a template code, each
 	 * invocation of this method will be substituted with the result of the
 	 * {@link #getSubstitution(CtSimpleType)} method.
+	 *
+	 * @return the parameter
 	 */
 	T S();
 
@@ -44,6 +46,8 @@ public interface TemplateParameter<T> {
 	 * @param targetType
 	 *            the type that defines the context of the substitution (for
 	 *            reference redirection).
+	 *
+	 * @return the substitution code element
 	 */
 	CtCodeElement getSubstitution(CtSimpleType<?> targetType);
 }


### PR DESCRIPTION
This pull request fixes problems with the javadocs which cause the build to fail during a release. This is necessary for #12 to be resolved.

The changes include:
- fixing wrong method and class references
- removing references to removed methods
- adding documentation to @return
- removing an unsued com.sun.\* import
