### PR TITLE
revert #114 to rollback on a previous state of JDTTreeBuilder.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -528,27 +528,10 @@ public class JDTTreeBuilder extends ASTVisitor {
 					ref.setSimpleName("");
 				} else {
 					ref.setSimpleName(new String(binding.sourceName()));
-					if (binding.enclosingType() != null) {
-						// If we don't have access at the super class, we try to access it
-						// by the super class enclosing the current class (stack must to be
-						// not empty).
-						final CtTypeReference<?> enclosingType = getTypeReference(binding.enclosingType());
-						final Set<ModifierKind> modifiers = getModifiers(binding.enclosingType().modifiers);
-						if (modifiers.isEmpty()) {
-							if (!context.stack.isEmpty()) {
-								final CtElement clazz = context.stack.peek().element;
-								if (clazz instanceof CtClass<?>) {
-									ref.setDeclaringType(((CtClass<?>) clazz).getSuperclass());
-								} else {
-									ref.setDeclaringType(enclosingType);
-								}
-							} else {
-								ref.setDeclaringType(enclosingType);
-							}
-						} else {
-							ref.setDeclaringType(enclosingType);
-						}
-					} else
+					if (binding.enclosingType() != null)
+						ref.setDeclaringType(getTypeReference(binding
+								.enclosingType()));
+					else
 						ref.setPackage(getPackageReference(binding.getPackage()));
 					// if(((SourceTypeBinding) binding).typeVariables!=null &&
 					// ((SourceTypeBinding) binding).typeVariables.length>0){

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1,5 +1,6 @@
 package spoon.test.imports;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
@@ -15,7 +16,9 @@ import static org.junit.Assert.assertEquals;
 
 public class ImportTest {
 
+	// TODO This test is ignored because we have proposed a wrong fix for the issue #114 on GitHub.
 	@Test
+	@Ignore
 	public void testImportOfAnInnerClassInAClassPackage() throws Exception {
 		Launcher spoon = new Launcher();
 		Factory factory = spoon.createFactory();

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -6,6 +6,8 @@ import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtSimpleType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.NameFilter;
@@ -19,7 +21,7 @@ public class ImportTest {
 	// TODO This test is ignored because we have proposed a wrong fix for the issue #114 on GitHub.
 	@Test
 	@Ignore
-	public void testImportOfAnInnerClassInAClassPackage() throws Exception {
+	public void testImportOfAnInnerClassInASuperClassPackage() throws Exception {
 		Launcher spoon = new Launcher();
 		Factory factory = spoon.createFactory();
 
@@ -40,5 +42,25 @@ public class ImportTest {
 
 		expected = "spoon.test.imports.testclasses.internal.ChildClass.InnerClassProtected";
 		assertEquals(expected, innerClass.getSuperclass().toString());
+	}
+
+	@Test
+	public void testImportOfAnInnerClassInAClassPackage() throws Exception {
+		Launcher spoon = new Launcher();
+		Factory factory = spoon.createFactory();
+
+		SpoonCompiler compiler = spoon.createCompiler(
+				factory,
+				SpoonResourceHelper.resources(
+						"./src/test/java/spoon/test/imports/testclasses/internal/PublicSuperClass.java",
+						"./src/test/java/spoon/test/imports/testclasses/DefaultClientClass.java"));
+
+		compiler.build();
+
+		final CtClass<?> client = (CtClass<?>) factory.Type().get("spoon.test.imports.testclasses.DefaultClientClass");
+		final CtMethod<?> methodVisit = client.getMethodsByName("visit").get(0);
+
+		final CtSimpleType<Object> innerClass = factory.Type().get("spoon.test.imports.testclasses.DefaultClientClass$InnerClass");
+		assertEquals("Type of the method must to be InnerClass accessed via DefaultClientClass.", innerClass, methodVisit.getType().getDeclaration());
 	}
 }

--- a/src/test/java/spoon/test/imports/testclasses/DefaultClientClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/DefaultClientClass.java
@@ -1,0 +1,13 @@
+package spoon.test.imports.testclasses;
+
+import spoon.test.imports.testclasses.internal.PublicSuperClass;
+
+class DefaultClientClass extends PublicSuperClass<DefaultClientClass.InnerClass> {
+	static final class InnerClass {
+	}
+
+	@Override
+	public DefaultClientClass.InnerClass visit() {
+		return null;
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal/PublicSuperClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal/PublicSuperClass.java
@@ -1,0 +1,7 @@
+package spoon.test.imports.testclasses.internal;
+
+public class PublicSuperClass<T> {
+	public T visit() {
+		return null;
+	}
+}


### PR DESCRIPTION
For the issue #114, we have proposed a fix to access at a inner class in a super class with a default visibility. This fix works in this specific case but not in other cases. Waiting for a new PR about the issue concerned,
I propose this roll back.