### PR TITLE
bug with generic invocation due to JDT (waiting for JDT fix)

### DIFF
--- a/src/test/java/spoon/test/casts/CastTest.java
+++ b/src/test/java/spoon/test/casts/CastTest.java
@@ -1,12 +1,14 @@
 package spoon.test.casts;
 
 import static org.junit.Assert.assertEquals;
+import static spoon.test.TestUtils.build;
 
 import org.junit.Test;
 
 import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
@@ -65,4 +67,8 @@ public class CastTest {
 				foo.getBody().getStatements().get(1).toString());
 	}
 
+	@Test
+	public void testCase4() throws Exception {
+		CtType<?> type = build("spoon.test.casts", "Castings");
+	}
 }

--- a/src/test/java/spoon/test/casts/Castings.java
+++ b/src/test/java/spoon/test/casts/Castings.java
@@ -1,0 +1,19 @@
+package spoon.test.casts;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Castings {
+	public void test(double a) {}
+
+	public void foo() {
+		List<Integer> list = new ArrayList<Integer>(1);
+		list.add(1);
+		test(getValue(list));
+	}
+
+	public final <T> T getValue(List<T> list)
+	{
+		return list.get(0);
+	}
+}


### PR DESCRIPTION
Type mismatch: cannot convert from Integer to double at D:\Programmieren\CubeEngine\spoon\src\test\java\spoon\test\casts\Castings.java:12

However this could be a jdt bug too. I didn't investigate it yet.

Don't merge it accidentally. :smile: The PR just shows a bug and doesn't fix it.  