### PR TITLE
Remove uneeded toLowerCase() method call as the lower case version is

### DIFF
--- a/src/main/java/spoon/reflect/declaration/ModifierKind.java
+++ b/src/main/java/spoon/reflect/declaration/ModifierKind.java
@@ -52,6 +52,7 @@ public enum ModifierKind {
 	/**
 	 * Returns this modifier's name in lowercase.
 	 */
+	@Override
 	public String toString() {
 		if (lowercase == null) {
 			lowercase = name().toLowerCase(java.util.Locale.US);

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1468,7 +1468,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	public DefaultJavaPrettyPrinter writeModifiers(CtModifiable m) {
 		for (ModifierKind mod : m.getModifiers()) {
-			write(mod.toString().toLowerCase() + " ");
+			write(mod.toString() + " ");
 		}
 		return this;
 	}


### PR DESCRIPTION
Remove uneeded toLowerCase() method call as the lower case version is cached in the Enum type instances and returned by toString().