### PR TITLE
modifying CtVisitor and its subtypes for managing UnboundVariableReference

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
@@ -1,0 +1,28 @@
+/* 
+ * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006 INRIA Futurs <renaud.pawlak@inria.fr>
+ * 
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify 
+ * and/or redistribute the software under the terms of the CeCILL-C license as 
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info. 
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT 
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *  
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.reflect.reference;
+
+
+/**
+ * This interface defines a reference to an unbound
+ * {@link spoon.reflect.declaration.CtVariable.
+ */
+public interface CtUnboundVariableReference<T> extends CtVariableReference<T> {
+		
+
+}

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -63,6 +63,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 
 public abstract class CtAbstractVisitor implements CtVisitor {
 	/**
@@ -329,5 +330,10 @@ public abstract class CtAbstractVisitor implements CtVisitor {
 	}
 
 	public <T> void visitCtCatchVariableReference(CtCatchVariableReference<T> reference) {
+	}
+
+	
+	public <T> void visitCtUnboundVariableReference(CtUnboundVariableReference<T> reference) {
+		
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -96,6 +96,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 
 /**
@@ -104,6 +105,8 @@ import spoon.reflect.reference.CtVariableReference;
  * (abstract) supertype scanning methods.
  */
 public abstract class CtInheritanceScanner implements CtVisitor {
+
+
 
 	/**
 	 * Default constructor.
@@ -544,4 +547,8 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtLoop(whileLoop);
 	}
 
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		
+	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -80,6 +80,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 
 /**
  * This visitor implements a deep-search scan on the metamodel.
@@ -662,6 +663,12 @@ public abstract class CtScanner implements CtVisitor {
 	}
 
 	public void visitCtCodeSnippetStatement(CtCodeSnippetStatement statement) {
+	}
+
+
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		
 	}
 
 }

--- a/src/main/java/spoon/reflect/visitor/CtVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitor.java
@@ -75,6 +75,7 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 
 import java.lang.annotation.Annotation;
 
@@ -211,6 +212,12 @@ public interface CtVisitor {
 	 */
 	<T> void visitCtFieldReference(CtFieldReference<T> reference);
 
+	
+	/**
+	 * Visits a reference to an unbound field
+	 */
+	<T> void visitCtUnboundVariableReference(CtUnboundVariableReference<T> reference);
+	
 	/**
 	 * Visits a <code>for</code> loop.
 	 */

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -80,6 +80,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.support.reflect.cu.CtLineElementComparator;
 import spoon.support.util.SortedList;
 
@@ -2125,5 +2126,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	public PrintingContext getContext() {
 		return context;
+	}
+
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		write(reference.getSimpleName());
 	}
 }

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -92,6 +92,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.util.RtHelper;
@@ -812,6 +813,12 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 					conditional.getElseExpression()));
 			setResult(ifRes);
 		}
+	}
+
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		throw new RuntimeException("Unknow Element");
+		
 	}
 
 }

--- a/src/main/java/spoon/support/reflect/eval/VisitorSymbolicEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorSymbolicEvaluator.java
@@ -102,6 +102,7 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.Query;
@@ -1060,5 +1061,8 @@ public class VisitorSymbolicEvaluator implements CtVisitor, SymbolicEvaluator {
 		getHeap().store(target);
 		invoke(target, executable, args);
 
+	}
+	public <T> void visitCtUnboundVariableReference(CtUnboundVariableReference<T> reference) { 
+		throw new RuntimeException("Not evaluable");
 	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
@@ -1,7 +1,16 @@
 package spoon.support.reflect.reference;
 
+import spoon.reflect.reference.CtUnboundVariableReference;
+import spoon.reflect.visitor.CtVisitor;
+
 /** represents a reference to an unbound field (used when no full classpath is available */
-public class CtUnboundVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> {
+public class CtUnboundVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtUnboundVariableReference<T> {
 	private static final long serialVersionUID = -932423216089690817L;
 
+	public void accept(CtVisitor visitor) {
+		
+		visitor.visitCtUnboundVariableReference(this);
+	}
+
+	
 }

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -84,6 +84,7 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 
 public class SignaturePrinter implements CtVisitor {
@@ -557,6 +558,11 @@ public class SignaturePrinter implements CtVisitor {
 		scan(whileLoop.getLoopingExpression());
 		write(")");
 		scan(whileLoop.getBody());
+	}
+
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		write(reference.getSimpleName());
 	}
 
 }

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -3,6 +3,7 @@ package spoon.test.signature;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -74,12 +75,12 @@ public class SignatureTest {
 		SpoonCompiler builder = new JDTSnippetCompiler(factory, content);
 		try {
 			builder.build();
+			Assert.fail();
 		} catch (Exception e) {
 			// Must fail due to the unbound element "Complex.I"
 		}
 		CtClass<?> clazz1 = (CtClass<?>) factory.Type().getAll().get(0);
-		System.out.println();
-
+		
 		CtMethod<?> method = (CtMethod<?>) clazz1.getAllMethods().toArray()[0];
 
 		CtInvocation<?> invo = (CtInvocation<?>) method.getBody().getStatement(0);

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -8,12 +8,16 @@ import org.junit.Test;
 import java.util.HashSet;
 
 import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.jdt.JDTSnippetCompiler;
 
 public class SignatureTest {
 
@@ -23,7 +27,7 @@ public class SignatureTest {
 		// University of Lille) on Nov 4 2014
 		// in their analysis, they put CtExpressions in a Map
 		// if one expression has an empty signature, an exception is thrown
-		
+
 		// the solution is to improve the signature of null literals
 
 		Factory factory = new Launcher().createFactory();
@@ -45,6 +49,51 @@ public class SignatureTest {
 		HashSet<CtExpression<?>> s = new HashSet<CtExpression<?>>();
 		s.add(lit);
 		s.add(lit2);
+	}
+
+	@Test
+	public void testNullSignatureInUnboundVariable() throws Exception {
+		//Unbound variable access bug fix: 
+		//Bug description: The signature printer ignored the element Unbound variable reference 
+		//(as well all Visitor that extend CtVisitor)
+		//Fix description: modify CtVisitor (including SignaturePrinter) for visiting unbound variable access.
+		
+		
+		Factory factory = new Launcher().createFactory();
+		// We want to compile a class with an reference to a class that is not
+		// in the classpath
+		// As consequence, we set the option NoClasspath as true.
+		factory.getEnvironment().setNoClasspath(true);
+
+		String unboundVarAccess = "Complex.I";
+
+		String content = "" + "class X {" + "public Object foo() {"
+				+ " Integer.toString(" + unboundVarAccess + ");"
+				+ " return null;" + "}};";
+
+		SpoonCompiler builder = new JDTSnippetCompiler(factory, content);
+		try {
+			builder.build();
+		} catch (Exception e) {
+			// Must fail due to the unbound element "Complex.I"
+		}
+		CtClass<?> clazz1 = (CtClass<?>) factory.Type().getAll().get(0);
+		System.out.println();
+
+		CtMethod<?> method = (CtMethod<?>) clazz1.getAllMethods().toArray()[0];
+
+		CtInvocation<?> invo = (CtInvocation<?>) method.getBody().getStatement(0);
+
+		CtExpression<?> argument1 = (CtExpression<?>) invo.getArguments().get(0);
+
+		String signatureUnbound = argument1.getSignature();
+
+		assertTrue(unboundVarAccess.equals(signatureUnbound));
+
+		String toStringUnbound = argument1.toString();
+
+		assertTrue(unboundVarAccess.equals(toStringUnbound));
+
 	}
 
 }


### PR DESCRIPTION
Modifying CtVisitor and its subtypes for managing UnboundVariableReference elements. This change allows us to modify Signature for printing correctly the signature of Unbound elements