### PR TITLE
fix: give an access of generic types in anonymous classes.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -851,6 +851,21 @@ public class JDTTreeBuilder extends ASTVisitor {
 			if (typeDeclaration.superclass != null) {
 				cl.setSuperclass(references.getTypeReference(typeDeclaration.superclass.resolvedType));
 			}
+
+			// If the current class is an anonymous class with a super interface and generic types, we add generic types
+			// in the current class.
+			if (typeDeclaration.binding.isAnonymousType() && typeDeclaration.superInterfaces != null) {
+				final TypeReference superInterface = typeDeclaration.superInterfaces[0];
+				if (superInterface.resolvedType instanceof ParameterizedTypeBinding) {
+					final ParameterizedTypeBinding resolvedType = (ParameterizedTypeBinding) superInterface.resolvedType;
+					if (resolvedType.arguments != null) {
+						for (TypeBinding b : resolvedType.arguments) {
+							cl.addFormalTypeParameter(references.getTypeReference(b));
+						}
+					}
+				}
+			}
+
 			if (typeDeclaration.superInterfaces != null) {
 				for (TypeReference ref : typeDeclaration.superInterfaces) {
 					cl.addSuperInterface(references.getTypeReference(ref.resolvedType));

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -282,12 +282,10 @@ public class GenericsTest {
 		final List<CtTypeReference<?>> barGenerics = bar.getFormalTypeParameters();
 		final CtClass<?> anonymousBar = newAnonymousBar.getAnonymousClass();
 
-		final CtTypeReference barInterface = anonymousBar.getSuperInterfaces().toArray(new CtTypeReference[0])[0];
-		final List<CtTypeReference<?>> newClassBarGenerics = barInterface.getActualTypeArguments();
 		assertEquals("Name of the first generic parameter in Bar interface must to be I.", "I", barGenerics.get(0).getSimpleName());
-		assertEquals("Name of the first generic parameter in Bar usage must to be K.", "K", newClassBarGenerics.get(0).getSimpleName());
+		assertEquals("Name of the first generic parameter in Bar usage must to be K.", "K", anonymousBar.getFormalTypeParameters().get(0).getSimpleName());
 
 		assertEquals("Name of the second generic parameter in Bar interface must to be O.", "O", barGenerics.get(1).getSimpleName());
-		assertEquals("Name of the second generic parameter in Bar usage must to be V.", "V", newClassBarGenerics.get(1).getSimpleName());
+		assertEquals("Name of the second generic parameter in Bar usage must to be V.", "V", anonymousBar.getFormalTypeParameters().get(1).getSimpleName());
 	}
 }


### PR DESCRIPTION
When we build a CtClass, we check if we have a anonymous class with
a super interface and with generic types to put them in formal type
of the anonymous class.

Closes #156