### PR TITLE
Bug fix for CtTypeImpl#getAllMethods.

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -540,11 +540,6 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 	@Override
 	public Set<CtMethod<?>> getAllMethods() {
 		Set<CtMethod<?>> l = new HashSet<CtMethod<?>>(getMethods());
-		CtTypeReference<?> st = ((CtClass<?>) this).getSuperclass();
-		if (st != null) {
-			l.addAll(((CtType) st).getAllMethods());
-		}
-		return l;		
-
+		return l;
 	}
 }

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -79,6 +79,7 @@ public class AnnotationTest {
 		CtType<?> type = this.factory.Type().get("spoon.test.annotation.testclasses.Bound");
 		assertEquals("Bound", type.getSimpleName());
 		assertEquals(1, type.getAnnotations().size());
+		assertEquals(0, type.getAllMethods().size());
 	}
 
 	@Test


### PR DESCRIPTION
CtTypeReference cannot be cast to CtType and CtTypeReference does not provide getAllMethods.
Associated test for CtAnnotationTypeImpl.
getAllMethods is redefined in other subtypes of CtType, i.e. in CtClassImpl and in CtInterfaceImpl.