### PR TITLE
Modifying  'equals' method from CtElementImpl. It has an if precondition...

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -127,8 +127,6 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			return false;
 		String current = getSignature();
 		String other = ((CtElement) o).getSignature();
-		if (current.length() <= 0 || other.length() <= 0)
-			throw new CtUncomparableException("Unable to compare elements");
 		return current.equals(other);
 	}
 

--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -1,0 +1,67 @@
+package spoon.test.comparison;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+import spoon.support.compiler.jdt.JDTSnippetCompiler;
+
+public class EqualTest {
+
+	@Test
+	public void testEqualsEmptyException() throws Exception {
+		
+		Factory factory = new Launcher().createFactory();
+
+		String realParam1 = "\"\"";
+
+		String content = "" + "class X {" + "public Object foo() {"
+				+ " Integer.getInteger(" + realParam1 + ");"
+				+ " return \"\";" + "}};";
+
+		SpoonCompiler builder = new JDTSnippetCompiler(factory, content);
+		try {
+			builder.build();
+		} catch (Exception e) {
+			fail("Unable create model");
+		}
+		
+		CtClass<?> clazz1 = (CtClass<?>) factory.Type().getAll().get(0);
+		
+		CtMethod<?> method = (CtMethod<?>) clazz1.getAllMethods().toArray()[0];
+
+		CtInvocation<?> invo = (CtInvocation<?>) method.getBody().getStatement(0);
+
+		CtLiteral<?> argument1 = (CtLiteral<?>) invo.getArguments().get(0);
+
+		String signatureArg1= argument1.getSignature();
+		
+		assertEquals("", signatureArg1);
+		
+		
+		CtReturn<?> returnStatement = (CtReturn<?>) method.getBody().getStatement(1);
+		
+		CtLiteral<?> returnExp = (CtLiteral<?>) returnStatement.getReturnedExpression();
+		
+		assertEquals("", returnExp.getSignature() );
+		
+		try{
+			assertEquals(argument1, returnExp);
+		}
+		catch(Exception e){
+			fail(e.getMessage());
+		}
+	
+
+	}
+
+
+}


### PR DESCRIPTION
... for checking the signature of the two elements under comparison: if at least one is empty the method throws an exception. This check produces that we can not compare empty literals