### PR TITLE
Uses diamond syntax for elements with actual generics

### DIFF
--- a/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
+++ b/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
  * using default capacity (10, in case of {@code ArrayList}) is a memory waste.
  */
 public final class ModelElementContainerDefaultCapacities {
-    /*
+	/*
      * Author Roman Leventov
      *  
      * Some element types were analyzed through JDK 7 sources,
@@ -38,62 +38,66 @@ public final class ModelElementContainerDefaultCapacities {
      * than ArrayList's default of 10.
      */
 
-    // JDK 7 average is 1.063 (methods), 1.207 (constructors)
-    public static final int PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // > 1 very rarely
-    public static final int CASTS_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // JDK 7 average is 2.150
-    public static final int BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 3;
-    
-    // JDK 7 average is 1.652
-    public static final int CASE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // > 1 very rarely
-    public static final int FOR_INIT_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // > 1 very rarely
-    public static final int FOR_UPDATE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 1;
+	// JDK 7 average is 1.063 (methods), 1.207 (constructors)
+	public static final int PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
 
-    // 1-2
-    public static final int CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // > 1 very rarely
-    public static final int NEW_ARRAY_DEFAULT_EXPRESSIONS_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // JDK 7 average is 6.487
-    public static final int SWITCH_CASES_CONTAINER_DEFAULT_CAPACITY = 7;
-    
-    // 1-2
-    public static final int CATCH_CASES_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // > 1 very rarely
-    public static final int RESOURCES_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // > 1 very rarely
-    public static final int COMPILATION_UNIT_DECLARED_TYPES_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // > 1 very rarely
-    public static final int ANONYMOUS_EXECUTABLES_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // In JDK 7 only 1, if any
-    public static final int CONSTRUCTOR_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 1;
-    
-    // 1-2
-    public static final int ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // 1-2
-    public static final int METHOD_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // 1-2
-    public static final int TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
-    
-    // JDK 7 average 3.861
-    public static final int FIELDS_CONTAINER_DEFAULT_CAPACITY = 4;
-    
-    // > 1 very rarely
-    public static final int TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY = 1;
+	// > 1 very rarely
+	public static final int CASTS_CONTAINER_DEFAULT_CAPACITY = 1;
 
-    private ModelElementContainerDefaultCapacities() {}
+	// JDK 7 average is 2.150
+	public static final int BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 3;
+
+	// JDK 7 average is 1.652
+	public static final int CASE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// > 1 very rarely
+	public static final int FOR_INIT_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// > 1 very rarely
+	public static final int FOR_UPDATE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// 1-2
+	public static final int CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// > 1 very rarely
+	public static final int NEW_ARRAY_DEFAULT_EXPRESSIONS_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// JDK 7 average is 6.487
+	public static final int SWITCH_CASES_CONTAINER_DEFAULT_CAPACITY = 7;
+
+	// 1-2
+	public static final int CATCH_CASES_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// > 1 very rarely
+	public static final int RESOURCES_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// > 1 very rarely
+	public static final int COMPILATION_UNIT_DECLARED_TYPES_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// > 1 very rarely
+	public static final int ANONYMOUS_EXECUTABLES_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// In JDK 7 only 1, if any
+	public static final int CONSTRUCTOR_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	// 1-2
+	public static final int ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// 1-2
+	public static final int METHOD_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// 1-2
+	public static final int TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// 1-2
+	public static final int CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
+
+	// JDK 7 average 3.861
+	public static final int FIELDS_CONTAINER_DEFAULT_CAPACITY = 4;
+
+	// > 1 very rarely
+	public static final int TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY = 1;
+
+	private ModelElementContainerDefaultCapacities() {
+	}
 }

--- a/src/main/java/spoon/reflect/code/CtConstructorCall.java
+++ b/src/main/java/spoon/reflect/code/CtConstructorCall.java
@@ -1,11 +1,15 @@
 package spoon.reflect.code;
 
+import spoon.reflect.reference.CtGenericElementReference;
+
 /**
  * This code element represents a constructor call.
  *
  * @param <T>
- *            created type
+ * 		created type
  */
 public interface CtConstructorCall<T> extends CtTargetedExpression<T, CtExpression<?>>,
-											  CtAbstractInvocation<T>, CtStatement {
+											  CtAbstractInvocation<T>,
+											  CtStatement,
+											  CtGenericElementReference {
 }

--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -85,6 +85,7 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -422,6 +423,11 @@ public interface CoreFactory {
 	 * Creates a type reference.
 	 */
 	<T> CtTypeReference<T> createTypeReference();
+
+	/**
+	 * Creates a inference type reference.
+	 */
+	<T> CtImplicitTypeReference<T> createImplicitTypeReference();
 
 	/**
 	 * Creates a type access expression.

--- a/src/main/java/spoon/reflect/reference/CtGenericElementReference.java
+++ b/src/main/java/spoon/reflect/reference/CtGenericElementReference.java
@@ -43,5 +43,4 @@ public interface CtGenericElementReference {
 	 * Removes a type argument.
 	 */
 	boolean removeActualTypeArgument(CtTypeReference<?> actualTypeArgument);
-
 }

--- a/src/main/java/spoon/reflect/reference/CtImplicitTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtImplicitTypeReference.java
@@ -1,0 +1,18 @@
+package spoon.reflect.reference;
+
+/**
+ * This interface defines a reference to a {@link spoon.reflect.declaration.CtType} or sub-type
+ * but when this type is implicit like given in the diamond operator.
+ *
+ * <pre>
+ * {@code
+ *     // The type in the diamond operator of ArrayList is a CtImplicitTypeReference with a String.
+ *     List<String> list = new ArrayList<>();
+ * }
+ * </pre>
+ *
+ * @param <T>
+ * 		Implicit type.
+ */
+public interface CtImplicitTypeReference<T> extends CtTypeReference<T> {
+}

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -639,6 +639,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtTargetedExpression(e);
 		scanCtAbstractInvocation(e);
 		scanCtStatement(e);
+		scanCtGenericElementReference(e);
 		scanCtExpression(e);
 		scanCtElement(e);
 		scanCtCodeElement(e);

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -96,6 +96,7 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -169,6 +170,7 @@ import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 import spoon.support.reflect.reference.CtCatchVariableReferenceImpl;
 import spoon.support.reflect.reference.CtExecutableReferenceImpl;
 import spoon.support.reflect.reference.CtFieldReferenceImpl;
+import spoon.support.reflect.reference.CtImplicitTypeReferenceImpl;
 import spoon.support.reflect.reference.CtLocalVariableReferenceImpl;
 import spoon.support.reflect.reference.CtPackageReferenceImpl;
 import spoon.support.reflect.reference.CtParameterReferenceImpl;
@@ -657,6 +659,13 @@ public class DefaultCoreFactory implements CoreFactory, Serializable {
 
 	public <T> CtTypeReference<T> createTypeReference() {
 		CtTypeReference<T> e = new CtTypeReferenceImpl<T>();
+		e.setFactory(getMainFactory());
+		return e;
+	}
+
+	@Override
+	public <T> CtImplicitTypeReference<T> createImplicitTypeReference() {
+		final CtImplicitTypeReferenceImpl<T> e = new CtImplicitTypeReferenceImpl<T>();
 		e.setFactory(getMainFactory());
 		return e;
 	}

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -10,18 +10,23 @@ import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtGenericElementReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
+import static spoon.reflect.ModelElementContainerDefaultCapacities.CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 
 public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>>
 		implements CtConstructorCall<T> {
 	private static final long serialVersionUID = 1L;
 
+	List<CtTypeReference<?>> actualTypeArguments = CtElementImpl.EMPTY_LIST();
 	List<CtExpression<?>> arguments = EMPTY_LIST();
 	CtExecutableReference<T> executable;
 	String label;
@@ -119,5 +124,33 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 	@Override
 	public void replace(CtStatement element) {
 		replace((CtElement)element);
+	}
+
+	@Override
+	public List<CtTypeReference<?>> getActualTypeArguments() {
+		return Collections.unmodifiableList(actualTypeArguments);
+	}
+
+	@Override
+	public <T extends CtGenericElementReference> T setActualTypeArguments(
+			List<CtTypeReference<?>> actualTypeArguments) {
+		this.actualTypeArguments = actualTypeArguments;
+		return (T) this;
+	}
+
+	@Override
+	public <T extends CtGenericElementReference> T addActualTypeArgument(
+			CtTypeReference<?> actualTypeArgument) {
+		if (actualTypeArguments == CtElementImpl.<CtTypeReference<?>>EMPTY_LIST()) {
+			actualTypeArguments = new ArrayList<CtTypeReference<?>>(CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+		}
+		actualTypeArguments.add(actualTypeArgument);
+		return (T) this;
+	}
+
+	@Override
+	public boolean removeActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+		return actualTypeArguments != CtElementImpl.<CtTypeReference<?>>EMPTY_LIST()
+				&& actualTypeArguments.remove(actualTypeArgument);
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -36,6 +36,7 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtReference;
@@ -187,7 +188,7 @@ public abstract class CtElementImpl implements CtElement, Serializable , Compara
 	public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
 		for (CtAnnotation<? extends Annotation> a : getAnnotations()) {
 			if (a.getAnnotationType().toString()
-					.equals(annotationType.getName().replace('$','.'))) {
+					.equals(annotationType.getName().replace('$', '.'))) {
 				return ((CtAnnotation<A>) a).getActualAnnotation();
 			}
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -421,6 +421,4 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements
 		return actualTypeArguments !=CtElementImpl.<CtTypeReference<?>>EMPTY_LIST() &&
 				actualTypeArguments.remove(actualTypeArgument);
 	}
-
-
 }

--- a/src/main/java/spoon/support/reflect/reference/CtImplicitTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtImplicitTypeReferenceImpl.java
@@ -1,0 +1,20 @@
+package spoon.support.reflect.reference;
+
+import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.reference.CtReference;
+
+public class CtImplicitTypeReferenceImpl<R> extends CtTypeReferenceImpl<R>
+		implements CtImplicitTypeReference<R> {
+	String name;
+
+	@Override
+	public <T extends CtReference> T setSimpleName(String simplename) {
+		name = simplename;
+		return (T) this;
+	}
+
+	@Override
+	public String getSimpleName() {
+		return name;
+	}
+}

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -24,11 +24,13 @@ import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtReturn;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtAnnotatedElementType;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
@@ -37,6 +39,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;
@@ -535,11 +538,35 @@ public class AnnotationTest {
 		assertEquals("Method with an type annotation must be well printed", "@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "T", formalTypeParameters.get(0).toString());
 
 		final CtBlock<?> body = method.getBody();
-		final String expectedFirstStatement = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "T> list = new java.util.ArrayList<@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "T>()";
-		assertEquals("Type annotation on generic parameter declared in the method", expectedFirstStatement, body.getStatement(0).toString());
+		final String expectedFirstStatement =
+				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" +
+						System.lineSeparator() + "T> list = new java.util.ArrayList<>()";
+		final CtStatement firstStatement = body.getStatement(0);
+		assertEquals("Type annotation on generic parameter declared in the method",
+					 expectedFirstStatement, firstStatement.toString());
+		final CtConstructorCall firstConstructorCall =
+				firstStatement.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+							  .get(0);
+		final CtTypeReference<?> firstTypeReference = firstConstructorCall.getType()
+																		  .getActualTypeArguments()
+																		  .get(0);
+		assertTrue(firstTypeReference instanceof CtImplicitTypeReference);
+		assertEquals("T", firstTypeReference.getSimpleName());
 
-		final String expectedSecondStatement = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "?> list2 = new java.util.ArrayList<java.lang.Object>()";
-		assertEquals("Wildcard with an type annotation must be well printed", expectedSecondStatement, body.getStatement(1).toString());
+		final String expectedSecondStatement =
+				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" +
+						System.lineSeparator() + "?> list2 = new java.util.ArrayList<>()";
+		final CtStatement secondStatement = body.getStatement(1);
+		assertEquals("Wildcard with an type annotation must be well printed",
+					 expectedSecondStatement, secondStatement.toString());
+		final CtConstructorCall secondConstructorCall =
+				secondStatement.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+							   .get(0);
+		final CtTypeReference<?> secondTypeReference = secondConstructorCall.getType()
+																			.getActualTypeArguments()
+																			.get(0);
+		assertTrue(secondTypeReference instanceof CtImplicitTypeReference);
+		assertEquals("Object", secondTypeReference.getSimpleName());
 
 		final String expectedThirdStatement = "java.util.List<spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation BasicAnnotation> list3 = new java.util.ArrayList<spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation BasicAnnotation>()";
 		assertEquals("Type in generic parameter with an type annotation must be well printed", expectedThirdStatement, body.getStatement(2).toString());

--- a/src/test/java/spoon/test/generics/testclasses/IBurritos.java
+++ b/src/test/java/spoon/test/generics/testclasses/IBurritos.java
@@ -1,0 +1,4 @@
+package spoon.test.generics.testclasses;
+
+public interface IBurritos<K, V> {
+}

--- a/src/test/java/spoon/test/generics/testclasses/ITacos.java
+++ b/src/test/java/spoon/test/generics/testclasses/ITacos.java
@@ -1,0 +1,4 @@
+package spoon.test.generics.testclasses;
+
+public interface ITacos<T> {
+}

--- a/src/test/java/spoon/test/generics/testclasses/Tacos.java
+++ b/src/test/java/spoon/test/generics/testclasses/Tacos.java
@@ -1,0 +1,63 @@
+package spoon.test.generics.testclasses;
+
+import javax.lang.model.util.SimpleTypeVisitor7;
+import java.util.AbstractSet;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class Tacos<K, V extends String> implements ITacos<V> {
+
+	public Tacos() {
+		<String>this(1);
+	}
+
+	public <T> Tacos(int nbTacos) {
+	}
+
+	public void m() {
+		List<String> l = new ArrayList<>();
+		List l2;
+		IBurritos<?, ?> burritos = new Burritos<>();
+		List<?> l3 = new ArrayList<Object>();
+		new <Integer>Tacos<Object, String>();
+		new Tacos<>();
+	}
+
+	public void m2() {
+		this.<String>makeTacos(null);
+		this.makeTacos(null);
+	}
+
+	public void m3() {
+		new SimpleTypeVisitor7<Tacos, Void>() {
+		};
+		new javax.lang.model.util.SimpleTypeVisitor7<Tacos, Void>() {
+		};
+	}
+
+	public <V, C extends List<V>> void m4() {
+		Tacos.<V, C>makeTacos();
+		Tacos.makeTacos();
+	}
+
+	public static <V, C extends List<V>> List<C> makeTacos() {
+		return null;
+	}
+
+	public <T> void makeTacos(T anObject) {
+	}
+
+	class Burritos<K, V> implements IBurritos<K, V> {
+	}
+
+	public class BeerFactory {
+		public Beer newBeer() {
+			return new Beer();
+		}
+	}
+
+	class Beer {
+	}
+}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -16,6 +16,7 @@ import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -106,14 +107,11 @@ public class ImportTest {
 
 		compiler.build();
 		final CtClass<?> subClass = (CtClass<?>) factory.Type().get(SubClass.class);
-		final CtConstructorCall<?> ctNewClass = subClass.getElements(new AbstractFilter<CtConstructorCall<?>>(CtConstructorCall.class) {
-			@Override
-			public boolean matches(CtConstructorCall<?> element) {
-				return true;
-			}
-		}).get(0);
+		final CtConstructorCall<?> ctConstructorCall = subClass.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class)).get(
+				0);
 
-		assertEquals("new spoon.test.imports.testclasses.SubClass.Item(\"\")", ctNewClass.toString());
+		assertEquals("new spoon.test.imports.testclasses.SubClass.Item(\"\")",
+					 ctConstructorCall.toString());
 		final String expected = "public class SubClass extends spoon.test.imports.testclasses.SuperClass {" + System.lineSeparator()
 				+ "    public void aMethod() {" + System.lineSeparator()
 				+ "        new spoon.test.imports.testclasses.SubClass.Item(\"\");" + System.lineSeparator()

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -5,10 +5,13 @@ import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.prettyprinter.testclasses.AClass;
@@ -76,10 +79,18 @@ public class DefaultPrettyPrinterTest {
 		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
 		final String expected = "public class AClass {" + System.lineSeparator()
 				+ "    public List<?> aMethod() {" + System.lineSeparator()
-				+ "        return new ArrayList<java.lang.Object>();" + System.lineSeparator()
+				+ "        return new ArrayList<>();" + System.lineSeparator()
 				+ "    }" + System.lineSeparator()
 				+ "}";
 		assertEquals(expected, aClass.toString());
+		final CtConstructorCall constructorCall =
+				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+					  .get(0);
+		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
+																  .getActualTypeArguments()
+																  .get(0);
+		assertTrue(ctTypeReference instanceof CtImplicitTypeReference);
+		assertEquals("Object", ctTypeReference.getSimpleName());
 	}
 
 	@Test
@@ -93,8 +104,17 @@ public class DefaultPrettyPrinterTest {
 
 		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
 		final String expected = "public List<?> aMethod() {" + System.lineSeparator()
-				+ "    return new ArrayList<java.lang.Object>();" + System.lineSeparator()
+				+ "    return new ArrayList<>();" + System.lineSeparator()
 				+ "}";
 		assertEquals(expected, aClass.getMethodsByName("aMethod").get(0).toString());
+
+		final CtConstructorCall constructorCall =
+				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+					  .get(0);
+		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
+																  .getActualTypeArguments()
+																  .get(0);
+		assertTrue(ctTypeReference instanceof CtImplicitTypeReference);
+		assertEquals("Object", ctTypeReference.getSimpleName());
 	}
 }


### PR DESCRIPTION
With this PR, when the source code uses the diamond syntax, Spoon prints also the diamond syntax but saves expected types in the generic types.

So we let the compiler of the developer handle generic types in the diamond and we allow the possibility to Spoon users to manipule expected types.