### PR TITLE
fixes a bug in getAllMethods

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -134,8 +134,9 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	void compileAndReplaceSnippets();
 	
 	/**
-	 * Return all the accessible methods for this type (the recursion stops when
-	 * the super-type is not in the model).
+	 * Return all the accessible methods (concrete and abstract) for this type.
+	 * 
+	 *  The recursion stops when the super-type/super-interface is not in the model.
 	 */
 	Set<CtMethod<?>> getAllMethods();
 

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -57,19 +57,6 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements
 		v.visitCtClass(this);
 	}
 
-	@Override
-	public Set<CtMethod<?>> getAllMethods() {
-		Set<CtMethod<?>> ret = new TreeSet<CtMethod<?>>();
-		ret.addAll(getMethods());
-
-		if ((getSuperclass() != null)
-				&& (getSuperclass().getDeclaration() != null)) {
-			CtType<?> t = (CtType<?>) getSuperclass().getDeclaration();
-			ret.addAll(t.getAllMethods());
-		}
-		return ret;
-	}
-
 	public List<CtAnonymousExecutable> getAnonymousExecutables() {
 		return anonymousExecutables;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -47,20 +47,6 @@ public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> 
 	// return ret;
 	// }
 
-	@Override
-	public Set<CtMethod<?>> getAllMethods() {
-		Set<CtMethod<?>> ret = new TreeSet<CtMethod<?>>();
-		ret.addAll(getMethods());
-
-		for (CtTypeReference<?> ref : getSuperInterfaces()) {
-			if (ref.getDeclaration() != null) {
-				CtType<?> t = (CtType<?>) ref.getDeclaration();
-				ret.addAll(t.getAllMethods());
-			}
-		}
-		return ret;
-	}
-
 	public void accept(CtVisitor visitor) {
 		visitor.visitCtInterface(this);
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -319,6 +319,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 
 	@Override
 	public CtTypeReference<?> getSuperclass() {
+		// overridden in CtClassImpl
 		return null;
 	}
 
@@ -560,11 +561,20 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 	@Override
 	public Set<CtMethod<?>> getAllMethods() {
 		Set<CtMethod<?>> l = new HashSet<CtMethod<?>>(getMethods());
-		CtTypeReference<?> st = ((CtClass<?>) this).getSuperclass();
-		if (st != null) {
-			l.addAll(((CtType) st).getAllMethods());
+		
+		if ((getSuperclass() != null)
+				&& (getSuperclass().getDeclaration() != null)) {
+			CtType<?> t = (CtType<?>) getSuperclass().getDeclaration();
+			l.addAll(t.getAllMethods());
 		}
-		return l;		
 
+		for (CtTypeReference<?> ref : getSuperInterfaces()) {
+			if (ref.getDeclaration() != null) {
+				CtType<?> t = (CtType<?>) ref.getDeclaration();
+				l.addAll(t.getAllMethods());
+			}
+		}
+
+		return Collections.unmodifiableSet(l);		
 	}
 }

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -1,8 +1,11 @@
 package spoon.reflect.declaration;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.reflect.declaration.testclasses.ExtendsObject;
@@ -12,6 +15,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.Set;
 
 public class CtTypeInformationTest
@@ -35,7 +39,7 @@ public class CtTypeInformationTest
     @Test
     public void testGetSuperclass() throws Exception {
         // test superclass of class
-        CtType<?> type = this.factory.Type().get(Subclass.class);
+        final CtType<?> type = this.factory.Type().get(Subclass.class);
 
         CtTypeReference<?> superclass = type.getSuperclass();
         Assert.assertEquals(ExtendsObject.class.getName(), superclass.getQualifiedName());
@@ -52,8 +56,25 @@ public class CtTypeInformationTest
         Assert.assertEquals(Subinterface.class.getName(), superinterface.getQualifiedName());
         Assert.assertNull(superinterface.getSuperclass());
 
+        assertEquals(2, type.getAllMethods().size());
+        
+        
         // test superclass of interface
-        type = this.factory.Type().get(Subinterface.class);
-        Assert.assertNull(type.getSuperclass());
+        final CtType<?> type2 = this.factory.Type().get(Subinterface.class);
+        Assert.assertNull(type2.getSuperclass());
+        
+        // the interface abstract method and the implementation method have the same signature 
+        CtMethod<?> fooConcrete = type.getMethodsByName("foo").get(0);
+        CtMethod<?> fooAbstract = type2.getMethodsByName("foo").get(0);
+        assertEquals(fooConcrete.getSignature(), fooAbstract.getSignature());
+        // and they are in considered the same in a set
+        Set<CtMethod<?>> l = new HashSet<CtMethod<?>>();
+        l.add(fooConcrete);
+        l.add(fooAbstract);
+        assertEquals(1, l.size());
+                
+        
+        assertEquals(type.getMethodsByName("foo").get(0).getSignature(), type2.getMethodsByName("foo").get(0).getSignature());
+        
     }
 }

--- a/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
@@ -5,4 +5,9 @@ public class Subclass extends ExtendsObject implements Subinterface {
     public int compareTo(Object o) {
         return 0;
     }
+
+	@Override
+	public void foo() {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/src/test/java/spoon/reflect/declaration/testclasses/Subinterface.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/Subinterface.java
@@ -1,4 +1,5 @@
 package spoon.reflect.declaration.testclasses;
 
 public interface Subinterface extends TestInterface, Comparable<Object> {
+	void foo();
 }

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -3,6 +3,7 @@ package spoon.test.annotation;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -306,6 +307,9 @@ public class AnnotationTest {
 		// load annotation type Bound and check the annotated element type of the annotations
 		CtAnnotationType<?> annotationType = pkg.getType("Bound");
 		assertEquals(Bound.class, annotationType.getActualClass());
+		assertNull(annotationType.getSuperclass());
+		assertEquals(0,annotationType.getAllMethods().size());
+		assertEquals(0,annotationType.getSuperInterfaces().size());
 
 		annotations = annotationType.getAnnotations();
 		assertEquals(1, annotations.size());


### PR DESCRIPTION
bug: ClassCastException for CtAnnotationType

boy scout rule:
- adds the missing tests
- clarifies the contract of getAllMethods

this bug was surfaced by @seintur in #210 