### PR TITLE
Added correct handling for enum's listed in an enum definition (CtEnum)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -877,7 +877,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 					} else {
 						write(",");
 					}
-					write(ctexpr.toString());
+					scan(ctexpr);
 				}
 				write(")");
 			}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -2456,6 +2456,14 @@ public class JDTTreeBuilder extends ASTVisitor {
 			}
 			fa.setVariable(ref);
 
+			if (qualifiedNameReference.binding != null
+					&& qualifiedNameReference.tokens.length - 1 == ((FieldBinding) qualifiedNameReference.binding).declaringClass.compoundName.length) {
+				// We get the binding information when we specify the complete fully qualified name of the delcaring class.
+				final ReferenceBinding declaringClass = ((FieldBinding) qualifiedNameReference.binding).declaringClass;
+				final CtTypeReference<Object> typeReference = references.getTypeReference(declaringClass);
+				fa.setTarget(factory.Code().createCodeSnippetExpression(typeReference.toString()));
+			}
+
 			if (qualifiedNameReference.otherBindings != null) {
 				int i = 0; //positions index;
 				int sourceStart = (int) (positions[0] >>> 32);

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -1,6 +1,13 @@
 package spoon.test.prettyprinter;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.util.List;
+
 import org.junit.Test;
+
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
@@ -9,25 +16,17 @@ import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.support.reflect.declaration.CtClassImpl;
-import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.test.TestUtils;
 import spoon.test.prettyprinter.testclasses.AClass;
 
-import java.io.File;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 public class DefaultPrettyPrinterTest {
+	private static final String nl = System.lineSeparator();
 
 	@Test
 	public void printerCanPrintInvocationWithoutException() throws Exception {
@@ -49,26 +48,26 @@ public class DefaultPrettyPrinterTest {
 		CtInvocation<?> mathAbsInvocation = elements.get(1);
 		assertEquals("java.lang.Math.abs(message.length())", mathAbsInvocation.toString());
 	}
-	
+
 	@Test
 	public void superInvocationWithEnclosingInstance() throws Exception {
-		
+
 		/**
 		 * To extend a nested class an enclosing instance must be provided
 		 * to call the super constructor.
 		 */
-		
+
 		String sourcePath = "./src/test/resources/spoon/test/prettyprinter/NestedSuperCall.java";
 		List<SpoonResource> files = SpoonResourceHelper.resources(sourcePath);
 		assertEquals(1, files.size());
-		
+
 		SpoonCompiler comp = new Launcher().createCompiler();
 		comp.addInputSources(files);
 		comp.build();
-		
+
 		Factory factory = comp.getFactory();
 		CtType<?> theClass = factory.Type().get("spoon.test.prettyprinter.NestedSuperCall");
-		
+
 		assertTrue(theClass.toString().contains("nc.super(\"a\")"));
 	}
 
@@ -81,19 +80,21 @@ public class DefaultPrettyPrinterTest {
 		compiler.addInputSource(new File("./src/test/java/spoon/test/prettyprinter/testclasses/"));
 		compiler.build();
 
+		final String expected =
+			  "public class AClass {" +nl+
+			  "    public List<?> aMethod() {" +nl+
+			  "        return new ArrayList<>();" +nl+
+			  "    }" +nl+
+			  "" +nl+
+			  "    public List<? extends ArrayList> aMethodWithGeneric() {" +nl+
+			  "        return new ArrayList<>();" +nl+
+			  "    }" +nl+
+			  "}";
 		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
-		final String expected = "public class AClass {" + System.lineSeparator()
-				+ "    public List<?> aMethod() {" + System.lineSeparator()
-				+ "        return new ArrayList<>();" + System.lineSeparator()
-				+ "    }"  + System.lineSeparator()  + System.lineSeparator()
-				+ "    public List<? extends ArrayList> aMethodWithGeneric() {" + System.lineSeparator()
-				+ "        return new ArrayList<>();"  + System.lineSeparator()
-				+ "    }" + System.lineSeparator()
-				+ "}";
 		assertEquals(expected, aClass.toString());
-		final CtConstructorCall constructorCall =
-				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
-					  .get(0);
+
+		final CtConstructorCall<?> constructorCall = aClass.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class)).get(0);
+
 		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
 																  .getActualTypeArguments()
 																  .get(0);
@@ -110,14 +111,19 @@ public class DefaultPrettyPrinterTest {
 		compiler.addInputSource(new File("./src/test/java/spoon/test/prettyprinter/testclasses/"));
 		compiler.build();
 
-		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
-		final String expected = "public List<?> aMethod() {" + System.lineSeparator()
-				+ "    return new ArrayList<>();" + System.lineSeparator()
-				+ "}";
-		assertEquals(expected, aClass.getMethodsByName("aMethod").get(0).toString());
+		final String expected =
+			  "public List<?> aMethod() {" +nl+
+			  "    return new ArrayList<>();" +nl+
+			  "}";
 
-		final CtConstructorCall constructorCall =
-				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter( launcher.getEnvironment() );
+		printer.computeImports( aClass );
+		String computed = printer.scan( aClass.getMethodsByName("aMethod").get(0) ).toString();
+		assertEquals( expected, computed );
+
+		final CtConstructorCall<?> constructorCall =
+				aClass.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class))
 					  .get(0);
 		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
 																  .getActualTypeArguments()
@@ -141,13 +147,112 @@ public class DefaultPrettyPrinterTest {
 				+ "}";
 		assertEquals(expected, aClass.getMethodsByName("aMethodWithGeneric").get(0).toString());
 
-		final CtConstructorCall constructorCall =
-				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+		final CtConstructorCall<?> constructorCall =
+				aClass.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class))
 						.get(0);
 		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
 				.getActualTypeArguments()
 				.get(0);
 		assertTrue(ctTypeReference instanceof CtImplicitTypeReference);
 		assertEquals("Object", ctTypeReference.getSimpleName());
+	}
+
+	@Test
+	public void autoImportUsesFullyQualifiedNameWhenImportedNameAlreadyPresent() throws Exception
+	{
+		Factory factory = TestUtils.build( spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.class, spoon.test.prettyprinter.testclasses.TypeIdentifierCollision.class );
+		factory.getEnvironment().setAutoImports(true);
+
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get( spoon.test.prettyprinter.testclasses.TypeIdentifierCollision.class );
+
+		String expected =
+			"public void setFieldUsingExternallyDefinedEnumWithSameNameAsLocal() {" +nl+
+			"    localField = spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1.ordinal();" +nl+
+			"}"
+		;
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
+		printer.computeImports(aClass);
+		String computed = printer.scan( aClass.getMethodsByName("setFieldUsingExternallyDefinedEnumWithSameNameAsLocal").get(0) ).toString();
+		assertEquals( "the externally defined enum should be fully qualified to avoid a name clash with the local enum of the same name", expected, computed );
+
+		expected = //This is what is expected
+			"public void setFieldUsingLocallyDefinedEnum() {" +nl+
+			"    localField = ENUM.E1.ordinal();" +nl+
+			"}"
+		;
+		expected = //This is correct however it could be more concise.
+			"public void setFieldUsingLocallyDefinedEnum() {" +nl+
+			"    localField = TypeIdentifierCollision.ENUM.E1.ordinal();" +nl+
+			"}"
+		;
+		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
+		printer.computeImports(aClass);
+		computed = printer.scan( aClass.getMethodsByName("setFieldUsingLocallyDefinedEnum").get(0) ).toString();
+		assertEquals( expected, computed );
+
+		expected =
+			"public void setFieldOfClassWithSameNameAsTheCompilationUnitClass() {" +nl+
+			"    spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField = localField;" +nl+
+			"}"
+		;
+		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
+		printer.computeImports(aClass);
+		computed = printer.scan( aClass.getMethodsByName("setFieldOfClassWithSameNameAsTheCompilationUnitClass").get(0) ).toString();
+		assertEquals( "The static field of an external type with the same identifier as the compilation unit should be fully qualified", expected, computed );
+
+		expected = //This is what is expected
+				"public void referToTwoInnerClassesWithTheSameName() {" +nl+
+				"    ClassA.VAR0 = ClassA.getNum();" +nl+
+				"    Class1.ClassA.VAR1 = Class1.ClassA.getNum();" +nl+
+				"}"
+			;
+		expected = //This is correct however it could be more concise.
+			"public void referToTwoInnerClassesWithTheSameName() {" +nl+
+			"    TypeIdentifierCollision.Class0.ClassA.VAR0 = TypeIdentifierCollision.Class0.ClassA.getNum();" +nl+
+			"    TypeIdentifierCollision.Class1.ClassA.VAR1 = TypeIdentifierCollision.Class1.ClassA.getNum();" +nl+
+			"}"
+		;
+		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
+
+		//Ensure the ClassA of Class0 takes precedence over an import statement for ClassA in Class1, and it's identifier can be the short version.
+		CtClass<?> innerClass = aClass.getNestedType("Class0");
+		printer.computeImports( innerClass );
+		printer.computeImports( innerClass.getNestedType("ClassA") );
+		printer.computeImports(aClass);
+
+		computed = printer.scan( aClass.getMethodsByName("referToTwoInnerClassesWithTheSameName").get(0) ).toString();
+		assertEquals( "where inner types have the same identifier only one may be shortened and the other should be fully qualified", expected, computed );
+
+		expected =
+			"public enum ENUM {" +nl+
+			"E1(spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField,spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1);" +nl+
+			"    final int NUM;" +nl+
+			"    final Enum<?> e;" +nl+
+			"    private ENUM(int num ,Enum<?> e) {" +nl+
+			"        NUM = num;" +nl+
+			"        this.e = e;" +nl+
+			"    }}"
+		;
+		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
+		printer.computeImports(aClass);
+		aClass.getNestedType("ENUM");
+		computed = printer.scan( (CtType<?>)aClass.getNestedType("ENUM") ).toString();
+		assertEquals( "Parameters in an enum constructor should be fully typed when they refer to externally defined static field of a class with the same identifier as another locally defined type", expected, computed );
+	}
+
+	@Test
+	public void useFullyQualifiedNamesInCtElementImpl_toString() throws Exception
+	{
+		Factory factory = TestUtils.build( AClass.class );
+		factory.getEnvironment().setAutoImports(false);
+
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get( AClass.class );
+		String computed = aClass.getMethodsByName("aMethod").get(0).toString();
+		final String expected =
+			  "public java.util.List<?> aMethod() {" +nl+
+			  "    return new java.util.ArrayList<>();" +nl+
+			  "}"
+		;
+		assertEquals( "the toString method of CtElementImpl should not shorten type names as it has no context or import statements", expected, computed );
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -19,7 +19,6 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.TestUtils;
@@ -117,10 +116,7 @@ public class DefaultPrettyPrinterTest {
 			  "}";
 
 		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
-		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter( launcher.getEnvironment() );
-		printer.computeImports( aClass );
-		String computed = printer.scan( aClass.getMethodsByName("aMethod").get(0) ).toString();
-		assertEquals( expected, computed );
+		assertEquals(expected, aClass.getMethodsByName("aMethod").get(0).toString());
 
 		final CtConstructorCall<?> constructorCall =
 				aClass.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class))
@@ -158,8 +154,7 @@ public class DefaultPrettyPrinterTest {
 	}
 
 	@Test
-	public void autoImportUsesFullyQualifiedNameWhenImportedNameAlreadyPresent() throws Exception
-	{
+	public void autoImportUsesFullyQualifiedNameWhenImportedNameAlreadyPresent() throws Exception {
 		Factory factory = TestUtils.build( spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.class, spoon.test.prettyprinter.testclasses.TypeIdentifierCollision.class );
 		factory.getEnvironment().setAutoImports(true);
 
@@ -170,9 +165,7 @@ public class DefaultPrettyPrinterTest {
 			"    localField = spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1.ordinal();" +nl+
 			"}"
 		;
-		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
-		printer.computeImports(aClass);
-		String computed = printer.scan( aClass.getMethodsByName("setFieldUsingExternallyDefinedEnumWithSameNameAsLocal").get(0) ).toString();
+		String computed = aClass.getMethodsByName("setFieldUsingExternallyDefinedEnumWithSameNameAsLocal").get(0).toString();
 		assertEquals( "the externally defined enum should be fully qualified to avoid a name clash with the local enum of the same name", expected, computed );
 
 		expected = //This is what is expected
@@ -185,9 +178,7 @@ public class DefaultPrettyPrinterTest {
 			"    localField = TypeIdentifierCollision.ENUM.E1.ordinal();" +nl+
 			"}"
 		;
-		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
-		printer.computeImports(aClass);
-		computed = printer.scan( aClass.getMethodsByName("setFieldUsingLocallyDefinedEnum").get(0) ).toString();
+		computed = aClass.getMethodsByName("setFieldUsingLocallyDefinedEnum").get(0).toString();
 		assertEquals( expected, computed );
 
 		expected =
@@ -195,9 +186,7 @@ public class DefaultPrettyPrinterTest {
 			"    spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField = localField;" +nl+
 			"}"
 		;
-		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
-		printer.computeImports(aClass);
-		computed = printer.scan( aClass.getMethodsByName("setFieldOfClassWithSameNameAsTheCompilationUnitClass").get(0) ).toString();
+		computed = aClass.getMethodsByName("setFieldOfClassWithSameNameAsTheCompilationUnitClass").get(0).toString();
 		assertEquals( "The static field of an external type with the same identifier as the compilation unit should be fully qualified", expected, computed );
 
 		expected = //This is what is expected
@@ -212,15 +201,10 @@ public class DefaultPrettyPrinterTest {
 			"    TypeIdentifierCollision.Class1.ClassA.VAR1 = TypeIdentifierCollision.Class1.ClassA.getNum();" +nl+
 			"}"
 		;
-		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
 
 		//Ensure the ClassA of Class0 takes precedence over an import statement for ClassA in Class1, and it's identifier can be the short version.
-		CtClass<?> innerClass = aClass.getNestedType("Class0");
-		printer.computeImports( innerClass );
-		printer.computeImports( innerClass.getNestedType("ClassA") );
-		printer.computeImports(aClass);
 
-		computed = printer.scan( aClass.getMethodsByName("referToTwoInnerClassesWithTheSameName").get(0) ).toString();
+		computed = aClass.getMethodsByName("referToTwoInnerClassesWithTheSameName").get(0).toString();
 		assertEquals( "where inner types have the same identifier only one may be shortened and the other should be fully qualified", expected, computed );
 
 		expected =
@@ -233,16 +217,12 @@ public class DefaultPrettyPrinterTest {
 			"        this.e = e;" +nl+
 			"    }}"
 		;
-		printer = new DefaultJavaPrettyPrinter( factory.getEnvironment() );
-		printer.computeImports(aClass);
-		aClass.getNestedType("ENUM");
-		computed = printer.scan( (CtType<?>)aClass.getNestedType("ENUM") ).toString();
+		computed = aClass.getNestedType("ENUM").toString();
 		assertEquals( "Parameters in an enum constructor should be fully typed when they refer to externally defined static field of a class with the same identifier as another locally defined type", expected, computed );
 	}
 
 	@Test
-	public void useFullyQualifiedNamesInCtElementImpl_toString() throws Exception
-	{
+	public void useFullyQualifiedNamesInCtElementImpl_toString() throws Exception {
 		Factory factory = TestUtils.build( AClass.class );
 		factory.getEnvironment().setAutoImports(false);
 

--- a/src/test/java/spoon/test/prettyprinter/testclasses/TypeIdentifierCollision.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/TypeIdentifierCollision.java
@@ -1,0 +1,65 @@
+package spoon.test.prettyprinter.testclasses;
+
+import spoon.test.prettyprinter.testclasses.TypeIdentifierCollision.Class0.ClassA;
+
+public class TypeIdentifierCollision
+{
+	public enum ENUM{
+		E1(spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField, spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1),
+		;
+		final int NUM;
+		final Enum<?> e;
+
+		private ENUM( int num, Enum<?> e )
+		{
+			NUM = num;
+			this.e = e;
+		}
+	}
+	private int localField;
+
+	public void setFieldUsingExternallyDefinedEnumWithSameNameAsLocal()
+	{
+		localField = spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1.ordinal();
+	}
+
+	public void setFieldUsingLocallyDefinedEnum()
+	{
+		localField = ENUM.E1.ordinal();
+	}
+
+	public void setFieldOfClassWithSameNameAsTheCompilationUnitClass()
+	{
+		spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField = localField;
+	}
+
+	public void referToTwoInnerClassesWithTheSameName()
+	{
+		ClassA.VAR0 = ClassA.getNum();
+		Class1.ClassA.VAR1 = Class1.ClassA.getNum();
+	}
+
+	static class Class0
+	{
+		public static class ClassA
+		{
+			public static int VAR0;
+			public static int getNum()
+			{
+				return 0;
+			}
+		}
+	}
+
+	static class Class1
+	{
+		public static class ClassA
+		{
+			public static int VAR1;
+			public static int getNum()
+			{
+				return 0;
+			}
+		}
+	}
+}

--- a/src/test/java/spoon/test/prettyprinter/testclasses/sub/TypeIdentifierCollision.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/sub/TypeIdentifierCollision.java
@@ -1,0 +1,10 @@
+package spoon.test.prettyprinter.testclasses.sub;
+
+
+public class TypeIdentifierCollision
+{
+	public enum ENUM{
+		E1
+	}
+	public static int globalField;
+}


### PR DESCRIPTION
- before the toString() method was simply used which does not take
account of the compilation unit's context.
* Removed the compute imports statement from CtElement's toString()
method as it has no context and therefore it cannot assume the
corresponding import is present that would allow it to be shown in
the shortened version.
* Added test to catch some edge cases in the shortening of identifiers
that may produce ambiguous/invalid code and updated ones that relied on
the toString() method to calculate the shorthand names.
* Made some minor modifications to remove some warnings in the code
as flagged by the IDE.