### PR TITLE
feat #63 Refactors ImportScanner to get imports for a class

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -1,0 +1,21 @@
+package spoon.reflect.visitor;
+
+import spoon.reflect.declaration.CtSimpleType;
+import spoon.reflect.reference.CtTypeReference;
+
+import java.util.Collection;
+
+public interface ImportScanner {
+	/**
+	 * Computes import of a {@link spoon.reflect.declaration.CtSimpleType}
+	 * (represent a class).
+	 *
+	 * @return Imports computes by Spoon, not original imports.
+	 */
+	Collection<CtTypeReference<?>> computeImports(CtSimpleType<?> simpleType);
+
+	/**
+	 * Checks if the type is already imported.
+	 */
+	boolean isImported(CtTypeReference<?> ref);
+}

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -1,0 +1,161 @@
+package spoon.reflect.visitor;
+
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTargetedAccess;
+import spoon.reflect.declaration.*;
+import spoon.reflect.reference.*;
+
+import java.lang.annotation.Annotation;
+import java.util.*;
+
+/**
+ * A scanner that calculates the imports for a given model.
+ */
+public class ImportScannerImpl extends CtScanner implements ImportScanner {
+	private Map<String, CtTypeReference<?>> imports = new TreeMap<String, CtTypeReference<?>>();
+
+	/**
+	 * Calculates needed imports for the given field access.
+	 */
+	@Override
+	public <T> void visitCtTargetedAccess(CtTargetedAccess<T> targetedAccess) {
+		enter(targetedAccess);
+		scan(targetedAccess.getVariable());
+		// scan(fieldAccess.getType());
+		scan(targetedAccess.getAnnotations());
+		scanReferences(targetedAccess.getTypeCasts());
+		scan(targetedAccess.getVariable());
+		scan(targetedAccess.getTarget());
+		exit(targetedAccess);
+	}
+
+	@Override
+	public <T> void visitCtFieldReference(CtFieldReference<T> reference) {
+		enterReference(reference);
+		scan(reference.getDeclaringType());
+		// scan(reference.getType());
+		exitReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtExecutableReference(
+			CtExecutableReference<T> reference) {
+		enterReference(reference);
+		if (reference.getDeclaringType() != null
+				&& reference.getDeclaringType().getDeclaringType() == null) {
+			addImport(reference.getDeclaringType());
+		}
+		scanReferences(reference.getActualTypeArguments());
+		exitReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
+		// For a ctinvocation, we don't have to import declaring type
+		scan(invocation.getTarget());
+	}
+
+	@Override
+	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+		if (!(reference instanceof CtArrayTypeReference)) {
+			if (reference.getDeclaringType() == null) {
+				addImport(reference);
+			} else {
+				addImport(reference.getDeclaringType());
+			}
+		}
+		super.visitCtTypeReference(reference);
+
+	}
+
+	@Override
+	public <A extends Annotation> void visitCtAnnotationType(
+			CtAnnotationType<A> annotationType) {
+		addImport(annotationType.getReference());
+		super.visitCtAnnotationType(annotationType);
+	}
+
+	@Override
+	public <T extends Enum<?>> void visitCtEnum(CtEnum<T> ctEnum) {
+		addImport(ctEnum.getReference());
+		super.visitCtEnum(ctEnum);
+	}
+
+	@Override
+	public <T> void visitCtInterface(CtInterface<T> intrface) {
+		addImport(intrface.getReference());
+		for (CtSimpleType<?> t : intrface.getNestedTypes()) {
+			addImport(t.getReference());
+		}
+		super.visitCtInterface(intrface);
+	}
+
+	@Override
+	public <T> void visitCtClass(CtClass<T> ctClass) {
+		addImport(ctClass.getReference());
+		for (CtSimpleType<?> t : ctClass.getNestedTypes()) {
+			addImport(t.getReference());
+		}
+		super.visitCtClass(ctClass);
+	}
+
+	@Override
+	public Collection<CtTypeReference<?>> computeImports(
+			CtSimpleType<?> simpleType) {
+		addImport(simpleType.getReference());
+		scan(simpleType);
+		return getImports(simpleType);
+	}
+
+	@Override
+	public boolean isImported(CtTypeReference<?> ref) {
+		if (imports.containsKey(ref.getSimpleName())) {
+			CtTypeReference<?> exist = imports.get(ref.getSimpleName());
+			if (exist.getQualifiedName().equals(ref.getQualifiedName())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Gets imports in imports Map for the key simpleType given.
+	 *
+	 * @param simpleType
+	 * @return Collection of {@link spoon.reflect.reference.CtTypeReference}
+	 */
+	private Collection<CtTypeReference<?>> getImports(
+			CtSimpleType<?> simpleType) {
+		if (imports.isEmpty()) {
+			return Collections.EMPTY_LIST;
+		}
+		CtPackageReference pack = ((CtTypeReference<?>) imports
+				.get(simpleType.getSimpleName())).getPackage();
+		Collection<CtTypeReference<?>> refs = new ArrayList<CtTypeReference<?>>();
+		for (CtTypeReference ref : imports.values()) {
+			// ignore non-top-level type
+			if (ref.getPackage() != null) {
+				// ignore java.lang package
+				if (!ref.getPackage().getSimpleName().equals("java.lang")) {
+					// ignore type in same package
+					if (!ref.getPackage().getSimpleName()
+							.equals(pack.getSimpleName())) {
+						refs.add(ref);
+					}
+				}
+			}
+		}
+		return Collections.unmodifiableCollection(refs);
+	}
+
+	/**
+	 * Adds a type to the imports.
+	 */
+	private boolean addImport(CtTypeReference<?> ref) {
+		if (imports.containsKey(ref.getSimpleName())) {
+			return isImported(ref);
+		}
+		imports.put(ref.getSimpleName(), ref);
+		return true;
+	}
+}

--- a/src/test/java/spoon/test/SampleImportClass.java
+++ b/src/test/java/spoon/test/SampleImportClass.java
@@ -1,0 +1,38 @@
+package spoon.test;
+
+import java.util.Collections;
+import java.util.List;
+
+public class SampleImportClass {
+
+	public SampleImportClass() {
+		new Thread() {
+		};
+	}
+
+	public SampleImportClass(int j) {
+		this(j, 0);
+		new Thread() {
+		};
+		List emptyList = Collections.EMPTY_LIST;
+	}
+
+	public SampleImportClass(int j, int k) {
+		super();
+		new Thread() {
+		};
+	}
+	
+	void method() {
+	}
+
+	void method2() {
+		new Thread() {
+		};
+	}
+
+	Thread method3() {
+		return new Thread() {
+		};
+	}
+}

--- a/src/test/java/spoon/test/imports/ImportScannerTest.java
+++ b/src/test/java/spoon/test/imports/ImportScannerTest.java
@@ -1,0 +1,39 @@
+package spoon.test.imports;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.declaration.CtSimpleType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.ImportScanner;
+import spoon.reflect.visitor.ImportScannerImpl;
+import spoon.test.TestUtils;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by gerard on 14/10/2014.
+ */
+public class ImportScannerTest {
+
+	@Test
+	public void testComputeImportsInClass() throws Exception {
+		String packageName = "spoon.test";
+		String className = "SampleImportClass";
+		String qualifiedName = packageName + "." + className;
+
+		Factory aFactory = TestUtils.build(packageName, className).getFactory();
+		CtSimpleType<?> theClass = aFactory.Type().get(qualifiedName);
+
+		ImportScanner importContext = new ImportScannerImpl();
+		Collection<CtTypeReference<?>> imports = importContext
+				.computeImports(theClass);
+
+		assertEquals(2, imports.size());
+	}
+}


### PR DESCRIPTION
Create a new class for the old inner class ImportScanner,
CtImportScanner, and his new interface, CtImport, to have a
contract to retrieve all imports for a CtSimpleType element
(represent a class, an interface or an annotation). And
add a new test case to check if we are all useful imports.
