### PR TITLE
fixes CtTypeInformation.getSuperclass bug

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -448,7 +448,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 	public CtTypeReference<?> getSuperclass() {
 		CtType<T> t = getDeclaration();
 		if (t != null) {
-			return ((CtClass<T>) t).getSuperclass();
+			return t.getSuperclass();
 		} else {
 			Class<T> c = getActualClass();
 			Class<?> sc = c.getSuperclass();

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -1,0 +1,59 @@
+package spoon.reflect.declaration;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.compiler.SpoonCompiler;
+import spoon.reflect.declaration.testclasses.ExtendsObject;
+import spoon.reflect.declaration.testclasses.Subclass;
+import spoon.reflect.declaration.testclasses.Subinterface;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+
+import java.io.File;
+import java.util.Set;
+
+public class CtTypeInformationTest
+{
+    private Factory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        final File testDirectory = new File("./src/test/java/spoon/reflect/declaration/testclasses/");
+
+        Launcher launcher = new Launcher();
+        factory = launcher.getFactory();
+        SpoonCompiler compiler = launcher.createCompiler();
+        compiler.setDestinationDirectory(new File("./target/spooned/"));
+        factory.getEnvironment().setComplianceLevel(8);
+        compiler.addInputSource(testDirectory);
+        compiler.build();
+        compiler.compileInputSources();
+    }
+
+    @Test
+    public void testGetSuperclass() throws Exception {
+        // test superclass of class
+        CtType<?> type = this.factory.Type().get(Subclass.class);
+
+        CtTypeReference<?> superclass = type.getSuperclass();
+        Assert.assertEquals(ExtendsObject.class.getName(), superclass.getQualifiedName());
+
+//        superclass = superclass.getSuperclass();
+//        Assert.assertEquals(Object.class.getName(), superclass.getQualifiedName());
+
+        Assert.assertNull(superclass.getSuperclass());
+
+        // test superclass of interface type reference
+        Set<CtTypeReference<?>> superInterfaces = type.getSuperInterfaces();
+        Assert.assertEquals(1, superInterfaces.size());
+        CtTypeReference<?> superinterface = superInterfaces.iterator().next();
+        Assert.assertEquals(Subinterface.class.getName(), superinterface.getQualifiedName());
+        Assert.assertNull(superinterface.getSuperclass());
+
+        // test superclass of interface
+        type = this.factory.Type().get(Subinterface.class);
+        Assert.assertNull(type.getSuperclass());
+    }
+}

--- a/src/test/java/spoon/reflect/declaration/testclasses/ExtendsObject.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/ExtendsObject.java
@@ -1,0 +1,4 @@
+package spoon.reflect.declaration.testclasses;
+
+public class ExtendsObject {
+}

--- a/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
@@ -1,0 +1,8 @@
+package spoon.reflect.declaration.testclasses;
+
+public class Subclass extends ExtendsObject implements Subinterface {
+    @Override
+    public int compareTo(Object o) {
+        return 0;
+    }
+}

--- a/src/test/java/spoon/reflect/declaration/testclasses/Subinterface.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/Subinterface.java
@@ -1,0 +1,4 @@
+package spoon.reflect.declaration.testclasses;
+
+public interface Subinterface extends TestInterface, Comparable<Object> {
+}

--- a/src/test/java/spoon/reflect/declaration/testclasses/TestInterface.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/TestInterface.java
@@ -1,0 +1,4 @@
+package spoon.reflect.declaration.testclasses;
+
+public interface TestInterface {
+}


### PR DESCRIPTION
Declaration was casted to a class object always, but an InterfaceTypeReference has the superclass method too and an interface isn't a class. In this case a ClassCastException occurred