### PR TITLE
removes ingoreImport in DefaultJavaPrettyPrinter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -157,15 +157,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 
 		/**
-		 * if false, no import are output
-		 */
-		boolean ignoreImport = false;
-
-		public boolean getIgnoreImport() {
-			return ignoreImport;
-		}
-
-		/**
 		 * Layout variables
 		 */
 		int jumped = 0;
@@ -195,7 +186,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 		@Override
 		public String toString() {
-			return "context.ignoreImport: " + context.ignoreImport + "\n" + "context.ignoreGenerics: " + context.ignoreGenerics + "\n";
+			return "context.ignoreGenerics: " + context.ignoreGenerics + "\n";
 		}
 	}
 
@@ -1818,7 +1809,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			return;
 		}
 
-		if (!context.ignoreImport && (importsContext.isImported(ref) && ref.getPackage() != null)) {
+		if (importsContext.isImported(ref) && ref.getPackage() != null) {
 			printTypeAnnotations(ref);
 			write(ref.getSimpleName());
 		} else {
@@ -2019,12 +2010,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 		if (params.size() > 0) {
 			write("<");
-			context.ignoreImport = true;
 			for (CtTypeReference<?> param : params) {
 				scan(param);
 				write(", ");
 			}
-			context.ignoreImport = false;
 			removeLastChar();
 			write(">");
 		}
@@ -2043,7 +2032,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (params != null && params.size() > 0) {
 			write("<");
 			boolean isImplicitTypeReference = true;
-			context.ignoreImport = true;
 			for (CtTypeReference<?> param : params) {
 				if (!(param instanceof CtImplicitTypeReference)) {
 					isImplicitTypeReference = false;
@@ -2051,7 +2039,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 					write(", ");
 				}
 			}
-			context.ignoreImport = false;
 			if (!isImplicitTypeReference) {
 				removeLastChar();
 			}

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -200,7 +200,6 @@ public class GenericsTest {
 			CtTypeReference<?> ref = x.getType();
 			DefaultJavaPrettyPrinter pp = new DefaultJavaPrettyPrinter(
 					new StandardEnvironment());
-			assertFalse(pp.getContext().getIgnoreImport());
 
 			// qualifed name
 			assertEquals("java.util.Map$Entry", ref.getQualifiedName());

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -85,6 +85,9 @@ public class DefaultPrettyPrinterTest {
 		final String expected = "public class AClass {" + System.lineSeparator()
 				+ "    public List<?> aMethod() {" + System.lineSeparator()
 				+ "        return new ArrayList<>();" + System.lineSeparator()
+				+ "    }"  + System.lineSeparator()  + System.lineSeparator()
+				+ "    public List<? extends ArrayList> aMethodWithGeneric() {" + System.lineSeparator()
+				+ "        return new ArrayList<>();"  + System.lineSeparator()
 				+ "    }" + System.lineSeparator()
 				+ "}";
 		assertEquals(expected, aClass.toString());
@@ -119,6 +122,31 @@ public class DefaultPrettyPrinterTest {
 		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
 																  .getActualTypeArguments()
 																  .get(0);
+		assertTrue(ctTypeReference instanceof CtImplicitTypeReference);
+		assertEquals("Object", ctTypeReference.getSimpleName());
+	}
+
+	@Test
+	public void testPrintAMethodWithGeneric() throws Exception {
+		final Launcher launcher = new Launcher();
+		final Factory factory = launcher.getFactory();
+		factory.getEnvironment().setAutoImports(true);
+		final SpoonCompiler compiler = launcher.createCompiler();
+		compiler.addInputSource(new File("./src/test/java/spoon/test/prettyprinter/testclasses/"));
+		compiler.build();
+
+		final CtClass<?> aClass = (CtClass<?>) factory.Type().get(AClass.class);
+		final String expected = "public List<? extends ArrayList> aMethodWithGeneric() {" + System.lineSeparator()
+				+ "    return new ArrayList<>();" + System.lineSeparator()
+				+ "}";
+		assertEquals(expected, aClass.getMethodsByName("aMethodWithGeneric").get(0).toString());
+
+		final CtConstructorCall constructorCall =
+				aClass.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
+						.get(0);
+		final CtTypeReference<?> ctTypeReference = constructorCall.getType()
+				.getActualTypeArguments()
+				.get(0);
 		assertTrue(ctTypeReference instanceof CtImplicitTypeReference);
 		assertEquals("Object", ctTypeReference.getSimpleName());
 	}

--- a/src/test/java/spoon/test/prettyprinter/testclasses/AClass.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/AClass.java
@@ -7,4 +7,8 @@ public class AClass {
 	public List<?> aMethod() {
 		return new ArrayList<>();
 	}
+
+	public List<? extends ArrayList> aMethodWithGeneric() {
+		return new ArrayList<>();
+	}
 }


### PR DESCRIPTION
This pull request removes the variable ignoreImport in DefaultJavaPrettyPrinter
which was used to force the use of qualified name for generics.