### PR TITLE
fixes a bug in noclasspath mode

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -567,6 +567,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		public <T> CtFieldReference<T> getVariableReference(
 				FieldBinding varbin) {
 			CtFieldReference<T> ref = factory.Core().createFieldReference();
+			if (varbin == null) {
+				return ref;
+			}
 			ref.setSimpleName(new String(varbin.name));
 			ref.setType((CtTypeReference<T>) getTypeReference(varbin.type));
 
@@ -1775,7 +1778,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 	@Override
 	public boolean visit(FieldReference fieldReference, BlockScope scope) {
 		CtFieldAccess<Object> acc = factory.Core().createFieldAccess();
-		acc.setVariable(references.getVariableReference(fieldReference.binding));
+		CtFieldReference<Object> variableReference = references.getVariableReference(fieldReference.binding);
+		if (variableReference.getSimpleName()==null) {
+			variableReference.setSimpleName(new String(fieldReference.token));
+		}
+		acc.setVariable(variableReference);
 		acc.setType(references.getTypeReference(fieldReference.resolvedType));
 
 		// Hmmm Maybe this should not be commented, but I cannot see why we need

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -3,6 +3,7 @@ package spoon.test.api;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -12,7 +13,11 @@ import org.junit.Test;
 
 import spoon.Launcher;
 import spoon.SpoonException;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
@@ -74,6 +79,20 @@ public class NoClasspathTest {
 			invocations.get(0);
 			assertEquals("x.y.z.method()", method.getBody().getStatement(0).toString());
 		}
+		
+		{
+			CtMethod<?> method = clazz.getMethod("m3",new CtTypeReference[0]);
+			assertNotNull(method);
+			List<CtInvocation<?>> invocations = method.getElements(new TypeFilter<CtInvocation<?>>(CtInvocation.class));
+			assertEquals(1, invocations.size());
+			invocations.get(0);
+			CtLocalVariable statement = method.getBody().getStatement(0);
+			CtFieldAccess  fa = (CtFieldAccess) statement.getDefaultExpression();
+			assertTrue(fa.getTarget() instanceof CtInvocation);
+			assertEquals("field", fa.getVariable().getSimpleName());			
+			assertEquals("int x = first().field", statement.toString());
+		}
+
 	}
 	
 	@Test

--- a/src/test/resources/spoon/test/noclasspath/Foo.java
+++ b/src/test/resources/spoon/test/noclasspath/Foo.java
@@ -17,4 +17,8 @@ public class Foo extends Unknown {
 		x.first().second().third();
 	}
 	
+	void m3(){
+		int x = first().field; // field after call
+	}
+
 }


### PR DESCRIPTION
bug: "call().field" results in an exception at model building time
solution: handle the case in JDTTreeBuilder (2 minor changes)
