### PR TITLE
modifies OutputType enum

### DIFF
--- a/src/main/java/spoon/OutputType.java
+++ b/src/main/java/spoon/OutputType.java
@@ -1,40 +1,43 @@
 package spoon;
 
+import java.util.Locale;
+
 /**
  * Types of output.
  */
 public enum OutputType {
-	/** Analysis only, models are not pretty-printed to disk. */
-	NO_OUTPUT("noouput"),
+	/**
+	 * Analysis only, models are not pretty-printed to disk.
+	 */
+	NO_OUTPUT,
 
-	/** One file per top-level class. */
-	CLASSES("classes"),
+	/**
+	 * One file per top-level class.
+	 */
+	CLASSES,
 
-	/** Follows the compilation units given by the input. */
-	COMPILATION_UNITS("compilationunits");
-
-	String string;
-
-	private OutputType(String string) {
-		this.string = string;
-	}
+	/**
+	 * Follows the compilation units given by the input.
+	 */
+	COMPILATION_UNITS;
 
 	@Override
 	public String toString() {
-		return string;
+		return this.name().toLowerCase(Locale.US).replaceAll("_", "");
 	}
 
 	/**
 	 * Gets the output type from an option string.
-	 * 
-	 * @param string
-	 *            the string, as given in the launcher's options
+	 *
+	 * @param string the string, as given in the launcher's options
+	 *
 	 * @return the corresponding output type, null if no match is found
+	 *
 	 * @see Launcher#printUsage()
 	 */
 	public static OutputType fromString(String string) {
 		for (OutputType outputType : OutputType.values()) {
-			if (outputType.string.equals(string)) {
+			if (outputType.toString().equals(string)) {
 				return outputType;
 			}
 		}

--- a/src/test/java/spoon/test/OutputTypeTest.java
+++ b/src/test/java/spoon/test/OutputTypeTest.java
@@ -1,0 +1,25 @@
+package spoon.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import spoon.OutputType;
+
+public class OutputTypeTest {
+
+	@Test
+	public void testOutputTypeLoading()
+	{
+		OutputType outputType = OutputType.fromString("nulltest");
+		Assert.assertNull(outputType);
+
+		outputType = OutputType.fromString("nooutput");
+		Assert.assertEquals(OutputType.NO_OUTPUT, outputType);
+
+		outputType = OutputType.fromString("classes");
+		Assert.assertEquals(OutputType.CLASSES, outputType);
+
+		outputType = OutputType.fromString("compilationunits");
+		Assert.assertEquals(OutputType.COMPILATION_UNITS, outputType);
+	}
+}


### PR DESCRIPTION
This pull request removes the string field of the OutputType enum because the values are producible without that field. This fixes #81
Furthermore I formatted the whole file with the formatter settings. 
