### PR TITLE
doc: Removes CtThisAccess reference in the javadoc of CtTargetedAccess.

### DIFF
--- a/src/main/java/spoon/reflect/code/CtTargetedAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTargetedAccess.java
@@ -23,10 +23,8 @@ import spoon.reflect.reference.CtFieldReference;
  * 
  * This code element defines an access to a target.
  * 
- * see {@link CtFieldAccess},
- * {@link CtSuperAccess}
- * or {@link CtThisAccess}
- * 
+ * see {@link CtFieldAccess} or {@link CtSuperAccess}
+ *
  * @param <T>
  *            Corresponding type
  */


### PR DESCRIPTION
Closes #227