### PR TITLE
fixes the parent mechanism

### DIFF
--- a/src/main/java/spoon/reflect/code/CtFor.java
+++ b/src/main/java/spoon/reflect/code/CtFor.java
@@ -54,15 +54,16 @@ public interface CtFor extends CtLoop {
 	 */
 	void setExpression(CtExpression<Boolean> expression);
 
-	/**
-	 * Sets the <i>init</i> statements.
-	 */
-	void setForInit(List<CtStatement> forInit);
 
-	/**
-	 * Sets the <i>update</i> statements.
-	 */
-	void setForUpdate(List<CtStatement> forUpdate);
+ 	/**
+ 	 * Sets the <i>init</i> statements.
+ 	 */
+ 	void setForInit(List<CtStatement> forInit);
+ 
+ 	/**
+ 	 * Sets the <i>update</i> statements.
+ 	 */
+ 	void setForUpdate(List<CtStatement> forUpdate);
 
 	/**
 	 * Adds an <i>update</i> statement.

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -18,6 +18,8 @@
 package spoon.reflect.declaration;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import spoon.reflect.code.CtExpression;
@@ -106,4 +108,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A> {
 	 * @return {@link spoon.reflect.declaration.CtAnnotatedElementType}
 	 */
 	CtAnnotatedElementType getAnnotatedElementType();
+	
+	/** Adds a new key-value pair for this annotation */
+	void addValue(String elementName, Object value);
 }

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -96,19 +96,6 @@ public interface CtElement extends FactoryAccessor, CtVisitable {
 	boolean isParentInitialized();
 
 	/**
-	 * Tells if this element is a root of the element tree (and thus has no
-	 * parent, which is different from being not initialized). When an element
-	 * is a root element, {@link #getParent()} will return null without throwing
-	 * an exception.
-	 */
-	boolean isRootElement();
-
-	/**
-	 * Sets the root element flag to this element.
-	 */
-	void setRootElement(boolean rootElement);
-
-	/**
 	 * Gets the signature of the element.
 	 */
 	String getSignature();

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -33,7 +33,7 @@ public interface CtPackage extends CtNamedElement {
 	public static final String PACKAGE_SEPARATOR = ".";
 
 	/**
-	 * The name for the top level package (default is "unnamed package").
+	 * The name for the top level package.
 	 */
 	public static final String TOP_LEVEL_PACKAGE_NAME = "unnamed package";
 

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -207,10 +207,6 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * Registers a top-level package.
 	 */
 	public void register(CtPackage pck) {
-		if (packages.containsKey(pck.getQualifiedName())) {
-			throw new RuntimeException("package " + pck.getQualifiedName()
-					+ " already created");
-		}
 		packages.put(pck.getQualifiedName(), pck);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -441,25 +441,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	 */
 	public DefaultJavaPrettyPrinter scan(CtElement e) {
 		if (e != null) {
-			if (!context.elementStack.isEmpty()) {
-				CtElement parent = context.elementStack.peek();
-				if (e.isParentInitialized()) {
-					if (parent != e.getParent()) {
-						env.report(null, Severity.WARNING,
-								"ignoring inconsistent parent for "
-										+ e.getClass().getSimpleName()
-										+ " ("
-										+ parent.getClass().getSimpleName()
-										+ " != "
-										+ e.getParent().getClass()
-										.getSimpleName() + ")"
-										+ e.getPosition()
-						);
-					}
-				} else {
-					e.setParent(parent);
-				}
-			}
 			context.elementStack.push(e);
 			if (env.isPreserveLineNumbers()) {
 				context.noNewLines = e.getPosition() == null
@@ -2034,7 +2015,18 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				removeLastChar();
 			}
 			write("}");
-		} else if (value instanceof Enum) {
+		} else if (value instanceof Object[]) {
+			write("{");
+			if (((Object[]) value).length>0) {
+				for (Object obj : (Object[]) value) {
+					writeAnnotationElement(factory, obj);
+					write(" ,");
+				}
+				removeLastChar();
+			}
+			write("}");
+		} 		
+		else if (value instanceof Enum) {
 			context.ignoreGenerics = true;
 			scan(factory.Type().createReference(
 					((Enum<?>) value).getDeclaringClass()));

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -1,6 +1,7 @@
 package spoon.support.compiler.jdt;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import org.eclipse.jdt.internal.compiler.ast.QualifiedAllocationExpression;
 import org.eclipse.jdt.internal.compiler.lookup.LocalTypeBinding;
@@ -174,7 +175,7 @@ public class ParentExiter extends CtInheritanceScanner {
 						"class")) {
 			value = ((CtFieldReference<?>) value).getType();
 		}
-		annotation.getElementValues().put(name, value);
+		annotation.addValue(name, value);
 		super.visitCtAnnotation(annotation);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
@@ -32,6 +32,7 @@ public class CtArrayAccessImpl<T, V extends CtExpression<?>> extends
 	}
 
 	public void setIndexExpression(CtExpression<Integer> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
@@ -33,6 +33,7 @@ public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	CtExpression<T> value;
 
 	public void setAssertExpression(CtExpression<Boolean> asserted) {
+		asserted.setParent(this);
 		this.asserted = asserted;
 	}
 
@@ -45,6 +46,7 @@ public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	}
 
 	public void setExpression(CtExpression<T> value) {
+		value.setParent(this);
 		this.value = value;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
@@ -69,12 +69,13 @@ public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements
 	}
 
 	public void setAssigned(CtExpression<T> assigned) {
+		assigned.setParent(this);
 		this.assigned = assigned;
 	}
 
 	public void setAssignment(CtExpression<A> assignment) {
+		assignment.setParent(this);
 		this.assignment = assignment;
-		this.assignment.setParent(this);
 	}
 
 	public void setType(CtTypeReference<T> type) {

--- a/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
@@ -39,11 +39,13 @@ public class CtBinaryOperatorImpl<T> extends CtExpressionImpl<T> implements
 	}
 
 	public void setLeftHandOperand(CtExpression<?> expression) {
+		expression.setParent(this);
 		leftHandOperand = expression;
 
 	}
 
 	public void setRightHandOperand(CtExpression<?> expression) {
+		expression.setParent(this);
 		rightHandOperand = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -66,8 +66,8 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	}
 
 	public void insertBegin(CtStatementList statements) {
-		if (getParentNoExceptions() != null
-				&& getParentNoExceptions() instanceof CtConstructor
+		if (getParent() != null
+				&& getParent() instanceof CtConstructor
 				&& getStatements().size() > 0) {
 			CtStatement first = getStatements().get(0);
 			if (first instanceof CtInvocation
@@ -84,8 +84,8 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	}
 
 	public void insertBegin(CtStatement statement) {
-		if (getParentNoExceptions() != null
-				&& getParentNoExceptions() instanceof CtConstructor
+		if (getParent() != null
+				&& getParent() instanceof CtConstructor
 				&& getStatements().size() > 0) {
 			CtStatement first = getStatements().get(0);
 			if (first instanceof CtInvocation
@@ -143,7 +143,10 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	}
 
 	public void setStatements(List<CtStatement> statements) {
-		this.statements = statements;
+		this.statements.clear();
+		for(CtStatement s:statements) {
+			addStatement(s);
+		}
 	}
 
 	public R S() {
@@ -163,6 +166,7 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 		if (this.statements == CtElementImpl.<CtStatement> EMPTY_LIST()) {
 			this.statements = new ArrayList<CtStatement>();
 		}
+		statement.setParent(this);
 		this.statements.add(statement);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -20,6 +20,7 @@ package spoon.support.reflect.code;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.locks.StampedLock;
 
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
@@ -47,11 +48,15 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 	}
 
 	public void setCaseExpression(CtExpression<E> caseExpression) {
+		caseExpression.setParent(this);
 		this.caseExpression = caseExpression;
 	}
 
-	public void setStatements(List<CtStatement> statements) {
-		this.statements = statements;
+	public void setStatements(List<CtStatement> statements) {		
+		this.statements.clear();
+		for (CtStatement stmt : statements) {
+			addStatement(stmt);
+		}
 	}
 
 	@Override
@@ -59,6 +64,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		if (statements == CtElementImpl.<CtStatement> EMPTY_LIST()) {
 			statements = new ArrayList<CtStatement>();
 		}
+		statement.setParent(this);
 		statements.add(statement);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
@@ -42,10 +42,12 @@ public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 	}
 
 	public void setBody(CtBlock<?> body) {
+		body.setParent(this);
 		this.body = body;
 	}
 
 	public void setParameter(CtCatchVariable<? extends Throwable> parameter) {
+		parameter.setParent(this);
 		this.parameter = parameter;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
@@ -49,14 +49,17 @@ public class CtConditionalImpl<T> extends CtExpressionImpl<T> implements
 	}
 
 	public void setElseExpression(CtExpression<T> elseExpression) {
+		elseExpression.setParent(this);
 		this.elseExpression = elseExpression;
 	}
 
 	public void setCondition(CtExpression<Boolean> condition) {
+		condition.setParent(this);
 		this.condition = condition;
 	}
 
 	public void setThenExpression(CtExpression<T> thenExpression) {
+		thenExpression.setParent(this);
 		this.thenExpression = thenExpression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -69,7 +69,10 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 
 	@Override
 	public void setArguments(List<CtExpression<?>> arguments) {
-		this.arguments = arguments;
+		this.arguments.clear();
+		for (CtExpression<?> expr: arguments) {
+			addArgument(expr);
+		}
 	}
 
 	@Override
@@ -77,6 +80,7 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 		if (arguments == CtElementImpl.<CtExpression<?>> EMPTY_LIST()) {
 			arguments = new ArrayList<CtExpression<?>>();
 		}
+		argument.setParent(this);
 		arguments.add(argument);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -37,6 +37,7 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	}
 
 	public void setLabelledStatement(CtStatement labelledStatement) {
+		labelledStatement.setParent(this);
 		this.labelledStatement = labelledStatement;
 	}
 	

--- a/src/main/java/spoon/support/reflect/code/CtDoImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtDoImpl.java
@@ -35,6 +35,7 @@ public class CtDoImpl extends CtLoopImpl implements CtDo {
 	}
 
 	public void setLoopingExpression(CtExpression<Boolean> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
@@ -42,10 +42,12 @@ public class CtForEachImpl extends CtLoopImpl implements CtForEach {
 	}
 
 	public void setExpression(CtExpression<?> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 
 	public void setVariable(CtLocalVariable<?> variable) {
+		variable.setParent(this);
 		this.variable = variable;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -52,22 +52,33 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 	}
 
 	public void setExpression(CtExpression<Boolean> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 
-	public void setForInit(List<CtStatement> forInit) {
-		this.forInit = forInit;
+	@Override
+	public void setForInit(List<CtStatement> statements) {
+		this.forInit.clear();
+		for (CtStatement stmt : statements) {
+			addForInit(stmt);
+		}
 	}
 
-	public void setForUpdate(List<CtStatement> forUpdate) {
-		this.forUpdate = forUpdate;
+	@Override
+	public void setForUpdate(List<CtStatement> statements) {
+		this.forUpdate.clear();
+		for (CtStatement stmt : statements) {
+			addForUpdate(stmt);
+		}
 	}
+	
 
 	@Override
 	public boolean addForInit(CtStatement statement) {
 		if (forInit == CtElementImpl.<CtStatement> EMPTY_LIST()) {
 			forInit = new ArrayList<CtStatement>();
 		}
+		statement.setParent(this);
 		return forInit.add(statement);
 	}
 
@@ -84,6 +95,7 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 		if (forUpdate == CtElementImpl.<CtStatement> EMPTY_LIST()) {
 			forUpdate = new ArrayList<CtStatement>();
 		}
+		statement.setParent(this);
 		return forUpdate.add(statement);
 	}
 
@@ -94,5 +106,5 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 		}
 		return forUpdate.remove(statement);
 	}
-	
+
 }

--- a/src/main/java/spoon/support/reflect/code/CtIfImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtIfImpl.java
@@ -60,14 +60,17 @@ public class CtIfImpl extends CtStatementImpl implements CtIf {
 	}
 
 	public void setCondition(CtExpression<Boolean> condition) {
+		condition.setParent(this);
 		this.condition = condition;
 	}
 
 	public void setElseStatement(CtStatement elseStatement) {
+		elseStatement.setParent(this);
 		this.elseStatement = elseStatement;
 	}
 
 	public void setThenStatement(CtStatement thenStatement) {
+		thenStatement.setParent(this);
 		this.thenStatement = thenStatement;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -57,11 +57,6 @@ public class CtInvocationImpl<T> extends
 		return this.genericTypes;
 	}
 
-	@Override
-	public void setTarget(CtExpression<?> target) {
-		super.setTarget(target);
-	}
-
 	public List<CtExpression<?>> getArguments() {
 		return arguments;
 	}
@@ -71,6 +66,7 @@ public class CtInvocationImpl<T> extends
 		if (arguments == CtElementImpl.<CtExpression<?>> EMPTY_LIST()) {
 			arguments = new ArrayList<CtExpression<?>>();
 		}
+		argument.setParent(this);
 		arguments.add(argument);
 	}
 
@@ -120,7 +116,10 @@ public class CtInvocationImpl<T> extends
 	};
 
 	public void setArguments(List<CtExpression<?>> arguments) {
-		this.arguments = arguments;
+		this.arguments.clear();
+		for (CtExpression expr : arguments) {
+			addArgument(expr);
+		}
 	}
 
 	public void setExecutable(CtExecutableReference<T> executable) {

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -11,6 +11,7 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -48,17 +49,21 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		if (expression != null) {
 			throw new SpoonException("A lambda can't have two bodys.");
 		}
+		body.setParent(this);
 		this.body = body;
 	}
 
 	@Override
 	public List<CtParameter<?>> getParameters() {
-		return parameters;
+		return Collections.unmodifiableList(parameters);
 	}
 
 	@Override
-	public void setParameters(List<CtParameter<?>> parameters) {
-		this.parameters = parameters;
+	public void setParameters(List<CtParameter<?>> params) {
+		this.parameters.clear();
+		for (CtParameter p : params) {
+			addParameter(p);
+		}
 	}
 
 	@Override
@@ -66,6 +71,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		if (parameters == CtElementImpl.<CtParameter<?>>EMPTY_LIST()) {
 			parameters = new ArrayList<CtParameter<?>>();
 		}
+		parameter.setParent(this);
 		return parameters.add(parameter);
 	}
 
@@ -112,6 +118,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		if (body != null) {
 			throw new SpoonException("A lambda can't have two bodys.");
 		}
+		expression.setParent(this);
 		this.expression = expression;
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -40,6 +40,7 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 	}
 
 	public void setBody(CtStatement body) {
+		body.setParent(this);
 		this.body = body;
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
@@ -47,7 +47,10 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements
 
 	public void setDimensionExpressions(
 			List<CtExpression<Integer>> dimensionExpressions) {
-		this.dimensionExpressions = dimensionExpressions;
+		this.dimensionExpressions.clear();
+		for (CtExpression expr : dimensionExpressions) {
+			addDimensionExpression(expr);
+		}
 	}
 
 	@Override
@@ -56,6 +59,7 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements
 				.<CtExpression<Integer>> EMPTY_LIST()) {
 			dimensionExpressions = new ArrayList<CtExpression<Integer>>();
 		}
+		dimension.setParent(this);
 		return dimensionExpressions.add(dimension);
 	}
 
@@ -68,8 +72,11 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements
 		return dimensionExpressions.remove(dimension);
 	}
 
-	public void setElements(List<CtExpression<?>> expression) {
-		this.expressions = expression;
+	public void setElements(List<CtExpression<?>> expressions) {
+		this.expressions.clear();
+		for (CtExpression expr: expressions) {
+			addElement(expr);
+		}
 	}
 
 	@Override
@@ -77,6 +84,7 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements
 		if (expressions == CtElementImpl.<CtExpression<?>> EMPTY_LIST()) {
 			this.expressions = new ArrayList<CtExpression<?>>();
 		}
+		expression.setParent(this);
 		return expressions.add(expression);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
@@ -38,6 +38,7 @@ public class CtNewClassImpl<T> extends CtConstructorCallImpl<T> implements CtNew
 
 	@Override
 	public void setAnonymousClass(CtClass<?> anonymousClass) {
+		anonymousClass.setParent(this);
 		this.anonymousClass = anonymousClass;
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
@@ -33,6 +33,7 @@ public class CtReturnImpl<R> extends CtStatementImpl implements CtReturn<R> {
 	}
 
 	public void setReturnedExpression(CtExpression<R> expression) {
+		expression.setParent(this);
 		this.returnedExpression = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -42,8 +42,11 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements
 		return statements;
 	}
 
-	public void setStatements(List<CtStatement> statements) {
-		this.statements = statements;
+	public void setStatements(List<CtStatement> stmts) {		
+		this.statements.clear();
+		for (CtStatement stmt : stmts) {
+			addStatement(stmt);
+		}
 	}
 
 	public R S() {
@@ -66,6 +69,7 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements
 		if (this.statements == CtElementImpl.<CtStatement> EMPTY_LIST()) {
 			this.statements = new ArrayList<CtStatement>();
 		}
+		statement.setParent(this);
 		this.statements.add(statement);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
@@ -46,10 +46,14 @@ public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 	}
 
 	public void setCases(List<CtCase<? super S>> cases) {
-		this.cases = cases;
+		this.cases.clear();
+		for(CtCase caseStmt: cases) {
+			addCase(caseStmt);
+		}
 	}
 
 	public void setSelector(CtExpression<S> selector) {
+		selector.setParent(this);
 		this.expression = selector;
 	}
 
@@ -58,6 +62,7 @@ public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 		if (cases == CtElementImpl.<CtCase<? super S>> EMPTY_LIST()) {
 			cases = new ArrayList<CtCase<? super S>>();
 		}
+		c.setParent(this);
 		return cases.add(c);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
@@ -43,10 +43,12 @@ public class CtSynchronizedImpl extends CtStatementImpl implements
 	}
 
 	public void setBlock(CtBlock<?> block) {
+		block.setParent(this);
 		this.block = block;
 	}
 
 	public void setExpression(CtExpression<?> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtTargetedAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTargetedAccessImpl.java
@@ -38,11 +38,12 @@ public abstract class CtTargetedAccessImpl<T> extends CtVariableAccessImpl<T> im
 	}
 
 	@Override
-	public void setVariable(CtVariableReference<T> variable) {
+	public void setVariable(CtVariableReference<T> variable) {		
 		super.setVariable(variable);
 	}
 
 	public void setTarget(CtExpression<?> target) {
+		target.setParent(this);
 		this.target = target;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
@@ -31,6 +31,7 @@ public abstract class CtTargetedExpressionImpl<E, T extends CtExpression<?>>
 	}
 
 	public void setTarget(T target) {
+		target.setParent(this);
 		this.target = target;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -38,7 +38,10 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	public void setCatchers(List<CtCatch> catchers) {
-		this.catchers = catchers;
+		this.catchers.clear();
+		for (CtCatch c : catchers) {
+			addCatcher(c);
+		}
 	}
 
 	@Override
@@ -46,6 +49,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 		if (catchers == CtElementImpl.<CtCatch> EMPTY_LIST()) {
 			catchers = new ArrayList<CtCatch>();
 		}
+		catcher.setParent(this);
 		return catchers.add(catcher);
 	}
 
@@ -68,6 +72,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	public void setFinalizer(CtBlock<?> finalizer) {
+		finalizer.setParent(this);
 		this.finalizer = finalizer;
 	}
 
@@ -78,6 +83,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	public void setBody(CtBlock<?> body) {
+		body.setParent(this);
 		this.body = body;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
@@ -25,8 +25,11 @@ public class CtTryWithResourceImpl extends CtTryImpl
 	}
 
 	@Override
-	public void setResources(List<CtLocalVariable<?>> resources) {
-		this.resources = resources;
+	public void setResources(List<CtLocalVariable<?>> resources) {		
+		this.resources.clear();
+		for(CtLocalVariable l:resources) {
+			addResource(l);
+		}
 	}
 
 	@Override
@@ -34,6 +37,7 @@ public class CtTryWithResourceImpl extends CtTryImpl
 		if (resources == CtElementImpl.<CtLocalVariable<?>>EMPTY_LIST()) {
 			resources = new ArrayList<CtLocalVariable<?>>();
 		}
+		resource.setParent(this);
 		return resources.add(resource);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
@@ -67,6 +67,7 @@ public class CtUnaryOperatorImpl<T> extends CtExpressionImpl<T> implements
 		CtStatementImpl.insertBefore(this, statements);
 	}
 
+	@Override
 	public void replace(CtElement element) {
 		if (element instanceof CtStatementList) {
 			CtStatementImpl.replace(this, (CtStatementList) element);
@@ -76,6 +77,7 @@ public class CtUnaryOperatorImpl<T> extends CtExpressionImpl<T> implements
 	}
 
 	public void setOperand(CtExpression<T> expression) {
+		expression.setParent(this);
 		this.operand = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
@@ -35,6 +35,7 @@ public class CtWhileImpl extends CtLoopImpl implements CtWhile {
 	}
 
 	public void setLoopingExpression(CtExpression<Boolean> expression) {
+		expression.setParent(this);
 		this.expression = expression;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -80,6 +80,7 @@ public class CtAnonymousExecutableImpl extends CtElementImpl implements
 	}
 
 	public void setBody(CtBlock<?> block) {
+		block.setParent(this);
 		body = block;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -87,6 +87,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements
 				.<CtAnonymousExecutable> EMPTY_LIST()) {
 			anonymousExecutables = new ArrayList<CtAnonymousExecutable>();
 		}
+		e.setParent(this);
 		return anonymousExecutables.add(e);
 	}
 
@@ -103,8 +104,11 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements
 		return superClass;
 	}
 
-	public void setAnonymousExecutables(List<CtAnonymousExecutable> e) {
-		anonymousExecutables = e;
+	public void setAnonymousExecutables(List<CtAnonymousExecutable> anonymousExecutables) {
+		this.anonymousExecutables.clear();
+		for (CtAnonymousExecutable exec : anonymousExecutables) {
+			addAnonymousExecutable(exec);
+		}
 	}
 
 	public void setConstructors(Set<CtConstructor<T>> constructors) {

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -54,6 +54,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	@Override
 	public <B extends R> void setBody(CtBlock<B> body) {
+		body.setParent(this);
 		this.body = body;
 	}
 
@@ -64,7 +65,10 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	@Override
 	public void setParameters(List<CtParameter<?>> parameters) {
-		this.parameters = parameters;
+		this.parameters.clear();
+		for(CtParameter<?> p: parameters) {
+			addParameter(p);
+		}
 	}
 
 	@Override
@@ -72,6 +76,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		if (parameters == CtElementImpl.<CtParameter<?>>EMPTY_LIST()) {
 			parameters = new ArrayList<CtParameter<?>>();
 		}
+		parameter.setParent(this);
 		return parameters.add(parameter);
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -69,6 +69,7 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	public void setDefaultExpression(CtExpression<T> defaultExpression) {
+		defaultExpression.setParent(this);
 		this.defaultExpression = defaultExpression;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtPackageReference;
@@ -34,15 +35,34 @@ import spoon.reflect.visitor.CtVisitor;
 public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	private static final long serialVersionUID = 1L;
 
-	Set<CtPackage> packs = new TreeSet<CtPackage>();
+	private Set<CtPackage> packs = new TreeSet<CtPackage>();
 
-	Set<CtType<?>> types = new TreeSet<CtType<?>>();
+	private Set<CtType<?>> types = new TreeSet<CtType<?>>();
 
+	public static CtPackage ROOT_PACKAGE = new CtPackageImpl() {
+		@Override
+		public String getSimpleName() {
+			return "";
+		};
+		
+		@Override
+		public String getQualifiedName() {
+			return "";
+		};
+
+		@Override
+		public CtElement getParent() {
+			return null;
+		};
+	};
+	
 	public CtPackageImpl() {
 		super();
+		setParent(ROOT_PACKAGE);
 	}
 
 	public boolean addPackage(CtPackage pack) {
+		pack.setParent(this);
 		return packs.add(pack);
 	}
 
@@ -56,7 +76,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	public CtPackage getDeclaringPackage() {
 		if (parent == null) {
-			setRootElement(true);
+			setParent(ROOT_PACKAGE);
 		}
 		return getParent(CtPackage.class);
 	}
@@ -74,7 +94,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	public String getQualifiedName() {
-		if (getDeclaringPackage() == null)
+		if (getDeclaringPackage() == null || getDeclaringPackage() == ROOT_PACKAGE)
 			return getSimpleName();
 		return getDeclaringPackage().getQualifiedName() + "." + getSimpleName();
 	}
@@ -94,11 +114,17 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	public void setPackages(Set<CtPackage> packs) {
-		this.packs = packs;
+		this.packs.clear();
+		for (CtPackage p : packs) {
+			addPackage(p);
+		}
 	}
 
 	public void setTypes(Set<CtType<?>> types) {
-		this.types = types;
+		this.types.clear();
+		for (CtType t : types) {
+			addType(t);
+		}
 	}
 
 	@Override
@@ -108,8 +134,8 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public void addType(CtType<?> type) {
-		types.add(type);
 		type.setParent(this);
+		types.add(type);
 	}
 
 	@Override
@@ -130,4 +156,10 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 		 */
 		return this.position;
 	}
+	
+	@Override
+	public String toString() {
+		return getQualifiedName();
+	}
+	
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -18,9 +18,11 @@
 package spoon.support.reflect.declaration;
 
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -58,11 +60,6 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	@Override
-	public CtExecutable<?> getParent() {
-		return (CtExecutable<?>) super.getParentNoExceptions();
-	}
-
-	@Override
 	public CtParameterReference<T> getReference() {
 		return getFactory().Executable().createParameterReference(this);
 	}
@@ -72,6 +69,7 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	public void setDefaultExpression(CtExpression<T> defaultExpression) {
+		defaultExpression.setParent(this);
 		this.defaultExpression = defaultExpression;
 	}
 
@@ -136,4 +134,10 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 			return ModifierKind.PRIVATE;
 		return null;
 	}
+	
+	@Override
+	public CtExecutable<?> getParent() {
+		return (CtExecutable<?>) super.getParent();
+	}
+	
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -102,6 +102,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 
 
 	public <N> boolean addNestedType(CtType<N> nestedType) {
+		nestedType.setParent(this);
 		return this.nestedTypes.add(nestedType);
 	}
 
@@ -154,7 +155,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 
 	public CtType<?> getDeclaringType() {
 		if(parent == null) {
-			setRootElement(true);
+			setParent(CtPackageImpl.ROOT_PACKAGE);
 		}
 		return getParent(CtType.class);
 	}
@@ -246,17 +247,6 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 		SnippetCompilationHelper.compileAndReplaceSnippetsIn(this);
 	}
 
-	@Override
-	public void setParent(CtElement parentElement) {
-		super.setParent(parentElement);
-		if (parentElement instanceof CtPackage) {
-			CtPackage pack = (CtPackage) parentElement;
-			Set<CtType<?>> types = pack.getTypes();
-			// TODO: define addType()
-			types.add(this);
-			//pack.setTypes(types);
-		}
-	}
 
 	@Override
 	public Set<ModifierKind> getModifiers() {
@@ -373,6 +363,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 		if (methods == CtElementImpl.<CtMethod<?>> EMPTY_SET()) {
 			methods = new TreeSet<CtMethod<?>>();
 		}
+		method.setParent(this);
 		return methods.add(method);
 	}
 
@@ -526,7 +517,10 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl  implements
 	}
 
 	public void setMethods(Set<CtMethod<?>> methods) {
-		this.methods = methods;
+		this.methods.clear();
+		for(CtMethod meth: methods) {
+			addMethod(meth);
+		}
 	}
 
 	public void setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -478,28 +478,24 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 
 		// Evaluate forInit
 		List<CtStatement> lst = forLoop.getForInit();
-		List<CtStatement> evaluatelst = new ArrayList<CtStatement>();
 		for (CtStatement s : lst) {
 			CtStatement evaluateStatement = evaluate(forLoop, s);
 			if (evaluateStatement != null) {
-				evaluatelst.add(evaluateStatement);
+				forLoop.addForInit(evaluateStatement);
 			}
 		}
-		forLoop.setForInit(evaluatelst);
 
 		// Evaluate Expression
 		forLoop.setExpression(evaluate(forLoop, forLoop.getExpression()));
 
 		// Evaluate forUpdate
 		lst = forLoop.getForUpdate();
-		evaluatelst = new ArrayList<CtStatement>();
 		for (CtStatement s : lst) {
 			CtStatement evaluateStatement = evaluate(forLoop, s);
 			if (evaluateStatement != null) {
-				evaluatelst.add(evaluateStatement);
+				forLoop.addForUpdate(evaluateStatement);
 			}
 		}
-		forLoop.setForUpdate(evaluatelst);
 
 		setResult(forLoop.getFactory().Core().clone(forLoop));
 	}
@@ -531,7 +527,9 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 				thenEnded = true;
 				flowEnded = false;
 			}
-			ifRes.setElseStatement(evaluate(ifRes, ifElement.getElseStatement()));
+			if (ifElement.getElseStatement() !=null) {
+			  ifRes.setElseStatement(evaluate(ifRes, ifElement.getElseStatement()));
+			}
 			if (flowEnded) {
 				elseEnded = true;
 				flowEnded = false;

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -57,7 +57,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 
 	CtTypeReference<?> declaringType;
 
-	CtPackageReference pack;
+	private CtPackageReference pack;
 
 	boolean isSuperReference = false;
 

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -137,9 +137,6 @@ public class SignaturePrinter implements CtVisitor {
 		write("@");
 		if (annotation.getAnnotationType() != null) {
 			write(annotation.getAnnotationType().getQualifiedName());
-		} else {
-			logger.error("null annotation type at " + annotation.getPosition(),
-					new Exception());
 		}
 	}
 
@@ -302,8 +299,10 @@ public class SignaturePrinter implements CtVisitor {
 		else
 			write("<no type>");
 		write(" ");
-		write(reference.getDeclaringType().getQualifiedName());
-		write(CtField.FIELD_SEPARATOR);
+		if (reference.getDeclaringType()!=null) {
+			write(reference.getDeclaringType().getQualifiedName());
+			write(CtField.FIELD_SEPARATOR);
+		}
 		write(reference.getSimpleName());
 	}
 

--- a/src/test/java/spoon/test/factory/FieldFactoryTest.java
+++ b/src/test/java/spoon/test/factory/FieldFactoryTest.java
@@ -35,7 +35,6 @@ public class FieldFactoryTest {
 		Assert.assertEquals(tref, field.getType());
 		
 		CtElement parent = field.getParent();
-		Assert.assertFalse(parent.isRootElement());
 		Assert.assertTrue(parent instanceof CtClass<?>);
 		Assert.assertEquals("SampleClass", ((CtClass<?>)parent).getSimpleName());
 	}
@@ -57,7 +56,6 @@ public class FieldFactoryTest {
 		Assert.assertEquals(tref, field.getType());
 		
 		CtElement parent = field.getParent();
-		Assert.assertFalse(parent.isRootElement());
 		Assert.assertTrue(parent instanceof CtClass<?>);
 		Assert.assertEquals("SampleClass", ((CtClass<?>)parent).getSimpleName());
 	}

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -1,11 +1,16 @@
 package spoon.test.main;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtPackage;
+import spoon.support.reflect.declaration.CtElementImpl;
+import spoon.test.parent.ParentTest;
 
 public class MainTest {
 
@@ -24,10 +29,27 @@ public class MainTest {
 		}
 		String systemClassPath = classpath.substring(0, classpath.length() - 1);
 
-		spoon.Launcher.main(new String[] { "-i", "src/main/java", "-o",
+		Launcher launcher = new Launcher();
+		
+		launcher.run(new String[] { "-i", "src/main/java", "-o",
 				"target/spooned", "--source-classpath",
-				systemClassPath, "--compile" });
-		// we should have no exception
+				systemClassPath, "--compile", "--compliance", "7" });
+		
+		for(CtPackage pack: launcher.getFactory().Package().getAllRoots()) {
+			ParentTest.checkParentContract(pack);
+		}
+	}
+
+	@Test
+	public void testTest() throws Exception {
+		// the tests should be spoonable
+		Launcher launcher = new Launcher();		
+		launcher.run(new String[] { "-i", "src/test/java", "-o",
+				"target/spooned", "--noclasspath", "--compliance", "8" });
+		
+		for(CtPackage pack: launcher.getFactory().Package().getAllRoots()) {
+			ParentTest.checkParentContract(pack);
+		}
 	}
 
 	@Test

--- a/src/test/java/spoon/test/parent/ParentContractTest.java
+++ b/src/test/java/spoon/test/parent/ParentContractTest.java
@@ -1,0 +1,119 @@
+package spoon.test.parent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+import spoon.reflect.declaration.CtAnnotationType;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.factory.CoreFactory;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtReference;
+import spoon.reflect.visitor.CtVisitable;
+import spoon.test.TestUtils;
+
+// check that all setters of the metamodel call setParent
+@RunWith(Parameterized.class)
+public class ParentContractTest<T extends CtVisitable> {
+
+	private static Factory factory = TestUtils.createFactory();
+
+	@Parameterized.Parameters(name = "{0}")
+	public static Collection<Object[]> data() throws Exception {
+		List<Object[]> values = new ArrayList<>();
+		for (Method method : CoreFactory.class.getDeclaredMethods()) {
+			if (method.getName().startsWith("create")
+					&& method.getReturnType().getSimpleName().startsWith("Ct")
+					&& !CtReference.class.isAssignableFrom(method.getReturnType())
+					){
+				values.add(new Object[] { method.getReturnType(), method.invoke(factory.Core()) });
+			}
+		}
+		return values;
+	}
+
+	@Parameterized.Parameter(0)
+	public Class<T> toTest;
+
+	@Parameterized.Parameter(1)
+	public T instance;
+
+	/**
+	 * Create the list of method we have to call for a class
+	 *
+	 * @param entry
+	 * @return
+	 * @throws Exception
+	 */
+	private List<Method> getMethodsToInvoke(Class<?> entry) throws Exception {
+		Queue<Class<?>> tocheck = new LinkedList<>();
+		tocheck.add(entry);
+
+		List<Method> toInvoke = new ArrayList<>();
+		while (!tocheck.isEmpty()) {
+			Class<?> intf = tocheck.poll();
+
+			Assert.assertTrue(intf.isInterface());
+			if (!intf.getSimpleName().startsWith("Ct")) {
+				continue;
+			}
+			
+			if (intf.getSimpleName().equals("CtElement")) {
+				continue;
+			}
+
+			// get all setters with take a CtElement as parameter
+			for(Method mth : intf.getDeclaredMethods()) {
+				if ((mth.getName().startsWith("set")
+						|| mth.getName().startsWith("add")) 
+						&& mth.getParameterTypes().length==1
+						&& CtElement.class.isAssignableFrom(mth.getParameterTypes()[0])
+						) {
+					if (!toInvoke.contains(mth)) {
+						toInvoke.add(mth);
+					}
+				}
+			}
+
+			for (Class<?> aClass : intf.getInterfaces()) {
+				tocheck.add(aClass);
+			}
+		}
+		return toInvoke;
+	}
+	
+	@Test
+	public void testContract() throws Throwable {
+		Object o = instance;
+		for (Method setter : getMethodsToInvoke(toTest)) {
+			
+			// special case: unsupported method
+			if (o instanceof CtAnnotationType && "addMethod".equals(setter.getName())) continue;
+			
+			CtElement mockedArgument = (CtElement) mock(setter.getParameters()[0].getType(),  Mockito.withSettings().extraInterfaces(Comparable.class));
+			try {
+				// we create a fresh object
+				CtElement receiver = (CtElement)factory.Core().clone(o);
+				// we invoke the setter
+				setter.invoke(receiver, new Object[]{mockedArgument});				
+				// we check that setParent has been called
+				verify(mockedArgument).setParent((CtElement) receiver);
+			} catch (AssertionError e) {
+				Assert.fail("call setParent contract failed for "+setter.toString()+" "+e.toString());
+			}
+		}
+	}
+
+}

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -1,6 +1,9 @@
 package spoon.test.parent;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Stack;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -15,10 +18,14 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.NameFilter;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.declaration.CtPackageImpl;
 
 public class ParentTest {
     
@@ -87,6 +94,29 @@ public class ParentTest {
 		pack.addType(clazz);
 		assertTrue(pack.getTypes().contains(clazz));
 		assertEquals(pack, clazz.getParent());
+	}
+
+	public static void checkParentContract(CtPackage pack) {
+		for(CtElement elem: pack.getElements(new TypeFilter<>(CtElement.class))) {
+			// there is always one parent
+			Assert.assertNotNull("no parent for "+elem.getClass()+"-"+elem.getPosition(), elem.getParent());
+		}
+		
+		// the scanner and the parent are in correspondence
+		new CtScanner() {
+			Stack<CtElement> elementStack = new Stack<CtElement>();
+			@Override
+			public void scan(CtElement e) {
+				if (e==null) { return; }
+				if (!elementStack.isEmpty()) {
+					assertEquals(elementStack.peek(), e.getParent());
+				}
+				elementStack.push(e);
+				e.accept(this);
+				elementStack.pop();
+			};
+		}.scan(pack);
+
 	}
 
 }

--- a/src/test/java/spoon/test/serializable/SerializableTest.java
+++ b/src/test/java/spoon/test/serializable/SerializableTest.java
@@ -29,7 +29,6 @@ public class SerializableTest {
 		
 		CtType<?> typeBef = sta2.getParent(CtType.class);
 		assertNotNull(typeBef);
-		typeBef.isRootElement();
 		
 		assertEquals(sigBef, sigAf);
 		
@@ -51,11 +50,7 @@ public class SerializableTest {
 		assertEquals(CtPackage.TOP_LEVEL_PACKAGE_NAME,parentOriginal.getSimpleName());
 		
 		assertEquals(CtPackage.TOP_LEVEL_PACKAGE_NAME,parentDeser.getSimpleName());
-		
-		assertTrue(parentOriginal.isRootElement());
 				
-		assertTrue(parentDeser.isRootElement());
-		
 	}
 
 	


### PR DESCRIPTION
It's no more the responsibility of JDTTreeBuilder to set the parent. It's the responsibility of each intercession method to do so. This should much ease the writing of complex transformations.