### PR TITLE
fixes testMain test

### DIFF
--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -2,18 +2,28 @@ package spoon.test.main;
 
 import org.junit.Test;
 
+import java.io.File;
+
+import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
+
 public class MainTest {
 
 	@Test
 	public void testMain() throws Exception {
-		
-		
-		String systemClassPath = System.getProperty("java.class.path");
 
 		// we have to remove the test-classes folder
 		// so that the precondition of --source-classpath is not violated
 		// (target/test-classes contains src/test/resources which itself contains Java files)
-		systemClassPath = systemClassPath.replaceAll("(:|^)[^:]*test-classes:", "$1");
+		StringBuilder classpath = new StringBuilder();
+		for (String classpathEntry : System.getProperty("java.class.path").split(File.pathSeparator))
+		{
+			if (!classpathEntry.contains("test-classes"))
+			{
+				classpath.append(classpathEntry);
+				classpath.append(JDTBasedSpoonCompiler.CLASSPATH_ELEMENT_SEPARATOR);
+			}
+		}
+		String systemClassPath = classpath.substring(0, classpath.length() - 1);
 		
 		spoon.Launcher.main(new String[] { "-i", "src/main/java", "-o",
 				"target/spooned", "--source-classpath",


### PR DESCRIPTION
This pull request based on #25 
I replaced the regex with a better readable system (at least it's better readable to me). The code splits the classpath into the single entries and adds every entry which doesn't contain the string "test-classes" to the new classpath. The new classpath also use the spoon related separator. 
