### PR TITLE
fix: Writes a correct this or super invocation after a class rename.

### DIFF
--- a/src/main/java/spoon/reflect/code/CtInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtInvocation.java
@@ -17,14 +17,31 @@
 
 package spoon.reflect.code;
 
-
 /**
  * This code element defines a concrete invocation.
- * 
+ *
  * @param <T>
- *            Return type of this invocation
+ * 		Return type of this invocation
  */
 public interface CtInvocation<T> extends CtAbstractInvocation<T>, CtStatement,
 		CtTargetedExpression<T, CtExpression<?>> {
+	/**
+	 * Checks if the invocation is a this invocation.
+	 */
+	boolean isThisInvocation();
 
+	/**
+	 * Sets type of the invocation for this invocation.
+	 */
+	void setThisInvocation(boolean isThisInvocation);
+
+	/**
+	 * Checks if the invocation is a super invocation.
+	 */
+	boolean isSuperInvocation();
+
+	/**
+	 * Sets type of the invocation for super invocation.
+	 */
+	void setSuperInvocation(boolean isSuperInvocation);
 }

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1246,14 +1246,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (invocation.getExecutable().getSimpleName().equals("<init>")) {
 			// It's a constructor (super or this)
 			try {
-				CtType<?> parentType = invocation.getParent(CtType.class);
-				if ((parentType != null)
-						&& (parentType.getQualifiedName() != null)
-						&& parentType.getQualifiedName().equals(
-						invocation.getExecutable().getDeclaringType()
-								.getQualifiedName())) {
+				if (invocation.isThisInvocation()) {
 					write("this");
-				} else {
+				} else if (invocation.isSuperInvocation()) {
 					if (invocation.getTarget() != null) {
 						write(invocation.getTarget().getSignature() + '.');
 					}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1874,9 +1874,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 	public boolean visit(ExplicitConstructorCall explicitConstructor,
 			BlockScope scope) {
 		CtInvocation<Object> inv = factory.Core().createInvocation();
-		if (explicitConstructor.isImplicitSuper()) {
-			inv.setImplicit(true);
-		}
+		inv.setImplicit(explicitConstructor.isImplicitSuper());
+		inv.setThisInvocation(explicitConstructor.accessMode == ExplicitConstructorCall.This);
+		inv.setSuperInvocation(explicitConstructor.accessMode == ExplicitConstructorCall.Super);
 		CtExecutableReference<Object> er = references
 				.getExecutableReference(explicitConstructor.binding);
 		inv.setExecutable(er);

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -20,6 +20,7 @@ package spoon.support.reflect.code;
 import java.util.ArrayList;
 import java.util.List;
 
+import spoon.SpoonException;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
@@ -31,19 +32,20 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-public class CtInvocationImpl<T> extends
-		CtTargetedExpressionImpl<T, CtExpression<?>> implements CtInvocation<T> {
+public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtInvocation<T> {
 	private static final long serialVersionUID = 1L;
 
 	List<CtExpression<?>> arguments = EMPTY_LIST();
-
-	CtBlock<?> block;
 
 	CtExecutableReference<T> executable;
 
 	List<CtExpression<Integer>> indexExpressions = EMPTY_LIST();
 
 	List<CtTypeReference<?>> genericTypes = EMPTY_LIST();
+
+	boolean isThisInvocation = false;
+
+	boolean isSuperInvocation = false;
 
 	public void accept(CtVisitor visitor) {
 		visitor.visitCtInvocation(this);
@@ -141,4 +143,29 @@ public class CtInvocationImpl<T> extends
 		this.label = label;
 	}
 
+	@Override
+	public boolean isThisInvocation() {
+		return isThisInvocation;
+	}
+
+	@Override
+	public void setThisInvocation(boolean isThisInvocation) {
+		if (isSuperInvocation() && isThisInvocation) {
+			throw new SpoonException("An invocation cannot be this and super.");
+		}
+		this.isThisInvocation = isThisInvocation;
+	}
+
+	@Override
+	public boolean isSuperInvocation() {
+		return isSuperInvocation;
+	}
+
+	@Override
+	public void setSuperInvocation(boolean isSuperInvocation) {
+		if (isThisInvocation() && isSuperInvocation) {
+			throw new SpoonException("An invocation cannot be this and super.");
+		}
+		this.isSuperInvocation = isSuperInvocation;
+	}
 }

--- a/src/test/java/spoon/test/thisconstructor/ThisConstructorTest.java
+++ b/src/test/java/spoon/test/thisconstructor/ThisConstructorTest.java
@@ -1,0 +1,49 @@
+package spoon.test.thisconstructor;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.test.thisconstructor.testclasses.AClass;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThisConstructorTest {
+	@Test
+	public void testThisInConstructor() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {
+				"-i", "src/test/java/spoon/test/thisconstructor/testclasses"
+		});
+		launcher.run();
+		final CtClass<?> aClass = (CtClass<?>) launcher.getFactory().Type().get(AClass.class);
+
+		final CtInvocation thisInvocation = aClass.getElements(new AbstractFilter<CtInvocation>(CtInvocation.class) {
+			@Override
+			public boolean matches(CtInvocation element) {
+				return element.getExecutable().isConstructor();
+			}
+		}).get(0);
+		assertEquals("this(\"\")", thisInvocation.toString());
+	}
+
+	@Test
+	public void testThisInConstructorAfterATransformation() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {
+				"-i", "src/test/java/spoon/test/thisconstructor/testclasses",
+				"-o", "target/spooned",
+				"-p", ThisTransformationProcessor.class.getName()
+		});
+		launcher.run();
+		final CtClass<?> aClassX = (CtClass<?>) launcher.getFactory().Type().get("spoon.test.thisconstructor.testclasses.AClassX");
+		final CtInvocation thisInvocation = aClassX.getElements(new AbstractFilter<CtInvocation>(CtInvocation.class) {
+			@Override
+			public boolean matches(CtInvocation element) {
+				return element.getExecutable().isConstructor();
+			}
+		}).get(0);
+		assertEquals("this(\"\")", thisInvocation.toString());
+	}
+}

--- a/src/test/java/spoon/test/thisconstructor/ThisTransformationProcessor.java
+++ b/src/test/java/spoon/test/thisconstructor/ThisTransformationProcessor.java
@@ -1,0 +1,11 @@
+package spoon.test.thisconstructor;
+
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.declaration.CtClass;
+
+public class ThisTransformationProcessor extends AbstractProcessor<CtClass<?>> {
+	@Override
+	public void process(CtClass<?> element) {
+		element.setSimpleName(element.getSimpleName() + "X");
+	}
+}

--- a/src/test/java/spoon/test/thisconstructor/testclasses/AClass.java
+++ b/src/test/java/spoon/test/thisconstructor/testclasses/AClass.java
@@ -1,0 +1,14 @@
+package spoon.test.thisconstructor.testclasses;
+
+public class AClass  extends AbstractClass{
+	private final String string;
+
+	public AClass() {
+		this("");
+	}
+
+	public AClass(String string) {
+		super();
+		this.string = string;
+	}
+}

--- a/src/test/java/spoon/test/thisconstructor/testclasses/AbstractClass.java
+++ b/src/test/java/spoon/test/thisconstructor/testclasses/AbstractClass.java
@@ -1,0 +1,6 @@
+package spoon.test.thisconstructor.testclasses;
+
+public abstract class AbstractClass {
+	public AbstractClass() {
+	}
+}


### PR DESCRIPTION
When a class is rename, references of the class concerned aren't renamed.
So we don't calculate no more the type of the invocation in the
DefaultJavaPrettyPrinter but when we build the model, in the JDTTreeBuilder.

Closes #166