### PR TITLE
Fixes bug #112 about fields typed by arrays in an inner class.

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1470,9 +1470,8 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public <T> void visitCtNewArray(CtNewArray<T> newArray) {
 		enterCtExpression(newArray);
 
-		if (!(context.currentTopLevel instanceof CtAnnotationType)
-				&& (newArray.getParent(CtAnnotation.class)==null)
-				) {
+		if ((newArray.getParent(CtAnnotationType.class) == null)
+				&& (newArray.getParent(CtAnnotation.class) == null)) {
 			CtTypeReference<?> ref = newArray.getType();
 
 			if (ref != null) {

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -9,6 +9,8 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.gui.SpoonModelTree;
+import spoon.support.gui.SpoonTreeBuilder;
 import spoon.test.annotation.testclasses.AnnotParamTypeEnum;
 import spoon.test.annotation.testclasses.AnnotParamTypes;
 import spoon.test.annotation.testclasses.Bound;
@@ -284,5 +286,21 @@ public class AnnotationTest
 		assertEquals(1, annotations.size());
 		assertTrue(annotations.get(0).getAnnotatedElement().equals(annotationType));
 		assertEquals(CtAnnotatedElementType.ANNOTATION_TYPE, annotations.get(0).getAnnotatedElementType());
+	}
+
+	@Test
+	public void testAnnotationWithDefaultArrayValue() throws  Throwable{
+		final String res = "java.lang.Class<?>[] value() default {  };";
+
+		CtSimpleType<?> type = this.factory.Type().get("spoon.test.annotation.testclasses.AnnotArrayInnerClass");
+		CtSimpleType<?> annotationInnerClass = type.getNestedType("Annotation");
+		assertEquals("Annotation", annotationInnerClass.getSimpleName());
+		assertEquals(1, annotationInnerClass.getAnnotations().size());
+		assertEquals(res, annotationInnerClass.getField("value").toString());
+
+		CtSimpleType<?> annotation = this.factory.Type().get("spoon.test.annotation.testclasses.AnnotArray");
+		assertEquals("AnnotArray", annotation.getSimpleName());
+		assertEquals(1, annotation.getAnnotations().size());
+		assertEquals(res, annotation.getField("value").toString());
 	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotArray.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotArray.java
@@ -1,0 +1,9 @@
+package spoon.test.annotation.testclasses;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface AnnotArray {
+	public Class<?>[] value() default { };
+}

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java
@@ -1,0 +1,11 @@
+package spoon.test.annotation.testclasses;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public class AnnotArrayInnerClass {
+	@Retention(value = RetentionPolicy.RUNTIME)
+	public @interface Annotation {
+		public Class<?>[] value() default { };
+	}
+}


### PR DESCRIPTION
Fixes visitCtNewArray method in DefaultJavaPrettyPrinter class to print a correct default value for fields typed by arrays.
