### PR TITLE
fix: Prints toString of elements with imports (no qualified named).

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -356,12 +356,21 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	/**
 	 * Make the imports for a given type.
 	 */
-	public Collection<CtTypeReference<?>> makeImports(CtSimpleType<?> type) {
+	public Collection<CtTypeReference<?>> computeImports(CtSimpleType<?> type) {
 		if (env.isAutoImports()) {
 			context.currentTopLevel = type;
 			return importsContext.computeImports(context.currentTopLevel);
 		}
 		return Collections.EMPTY_LIST;
+	}
+
+	/**
+	 * Make the imports for all elements.
+	 */
+	public void computeImports(CtElement element) {
+		if (env.isAutoImports()) {
+			importsContext.computeImports(element);
+		}
 	}
 
 	/**
@@ -2199,7 +2208,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		this.sourceCompilationUnit = sourceCompilationUnit;
 		Collection<CtTypeReference<?>> imports = Collections.EMPTY_LIST;
 		for (CtSimpleType<?> t : types) {
-			imports = makeImports(t);
+			imports = computeImports(t);
 		}
 		writeHeader(types, imports);
 		for (CtSimpleType<?> t : types) {

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -1,5 +1,6 @@
 package spoon.reflect.visitor;
 
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtSimpleType;
 import spoon.reflect.reference.CtTypeReference;
 
@@ -13,6 +14,11 @@ public interface ImportScanner {
 	 * @return Imports computes by Spoon, not original imports.
 	 */
 	Collection<CtTypeReference<?>> computeImports(CtSimpleType<?> simpleType);
+
+	/**
+	 * Computes imports for all elements.
+	 */
+	void computeImports(CtElement element);
 
 	/**
 	 * Checks if the type is already imported.

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -129,6 +129,11 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	}
 
 	@Override
+	public void computeImports(CtElement element) {
+		scan(element);
+	}
+
+	@Override
 	public boolean isImported(CtTypeReference<?> ref) {
 		if (imports.containsKey(ref.getSimpleName())) {
 			CtTypeReference<?> exist = imports.get(ref.getSimpleName());

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -81,7 +81,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private boolean verbose = false;
 
-	private boolean autoImports = true;
+	private boolean autoImports = false;
 
 	private int warningCount = 0;
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -357,8 +357,8 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String toString() {
-		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(
-				getFactory().getEnvironment());
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(getFactory().getEnvironment());
+		printer.computeImports(this);
 		printer.scan(this);
 		return printer.toString();
 	}

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -1,21 +1,23 @@
 package spoon.test.prettyprinter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.util.List;
-
 import org.junit.Test;
-
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtSimpleType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.prettyprinter.testclasses.AClass;
+
+import java.io.File;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DefaultPrettyPrinterTest {
 
@@ -60,5 +62,39 @@ public class DefaultPrettyPrinterTest {
 		CtSimpleType<?> theClass = factory.Type().get("spoon.test.prettyprinter.NestedSuperCall");
 		
 		assertTrue(theClass.toString().contains("nc.super(\"a\")"));
+	}
+
+	@Test
+	public void testPrintAClassWithImports() throws Exception {
+		final Launcher launcher = new Launcher();
+		final Factory factory = launcher.getFactory();
+		factory.getEnvironment().setAutoImports(true);
+		final SpoonCompiler compiler = launcher.createCompiler();
+		compiler.addInputSource(new File("./src/test/java/spoon/test/prettyprinter/testclasses/"));
+		compiler.build();
+
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
+		final String expected = "public class AClass {\n"
+				+ "    public List<?> aMethod() {\n"
+				+ "        return new ArrayList<java.lang.Object>();\n"
+				+ "    }\n"
+				+ "}";
+		assertEquals(expected, aClass.toString());
+	}
+
+	@Test
+	public void testPrintAMethodWithImports() throws Exception {
+		final Launcher launcher = new Launcher();
+		final Factory factory = launcher.getFactory();
+		factory.getEnvironment().setAutoImports(true);
+		final SpoonCompiler compiler = launcher.createCompiler();
+		compiler.addInputSource(new File("./src/test/java/spoon/test/prettyprinter/testclasses/"));
+		compiler.build();
+
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
+		final String expected = "public List<?> aMethod() {\n"
+				+ "    return new ArrayList<java.lang.Object>();\n"
+				+ "}";
+		assertEquals(expected, aClass.getMethodsByName("aMethod").get(0).toString());
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/testclasses/AClass.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/AClass.java
@@ -1,0 +1,10 @@
+package spoon.test.prettyprinter.testclasses;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AClass {
+	public List<?> aMethod() {
+		return new ArrayList<>();
+	}
+}


### PR DESCRIPTION
Creates a new computeImports method in ImportScanner to compute imports
of all elements. So, for the future, if we would like qualified name
in toString of elements, we must to specify it in the environment.

Closes #162