### PR TITLE
Changes in Signature Printer and Test Cases

### DIFF
--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -353,7 +353,15 @@ public class SignaturePrinter implements CtVisitor {
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
 		write("(");
 		scan(invocation.getExecutable());
-		write("(...)");
+		write("(");
+		for(int i = 0; i < invocation.getArguments().size();i++){
+			CtExpression<?> arg_i = invocation.getArguments().get(i);
+			scan(arg_i);
+			if(i != (invocation.getArguments().size() -1) ){
+				write(",");
+			}
+		}
+		write(")");
 		write(")");
 	}
 

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -359,7 +359,7 @@ public class SignaturePrinter implements CtVisitor {
 
 	public <T> void visitCtLiteral(CtLiteral<T> literal) {
 		if (literal.getValue() != null)
-			write(literal.getValue().toString());
+			write(literal.toString());
 		else write("null");
 	}
 

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -294,16 +294,14 @@ public class SignaturePrinter implements CtVisitor {
 	}
 
 	public <T> void visitCtFieldReference(CtFieldReference<T> reference) {
-		// TODO: Fix this null pointer catch
-		try {
-			write(reference.getType().getQualifiedName()).write(" ");
-			write(reference.getDeclaringType().getQualifiedName());
-			write(CtField.FIELD_SEPARATOR);
-			write(reference.getSimpleName());
-		} catch (NullPointerException npe) {
-			System.err
-					.println("Null Pointer Exception in SignaturePrinter.visitCtFieldReference()");
-		}
+		if(reference.getType() != null)
+			write(reference.getType().getQualifiedName());
+		else
+			write("<no type>");
+		write(" ");
+		write(reference.getDeclaringType().getQualifiedName());
+		write(CtField.FIELD_SEPARATOR);
+		write(reference.getSimpleName());
 	}
 
 	public void visitCtFor(CtFor forLoop) {
@@ -377,13 +375,9 @@ public class SignaturePrinter implements CtVisitor {
 
 	public <T> void visitCtLocalVariableReference(
 			CtLocalVariableReference<T> reference) {
-		try {
-			write(reference.getType().getQualifiedName()).write(" ");
-			write(reference.getSimpleName());
-		} catch (NullPointerException npe) {
-			System.err
-					.println("Null Pointer Exception in SignaturePrinter.visitCtFieldReference()");
-		}
+		write(reference.getType().getQualifiedName()).write(" ");
+		write(reference.getSimpleName());
+		
 	}
 
 	@Override
@@ -495,13 +489,8 @@ public class SignaturePrinter implements CtVisitor {
 	}
 
 	public <T> void visitCtParameterReference(CtParameterReference<T> reference) {
-		try {
-			write(reference.getType().getQualifiedName()).write(" ");
-			write(reference.getSimpleName());
-		} catch (NullPointerException npe) {
-			System.err
-					.println("Null Pointer Exception in SignaturePrinter.visitCtFieldReference()");
-		}
+		write(reference.getType().getQualifiedName()).write(" ");
+		write(reference.getSimpleName());
 	}
 
 	public <R> void visitCtReturn(CtReturn<R> returnStatement) {

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -377,7 +377,13 @@ public class SignaturePrinter implements CtVisitor {
 
 	public <T> void visitCtLocalVariableReference(
 			CtLocalVariableReference<T> reference) {
-		scan(reference.getDeclaration());
+		try {
+			write(reference.getType().getQualifiedName()).write(" ");
+			write(reference.getSimpleName());
+		} catch (NullPointerException npe) {
+			System.err
+					.println("Null Pointer Exception in SignaturePrinter.visitCtFieldReference()");
+		}
 	}
 
 	@Override
@@ -489,7 +495,13 @@ public class SignaturePrinter implements CtVisitor {
 	}
 
 	public <T> void visitCtParameterReference(CtParameterReference<T> reference) {
-		write(reference.getSimpleName());
+		try {
+			write(reference.getType().getQualifiedName()).write(" ");
+			write(reference.getSimpleName());
+		} catch (NullPointerException npe) {
+			System.err
+					.println("Null Pointer Exception in SignaturePrinter.visitCtFieldReference()");
+		}
 	}
 
 	public <R> void visitCtReturn(CtReturn<R> returnStatement) {

--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -44,14 +44,14 @@ public class EqualTest {
 
 		String signatureArg1= argument1.getSignature();
 		
-		assertEquals("", signatureArg1);
+		assertEquals(realParam1 , signatureArg1);
 		
 		
 		CtReturn<?> returnStatement = (CtReturn<?>) method.getBody().getStatement(1);
 		
 		CtLiteral<?> returnExp = (CtLiteral<?>) returnStatement.getReturnedExpression();
 		
-		assertEquals("", returnExp.getSignature() );
+		assertEquals(realParam1 , returnExp.getSignature() );
 		
 		try{
 			assertEquals(argument1, returnExp);

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -1,7 +1,6 @@
 package spoon.test.signature;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,10 +13,14 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtReturn;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.DefaultCoreFactory;
+import spoon.support.StandardEnvironment;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 
 public class SignatureTest {
@@ -96,5 +99,23 @@ public class SignatureTest {
 		assertTrue(unboundVarAccess.equals(toStringUnbound));
 
 	}
-
+	
+	@Test
+	public void testLiteralSignature(){
+		Factory factory = new FactoryImpl(new DefaultCoreFactory(),
+				new StandardEnvironment());
+		CtStatement sta1 = (factory).Code().createCodeSnippetStatement("System.out.println(\"hello\")")
+				.compile();
+	
+		
+		String signatureParameterWithQuotes = ((CtInvocation<?>)sta1).getArguments().get(0).getSignature();
+		assertEquals("\"hello\"",signatureParameterWithQuotes);
+		
+		CtStatement stb1 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(20)")
+				.compile();
+		
+		String signatureParameterWithoutQuotes = ((CtInvocation<?>)stb1).getArguments().get(0).getSignature();
+		assertEquals("20",signatureParameterWithoutQuotes);
+	}
+	
 }

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
@@ -104,12 +105,23 @@ public class SignatureTest {
 	public void testLiteralSignature(){
 		Factory factory = new FactoryImpl(new DefaultCoreFactory(),
 				new StandardEnvironment());
-		CtStatement sta1 = (factory).Code().createCodeSnippetStatement("System.out.println(\"hello\")")
+		String stConstant = "\"hello\"";
+		CtStatement sta1 = (factory).Code().createCodeSnippetStatement("System.out.println("+stConstant+")")
 				.compile();
 	
+		CtStatement sta2 = (factory).Code().createCodeSnippetStatement("String hello =\"t1\"; System.out.println(hello)")
+				.compile();
+				
+		CtStatement sta2bis = ((CtBlock<?>)sta2.getParent()).getStatement(1);
+		
+		String signature1 = sta1.getSignature();
+		String signature2 = sta2bis.getSignature();
+				
+		assertFalse(signature1.equals(signature2));
+		assertFalse(sta1.equals(sta2bis));
 		
 		String signatureParameterWithQuotes = ((CtInvocation<?>)sta1).getArguments().get(0).getSignature();
-		assertEquals("\"hello\"",signatureParameterWithQuotes);
+		assertEquals(stConstant,signatureParameterWithQuotes);
 		
 		CtStatement stb1 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(20)")
 				.compile();
@@ -118,4 +130,42 @@ public class SignatureTest {
 		assertEquals("20",signatureParameterWithoutQuotes);
 	}
 	
+	@Test
+	public void testMethodInvocationSignature(){
+		Factory factory = new FactoryImpl(new DefaultCoreFactory(),
+				new StandardEnvironment());
+		CtStatement sta1 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(Integer.MAX_VALUE)")
+				.compile();
+		
+		CtStatement sta2 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(Integer.MIN_VALUE)")
+				.compile();
+				
+		String signature1 = sta1.getSignature();
+		String signature2 = sta2.getSignature();
+				
+		assertFalse(signature1.equals(signature2));
+		assertFalse(sta1.equals(sta2));
+		
+		
+		CtStatement stb1 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(20)")
+				.compile();
+		
+		CtStatement stb2 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(30)")
+				.compile();
+	
+		assertFalse(stb1.equals(stb2));
+		assertFalse(sta1.getSignature().equals(sta2.getSignature()));
+	
+		
+		CtStatement stc1 = (factory).Code().createCodeSnippetStatement("String.format(\"format1\",\"f2\" )")
+				.compile();
+		
+		CtStatement stc2 = (factory).Code().createCodeSnippetStatement("String.format(\"format2\",\"f2\" )")
+				.compile();
+	
+		assertFalse(stc2.equals(stc1));
+		assertFalse(stc2.getSignature().equals(stc1.getSignature()));
+		
+	}
+
 }


### PR DESCRIPTION
The signature printer loses information by printing invocation and literals.