### PR TITLE
fix: Adds all references via TypeReferenceScanner.

### DIFF
--- a/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
+++ b/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
@@ -108,10 +108,7 @@ public class TypeReferenceScanner extends CtScanner {
 	@Override
 	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
 		if (!(reference instanceof CtArrayTypeReference)) {
-			if (reference.getDeclaringType() == null)
-				addReference(reference);
-			else
-				addReference(reference.getDeclaringType());
+			addReference(reference);
 		}
 		super.visitCtTypeReference(reference);
 

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -7,7 +7,9 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -16,14 +18,17 @@ import spoon.SpoonException;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.visitor.SignaturePrinter;
+import spoon.test.api.testclasses.Bar;
 
 public class NoClasspathTest {
 
@@ -107,6 +112,23 @@ public class NoClasspathTest {
 		String s = pr.getSignature();	
 		
 		assertEquals("#foo()", s);
+	}
+
+	@Test
+	public void testGetStaticDependency() {
+		Launcher spoon = new Launcher();
+		final Factory factory = spoon.getFactory();
+		factory.getEnvironment().setAutoImports(false);
+		spoon.addInputResource("./src/test/java/spoon/test/api/testclasses/");
+		spoon.run();
+
+		CtTypeReference expectedType = factory.Type().createReference(javax.sound.sampled.AudioFormat.Encoding.class);
+		CtClass<?> clazz = factory.Class().get(Bar.class);
+
+		CtMethod<?> method = clazz.getMethodsByName("doSomething").get(0);
+		CtReturn ctReturn = method.getElements(new TypeFilter<CtReturn>(CtReturn.class)).get(0);
+
+		assertEquals(true, ctReturn.getReferencedTypes().contains(expectedType));
 	}
 	
 }

--- a/src/test/java/spoon/test/api/testclasses/Bar.java
+++ b/src/test/java/spoon/test/api/testclasses/Bar.java
@@ -1,0 +1,11 @@
+package spoon.test.api.testclasses;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioFormat.Encoding;
+import java.util.HashMap;
+
+public class Bar {
+	public AudioFormat doSomething() {
+		return new AudioFormat(Encoding.ALAW, (float) 1.0, 8, 2, 1, (float) 1.0, true, new HashMap<String, Object>());
+	}
+}


### PR DESCRIPTION
Before, in the TypeReferenceScanner, if the enclosing reference
of the current reference is already in the set of references,
we didn't add it in the set. Now, we add all in set and the Set
class remove all duplicate items.

Closes #174