### PR TITLE
Bug fixes #106 references of executables

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -19,6 +19,7 @@ package spoon.reflect.reference;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.List;
 
 import spoon.reflect.declaration.CtExecutable;
 
@@ -65,6 +66,16 @@ public interface CtExecutableReference<T> extends CtReference,
 	 * Gets the return type of the executable (may be null in noclasspath mode).
 	 */
 	CtTypeReference<T> getType();
+
+	/**
+	 * Gets parameters of the executable.
+	 */
+	List<CtTypeReference<?>> getParameters();
+
+	/**
+	 * Sets parameters of the executable.
+	 */
+	void setParameters(List<CtTypeReference<?>> parameters);
 
 	/**
 	 * Returns <code>true</code> if this executable overrides the given

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -367,10 +367,22 @@ public class JDTTreeBuilder extends ASTVisitor {
 			ref.setType((CtTypeReference<T>) getTypeReference(exec.returnType));
 			ref.setSimpleName(new String(exec.selector));
 			ref.setStatic(exec.isStatic());
-			if (exec.typeVariables != null) {
-				for (TypeVariableBinding b : exec.typeVariables) {
-					ref.addActualTypeArgument(getTypeReference(b));
+
+			// original() method returns a result not null when the current method is generic.
+			if (exec.original() != null) {
+				final List<CtTypeReference<?>> parameters = new ArrayList<CtTypeReference<?>>();
+				for (TypeBinding b : exec.original().parameters) {
+					parameters.add(getTypeReference(b));
 				}
+				ref.setParameters(parameters);
+			}
+			// This is a method without a generic argument.
+			else if (exec.parameters != null) {
+				final List<CtTypeReference<?>> parameters = new ArrayList<CtTypeReference<?>>();
+				for (TypeBinding b : exec.parameters) {
+					parameters.add(getTypeReference(b));
+				}
+				ref.setParameters(parameters);
 			}
 
 			return ref;

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -22,12 +22,14 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
 import spoon.Launcher;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtSimpleType;
@@ -50,6 +52,8 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 	CtTypeReference<?> declaringType;
 
 	CtTypeReference<T> type;
+
+	List<CtTypeReference<?>> parameters = CtElementImpl.EMPTY_LIST();
 
 	public CtExecutableReferenceImpl() {
 		super();
@@ -134,19 +138,20 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 			return null;
 		}
 
-		CtExecutable<?> ret = typeDecl.getMethod(getSimpleName(),
-				actualTypeArguments.toArray(new CtTypeReference<?>[0]));
-		if ((ret == null) && (typeDecl instanceof CtClass)
+		CtExecutable<T> method = typeDecl
+				.getMethod(getSimpleName(), parameters.toArray(
+						new CtTypeReferenceImpl<?>[parameters.size()]));
+		if ((method == null) && (typeDecl instanceof CtClass)
 				&& (getSimpleName().equals("<init>"))) {
 			try {
 				return (CtExecutable<T>) ((CtClass<?>) typeDecl)
-						.getConstructor(actualTypeArguments
-								.toArray(new CtTypeReference<?>[0]));
+						.getConstructor(parameters.toArray(
+								new CtTypeReferenceImpl<?>[parameters.size()]));
 			} catch (ClassCastException e) {
 				Launcher.logger.error(e.getMessage(), e);
 			}
 		}
-		return (CtExecutable<T>) ret;
+		return method;
 	}
 
 	public CtTypeReference<?> getDeclaringType() {
@@ -155,6 +160,19 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 
 	public CtTypeReference<T> getType() {
 		return type;
+	}
+
+	@Override
+	public List<CtTypeReference<?>> getParameters() {
+		return Collections.unmodifiableList(parameters);
+	}
+
+	@Override
+	public void setParameters(List<CtTypeReference<?>> parameters) {
+		if (this.parameters == CtElementImpl.<CtTypeReference<?>> EMPTY_LIST()) {
+			this.parameters = new ArrayList<CtTypeReference<?>>();
+			this.parameters.addAll(parameters);
+		}
 	}
 
 	@SuppressWarnings("unchecked")
@@ -366,7 +384,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 				.<CtTypeReference<?>> EMPTY_LIST()) {
 			actualTypeArguments = new ArrayList<CtTypeReference<?>>();
 		}
-		return actualTypeArguments.add(type);
+		return actualTypeArguments.add(actualTypeArgument);
 	}
 
 	@Override
@@ -376,7 +394,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 				.<CtTypeReference<?>> EMPTY_LIST()) {
 			return false;
 		}
-		return actualTypeArguments.remove(type);
+		return actualTypeArguments.remove(actualTypeArgument);
 	}
 
 }

--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -1,0 +1,283 @@
+package spoon.test.reference;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.reflect.visitor.filter.AbstractReferenceFilter;
+import spoon.reflect.visitor.filter.ReferenceTypeFilter;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Created by gerard on 21/11/2014.
+ */
+public class ExecutableReferenceGenericTest {
+
+	private Factory factory;
+	public static final String NAME_MY_CLASS_1 = "MyClass";
+
+	@Before
+	public void setUp() throws Exception {
+		Launcher spoon = new Launcher();
+		factory = spoon.createFactory();
+
+		SpoonCompiler compiler = spoon.createCompiler(
+				factory,
+				SpoonResourceHelper.resources(
+						"./src/test/java/spoon/test/reference/MyClass.java",
+						"./src/test/java/spoon/test/reference/MyClass2.java",
+						"./src/test/java/spoon/test/reference/MyClass3.java"));
+
+		compiler.build();
+	}
+
+	@Test
+	public void testReferencesBetweenConstructors() throws Exception {
+		final List<CtConstructor> constructors = getConstructorsByClass("MyClass");
+
+		CtConstructor emptyConstructor = constructors.get(0);
+		CtConstructor oneParamConstructor = constructors.get(1);
+		CtConstructor twoParamsConstructor = constructors.get(2);
+
+		// Empty constructor which has a reference to the constructor with one parameter.
+		List<CtExecutableReference> refConstructors = getCtConstructorsByCtConstructor(emptyConstructor);
+		assertEquals(1, refConstructors.size());
+		assertEquals(1, refConstructors.get(0).getDeclaration().getParameters().size());
+		assertEquals(oneParamConstructor, refConstructors.get(0).getDeclaration());
+
+		// Constructor with one parameter which has a reference to the constructor with two parameter.
+		refConstructors = getCtConstructorsByCtConstructor(oneParamConstructor);
+		assertEquals(1, refConstructors.size());
+		assertEquals(2, refConstructors.get(0).getDeclaration().getParameters().size());
+		assertEquals(twoParamsConstructor, refConstructors.get(0).getDeclaration());
+	}
+
+	@Test
+	public void testReferencesBetweenConstructorsInOtherClass() throws Exception {
+		final List<CtConstructor> constructors = getConstructorsByClass("MyClass2");
+		final CtConstructor ctConstructor = constructors.get(0);
+		final List<CtExecutableReference> refConstructors = getCtConstructorsByCtConstructor(ctConstructor);
+
+		final CtClass<?> clazz1 = getCtClassByName("MyClass");
+		final CtConstructor emptyConstructorClass1 = getConstructorsByClass(clazz1.getSimpleName()).get(0);
+		final CtClass<?> clazz3 = getCtClassByName("MyClass3");
+		final CtConstructor emptyConstructorClass3 = getConstructorsByClass(clazz3.getSimpleName()).get(0);
+
+		assertEquals(3, refConstructors.size());
+		assertEquals(0, emptyConstructorClass1.getParameters().size());
+		assertEquals(0, emptyConstructorClass3.getParameters().size());
+		assertNull(refConstructors.get(0).getDeclaration()); // reference to Object constructor.
+		assertEquals(emptyConstructorClass1, refConstructors.get(1).getDeclaration());
+		assertEquals(emptyConstructorClass3, refConstructors.get(2).getDeclaration());
+	}
+
+	@Test
+	public void testOneReferenceBetweenMethodsInSameClass() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+
+		CtMethod<?> method1 = getCtMethodByNameFromCtClass(clazz, "method1");
+		List<CtExecutableReference> refsMethod1 = getReferencesOfAMethod(method1);
+		CtMethod<?> expected = getCtMethodByNameFromCtClass(clazz, "method2");
+
+		assertEquals(1, refsMethod1.size());
+		assertEquals(expected, refsMethod1.get(0).getDeclaration());
+	}
+
+	@Test
+	public void testMultiReferenceBetweenMethodsWithGenericInSameClass() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+
+		CtMethod<?> method2 = getCtMethodByNameFromCtClass(clazz, "method2");
+		List<CtExecutableReference> refsMethod2 = getReferencesOfAMethod(method2);
+		CtMethod<?> expectedMethod1 = getCtMethodByNameFromCtClass(clazz, "method1");
+		CtMethod<?> expectedMethod5 = getCtMethodByNameFromCtClass(clazz, "method5");
+
+		assertEquals(3, refsMethod2.size());
+		assertEquals(expectedMethod1, refsMethod2.get(0).getDeclaration());
+		assertEquals(expectedMethod1, refsMethod2.get(1).getDeclaration());
+		assertEquals(expectedMethod5, refsMethod2.get(2).getDeclaration());
+	}
+
+	@Test
+	public void testMultiReferencesBetweenMethodsWithoutGenericInSameClass() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+
+		CtMethod<?> method3 = getCtMethodByNameFromCtClass(clazz, "method3");
+		List<CtExecutableReference> refsMethod3 = getReferencesOfAMethod(method3);
+		CtMethod<?> expectedMethod2 = getCtMethodByNameFromCtClass(clazz, "method2");
+		CtMethod<?> expectedMethod4 = getCtMethodByNameFromCtClass(clazz, "method4");
+
+		assertEquals(2, refsMethod3.size());
+		assertEquals(expectedMethod2, refsMethod3.get(0).getDeclaration());
+		assertEquals(expectedMethod4, refsMethod3.get(1).getDeclaration());
+	}
+
+	@Test
+	public void testMethodWithoutReferences() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+
+		CtMethod<?> method4 = getCtMethodByNameFromCtClass(clazz, "method4");
+		List<CtExecutableReference> refsMethod4 = getReferencesOfAMethod(method4);
+
+		assertEquals(0, refsMethod4.size());
+	}
+
+	@Test
+	public void testMethodGenericWithoutReferences() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+
+		CtMethod<?> method5 = getCtMethodByNameFromCtClass(clazz, "method5");
+		List<CtExecutableReference> refsMethod5 = getReferencesOfAMethod(method5);
+
+		assertEquals(0, refsMethod5.size());
+	}
+
+	@Test
+	public void testOneReferenceWithGenericMethodOutOfTheClass() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+		final CtClass<?> clazz2 = getCtClassByName("MyClass2");
+
+		CtMethod<?> methodA = getCtMethodByNameFromCtClass(clazz2, "methodA");
+		List<CtExecutableReference> refsMethodA = getReferencesOfAMethod(methodA);
+		CtMethod<?> expectedMethod1 = getCtMethodByNameFromCtClass(clazz, "method1");
+
+		assertEquals(1, refsMethodA.size());
+		assertEquals(expectedMethod1, refsMethodA.get(0).getDeclaration());
+	}
+
+	@Test
+	public void testOneReferenceWithMethodNotGenericOutOfTheClass() throws Exception {
+		final CtClass<?> clazz = getCtClassByName("MyClass");
+		final CtClass<?> clazz2 = getCtClassByName("MyClass2");
+
+		CtMethod<?> methodB = getCtMethodByNameFromCtClass(clazz2, "methodB");
+		List<CtExecutableReference> refsMethodB = getReferencesOfAMethod(methodB);
+		CtMethod<?> expectedMethod2 = getCtMethodByNameFromCtClass(clazz, "method2");
+
+		assertEquals(1, refsMethodB.size());
+		assertEquals(expectedMethod2, refsMethodB.get(0).getDeclaration());
+	}
+
+	@Test
+	public void testMultiReferenceWithGenericMethodOutOfTheClass() throws Exception {
+		final CtClass<?> clazz2 = getCtClassByName("MyClass2");
+		final CtClass<?> clazz3 = getCtClassByName("MyClass3");
+
+		CtMethod<?> methodC = getCtMethodByNameFromCtClass(clazz2, "methodC");
+		List<CtExecutableReference> refsMethodC = getReferencesOfAMethod(methodC);
+		CtMethod<?> expectedMethodI = getCtMethodByNameFromCtClass(clazz3, "methodI");
+		CtMethod<?> expectedMethodII = getCtMethodByNameFromCtClass(clazz3, "methodII");
+
+		assertEquals(2, refsMethodC.size());
+		assertEquals(expectedMethodI, refsMethodC.get(0).getDeclaration());
+		assertEquals(expectedMethodII, refsMethodC.get(1).getDeclaration());
+	}
+
+	@Test
+	public void testReferencesBetweenMethods() throws Exception {
+		final CtClass<?> clazz2 = getCtClassByName("MyClass2");
+
+		CtMethod<?> methodD = getCtMethodByNameFromCtClass(clazz2, "methodD");
+
+		// Method D references the method E.
+		List<CtExecutableReference> refsMethodD = getReferencesOfAMethod(methodD);
+		CtMethod<?> expectedMethodE = getCtMethodByNameFromCtClass(clazz2, "methodE");
+		assertEquals(1, refsMethodD.size());
+		assertEquals(expectedMethodE, refsMethodD.get(0).getDeclaration());
+
+		// Method E references the method F.
+		List<CtExecutableReference> refsMethodE = getReferencesOfAMethod(expectedMethodE);
+		CtMethod<?> expectedMethodF = getCtMethodByNameFromCtClass(clazz2, "methodF");
+		assertEquals(1, refsMethodE.size());
+		assertEquals(expectedMethodF, refsMethodE.get(0).getDeclaration());
+	}
+
+	@Test
+	public void testExecutableReferences() throws Exception {
+		List<CtClass> classes = Query.getElements(factory, new TypeFilter<CtClass>(CtClass.class));
+
+		List<CtExecutableReference> refsExecutableClass1 = Query.getReferences(classes.get(0),
+				new AbstractReferenceFilter<CtExecutableReference>(CtExecutableReference.class) {
+					public boolean matches(CtExecutableReference reference) {
+						return true;
+					}
+				});
+
+		List<CtExecutableReference> refsExecutableClass2 = Query.getReferences(classes.get(1),
+				new AbstractReferenceFilter<CtExecutableReference>(CtExecutableReference.class) {
+					public boolean matches(CtExecutableReference reference) {
+						return true;
+					}
+				});
+
+		assertEquals(9, refsExecutableClass1.size());
+		for (CtExecutableReference ref : refsExecutableClass1) {
+			assertNotNull(ref);
+			if (!ref.toString().equals("java.lang.Object.Object")) {
+				assertNotNull(ref.getDeclaration());
+			}
+		}
+
+		assertEquals(9, refsExecutableClass2.size());
+		for (CtExecutableReference ref : refsExecutableClass2) {
+			assertNotNull(ref);
+			if (!ref.toString().equals("java.lang.Object.Object")) {
+				assertNotNull(ref.getDeclaration());
+			}
+		}
+	}
+
+	private List<CtConstructor> getConstructorsByClass(final String myClass) {
+		return Query.getElements(factory, new AbstractFilter<CtConstructor>(CtConstructor.class) {
+			@Override
+			public boolean matches(CtConstructor element) {
+				return myClass.equals(((CtClass) element.getParent()).getSimpleName());
+			}
+		});
+	}
+
+	private List<CtExecutableReference> getCtConstructorsByCtConstructor(CtConstructor emptyConstructor) {
+		return emptyConstructor.getReferences(new AbstractReferenceFilter<CtExecutableReference>(CtExecutableReference.class) {
+			@Override
+			public boolean matches(CtExecutableReference reference) {
+				return reference.isConstructor();
+			}
+		});
+	}
+
+	private CtClass<?> getCtClassByName(final String name) {
+		return Query.getElements(factory, new AbstractFilter<CtClass>(CtClass.class) {
+			@Override
+			public boolean matches(CtClass element) {
+				return name.equals(element.getSimpleName());
+			}
+		}).get(0);
+	}
+
+	private List<CtExecutableReference> getReferencesOfAMethod(CtMethod<?> method1) {
+		return method1.getReferences(new ReferenceTypeFilter<CtExecutableReference>(CtExecutableReference.class));
+	}
+
+	private CtMethod<?> getCtMethodByNameFromCtClass(CtClass<?> clazz, String nameMethod5) {
+		return clazz.getMethodsByName(nameMethod5).get(0);
+	}
+}

--- a/src/test/java/spoon/test/reference/MyClass.java
+++ b/src/test/java/spoon/test/reference/MyClass.java
@@ -1,0 +1,38 @@
+package spoon.test.reference;
+
+public class MyClass {
+	public MyClass() {
+		this("Default");
+	}
+
+	public MyClass(String param) {
+		this(param, 0);
+	}
+
+	public MyClass(String param, int paramint) {
+
+	}
+
+	public <T> void method1(T t) {
+		method2();
+	}
+
+	public void method2() {
+		method1("String");
+		method1(5);
+		method5(1, "Call method 5");
+	}
+
+	public void method3() {
+		method2();
+		method4("Call method 4");
+	}
+
+	public void method4(String param) {
+
+	}
+
+	public <S> void method5(S s, String s2) {
+
+	}
+}

--- a/src/test/java/spoon/test/reference/MyClass2.java
+++ b/src/test/java/spoon/test/reference/MyClass2.java
@@ -1,0 +1,35 @@
+package spoon.test.reference;
+
+public class MyClass2 {
+	final MyClass myClass;
+	final MyClass3<Integer, String> myClass3;
+
+	public MyClass2() {
+		myClass = new MyClass();
+		myClass3 = new MyClass3<Integer, String>();
+	}
+
+	public void methodA() {
+		myClass.method1("guyfez");
+	}
+
+	public void methodB() {
+		myClass.method2();
+	}
+
+	public void methodC() {
+		myClass3.methodI(1);
+		myClass3.methodII(42, "Call method II");
+	}
+
+	public void methodD() {
+		methodE("Call method B");
+	}
+
+	public void methodE(String param) {
+		methodF(42, "Call method C");
+	}
+
+	public void methodF(int param1, String param2) {
+	}
+}

--- a/src/test/java/spoon/test/reference/MyClass3.java
+++ b/src/test/java/spoon/test/reference/MyClass3.java
@@ -1,0 +1,12 @@
+package spoon.test.reference;
+
+public class MyClass3<T, K> {
+
+	public void methodI(T t) {
+
+	}
+
+	public void methodII(T t, K k) {
+
+	}
+}


### PR DESCRIPTION
Bug fixes the method getExecutableReference in JDTTreeBuilder class to build correct references for CtExecutable concepts and bug fixes getDeclaration method in CtExecutableReference to get the CtExecutable class according to its reference.
