### PR TITLE
fix #60 when there are array of annotations in an annotation.

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -20,6 +20,7 @@ package spoon.reflect.declaration;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtTypeReference;
 
 /**
@@ -28,7 +29,7 @@ import spoon.reflect.reference.CtTypeReference;
  * @param <A>
  *            type of represented annotation
  */
-public interface CtAnnotation<A extends Annotation> extends CtElement {
+public interface CtAnnotation<A extends Annotation> extends CtExpression<A> {
 
 	/**
 	 * Returns the actual annotation (a dynamic proxy for this element).

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -317,8 +317,7 @@ public class ParentExiter extends CtInheritanceScanner {
 
 	@Override
 	public <T> void visitCtField(CtField<T> f) {
-		if (f.getDefaultExpression() == null
-				&& child instanceof CtExpression) {
+		if (f.getDefaultExpression() == null && child instanceof CtExpression && !(child instanceof CtAnnotation)) {
 			f.setDefaultExpression((CtExpression<T>) child);
 			return;
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -51,13 +51,15 @@ import spoon.reflect.eval.PartialEvaluator;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.reflect.code.CtExpressionImpl;
+import spoon.support.reflect.eval.VisitorPartialEvaluator;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotation}.
  *
  * @author Renaud Pawlak
  */
-public class CtAnnotationImpl<A extends Annotation> extends CtElementImpl
+public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A>
 		implements CtAnnotation<A> {
 	class AnnotationInvocationHandler implements InvocationHandler {
 		CtAnnotation<? extends Annotation> annotation;

--- a/src/test/java/spoon/test/annotation/testclasses/Foo.java
+++ b/src/test/java/spoon/test/annotation/testclasses/Foo.java
@@ -1,0 +1,19 @@
+package spoon.test.annotation.testclasses;
+
+public class Foo {
+	@OuterAnnotation({ @MiddleAnnotation(@InnerAnnotation("hello")), @MiddleAnnotation(@InnerAnnotation("hello again")) })
+	public void test() {
+	}
+
+	public @interface OuterAnnotation {
+		public MiddleAnnotation[] value();
+	}
+
+	public @interface MiddleAnnotation {
+		public InnerAnnotation value();
+	}
+
+	public @interface InnerAnnotation {
+		public String value();
+	}
+}


### PR DESCRIPTION
Changes inheritance of the CtAnnotation interface from `CtElement` to `CtExpression`. So we can add a `CtAnnotation` inner another `CtAnnotation` or an array in a `CtAnnotation`. And adds the test case in `AnnotationTest` class.