### PR TITLE
Disable filtering for log4j properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,16 @@
       <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
+        <excludes>
+          <exclude>log4j.properties</exclude>
+        </excludes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <includes>
+          <include>log4j.properties</include>
+        </includes>
       </resource>
     </resources>
 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -7,7 +7,7 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %p %c - %m%n
 
 log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.File=spoon-log.log
+log4j.appender.R.File=${java.io.tmpdir}/spoon-log.log
 
 log4j.appender.R.MaxFileSize=1000KB
 log4j.appender.R.MaxBackupIndex=3


### PR DESCRIPTION
Change pom.xml to include `log4j.properties` in resources not filtered and add path to temp directory for logs of Spoon.

This PR may fix issue #12 to push on Maven.
