### PR TITLE
Fix Type package with incomplete sources

### DIFF
--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1,6 +1,8 @@
 package spoon.test.imports;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 
@@ -15,6 +17,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.NameFilter;
@@ -101,5 +104,21 @@ public class ImportTest {
 				+ "    }" + System.lineSeparator()
 				+ "}";
 		assertEquals(expected, subClass.toString());
+	}
+
+	@Test
+	public void testMissingImport() throws Exception {
+		Launcher spoon = new Launcher();
+		Factory factory = spoon.createFactory();
+		factory.getEnvironment().setNoClasspath(true);
+
+		SpoonCompiler compiler = spoon.createCompiler(
+				factory,
+				SpoonResourceHelper.resources("./src/test/resources/import-resources/fr/inria/MissingImport.java"));
+
+		compiler.build();
+		CtTypeReference<?> type = factory.Class().getAll().get(0).getFields().get(0).getType();
+		assertEquals("Abcd", type.getSimpleName());
+		assertEquals("fr.inria.internal", type.getPackage().getSimpleName());
 	}
 }

--- a/src/test/resources/import-resources/fr/inria/MissingImport.java
+++ b/src/test/resources/import-resources/fr/inria/MissingImport.java
@@ -1,0 +1,8 @@
+
+package fr.inria;
+import fr.inria.internal.Abcd;
+
+public class MissingImport {
+
+    private final Abcd abcd = new Abcd();
+}


### PR DESCRIPTION
I triggered an issue with packaging and incomplete sources.
For example if a class is missing (generated or something like that).
The file add a import

package com.abcd.project2
import com.abcd.project1.MyClass

void aa() {
  new MyClass();
}

The MyClass object will be reported as com.abcd.project2.MyClass. Even if the class is not present we explicitly have an import. Shouldn't we use the import?