### PR TITLE
No innerclass import

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -913,6 +913,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	private void writeEnumField(CtField<?> f) {
+		visitCtNamedElement(f);
 		write(f.getSimpleName());
 		if (f.getDefaultExpression() != null) {
 			CtConstructorCall<?> constructorCall = (CtConstructorCall<?>) f.getDefaultExpression();

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -2112,8 +2112,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(pack).writeln().writeln().writeTabs();
 			if (env.isAutoImports()) {
 				for (CtTypeReference<?> ref : imports) {
-					write("import " + ref.getQualifiedName() + ";")
+					if (!ref.getQualifiedName().contains("$")) {
+						write("import " + ref.getQualifiedName() + ";")
 							.writeln().writeTabs();
+					}
 				}
 			}
 			writeln().writeTabs();

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -704,7 +704,7 @@ public class AnnotationTest {
 		assertEquals(2,annot.value().length);
 	}
 
-	private Class<? extends Annotation> getActualClassFromAnnotation(CtAnnotation<? extends Annotation> annotation) {
+	public static Class<? extends Annotation> getActualClassFromAnnotation(CtAnnotation<? extends Annotation> annotation) {
 		return annotation.getAnnotationType().getActualClass();
 	}
 

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -5,17 +5,38 @@ import static spoon.test.TestUtils.build;
 
 import org.junit.Test;
 
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtEnum;
+import spoon.reflect.visitor.filter.FieldAccessFilter;
+import spoon.test.annotation.AnnotationTest;
+import spoon.test.enums.testclasses.Foo;
 
 public class EnumsTest {
 
-	@Test 
+	@Test
 	public void testModelBuildingEnum() throws Exception {
-		CtEnum<Regular> enumeration = build ("spoon.test.enums",  "Regular");
+		CtEnum<Regular> enumeration = build("spoon.test.enums", "Regular");
 		assertEquals("Regular", enumeration.getSimpleName());
 		assertEquals(3, Regular.values().length);
 		assertEquals(3, enumeration.getValues().size());
 		assertEquals("A", enumeration.getValues().get(0).getSimpleName());
 		assertEquals(5, enumeration.getFields().size());
+	}
+
+	@Test
+	public void testAnnotationsOnEnum() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.run(new String[] {
+				"-i", "./src/test/java/spoon/test/enums/testclasses",
+				"-o", "./target/spooned"
+		});
+
+		final CtEnum<?> foo = (CtEnum) launcher.getFactory().Type().get(Foo.class);
+		assertEquals(1, foo.getFields().size());
+		assertEquals(1, foo.getFields().get(0).getAnnotations().size());
+		assertEquals(Deprecated.class, AnnotationTest.getActualClassFromAnnotation(
+				foo.getFields().get(0).getAnnotations().get(0)));
+		assertEquals("public enum Foo {\n@java.lang.Deprecated\n    Bar;}", foo.toString());
 	}
 }

--- a/src/test/java/spoon/test/enums/testclasses/Foo.java
+++ b/src/test/java/spoon/test/enums/testclasses/Foo.java
@@ -1,0 +1,6 @@
+package spoon.test.enums.testclasses;
+
+public enum Foo {
+	@Deprecated
+	Bar;
+}


### PR DESCRIPTION
When "with-imports" option is turned on, the generated output code will add:

import pkg.Klass$InnerKlass

with code defined as
```java
package pkg
public class Klass {
public class InnerKlass {}
}
```

This pull requests prevents those imports from being generated (as in my case, I have the import of the Klass class). However, I believe that it should be replaced by pkg.Klass.InnerKlass, although I am not sure how this works with non-static inner classes.