### PR TITLE
fix(jdk8): Makes spoon compatible with Java 1.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,28 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-maven-plugin</artifactId>
+        <version>1.9</version>
+        <configuration>
+          <signature>
+            <groupId>org.codehaus.mojo.signature</groupId>
+            <artifactId>java16</artifactId>
+            <version>1.0</version>
+          </signature>
+        </configuration>
+        <executions>
+          <execution>
+            <id>ensure-java-1.6-class-library</id>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.1</version>

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -20,7 +20,6 @@ package spoon.support.reflect.code;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.locks.StampedLock;
 
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -25,12 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.ListIterator;
-import java.util.RandomAccess;
 import java.util.Set;
-import java.util.TreeSet;
-import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 
 import org.apache.log4j.Logger;
 
@@ -68,8 +63,7 @@ public abstract class CtElementImpl implements CtElement, Serializable , Compara
 	// we don't use Collections.unmodifiableList and Collections.unmodifiableSet 
 	// because we need clear() for all set* methods
 	// and UnmodifiableList and unmodifiableCollection are not overridable (not visible grrrr)
-	private static class UNMODIFIABLE_COLLECTION<Object> extends
-			ArrayList<Object> implements Set<Object> {
+	private static class UNMODIFIABLE_COLLECTION<Object> extends ArrayList<Object> implements Set<Object> {
 		@Override
 		public Object set(int index, Object element) {
 			throw new UnsupportedOperationException();
@@ -91,17 +85,7 @@ public abstract class CtElementImpl implements CtElement, Serializable , Compara
 		}
 
 		@Override
-		public void replaceAll(UnaryOperator<Object> operator) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void sort(Comparator<? super Object> c) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public java.lang.Object[] toArray(java.lang.Object[] a) {
+		public Object[] toArray(java.lang.Object[] a) {
 			throw new UnsupportedOperationException();
 		}
 


### PR DESCRIPTION
Removes usage of java 8 classes in the project and adds a maven plugin
to check if we don't use methods in java version higher than Java 1.6.

Closes #237