### PR TITLE
fix(super): Gets a SuperAccess node in qualified super reference or not.

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -90,15 +90,4 @@ public interface CtTypeReference<T> extends CtReference,
 	 * Sets the reference to the declaring package.
 	 */
 	void setPackage(CtPackageReference pack);
-
-	/**
-	 * Returns true if the reference refers to the super implementation
-	 */
-	boolean isSuperReference();
-
-	/**
-	 * Says that this reference refers to the super implementation
-	 */
-	void setSuperReference(boolean b);
-
 }

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1888,9 +1888,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				write(ref.getQualifiedName());
 			}
 		}
-		if (ref.isSuperReference()) {
-			write(".super");
-		}
 		if (!context.ignoreGenerics) {
 			writeGenericsParameter(ref.getActualTypeArguments());
 		}
@@ -1937,9 +1934,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			write(ref.getSimpleName());
 		} else {
 			write(ref.getQualifiedName());
-		}
-		if (ref.isSuperReference()) {
-			write(".super");
 		}
 	}
 

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -484,14 +484,6 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements
 		return true;
 	}
 
-	public boolean isSuperReference() {
-		return isSuperReference;
-	}
-
-	public void setSuperReference(boolean b) {
-		isSuperReference = b;
-	}
-
 	@Override
 	public boolean addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
 		if (actualTypeArguments == CtElementImpl

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -1,6 +1,7 @@
 package spoon.test.fieldaccesses;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static spoon.test.TestUtils.build;
 
@@ -10,11 +11,15 @@ import org.junit.Test;
 
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtSuperAccess;
 import spoon.reflect.code.CtTargetedAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.code.CtThisAccessImpl;
@@ -100,6 +105,21 @@ public class FieldAccessTest {
 		assertEquals(
 				"spoon.test.fieldaccesses.InternalSuperCall.super.toString()",
 				meth0.getBody().getStatements().get(0).toString());
+	}
+
+	@Test
+	public void testTargetOfSuperAccesses() throws Exception {
+		final Factory factory = build(InternalSuperCall.class);
+		final CtClass<?> ctClass = factory.Class().get(InternalSuperCall.class);
+		final List<CtSuperAccess> superAccesses = ctClass.getElements(new AbstractFilter<CtSuperAccess>(CtSuperAccess.class) {
+			@Override
+			public boolean matches(CtSuperAccess element) {
+				return super.matches(element);
+			}
+		});
+		assertEquals(2, superAccesses.size());
+		assertNull(superAccesses.get(0).getTarget());
+		assertNotNull(superAccesses.get(1).getTarget());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/fieldaccesses/InternalSuperCall.java
+++ b/src/test/java/spoon/test/fieldaccesses/InternalSuperCall.java
@@ -1,9 +1,14 @@
 package spoon.test.fieldaccesses;
 
 public class InternalSuperCall{
-	
+
 	public void methode(){
 		InternalSuperCall.super.toString();
+	}
+
+	@Override
+	public String toString() {
+		return super.toString();
 	}
 }
 


### PR DESCRIPTION
1. Creates a SuperAccess node when we have a QualifiedSuperReference.
In this case, we create a CtTypeAccess for the target of the super access.
2. Removes useless methods in CtTypeReference to know if it is a super
reference or not. So, we remove its usafe in JDTTreeBuilder and
DefaultJavaPrettyPrinter.
3. Creates a test case to test than we have a SuperAccess node in these
cases.