### PR TITLE
fix(invocation): Gets a CtTypeAccess for all static invocations.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -2463,6 +2463,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 			}
 			context.enter(va, qualifiedNameReference);
 			return false;
+		} else if (qualifiedNameReference.binding instanceof TypeBinding) {
+			CtTypeAccess<Object> ta = factory.Core().createTypeAccess();
+			ta.setType(references.getTypeReference((TypeBinding) qualifiedNameReference.binding));
+			context.enter(ta, qualifiedNameReference);
+			return false;
 		} else {
 			CtVariableAccess<Object> va = factory.Core().createVariableAccess();
 			CtVariableReference<Object> varRef = new CtUnboundVariableReferenceImpl<Object>();

--- a/src/test/java/spoon/test/invocations/InvocationTest.java
+++ b/src/test/java/spoon/test/invocations/InvocationTest.java
@@ -1,0 +1,40 @@
+package spoon.test.invocations;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.SpoonAPI;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.test.invocations.testclasses.Foo;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InvocationTest {
+	@Test
+	public void testTypeOfStaticInvocation() throws Exception {
+		SpoonAPI launcher = new Launcher();
+		launcher.run(new String[] {
+				"-i", "./src/test/java/spoon/test/invocations/testclasses/",
+				"-o", "./target/spooned/"
+		});
+		Factory factory = launcher.getFactory();
+		CtClass<?> aClass = factory.Class().get(Foo.class);
+
+		final List<CtInvocation<?>> elements = aClass.getElements(new AbstractFilter<CtInvocation<?>>(CtInvocation.class) {
+			@Override
+			public boolean matches(CtInvocation<?> element) {
+				return element.getTarget() != null;
+			}
+		});
+
+		assertEquals(2, elements.size());
+		assertTrue(elements.get(0).getTarget() instanceof CtTypeAccess);
+		assertTrue(elements.get(1).getTarget() instanceof CtTypeAccess);
+	}
+}

--- a/src/test/java/spoon/test/invocations/testclasses/Foo.java
+++ b/src/test/java/spoon/test/invocations/testclasses/Foo.java
@@ -1,0 +1,8 @@
+package spoon.test.invocations.testclasses;
+
+public class Foo {
+	public Foo() {
+		String.valueOf(0);
+		java.lang.String.valueOf(0);
+	}
+}


### PR DESCRIPTION
When we have: 

```java
String.valueOf(0);
java.lang.String.valueOf(0);
```

The target of the first one was a `CtTypeAccess` and the second one a `CtVariableAccess`. Now, both are a `CtTypeAccess`.