### PR TITLE
updates the ecj version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
-      <version>4.4</version>
+      <version>4.4.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
the change fixes #308 

The problem was a type inference problem at [this point](https://github.com/CubeEngine/core/blob/sponge/coremodule/src/main/java/org/cubeengine/service/user/SpongeUserManager.java#L436)

The ecj compiler had problems with the reference ```Record1::value1```. The debugger showed this warning:

``` 
Filename : D:\Programmieren\CubeEngine\core\coremodule\src\main\java\org\cubeengine\service\user\SpongeUserManager.java
COMPILED type(s)    
2 PROBLEM(s) detected 
     - Pb(201) Cannot make a static reference to the non-static method value1(Object) from the type Record1
     - Pb(19) Type mismatch: cannot convert from Set<Object> to Set<UInteger>
```

changing the line to
```java
return database.getDSL().select(TABLE_USER.KEY).from(TABLE_USER).fetch().stream().map(Record1<UInteger>::value1).collect(toSet());
```
(note the ```Record<UInteger>```) fixes the problem with the currently released spoon version. But the issue is fixed with the newest ecj release, therefore I simply increased the version number.
It's just a patch version change, therefore it should be a safe update. All tests are still working. 