### PR TITLE
Set Type arguments in reference

### DIFF
--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -106,8 +106,10 @@ public class ExecutableFactory extends SubFactory {
 			refs[i++] = param.getType();
 		}
 		if (e instanceof CtMethod) {
-			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(),
+			CtExecutableReference<T> reference = createReference(((CtMethod<T>) e).getDeclaringType().getReference(),
 					((CtMethod<T>) e).getType(), e.getSimpleName(), refs);
+			reference.setActualTypeArguments(((CtMethod<T>) e).getFormalTypeParameters());
+			return reference;
 		}
 		return createReference(((CtConstructor<T>) e).getDeclaringType().getReference(),
 				((CtConstructor<T>) e).getType(),

--- a/src/test/java/spoon/test/factory/ExecutableFactoryTest.java
+++ b/src/test/java/spoon/test/factory/ExecutableFactoryTest.java
@@ -5,11 +5,15 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.ExecutableFactory;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.test.TestUtils;
+
+import static spoon.test.TestUtils.build;
 
 public class ExecutableFactoryTest {
 
@@ -29,7 +33,18 @@ public class ExecutableFactoryTest {
 		Assert.assertEquals("boolean",type);
 		Assert.assertEquals("Object",decltype);
 		Assert.assertEquals("equals",name);
-		Assert.assertEquals(1,params.size());		
-		Assert.assertEquals(0,atas.size());		
+		Assert.assertEquals(1,params.size());
+		Assert.assertEquals(0,atas.size());
+	}
+
+	@Test
+	public void testCreateReference2() throws Exception {
+		CtClass<?> type = build("spoon.test.factory", "ExecutableTestClass");
+		CtMethod<?> get = type.getMethodsByName("get").get(0);
+		Assert.assertEquals(get.getFormalTypeParameters().size(), 1);
+		Assert.assertEquals(get.getFormalTypeParameters().get(0).getSimpleName(), "E");
+		CtExecutableReference<?> reference = get.getReference();
+		Assert.assertEquals(reference.getActualTypeArguments().size(), 1);
+		Assert.assertEquals(reference.getActualTypeArguments().get(0).getSimpleName(), "E");
 	}
 }

--- a/src/test/java/spoon/test/factory/ExecutableTestClass.java
+++ b/src/test/java/spoon/test/factory/ExecutableTestClass.java
@@ -1,0 +1,15 @@
+/**
+ * spoon.test.factory.ExecutableTestClass.java
+ * <p>
+ * Copyright (c) 2007-2015 UShareSoft SAS, All rights reserved
+ *
+ * @author UShareSoft
+ */
+package spoon.test.factory;
+
+import java.util.List;
+
+public abstract class ExecutableTestClass {
+
+	public abstract <E> List<E> get();
+}


### PR DESCRIPTION
The reference doesn't copy the CtMethod ActualTypeArguments