### PR TITLE
fixes two bugs introduces by ab6118b 

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -229,43 +229,41 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 	}
 	
 	public Method getActualMethod() {
-		for (Method m : getDeclaringType().getActualClass()
-				.getDeclaredMethods()) {
+		List<CtTypeReference<?>> parameters = this.getParameters();
+		
+		method_loop:
+		for (Method m : getDeclaringType().getActualClass().getDeclaredMethods()) {
 			if (!m.getName().equals(getSimpleName())) {
 				continue;
 			}
-			boolean matches = true;
-			for (int i = 0; i < m.getParameterTypes().length; i++) {
-				if (m.getParameterTypes()[i] != getActualTypeArguments().get(i)
-						.getActualClass()) {
-					matches = false;
-					break;
+			if (m.getParameterTypes().length != parameters.size()) {
+				continue;
+			}
+			for (int i = 0; i < parameters.size(); i++) {
+				if (m.getParameterTypes()[i] != parameters.get(i).getActualClass()) {
+					continue method_loop;
 				}
 			}
-			if (matches) {
-				return m;
-			}
+			
+			return m;
 		}
 		return null;
 	}
 
 	public Constructor<?> getActualConstructor() {
-		for (Constructor<?> c : getDeclaringType().getActualClass()
-				.getDeclaredConstructors()) {
-			if (c.getParameterTypes().length != getActualTypeArguments().size()) {
+		List<CtTypeReference<?>> parameters = this.getParameters();
+		
+		constructor_loop:
+		for (Constructor<?> c : getDeclaringType().getActualClass().getDeclaredConstructors()) {
+			if (c.getParameterTypes().length != parameters.size()) {
 				continue;
 			}
-			boolean matches = true;
-			for (int i = 0; i < c.getParameterTypes().length; i++) {
-				if (c.getParameterTypes()[i] != getActualTypeArguments().get(i)
-						.getActualClass()) {
-					matches = false;
-					break;
+			for (int i = 0; i < parameters.size(); i++) {
+				if (c.getParameterTypes()[i] != parameters.get(i).getActualClass()) {
+					continue constructor_loop;
 				}
 			}
-			if (matches) {
-				return c;
-			}
+			return c;
 		}
 		return null;
 	}

--- a/src/test/java/spoon/test/executable/ExecutableRefTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableRefTest.java
@@ -1,0 +1,67 @@
+package spoon.test.executable;
+
+import org.junit.Assert;
+import org.junit.Test;
+import spoon.reflect.code.*;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.test.TestUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+
+public class ExecutableRefTest {
+
+    @Test
+    public void methodTest() throws Exception {
+        CtAbstractInvocation<?> ctAbstractInvocation = this.getInvocationFromMethod("testMethod");
+        Assert.assertTrue(ctAbstractInvocation instanceof CtInvocation<?>);
+
+        CtExecutableReference<?> executableReference = ctAbstractInvocation.getExecutable();
+        Assert.assertNotNull(executableReference);
+
+        Method method = executableReference.getActualMethod();
+        Assert.assertNotNull(method);
+
+        Assert.assertEquals("Hello World", method.invoke(null, ((CtLiteral<?>) ctAbstractInvocation.getArguments().get(0)).getValue()));
+    }
+
+    @Test
+    public void constructorTest() throws Exception {
+        CtAbstractInvocation<?> ctAbstractInvocation = this.getInvocationFromMethod("testConstructor");
+        Assert.assertTrue(ctAbstractInvocation instanceof CtNewClass<?>);
+
+        CtExecutableReference<?> executableReference = ctAbstractInvocation.getExecutable();
+        Assert.assertNotNull(executableReference);
+
+        Constructor<?> constructor = executableReference.getActualConstructor();
+        Assert.assertNotNull(constructor);
+
+        Assert.assertEquals("Hello World", constructor.newInstance(((CtLiteral<?>) ctAbstractInvocation.getArguments().get(0)).getValue()));
+    }
+
+    private CtAbstractInvocation<?> getInvocationFromMethod(String methodName) throws Exception {
+        Factory factory = TestUtils.build(ExecutableRefTestSource.class);
+
+        CtClass<ExecutableRefTestSource> clazz = factory.Class().get(ExecutableRefTestSource.class);
+        Assert.assertNotNull(clazz);
+
+        List<CtMethod<?>> methods = clazz.getMethodsByName(methodName);
+        Assert.assertEquals(1, methods.size());
+
+        CtMethod<?> ctMethod = methods.get(0);
+        CtBlock<?> ctBody = (CtBlock<?>) ctMethod.getBody();
+        Assert.assertNotNull(ctBody);
+
+        List<CtStatement> ctStatements = ctBody.getStatements();
+        Assert.assertEquals(1, ctStatements.size());
+
+        CtStatement ctStatement = ctStatements.get(0);
+        Assert.assertTrue(ctStatement instanceof CtAbstractInvocation<?>);
+
+        return (CtAbstractInvocation<?>) ctStatement;
+    }
+}

--- a/src/test/java/spoon/test/executable/ExecutableRefTestSource.java
+++ b/src/test/java/spoon/test/executable/ExecutableRefTestSource.java
@@ -1,0 +1,12 @@
+package spoon.test.executable;
+
+public class ExecutableRefTestSource {
+    
+    public void testMethod() {
+        String.valueOf("Hello World");
+    }
+    
+    public void testConstructor() {
+        new String("Hello World");
+    }
+}


### PR DESCRIPTION
getActualMethod threw an OutOfBoundsException because it wasn't ensured that the java Method instance and the ExecutableRef have the same amount of parameters ([introduced here](https://github.com/INRIA/spoon/commit/ab6118bfd52e18cc5d296a70a89bebb1b222ea58#diff-21aad886cfe9c33552d811cbb87e539eL240)). Also fixes a bug that getActualMethod and getActualClass returned null because of using getActualTypeParameters instead of getParameters..

Also this PR refactors the code of the methods and removes a unnecessary variable