### PR TITLE
Bug fix for nested annotation types.

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -17,13 +17,14 @@
 
 package spoon.support.reflect.declaration;
 
+import static spoon.reflect.ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -49,8 +50,6 @@ import spoon.reflect.visitor.filter.AnnotationFilter;
 import spoon.support.util.RtHelper;
 import spoon.support.visitor.SignaturePrinter;
 import spoon.support.visitor.TypeReferenceScanner;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY;
 
 /** 
  * Contains the default implementation of most CtElement methods.
@@ -186,7 +185,7 @@ public abstract class CtElementImpl implements CtElement, Serializable , Compara
 	public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
 		for (CtAnnotation<? extends Annotation> a : getAnnotations()) {
 			if (a.getAnnotationType().toString()
-					.equals(annotationType.getName())) {
+					.equals(annotationType.getName().replace('$','.'))) {
 				return ((CtAnnotation<A>) a).getActualAnnotation();
 			}
 		}

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -51,6 +51,7 @@ import spoon.test.annotation.testclasses.AnnotationRepeated;
 import spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass;
 import spoon.test.annotation.testclasses.AnnotationsRepeated;
 import spoon.test.annotation.testclasses.Bound;
+import spoon.test.annotation.testclasses.Foo;
 import spoon.test.annotation.testclasses.Foo.InnerAnnotation;
 import spoon.test.annotation.testclasses.Foo.MiddleAnnotation;
 import spoon.test.annotation.testclasses.Foo.OuterAnnotation;
@@ -692,6 +693,15 @@ public class AnnotationTest {
 		assertEquals("Field is typed by an annotation.", InnerAnnot.class, ctField.getType().getActualClass());
 		assertEquals("Default value of a field typed by an annotation must be an annotation",
 				InnerAnnot.class, ctField.getDefaultExpression().getType().getActualClass());
+	}
+
+	@Test
+	public void testGetAnnotationOuter() throws Exception {
+		final CtClass<?> ctClass = (CtClass<?>) this.factory.Type().get("spoon.test.annotation.testclasses.Foo");
+		final CtMethod<?> testMethod = ctClass.getMethodsByName("test").get(0);
+		Foo.OuterAnnotation annot = testMethod.getAnnotation(Foo.OuterAnnotation.class);
+		assertNotNull(annot);
+		assertEquals(2,annot.value().length);
 	}
 
 	private Class<? extends Annotation> getActualClassFromAnnotation(CtAnnotation<? extends Annotation> annotation) {


### PR DESCRIPTION
Class#getName() returns a pattern of the form "_type_name_$nested" for nested types whereas CtAnnotation#getAnnotationType() returns a pattern of the form "_type_name.nested". The dollar character needs to be replaced by the dot character for the equality to match.