### PR TITLE
test: Imports custom classes rather than java lang classes.

### DIFF
--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -1,13 +1,19 @@
 package spoon.test.visibility;
 
-import static org.junit.Assert.assertEquals;
-import static spoon.test.TestUtils.build;
-
 import org.junit.Test;
-
+import spoon.Launcher;
+import spoon.OutputType;
+import spoon.compiler.SpoonCompiler;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static spoon.test.TestUtils.build;
+import static spoon.test.TestUtils.canBeBuild;
 
 public class VisibilityTest {
     @Test
@@ -20,8 +26,34 @@ public class VisibilityTest {
         assertEquals("MethodeWithNonAccessibleTypeArgument", type.getSimpleName());
         CtMethod<?> m = type.getMethodsByName("method").get(0);
         assertEquals(
-                "new spoon.test.visibility.packageprotected.AccessibleClassFromNonAccessibleInterf().method(new spoon.test.visibility.packageprotected.AccessibleClassFromNonAccessibleInterf())",
-                m.getBody().getStatement(0).toString()
-        );
+				"new spoon.test.visibility.packageprotected.AccessibleClassFromNonAccessibleInterf().method(new spoon.test.visibility.packageprotected.AccessibleClassFromNonAccessibleInterf())",
+				m.getBody().getStatement(0).toString()
+		);
     }
+
+	@Test
+	public void testVisibilityOfClassesNamedByClassesInJavaLangPackage() throws Exception {
+		final File sourceOutputDir = new File("target/spooned");
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(true);
+		launcher.getEnvironment().setDefaultFileGenerator(launcher.createOutputWriter(sourceOutputDir, launcher.getEnvironment()));
+		final Factory factory = launcher.getFactory();
+		final SpoonCompiler compiler = launcher.createCompiler();
+		compiler.addInputSource(new File("./src/test/java/spoon/test/visibility/testclasses/"));
+		compiler.setOutputDirectory(sourceOutputDir);
+		compiler.build();
+		compiler.generateProcessedSourceFiles(OutputType.CLASSES);
+
+		// Class must be imported.
+		final CtClass<?> aDouble = (CtClass<?>) factory.Type().get(spoon.test.visibility.testclasses.internal.Double.class);
+		assertNotNull(aDouble);
+		assertEquals(spoon.test.visibility.testclasses.internal.Double.class, aDouble.getActualClass());
+
+		// Class mustn't be imported.
+		final CtClass<?> aFloat = (CtClass<?>) factory.Type().get(spoon.test.visibility.testclasses.Float.class);
+		assertNotNull(aFloat);
+		assertEquals(spoon.test.visibility.testclasses.Float.class, aFloat.getActualClass());
+
+		canBeBuild(new File("./target/spooned/spoon/test/visibility/testclasses/"), 7);
+	}
 }

--- a/src/test/java/spoon/test/visibility/testclasses/Float.java
+++ b/src/test/java/spoon/test/visibility/testclasses/Float.java
@@ -1,0 +1,14 @@
+package spoon.test.visibility.testclasses;
+
+public class Float {
+	public static float sum(float a, float b) {
+		return a + b;
+	}
+
+	public static java.lang.Float aMethodNotInJavaLangFloatClass(String param1, String param2) {
+		return 0.0f;
+	}
+
+	public void aMethodNotStatic() {
+	}
+}

--- a/src/test/java/spoon/test/visibility/testclasses/UseDouble.java
+++ b/src/test/java/spoon/test/visibility/testclasses/UseDouble.java
@@ -1,0 +1,23 @@
+package spoon.test.visibility.testclasses;
+
+import spoon.test.visibility.testclasses.internal.Double;
+
+public class UseDouble {
+	public final spoon.test.visibility.testclasses.internal.Double aDouble;
+	public final Float aFloat;
+
+	public UseDouble(Double aDouble, Float aFloat) {
+		this.aDouble = aDouble;
+		this.aFloat = aFloat;
+	}
+
+	public void aMethod() {
+		aDouble.aMethodNotStatic();
+		Double.aMethodNotInJavaLangDoubleClass("", "");
+		Double.toHexString(42);
+
+		aFloat.aMethodNotStatic();
+		Float.aMethodNotInJavaLangFloatClass("", "");
+		Float.sum(0f, 0f);
+	}
+}

--- a/src/test/java/spoon/test/visibility/testclasses/internal/Double.java
+++ b/src/test/java/spoon/test/visibility/testclasses/internal/Double.java
@@ -1,0 +1,14 @@
+package spoon.test.visibility.testclasses.internal;
+
+public class Double {
+	public static String toHexString(double d) {
+		return "";
+	}
+
+	public static java.lang.Double aMethodNotInJavaLangDoubleClass(String param1, String param2) {
+		return 0.0;
+	}
+
+	public void aMethodNotStatic() {
+	}
+}


### PR DESCRIPTION
A bug has been reported but it can't be reproduced in a test case.
testVisibilityOfClassesNamedByClassesInJavaLangPackage in VisibilityTest
class test custom Double and Float classes used in another class. We
check than these classes is well typed in the model and can be build.

Closes #163