### PR TITLE
fixes the auto-import of CtInvocations

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -63,7 +63,13 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	@Override
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
 		// For a ctinvocation, we don't have to import declaring type
+		enter(invocation);
+		scan(invocation.getAnnotations());
+		scanReferences(invocation.getTypeCasts());
 		scan(invocation.getTarget());
+		scan(invocation.getExecutable());
+		scan(invocation.getArguments());
+		exit(invocation);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -16,6 +16,7 @@ import spoon.reflect.visitor.ImportScannerImpl;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.imports.testclasses.ClassWithInvocation;
 import spoon.test.imports.testclasses.ClientClass;
 import spoon.test.imports.testclasses.SubClass;
 import spoon.test.imports.testclasses.internal.ChildClass;
@@ -150,11 +151,14 @@ public class ImportTest {
 		});
 		final CtClass<ImportTest> aClass = launcher.getFactory().Class().get(ChildClass.class);
 		final CtClass<ImportTest> anotherClass = launcher.getFactory().Class().get(ClientClass.class);
+		final CtClass<ImportTest> classWithInvocation = launcher.getFactory().Class().get(ClassWithInvocation.class);
 
 		final ImportScanner importScanner = new ImportScannerImpl();
 		final Collection<CtTypeReference<?>> imports = importScanner.computeImports(aClass);
 		assertEquals(2, imports.size());
 		final Collection<CtTypeReference<?>> imports1 = importScanner.computeImports(anotherClass);
 		assertEquals(1, imports1.size());
+		final Collection<CtTypeReference<?>> imports2 = importScanner.computeImports(classWithInvocation);
+		assertEquals("Spoon ignores the arguments of CtInvocations", 1, imports2.size());
 	}
 }

--- a/src/test/java/spoon/test/imports/testclasses/ClassWithInvocation.java
+++ b/src/test/java/spoon/test/imports/testclasses/ClassWithInvocation.java
@@ -1,0 +1,15 @@
+package spoon.test.imports.testclasses;
+
+import sun.reflect.annotation.TypeAnnotation;
+
+/**
+ * Created by thomas on 11/09/15.
+ */
+public class ClassWithInvocation {
+    public ClassWithInvocation() {
+        test(TypeAnnotation.class);
+    }
+    public String test(Class cl) {
+        return cl.getCanonicalName();
+    }
+}


### PR DESCRIPTION
The ```ImportScanner``` ignored some elements of invocations such as invocation arguments.

With this pull request, ```ImportScanner``` scans annotations, cast, target and arguments of all invocations.