### PR TITLE
fix: Writes fully qualified names of CtTypeReferene when its declaring type uses generics.

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -104,6 +104,7 @@ import spoon.support.reflect.cu.CtLineElementComparator;
 import spoon.support.util.SortedList;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -1868,13 +1869,14 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		} else {
 			if (ref.getDeclaringType() != null) {
 				if (!context.currentThis.contains(ref.getDeclaringType())
-						|| ref.getModifiers().contains(ModifierKind.STATIC)) {
+						|| ref.getModifiers().contains(ModifierKind.STATIC)
+						|| hasDeclaringTypeWithGenerics(ref)) {
 					if (!context.ignoreEnclosingClass) {
-						//						boolean ign = context.ignoreGenerics;
-						//						context.ignoreGenerics = false;
+						boolean ign = context.ignoreGenerics;
+						context.ignoreGenerics = false;
 						scan(ref.getDeclaringType());
 						write(".");
-						//						context.ignoreGenerics = ign;
+						context.ignoreGenerics = ign;
 					}
 				}
 				write(ref.getSimpleName());
@@ -1888,6 +1890,33 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (!context.ignoreGenerics) {
 			writeGenericsParameter(ref.getActualTypeArguments());
 		}
+	}
+
+	private <T> boolean hasDeclaringTypeWithGenerics(CtTypeReference<T> reference) {
+		// If current reference use generic types, we don't need this hack.
+		if (reference.getActualTypeArguments().size() != 0) {
+			return false;
+		}
+		// If current reference is a class declared in a method, we don't need this hack.
+		if (reference.getDeclaration() == null) {
+			return false;
+		}
+		if (reference.getDeclaration().getParent(CtMethod.class) != null) {
+			return false;
+		}
+		// If the declaring type isn't a CtType, we don't need this hack.
+		if (reference.getDeclaringType() == null) {
+			return false;
+		}
+		final CtSimpleType<?> declaration = reference.getDeclaringType().getDeclaration();
+		if (declaration == null) {
+			return false;
+		}
+		if (!(declaration instanceof CtType)) {
+			return false;
+		}
+		// Checks if the declaring type has generic types.
+		return ((CtType) declaration).getFormalTypeParameters().size() != 0;
 	}
 
 	@Override

--- a/src/test/java/spoon/test/TestUtils.java
+++ b/src/test/java/spoon/test/TestUtils.java
@@ -53,17 +53,20 @@ public class TestUtils {
 		return comp.getFactory();
 	}
 
-	public static void canBeBuild(File testDirectory, int complianceLevel) throws IOException {
+	public static void canBeBuild(File outputDirectoryFile, int complianceLevel) throws IOException {
 		final Launcher launcher = new Launcher();
 		final Factory factory = launcher.createFactory();
 		factory.getEnvironment().setComplianceLevel(complianceLevel);
 		final SpoonCompiler compiler = launcher.createCompiler(factory);
-		compiler.addInputSource(testDirectory);
+		compiler.addInputSource(outputDirectoryFile);
 		try {
 			compiler.build();
 		} catch (Exception e) {
-			throw new AssertionError("Can't compile " + testDirectory.getName(), e);
+			throw new AssertionError("Can't compile " + outputDirectoryFile.getName(), e);
 		}
 	}
 
+	public static void canBeBuild(String outputDirectory, int complianceLevel) throws IOException {
+		canBeBuild(new File(outputDirectory), complianceLevel);
+	}
 }

--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -3,10 +3,12 @@ package spoon.test.visibility;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
+import spoon.SpoonAPI;
 import spoon.compiler.SpoonCompiler;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
+import spoon.test.visibility.testclasses.A;
 
 import java.io.File;
 
@@ -55,5 +57,16 @@ public class VisibilityTest {
 		assertEquals(spoon.test.visibility.testclasses.Float.class, aFloat.getActualClass());
 
 		canBeBuild(new File("./target/spooned/spoon/test/visibility/testclasses/"), 7);
+	}
+
+	@Test
+	public void testComplexVisibilityWithGenerics() throws Exception {
+		final SpoonAPI launcher = new Launcher();
+		launcher.run(new String[] {
+				"-i", "./src/test/java/spoon/test/visibility/testclasses/A.java",
+				"-o", "./target/spooned/"
+		});
+
+		canBeBuild("./target/spooned/spoon/test/visibility/testclasses/", 8);
 	}
 }

--- a/src/test/java/spoon/test/visibility/testclasses/A.java
+++ b/src/test/java/spoon/test/visibility/testclasses/A.java
@@ -1,0 +1,23 @@
+package spoon.test.visibility.testclasses;
+
+public class A<T> {
+	public class B {
+	}
+
+	public class C<T> {
+	}
+
+	public boolean m(Object o) {
+		return o instanceof A.B;
+	}
+
+	public C<T> m() {
+		return new C<T>();
+	}
+
+	public void aMethod() {
+		class D {
+		}
+		new D();
+	}
+}


### PR DESCRIPTION
When we visit CtTypeReference in DefaultJavaPrettyPrinter, we check if
the current reference doesn't use generic types, if it isn't declared
in a method, if the declaring type is a CtType and if this declaring
type use generic types to write the fully qualified name.

Closes #146