### PR TITLE
changes Log4j settings

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %p %c - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.File=${user.home}/spoon-log.log
+log4j.appender.R.File=${java.io.tmpdir}/spoon-log.log
 
 log4j.appender.R.MaxFileSize=1000KB
 log4j.appender.R.MaxBackupIndex=3


### PR DESCRIPTION
Another thing which has to be done before you release spoon in central is to change the current log4j log settings. 

I started with three simple changes. 
1. I set the root log level to info, because, I don't want to see the debug messages of every dependency of my project which uses the log4j logger. 
2. I removed the file appender from the root logger and added it to the spoon logger. Now just the spoon logs are stored in the file. Before this change logs from every log4j logger were stored in the file. 
3. I changed the location of the file. To me it's annoying to remove thousands of spoon log files from the user directory again and again. Therefore the new directory is the temp directory. One sees log messages in the console and can move the file if one wants to store it. Otherwise the file will be deleted with the next reboot. 

What do you thing? 
