### PR TITLE
Bug in getReferencedTypes

### DIFF
--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -7,26 +7,25 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 
 import org.junit.Test;
 
 import spoon.Launcher;
 import spoon.SpoonException;
-import spoon.reflect.code.CtFieldAccess;
-import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.*;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.visitor.SignaturePrinter;
 
 public class NoClasspathTest {
-
 	@Test
 	public void test() throws Exception {
 		// do we still have a correct model when the complete classpath is not given as input?
@@ -108,5 +107,36 @@ public class NoClasspathTest {
 		
 		assertEquals("#foo()", s);
 	}
-	
+
+	@Test
+	public void testGetStaticDependency() {
+		Launcher spoon = new Launcher();
+		spoon.getFactory().getEnvironment().setNoClasspath(true);
+		String workingDirectoryPath = System.getProperty("user.dir");
+		spoon.addInputResource(new FileSystemFile(new File(workingDirectoryPath +"/src/test/resources/spoon/test/noclasspath/Bar.java")));
+
+		CtTypeReference expectedType = spoon.getFactory().Class().createReference(javax.sound.sampled.AudioFormat.Encoding.class);
+
+		try {
+			spoon.run();
+			Factory factory = spoon.getFactory();
+			CtClass<Object> clazz = factory.Class().get("Bar");
+
+			CtMethod<?> method = clazz.getMethod("doSomething", new CtTypeReference[0]);
+			List<CtReturn> returns = method.getElements(new TypeFilter<CtReturn>(CtReturn.class));
+
+			HashSet<CtTypeReference> set = new HashSet<CtTypeReference>();
+
+			for(CtReturn response : returns) {
+				for(CtTypeReference<?> type : response.getReferencedTypes()) {
+					set.add(type);
+				}
+			}
+
+			assertEquals(true, set.contains(expectedType));
+		}
+		catch(Exception e) {
+			fail("Spoon compilation error - testGetQualifiedName method");
+		}
+	}
 }

--- a/src/test/resources/spoon/test/noclasspath/Bar.java
+++ b/src/test/resources/spoon/test/noclasspath/Bar.java
@@ -1,0 +1,9 @@
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioFormat.Encoding;
+import java.util.HashMap;
+
+public class Bar {
+    public AudioFormat doSomething() {
+        return new AudioFormat(Encoding.ALAW, (float)1.0, 8, 2, 1, (float)1.0, true, new HashMap<String, Object>());
+    }
+}


### PR DESCRIPTION
**Message from last commit in bug branch :**
Adds one unit test that failed when you try to git a static reference type (in this case Encoding class which is a static class belonging to java.sound.sampled.AudioFormat). AudioFormat class takes several arguments to be instantiated including an Encoding instance. But Encoding class is a special case : It has public attributes which returns an Encoding object. But when you spoon an AudioFormat instantiation, it seems that Encoding dependency is not detected. The unit test I tried is in NoClasspathTest test file. It simply spoons a Bar class containing one method (doSomething) returning an AudioFormat object. The test get type references from the return statement to check if Encoding type is there.