### PR TITLE
the TypeFilter import is missing in the ImportTest class

### DIFF
--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -17,6 +17,7 @@ import spoon.reflect.visitor.ImportScannerImpl;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.NameFilter;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.imports.testclasses.ClientClass;
 import spoon.test.imports.testclasses.SubClass;
 import spoon.test.imports.testclasses.internal.ChildClass;


### PR DESCRIPTION
This PR fixes a missing import which was introduced today with [this pr](https://github.com/INRIA/spoon/pull/315/files). I guess @GerardPaligot deleted the import and at the same time another PR used the import. Therefore travis succeed and the mistake wasn't noticed. Anyway. This adds the import again. 