### PR TITLE
fix #126 Declaration of an executable reference is null in anonymous class

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -30,8 +30,10 @@ import java.util.TreeSet;
 
 import spoon.Launcher;
 import spoon.SpoonException;
+import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
@@ -46,6 +48,7 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.util.RtHelper;
 
@@ -177,9 +180,19 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 	
 	@SuppressWarnings("unchecked")
 	public CtSimpleType<T> getDeclaration() {
-		if (!isPrimitive() && (getQualifiedName().length() > 0)) {
+		if (!isPrimitive() && !isAnonymous()) {
 			return (CtSimpleType<T>) getFactory().Type()
 					.get(getQualifiedName());
+		}
+		if (!isPrimitive() && isAnonymous()) {
+			final CtSimpleType<?> rootType = getFactory().Type().get(getDeclaringType().getQualifiedName());
+			final CtNewClass elements = rootType.getElements(new AbstractFilter<CtNewClass>(CtNewClass.class) {
+				@Override
+				public boolean matches(CtNewClass element) {
+					return getSimpleName().equals(element.getAnonymousClass().getSimpleName());
+				}
+			}).get(0);
+			return elements.getAnonymousClass();
 		}
 		return null;
 	}
@@ -543,8 +556,14 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 		return new TreeSet<CtTypeReference<?>>();
 	}
 
+	@Override
 	public boolean isAnonymous() {
-		return getSimpleName().length() == 0;
+		try {
+			Integer.parseInt(getSimpleName());
+		} catch (NumberFormatException e) {
+			return false;
+		}
+		return true;
 	}
 
 	public boolean isSuperReference() {

--- a/src/test/java/spoon/test/reference/FooBar.java
+++ b/src/test/java/spoon/test/reference/FooBar.java
@@ -1,0 +1,25 @@
+package spoon.test.reference;
+
+public class FooBar {
+	public class Bar {
+	}
+
+	public class Foo {
+	}
+
+	public Foo getFoo() {
+		return new Foo() {
+			public void printString(String myArgFoo) {
+				System.out.println(myArgFoo);
+			}
+		};
+	}
+
+	public Bar getBar() {
+		return new Bar() {
+			public void printString(String myArg) {
+				System.out.println(myArg);
+			}
+		};
+	}
+}

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -1,0 +1,32 @@
+package spoon.test.reference;
+
+import org.junit.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.reference.CtParameterReference;
+import spoon.reflect.visitor.filter.AbstractReferenceFilter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static spoon.test.TestUtils.build;
+
+public class VariableAccessTest {
+
+	@Test
+	public void testVariableAccessDeclarationInAnonymousClass() throws Exception {
+		CtClass<?> type = build("spoon.test.reference", "FooBar");
+		assertEquals("FooBar", type.getSimpleName());
+
+		final CtParameterReference ref = type.getReferences(new AbstractReferenceFilter<CtParameterReference>(CtParameterReference.class) {
+			@Override
+			public boolean matches(CtParameterReference reference) {
+				return "myArg".equals(reference.getSimpleName());
+			}
+		}).get(0);
+
+		assertNotNull("Parameter can't be null", ref.getDeclaration());
+		assertNotNull("Declaring method reference can't be null", ref.getDeclaringExecutable());
+		assertNotNull("Declaring type of the method can't be null", ref.getDeclaringExecutable().getDeclaringType());
+		assertNotNull("Declaration of declaring type of the method can't be null", ref.getDeclaringExecutable().getDeclaringType().getDeclaration());
+		assertNotNull("Declaration of root class can't be null", ref.getDeclaringExecutable().getDeclaringType().getDeclaringType().getDeclaration());
+	}
+}

--- a/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
+++ b/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
@@ -72,11 +72,11 @@ public class ClassesTest {
 		CtClass<?> anonymousClass0 = x.getAnonymousClass();
 		CtClass<?> anonymousClass1 = y.getAnonymousClass();
 
-		assertEquals("0",anonymousClass0.getSimpleName());
-		assertEquals("1",anonymousClass1.getSimpleName());
+		assertEquals("1",anonymousClass0.getSimpleName());
+		assertEquals("2",anonymousClass1.getSimpleName());
 
-		assertEquals("spoon.test.secondaryclasses.AnonymousClass$0",anonymousClass0.getQualifiedName());
-		assertEquals("spoon.test.secondaryclasses.AnonymousClass$1",anonymousClass1.getQualifiedName());
+		assertEquals("spoon.test.secondaryclasses.AnonymousClass$1",anonymousClass0.getQualifiedName());
+		assertEquals("spoon.test.secondaryclasses.AnonymousClass$2",anonymousClass1.getQualifiedName());
 
 		// ActionListner is not in the Spoon path
 		assertNull(x.getType().getDeclaration());
@@ -86,7 +86,7 @@ public class ClassesTest {
 
 		assertNotNull(y.getType().getDeclaration());
 
-		assertEquals(".", y.getExecutable().toString());
+		assertEquals("spoon.test.secondaryclasses.AnonymousClass.2.2", y.getExecutable().toString());
 
 		// the superclass of an anonymous class can be an interface (the one
 		// from which it is built)
@@ -109,8 +109,8 @@ public class ClassesTest {
 		assertTrue(anonymousClass.get(0).isAnonymous());
 		assertTrue(anonymousClass.get(1).isAnonymous());
 		assertEquals(2, anonymousClass.size());
-		assertEquals("spoon.test.secondaryclasses.AnonymousClass$1", anonymousClass.get(0).getQualifiedName());
-		assertEquals("spoon.test.secondaryclasses.AnonymousClass$0", anonymousClass.get(1).getQualifiedName());
+		assertEquals("spoon.test.secondaryclasses.AnonymousClass$2", anonymousClass.get(0).getQualifiedName());
+		assertEquals("spoon.test.secondaryclasses.AnonymousClass$1", anonymousClass.get(1).getQualifiedName());
 	}
 
 	@Test


### PR DESCRIPTION
- Lets JDT computes anonymous class name.
- Gives a name for anonymous classes for elements and references.
- Fixes getDeclaration method in CtTypeReference to access at anonymous class elements.