### PR TITLE
Test and fix for a bug with getAllExecutables() that does not recurse into the type hierarchy for CtInterface.

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -459,6 +459,13 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 					l.addAll(st.getAllExecutables());
 				}
 			}
+			if( t instanceof CtInterface ) {
+				Set<CtTypeReference<?>> sups =
+					((CtInterface<?>) t).getSuperInterfaces();
+				for (CtTypeReference<?> sup : sups) {
+					l.addAll(sup.getAllExecutables());
+				}
+			}
 		}
 		return l;
 	}

--- a/src/test/java/spoon/test/reference/Foo.java
+++ b/src/test/java/spoon/test/reference/Foo.java
@@ -1,0 +1,9 @@
+package spoon.test.reference;
+
+public interface Foo extends Sup {
+	void foo();
+}
+
+interface Sup {
+	void sup();
+}

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -1,0 +1,45 @@
+package spoon.test.reference;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
+
+/**
+ * @author Lionel Seinturier <Lionel.Seinturier@univ-lille1.fr>
+ */
+public class TypeReferenceTest {
+
+	@Test
+	public void testGetAllExecutablesForInterfaces() throws Exception {
+		
+		/*
+		 * This test has been written because getAllExecutables wasn't recursing
+		 * into the type hierarchy for interfaces.
+		 */
+		
+		Launcher spoon = new Launcher();
+		Factory factory = spoon.createFactory();
+		spoon.createCompiler(
+			factory,
+			SpoonResourceHelper
+				.resources("./src/test/java/spoon/test/reference/Foo.java"))
+			.build();
+		
+		CtInterface<Foo> foo =
+			factory.Package().get("spoon.test.reference").getType("Foo");
+		Collection<CtExecutableReference<?>> execs =
+			foo.getReference().getAllExecutables();
+		
+		assertEquals(2,execs.size());
+	}
+	
+	
+}


### PR DESCRIPTION
Subject says it all.

This pull request comes with a fix ... and a test (private joke for @monperrus)

Lionel.
