### PR TITLE
Scanning of constructors in Enums added to CtScanner

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -1,16 +1,16 @@
-/* 
+/*
  * Spoon - http://spoon.gforge.inria.fr/
  * Copyright (C) 2006 INRIA Futurs <renaud.pawlak@inria.fr>
- * 
+ *
  * This software is governed by the CeCILL-C License under French law and
- * abiding by the rules of distribution of free software. You can use, modify 
- * and/or redistribute the software under the terms of the CeCILL-C license as 
- * circulated by CEA, CNRS and INRIA at http://www.cecill.info. 
- * 
- * This program is distributed in the hope that it will be useful, but WITHOUT 
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or 
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
- *  
+ *
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
@@ -358,6 +358,7 @@ public abstract class CtScanner implements CtVisitor {
 		enter(ctEnum);
 		scan(ctEnum.getAnnotations());
 		scan(ctEnum.getFields());
+		scan(ctEnum.getConstructors());
 		scan(ctEnum.getMethods());
 		scan(ctEnum.getNestedTypes());
 		exit(ctEnum);
@@ -732,7 +733,7 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtUnboundVariableReference(
 			CtUnboundVariableReference<T> reference) {
-		
+
 	}
 
 	@Override

--- a/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTest.java
+++ b/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTest.java
@@ -1,0 +1,26 @@
+package spoon.test.reflect.visitor;
+
+import static spoon.test.TestUtils.build;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import spoon.reflect.declaration.CtEnum;
+import spoon.reflect.factory.TypeFactory;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.ReferenceTypeFilter;
+
+public class ReferenceQueryTest {
+	@Test
+	public void getAllTypeReferencesInEnum() throws Exception {
+		CtEnum<ReferenceQueryTestEnum> testEnum = build("spoon.test.reflect.visitor", "ReferenceQueryTestEnum");
+		List< CtTypeReference<?> > enumTypeRefs = Query.getReferences(testEnum, new ReferenceTypeFilter< CtTypeReference<?> >(CtTypeReference.class));
+		TypeFactory typeFactory = testEnum.getFactory().Type();
+		for (Class<?> c : new Class<?>[]{Integer.class, Long.class, Boolean.class, Number.class, String.class, Void.class}) {
+			Assert.assertTrue("the reference query on the enum should return all the types defined in the enum declaration", enumTypeRefs.contains(typeFactory.createReference(c)));
+		}
+	}
+}

--- a/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTestEnum.java
+++ b/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTestEnum.java
@@ -1,0 +1,18 @@
+package spoon.test.reflect.visitor;
+
+
+public enum ReferenceQueryTestEnum {
+	E0(new Integer(0)),
+	E1(new Long(1)),
+	;
+    Boolean bool;
+
+    ReferenceQueryTestEnum(Number throwable) {
+        String t = "true";
+        bool = Boolean.valueOf(t);
+    }
+
+    public Void getNumber() {
+        return null;
+    }
+}


### PR DESCRIPTION
* Additional change - Eclipse project file removed as without the
.classpath file the imported project is erroneous, the .classpath file
is subject to evolving 3rd party libraries therefore added instructions
to generate a valid Eclipse project using Maven.