### PR TITLE
Changes on the menu of the website

### DIFF
--- a/00-examples.md
+++ b/00-examples.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Usage
+title: Examples
 permalink: /Spoon/Examples/
 ---
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -15,12 +15,12 @@
 
       <div class="trigger">
 
+          <a class="page-link" href="http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs">Javadoc</a>
         {% for page in site.pages %}
           {% if page.title %}
           <a class="page-link" href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a>
           {% endif %}
         {% endfor %}
-          <a class="page-link" href="http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs">Javadoc</a>
       </div>
     </nav>
 


### PR DESCRIPTION
Changes the position of the Javadoc link in the menu
and renames Usage link to Examples in the menu.
