### PR TITLE
fix #114 Import of an inner class in a class package.

### DIFF
--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1,0 +1,41 @@
+package spoon.test.imports;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.NameFilter;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ImportTest {
+
+	@Test
+	public void testImportOfAnInnerClassInAClassPackage() throws Exception {
+		Launcher spoon = new Launcher();
+		Factory factory = spoon.createFactory();
+
+		SpoonCompiler compiler = spoon.createCompiler(
+				factory,
+				SpoonResourceHelper.resources(
+						"./src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java",
+						"./src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java",
+						"./src/test/java/spoon/test/imports/testclasses/ClientClass.java"));
+
+		compiler.build();
+
+		final List<CtClass<?>> classes = Query.getElements(factory, new NameFilter<CtClass<?>>("ClientClass"));
+
+		final CtClass<?> innerClass = classes.get(0).getNestedType("InnerClass");
+		String expected = "spoon.test.imports.testclasses.ClientClass.InnerClass";
+		assertEquals(expected, innerClass.getReference().toString());
+
+		expected = "spoon.test.imports.testclasses.internal.ChildClass.InnerClassProtected";
+		assertEquals(expected, innerClass.getSuperclass().toString());
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/ClientClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/ClientClass.java
@@ -1,0 +1,8 @@
+package spoon.test.imports.testclasses;
+
+import spoon.test.imports.testclasses.internal.ChildClass;
+
+public class ClientClass extends ChildClass {
+	private class InnerClass extends InnerClassProtected {
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java
@@ -1,0 +1,4 @@
+package spoon.test.imports.testclasses.internal;
+
+public class ChildClass extends SuperClass {
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java
@@ -1,0 +1,6 @@
+package spoon.test.imports.testclasses.internal;
+
+class SuperClass {
+	protected class InnerClassProtected {
+	}
+}


### PR DESCRIPTION
Sets the declaring type of a class with its enclosing type if we have a correct visibility to it or uses the super class of the current class analyzed to access at the correct declaring type. And adds test case in ImportTest class.