### PR TITLE
doc(access): Explains changes in the AST for access concepts.

### DIFF
--- a/src/main/java/spoon/reflect/code/CtArrayRead.java
+++ b/src/main/java/spoon/reflect/code/CtArrayRead.java
@@ -3,6 +3,9 @@ package spoon.reflect.code;
 /**
  * This code element defines an read access to an array.
  *
+ * In Java, it is a usage of a array outside an assignment. For example,
+ * <code>System.out.println(array[0]);</code>
+ *
  * @param <T>
  * 		type of the array
  */

--- a/src/main/java/spoon/reflect/code/CtArrayWrite.java
+++ b/src/main/java/spoon/reflect/code/CtArrayWrite.java
@@ -3,6 +3,9 @@ package spoon.reflect.code;
 /**
  * This code element defines an write access to an array.
  *
+ * In Java, it is a usage of a array inside an assignment. For example,
+ * <code>array[0] = "new value";</code>
+ *
  * @param <T>
  * 		type of the array
  */

--- a/src/main/java/spoon/reflect/code/CtFieldRead.java
+++ b/src/main/java/spoon/reflect/code/CtFieldRead.java
@@ -3,6 +3,9 @@ package spoon.reflect.code;
 /**
  * This code element defines an read access to a field.
  *
+ * In Java, it is a usage of a field outside an assignment. For example,
+ * <code>System.out.println(this.field);</code>
+ *
  * @param <T>
  * 		type of the field
  */

--- a/src/main/java/spoon/reflect/code/CtFieldWrite.java
+++ b/src/main/java/spoon/reflect/code/CtFieldWrite.java
@@ -3,6 +3,9 @@ package spoon.reflect.code;
 /**
  * This code element defines a write to a field.
  *
+ * In Java, it is a usage of a field inside an assignment. For example,
+ * <code>this.field = "new value";</code>
+ *
  * @param <T>
  * 		type of the field
  */

--- a/src/main/java/spoon/reflect/code/CtSuperAccess.java
+++ b/src/main/java/spoon/reflect/code/CtSuperAccess.java
@@ -27,9 +27,15 @@ import spoon.reflect.reference.CtVariableReference;
  * 		Type of super
  */
 public interface CtSuperAccess<T> extends CtTargetedAccess<T> {
+	/**
+	 * @deprecated super isn't a variable. So this method will be removed in a next release.
+	 */
 	@Deprecated
 	CtFieldReference<T> getVariable();
 
+	/**
+	 * @deprecated super isn't a variable. So this method will be removed in a next release.
+	 */
 	@Deprecated
 	void setVariable(CtVariableReference<T> variable);
 }

--- a/src/main/java/spoon/reflect/code/CtTargetedAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTargetedAccess.java
@@ -1,5 +1,11 @@
 package spoon.reflect.code;
 
+/**
+ * @deprecated Methods defined in CtTargetedAccess have been moved in
+ * {@link spoon.reflect.code.CtFieldAccess} and it will be replaced by
+ * {@link spoon.reflect.code.CtTargetedExpression} in a future version.
+ * Think to update our usage of this class for the next release of Spoon.
+ */
 @Deprecated
 public interface CtTargetedAccess<T>
 		extends CtVariableRead<T>, CtTargetedExpression<T, CtExpression<?>> {

--- a/src/main/java/spoon/reflect/code/CtVariableRead.java
+++ b/src/main/java/spoon/reflect/code/CtVariableRead.java
@@ -20,6 +20,9 @@ package spoon.reflect.code;
 /**
  * This code element defines an read access to a variable.
  *
+ * In Java, it is a usage of a variable outside an assignment. For example,
+ * <code>System.out.println(variable);</code>
+ *
  * @param <T>
  * 		type of the variable
  */

--- a/src/main/java/spoon/reflect/code/CtVariableWrite.java
+++ b/src/main/java/spoon/reflect/code/CtVariableWrite.java
@@ -3,6 +3,9 @@ package spoon.reflect.code;
 /**
  * This code element defines a write to a variable.
  *
+ * In Java, it is a usage of a variable inside an assignment. For example,
+ * <code>variable = "new value";</code>
+ *
  * @param <T>
  * 		type of the variable
  */

--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -131,6 +131,9 @@ public interface CoreFactory {
 
 	/**
 	 * Creates an array access expression.
+	 *
+	 * @deprecated See {@link #createArrayRead() createArrayRead}
+	 * or {@link #createArrayWrite() createArrayWrite}
 	 */
 	@Deprecated
 	<T, E extends CtExpression<?>> CtArrayAccess<T, E> createArrayAccess();
@@ -227,6 +230,9 @@ public interface CoreFactory {
 
 	/**
 	 * Creates a field access expression.
+	 *
+	 * @deprecated See {@link #createFieldRead() createFieldRead}
+	 * or {@link #createFieldWrite() createFieldWrite}
 	 */
 	@Deprecated
 	<T> CtFieldAccess<T> createFieldAccess();
@@ -429,6 +435,9 @@ public interface CoreFactory {
 
 	/**
 	 * Creates a variable access expression.
+	 *
+	 * @deprecated See {@link #createVariableRead() createVariableRead}
+	 * or {@link #createVariableWrite() createVariableWrite}
 	 */
 	@Deprecated
 	<T> CtVariableAccess<T> createVariableAccess();


### PR DESCRIPTION
1. Adds deprecated information in CtTargetedAccess to explain that
methods have been moved in CtFieldAccess and the new class will be
CtTargetedExpression.
2. Adds examples code in Ct*Read and Ct*Write interfaces.