### PR TITLE
refactors the filtering API

### DIFF
--- a/src/main/java/spoon/reflect/visitor/Filter.java
+++ b/src/main/java/spoon/reflect/visitor/Filter.java
@@ -32,12 +32,4 @@ public interface Filter<T extends CtElement> {
 	 */
 	boolean matches(T element);
 
-	/**
-	 * Gets the runtime type that corresponds to the <code>T</code> parameter
-	 * (the type of the filtered elements). Any element assignable from this
-	 * type is a potential match and is tested using the
-	 * {@link #matches(CtElement)} method, while other elements are never a
-	 * match.
-	 */
-	Class<?> getType();
 }

--- a/src/main/java/spoon/reflect/visitor/QueryVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/QueryVisitor.java
@@ -49,12 +49,14 @@ public class QueryVisitor<T extends CtElement> extends CtScanner {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void scan(CtElement element) {
-		if (element == null)
+		if (element == null) 
 			return;
-		if (filter.getType().isAssignableFrom(element.getClass())) {
+		try {
 			if (filter.matches((T) element)) {
 				result.add((T) element);
 			}
+		} catch (ClassCastException e) {
+			// expected, some elements are not of type T
 		}
 		super.scan(element);
 	}

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -21,26 +21,25 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.Filter;
 
 /**
- * This class defines an abstract filter that needs to be subclassed in order to
- * define the matching criteria.
+ * Defines an abstract filter based on matching on the element types.
  * 
- * @see spoon.reflect.visitor.Filter#matches(CtElement)
+ * Not necessary in simple cases thanks to the use of runtime reflection.
  */
 public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 
-	Class<T> type;
+	private Class<T> type;
 
 	/**
 	 * Creates a filter with the type of the potentially matching elements.
 	 */
-	// TODO: INFER TYPE BY INTROSPECTION
 	@SuppressWarnings("unchecked")
 	public AbstractFilter(Class<?> type) {
 		this.type = (Class<T>) type;
 	}
 
-	public Class<T> getType() {
-		return type;
+	@Override
+	public boolean matches(T element) {
+		return type.isAssignableFrom(element.getClass());
 	}
 
 }

--- a/src/main/java/spoon/reflect/visitor/filter/AnnotationFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AnnotationFilter.java
@@ -20,12 +20,14 @@ package spoon.reflect.visitor.filter;
 import java.lang.annotation.Annotation;
 
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.Filter;
 
 /**
  * This filter matches all the elements annotated with a given annotation type.
  */
-public class AnnotationFilter<E extends CtElement> extends AbstractFilter<E> {
-	Class<? extends Annotation> annotationType;
+public class AnnotationFilter<E extends CtElement> extends TypeFilter<E> {
+	
+	private Class<? extends Annotation> annotationType;
 
 	/**
 	 * Creates the filter.
@@ -47,7 +49,8 @@ public class AnnotationFilter<E extends CtElement> extends AbstractFilter<E> {
 		this.annotationType = annotationType;
 	}
 
+	@Override
 	public boolean matches(E element) {
-		return element.getAnnotation(annotationType) != null;
+		return super.matches(element) && element.getAnnotation(annotationType) != null;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/CompositeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CompositeFilter.java
@@ -79,10 +79,11 @@ public class CompositeFilter<T extends CtElement> implements Filter<T> {
 	}
 
 	private boolean hasMatch(Filter<T> filter, T element) {
-		if (filter.getType().isAssignableFrom(element.getClass())) {
+		try {
 			return filter.matches(element);
+		} catch (ClassCastException e) {
+			return false;
 		}
-		return false;
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/reflect/visitor/filter/FieldAccessFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldAccessFilter.java
@@ -23,9 +23,8 @@ import spoon.reflect.reference.CtFieldReference;
 /**
  * This simple filter matches all the accesses to a given field.
  */
-public class FieldAccessFilter extends AbstractFilter<CtFieldAccess<?>> {
-	CtFieldReference<?> field;
-
+public class FieldAccessFilter extends VariableAccessFilter<CtFieldAccess<?>> {
+	
 	/**
 	 * Creates a new field access filter.
 	 * 
@@ -33,11 +32,7 @@ public class FieldAccessFilter extends AbstractFilter<CtFieldAccess<?>> {
 	 *            the accessed field
 	 */
 	public FieldAccessFilter(CtFieldReference<?> field) {
-		super(CtFieldAccess.class);
-		this.field = field;
+		super(field);
 	}
 
-	public boolean matches(CtFieldAccess<?> fieldAccess) {
-		return fieldAccess.getVariable().equals(field);
-	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/InvocationFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/InvocationFilter.java
@@ -19,13 +19,15 @@ package spoon.reflect.visitor.filter;
 
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.visitor.Filter;
 
 /**
  * This simple filter matches all the accesses to a given executable or any
  * executable that overrides it.
  */
-public class InvocationFilter extends AbstractFilter<CtInvocation<?>> {
-	CtExecutableReference<?> executable;
+public class InvocationFilter implements Filter<CtInvocation<?>> {
+	
+	private CtExecutableReference<?> executable;
 
 	/**
 	 * Creates a new invocation filter.
@@ -34,10 +36,10 @@ public class InvocationFilter extends AbstractFilter<CtInvocation<?>> {
 	 *            the executable to be tested for being invoked
 	 */
 	public InvocationFilter(CtExecutableReference<?> executable) {
-		super(CtInvocation.class);
 		this.executable = executable;
 	}
 
+	@Override
 	public boolean matches(CtInvocation<?> invocation) {
 		return invocation.getExecutable().isOverriding(executable);
 	}

--- a/src/main/java/spoon/reflect/visitor/filter/ReturnOrThrowFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ReturnOrThrowFilter.java
@@ -20,20 +20,15 @@ package spoon.reflect.visitor.filter;
 import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtThrow;
+import spoon.reflect.visitor.Filter;
 
 /**
  * This simple filter matches all the occurrences of a return or a throw
  * statement (end of execution flow).
  */
-public class ReturnOrThrowFilter extends AbstractFilter<CtCFlowBreak> {
+public class ReturnOrThrowFilter implements Filter<CtCFlowBreak> {
 
-	/**
-	 * Creates a filter.
-	 */
-	public ReturnOrThrowFilter() {
-		super(CtCFlowBreak.class);
-	}
-
+	@Override
 	public boolean matches(CtCFlowBreak cflowBreak) {
 		return (cflowBreak instanceof CtReturn)
 				|| (cflowBreak instanceof CtThrow);

--- a/src/main/java/spoon/reflect/visitor/filter/TypeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/TypeFilter.java
@@ -21,6 +21,7 @@ import spoon.reflect.declaration.CtElement;
 
 /**
  * This simple filter matches all the elements of a given type.
+ * 
  */
 public class TypeFilter<T extends CtElement> extends AbstractFilter<T> {
 
@@ -34,7 +35,4 @@ public class TypeFilter<T extends CtElement> extends AbstractFilter<T> {
 		super(type);
 	}
 
-	public boolean matches(T element) {
-		return true;
-	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
@@ -19,11 +19,12 @@ package spoon.reflect.visitor.filter;
 
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.reference.CtVariableReference;
+import spoon.reflect.visitor.Filter;
 
 /**
  * This simple filter matches all the accesses to a given field.
  */
-public class VariableAccessFilter extends AbstractFilter<CtVariableAccess<?>> {
+public class VariableAccessFilter<T extends CtVariableAccess<?>> implements Filter<T> {
 	CtVariableReference<?> variable;
 
 	/**
@@ -33,11 +34,12 @@ public class VariableAccessFilter extends AbstractFilter<CtVariableAccess<?>> {
 	 *            the accessed variable
 	 */
 	public VariableAccessFilter(CtVariableReference<?> variable) {
-		super(CtVariableAccess.class);
 		this.variable = variable;
 	}
 
-	public boolean matches(CtVariableAccess<?> variableAccess) {
+	@Override
+	public boolean matches(T variableAccess) {
 		return variableAccess.getVariable().equals(variable);
 	}
+
 }

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -243,7 +243,7 @@ public class SubstitutionVisitor extends CtScanner {
 					for (Object element : value) {
 						CtStatement b = foreach.getFactory().Core().clone(body);
 						for (CtVariableAccess<?> va : Query.getElements(b,
-								new VariableAccessFilter(foreach.getVariable()
+								new VariableAccessFilter<CtVariableAccess<?>>(foreach.getVariable()
 										.getReference()))) {
 							va.replace((CtElement) element);
 						}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -11,18 +11,27 @@ import org.junit.Test;
 
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.AnnotationFilter;
 import spoon.reflect.visitor.filter.CompositeFilter;
+import spoon.reflect.visitor.filter.FieldAccessFilter;
 import spoon.reflect.visitor.filter.FilteringOperator;
+import spoon.reflect.visitor.filter.InvocationFilter;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.RegexFilter;
+import spoon.reflect.visitor.filter.ReturnOrThrowFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.declaration.CtMethodImpl;
 import spoon.test.TestUtils;
@@ -44,6 +53,40 @@ public class FilterTest {
 		assertEquals("Foo", foo.getSimpleName());
 		List<CtExpression<?>> expressions = foo.getElements(new RegexFilter<CtExpression<?>>(".* = .*"));
 		assertEquals(2, expressions.size());
+	}
+
+	@Test
+	public void testReturnOrThrowFilter() throws Exception {
+		CtClass<?> foo = factory.Package().get("spoon.test.filters").getType("Foo");
+		assertEquals("Foo", foo.getSimpleName());
+		List<CtCFlowBreak> expressions = foo.getElements(new ReturnOrThrowFilter());
+		assertEquals(2, expressions.size());
+	}
+
+
+	@Test
+	public void testFieldAccessFilter() throws Exception {
+		// also specifies VariableAccessFilter since FieldAccessFilter is only a VariableAccessFilter with additional static typing
+		CtClass<?> foo = factory.Package().get("spoon.test.filters").getType("Foo");
+		assertEquals("Foo", foo.getSimpleName());
+
+		List<CtNamedElement> elements = foo.getElements(new NameFilter<>("i"));
+		assertEquals(1, elements.size());
+		
+		CtFieldReference ref = (CtFieldReference)(elements.get(0)).getReference();
+		List<CtFieldAccess<?>> expressions = foo.getElements(new FieldAccessFilter(ref));
+		assertEquals(2, expressions.size());
+	}
+
+
+	@Test
+	public void testAnnotationFilter() throws Exception {
+		CtClass<?> foo = factory.Package().get("spoon.test.filters").getType("Foo");
+		assertEquals("Foo", foo.getSimpleName());
+		List<CtElement> expressions = foo.getElements(new AnnotationFilter<>(SuppressWarnings.class));
+		assertEquals(2, expressions.size());
+		List<CtMethod> methods = foo.getElements(new AnnotationFilter<>(CtMethod.class, SuppressWarnings.class));
+		assertEquals(1, methods.size());
 	}
 
 	@SuppressWarnings("rawtypes")

--- a/src/test/java/spoon/test/filters/Foo.java
+++ b/src/test/java/spoon/test/filters/Foo.java
@@ -1,12 +1,21 @@
 package spoon.test.filters;
 
+@SuppressWarnings("bar")
 class Foo {
 	int i;
 	void foo() {
 		int x = 3;
 		int z;
-		z= x+1;
+		z= x+i;
 		System.out.println(z);
+	}
+	
+	@SuppressWarnings("foo")
+	int bar () {
+		if (0==1) {
+			throw new RuntimeException();
+		}
+		return i;
 	}
 }
 

--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -17,6 +17,7 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.AbstractReferenceFilter;
@@ -243,7 +244,7 @@ public class ExecutableReferenceGenericTest {
 	}
 
 	private List<CtConstructor<?>> getConstructorsByClass(final String myClass) {
-		return Query.getElements(factory, new AbstractFilter<CtConstructor<?>>(CtConstructor.class) {
+		return Query.getElements(factory, new Filter<CtConstructor<?>>() {
 			@Override
 			public boolean matches(CtConstructor<?> element) {
 				return myClass.equals(((CtClass<?>) element.getParent()).getSimpleName());
@@ -261,7 +262,7 @@ public class ExecutableReferenceGenericTest {
 	}
 
 	private CtClass<?> getCtClassByName(final String name) {
-		return Query.getElements(factory, new AbstractFilter<CtClass<?>>(CtClass.class) {
+		return Query.getElements(factory, new Filter<CtClass<?>>() {
 			@Override
 			public boolean matches(CtClass<?> element) {
 				return name.equals(element.getSimpleName());


### PR DESCRIPTION
1) uses runtime reflection instead of explicit and duplicate static typing
2) consequently, removes one of the oldest todos of Spoon
2) simplifies the API of filters (now only one method "matches")
3) adds test cases for the untested filters
4) cleans FieldAccesFilter, now a subtype of VariableAccessFilter