### PR TITLE
Adds test case about target of CtFieldAccess.

### DIFF
--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -1,6 +1,7 @@
 package spoon.test.fieldaccesses;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static spoon.test.TestUtils.build;
 
 import java.util.List;
@@ -10,12 +11,14 @@ import org.junit.Test;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtTargetedAccess;
+import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtSimpleType;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.code.CtThisAccessImpl;
 
 public class FieldAccessTest {
 
@@ -147,5 +150,17 @@ public class FieldAccessTest {
 		// 0 is length(t)-1
 		assertEquals(0, ((CtTargetedAccess<?>)vars.get(0).getTarget()).getTarget().getPosition().getSourceEnd() - 
 				((CtTargetedAccess<?>)vars.get(0).getTarget()).getTarget().getPosition().getSourceStart());
+	}
+
+	@Test
+	public void testTargetOfFieldAccess() throws Exception {
+		CtClass<?> type = build("spoon.test.fieldaccesses.testclasses", "Foo");
+		CtConstructor<?> constructor = type.getConstructors().toArray(new CtConstructor<?>[0])[0];
+
+		final List<CtFieldAccess<?>> elements = constructor.getElements(new TypeFilter<CtFieldAccess<?>>(CtFieldAccess.class));
+		assertEquals(2, elements.size());
+
+		assertEquals("Target is CtThisAccessImpl if there is a 'this' explicit.", CtThisAccessImpl.class, elements.get(0).getTarget().getClass());
+		assertNull("Targets is null if there isn't a 'this' explicit.", elements.get(1).getTarget());
 	}
 }

--- a/src/test/java/spoon/test/fieldaccesses/testclasses/Foo.java
+++ b/src/test/java/spoon/test/fieldaccesses/testclasses/Foo.java
@@ -1,0 +1,11 @@
+package spoon.test.fieldaccesses.testclasses;
+
+public class Foo {
+	private int i;
+	private int j;
+
+	public Foo(int i, int k) {
+		this.i = i;
+		j = k;
+	}
+}


### PR DESCRIPTION
Target of `CtFieldAccess` can be `CtThisAccess` if there is a "this" explicit or null if there is none.