### PR TITLE
removes classpath element separator constant 

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -69,8 +69,6 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 	// private Logger logger = Logger.getLogger(SpoonBuildingManager.class);
 
-	public static final String CLASSPATH_ELEMENT_SEPARATOR = ":";
-
 	public int javaCompliance = 7;
 
 	String sourceClasspath = null;
@@ -880,7 +878,7 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 	@Override
 	public void setSourceClasspath(String classpath) {
 		for (String classPathElem : classpath
-				.split(CLASSPATH_ELEMENT_SEPARATOR)) {
+				.split(File.pathSeparator)) {
 			// preconditions
 			File classOrJarFolder = new File(classPathElem);
 			if (!classOrJarFolder.exists()) {

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -4,8 +4,6 @@ import org.junit.Test;
 
 import java.io.File;
 
-import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
-
 public class MainTest {
 
 	@Test
@@ -20,7 +18,7 @@ public class MainTest {
 			if (!classpathEntry.contains("test-classes"))
 			{
 				classpath.append(classpathEntry);
-				classpath.append(JDTBasedSpoonCompiler.CLASSPATH_ELEMENT_SEPARATOR);
+				classpath.append(File.pathSeparator);
 			}
 		}
 		String systemClassPath = classpath.substring(0, classpath.length() - 1);


### PR DESCRIPTION
This pull request fixes #24
It removes the classpath element separator constant and uses the path separator constant of the File class instead. 

I hope you want this change but it's the only reasonable possibility for this. 
