### PR TITLE
Refactor source and binary outputs of Spoon.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
 
     <pluginManagement>
       <plugins>
-        <!--This plugin's configuration is used to store Eclipse m2e settings 
+        <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -445,6 +445,8 @@ public class Launcher implements SpoonAPI {
 		environment.setCopyResources(!jsapActualArgs.getBoolean("no-copy-resources"));
 		environment.setGenerateJavadoc(jsapActualArgs.getBoolean("generate-javadoc"));
 
+		environment.setShouldCompile(jsapActualArgs.getBoolean("compile"));
+
 		// now we are ready to create a spoon compiler
 		modelBuilder = createCompiler();
 
@@ -587,7 +589,7 @@ public class Launcher implements SpoonAPI {
 		// building
 		comp.setEncoding(getArguments().getString("encoding"));
 		comp.setBuildOnlyOutdatedFiles(jsapActualArgs.getBoolean("buildOnlyOutdatedFiles"));
-		comp.setDestinationDirectory(jsapActualArgs.getFile("destination"));
+		comp.setBinaryOutputDirectory(jsapActualArgs.getFile("destination"));
 		comp.setSourceOutputDirectory(jsapActualArgs.getFile("output"));
 		comp.setEncoding(jsapActualArgs.getString("encoding"));
 
@@ -598,7 +600,7 @@ public class Launcher implements SpoonAPI {
 		}
 
 		env.debugMessage("output: " + comp.getSourceOutputDirectory());
-		env.debugMessage("destination: " + comp.getDestinationDirectory());
+		env.debugMessage("destination: " + comp.getBinaryOutputDirectory());
 		env.debugMessage("source classpath: " + Arrays.toString(comp.getSourceClasspath()));
 		env.debugMessage("template classpath: " + Arrays.toString(comp.getTemplateClasspath()));
 
@@ -701,7 +703,7 @@ public class Launcher implements SpoonAPI {
 
 		prettyprint();
 
-		if (jsapActualArgs.getBoolean("compile")) {
+		if (env.shouldCompile()) {
 			modelBuilder.compile();
 		}
 
@@ -804,6 +806,16 @@ public class Launcher implements SpoonAPI {
 	public void setSourceOutputDirectory(File outputDirectory) {
 		modelBuilder.setSourceOutputDirectory(outputDirectory);
 		getEnvironment().setDefaultFileGenerator(createOutputWriter(outputDirectory, getEnvironment()));
+	}
+
+	@Override
+	public void setBinaryOutputDirectory(String path) {
+		setBinaryOutputDirectory(new File(path));
+	}
+
+	@Override
+	public void setBinaryOutputDirectory(File outputDirectory) {
+		modelBuilder.setBinaryOutputDirectory(outputDirectory);
 	}
 
 }

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -772,7 +772,7 @@ public class Launcher implements SpoonAPI {
 					for (Object resource : resources) {
 						final String resourceParentPath = ((File) resource).getParent();
 						final String packageDir = resourceParentPath.substring(dirInputSource.getPath().length());
-						final String targetDirectory = modelBuilder.getOutputDirectory() + packageDir;
+						final String targetDirectory = modelBuilder.getSourceOutputDirectory() + packageDir;
 						try {
 							FileUtils.copyFileToDirectory((File) resource, new File(targetDirectory));
 						} catch (IOException e) {
@@ -802,7 +802,7 @@ public class Launcher implements SpoonAPI {
 
 	@Override
 	public void setSourceOutputDirectory(File outputDirectory) {
-		modelBuilder.setOutputDirectory(outputDirectory);
+		modelBuilder.setSourceOutputDirectory(outputDirectory);
 		getEnvironment().setDefaultFileGenerator(createOutputWriter(outputDirectory, getEnvironment()));
 	}
 

--- a/src/main/java/spoon/SpoonAPI.java
+++ b/src/main/java/spoon/SpoonAPI.java
@@ -6,6 +6,8 @@ import spoon.processing.Processor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
 
+import java.io.File;
+
 /**
  * Is the core entry point of Spoon. Implemented by Launcher.
  */
@@ -24,7 +26,24 @@ public interface SpoonAPI {
 	/**
 	 * Sets the output directory
 	 */
+	@Deprecated
 	void setOutputDirectory(String string);
+
+	/**
+	 * Sets the output directory for source generated.
+	 *
+	 * @param path
+	 * 		Path for the output directory.
+	 */
+	void setSourceOutputDirectory(String path);
+
+	/**
+	 * Sets the output directory for source generated.
+	 *
+	 * @param outputDirectory
+	 * 		{@link File} for output directory.
+	 */
+	void setSourceOutputDirectory(File outputDirectory);
 
 	/**
 	 * Adds a processor (fully qualified name).

--- a/src/main/java/spoon/SpoonAPI.java
+++ b/src/main/java/spoon/SpoonAPI.java
@@ -46,6 +46,22 @@ public interface SpoonAPI {
 	void setSourceOutputDirectory(File outputDirectory);
 
 	/**
+	 * Sets the output directory for binary generated.
+	 *
+	 * @param path
+	 * 		Path for the binary output directory.
+	 */
+	void setBinaryOutputDirectory(String path);
+
+	/**
+	 * Sets the output directory for binary generated.
+	 *
+	 * @param outputDirectory
+	 * 		{@link File} for the binary output directory.
+	 */
+	void setBinaryOutputDirectory(File outputDirectory);
+
+	/**
 	 * Adds a processor (fully qualified name).
 	 */
 	void addProcessor(String name);

--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -72,12 +72,27 @@ public interface SpoonModelBuilder {
 	 * @param outputDirectory
 	 * 		output directory
 	 */
+	@Deprecated
 	void setOutputDirectory(File outputDirectory);
 
 	/**
 	 * Gets the output directory of this compiler.
 	 */
+	@Deprecated
 	File getOutputDirectory();
+
+	/**
+	 * Sets the output directory for source generated.
+	 *
+	 * @param outputDirectory
+	 * 		{@link File} for output directory.
+	 */
+	void setSourceOutputDirectory(File outputDirectory);
+
+	/**
+	 * Gets the output directory of this compiler.
+	 */
+	File getSourceOutputDirectory();
 
 	/**
 	 * Adds a file/directory (as a CtResource) to be built. By default, the

--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -59,12 +59,27 @@ public interface SpoonModelBuilder {
 	 * @param destinationDirectory
 	 * 		destination directory
 	 */
+	@Deprecated
 	void setDestinationDirectory(File destinationDirectory);
 
 	/**
 	 * Gets the output directory of this compiler.
 	 */
+	@Deprecated
 	File getDestinationDirectory();
+
+	/**
+	 * Sets the output directory for binary generated.
+	 *
+	 * @param binaryOutputDirectory
+	 * 		{@link File} for binary output directory.
+	 */
+	void setBinaryOutputDirectory(File binaryOutputDirectory);
+
+	/**
+	 * Gets the binary output directory of the compiler.
+	 */
+	File getBinaryOutputDirectory();
 
 	/**
 	 * Sets the output directory for the source files.
@@ -182,7 +197,7 @@ public interface SpoonModelBuilder {
 	/**
 	 * Generates the bytecode associated to the classes stored in this
 	 * compiler's factory. The bytecode is generated in the directory given by
-	 * {@link #getDestinationDirectory()}.
+	 * {@link #getBinaryOutputDirectory()}.
 	 *
 	 * @see #getSourceClasspath()
 	 */
@@ -190,7 +205,7 @@ public interface SpoonModelBuilder {
 
 	/**
 	 * Generates the bytecode by compiling the input sources. The bytecode is
-	 * generated in the directory given by {@link #getDestinationDirectory()}.
+	 * generated in the directory given by {@link #getBinaryOutputDirectory()}.
 	 *
 	 * @see #getSourceClasspath()
 	 */

--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -172,7 +172,7 @@ public interface SpoonModelBuilder {
 	/**
 	 * Generates the source code associated to the classes stored in this
 	 * compiler's factory. The source code is generated in the directory given
-	 * by {@link #getOutputDirectory()}.
+	 * by {@link #getSourceOutputDirectory()}.
 	 *
 	 * @param outputType
 	 * 		the output method

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -397,4 +397,14 @@ public interface Environment {
 	 * Sets the level of loggers asked by the user.
 	 */
 	void setLevel(String level);
+
+	/**
+	 * Checks if we want compile the target source code and get their binary.
+	 */
+	boolean shouldCompile();
+
+	/**
+	 * Sets the compile argument.
+	 */
+	void setShouldCompile(boolean shouldCompile);
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -98,6 +98,8 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private Level level = Level.OFF;
 
+	private boolean shouldCompile;
+
 	/**
 	 * Creates a new environment with a <code>null</code> default file
 	 * generator.
@@ -139,6 +141,16 @@ public class StandardEnvironment implements Serializable, Environment {
 	public void setLevel(String level) {
 		this.level = toLevel(level);
 		logger.setLevel(this.level);
+	}
+
+	@Override
+	public boolean shouldCompile() {
+		return shouldCompile;
+	}
+
+	@Override
+	public void setShouldCompile(boolean shouldCompile) {
+		this.shouldCompile = shouldCompile;
 	}
 
 	private Level toLevel(String level) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -99,16 +99,26 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 	/**
 	 * output directory for binary code .class file
 	 */
-	File destinationDirectory;
+	File binaryOutputDirectory;
 
 	@Override
 	public File getDestinationDirectory() {
-		return destinationDirectory;
+		return getBinaryOutputDirectory();
 	}
 
 	@Override
 	public void setDestinationDirectory(File destinationDirectory) {
-		this.destinationDirectory = destinationDirectory;
+		setBinaryOutputDirectory(destinationDirectory);
+	}
+
+	@Override
+	public void setBinaryOutputDirectory(File binaryOutputDirectory) {
+		this.binaryOutputDirectory = binaryOutputDirectory;
+	}
+
+	@Override
+	public File getBinaryOutputDirectory() {
+		return binaryOutputDirectory;
 	}
 
 	/**
@@ -575,9 +585,9 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 		args.add("-noExit");
 		// args.add("-verbose");
 		args.add("-proc:none");
-		if (getDestinationDirectory() != null) {
+		if (getBinaryOutputDirectory() != null) {
 			args.add("-d");
-			args.add(getDestinationDirectory().getAbsolutePath());
+			args.add(getBinaryOutputDirectory().getAbsolutePath());
 		} else {
 			args.add("-d");
 			args.add("none");
@@ -633,7 +643,7 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 				}
 			}
 
-			args.add(getDestinationDirectory().getAbsolutePath());
+			args.add(getBinaryOutputDirectory().getAbsolutePath());
 
 		} else {
 			args.addAll(toStringList(sources.getAllJavaFiles()));
@@ -790,9 +800,9 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 		args.add("-enableJavadoc");
 		args.add("-noExit");
 		args.add("-proc:none");
-		if (getDestinationDirectory() != null) {
+		if (getBinaryOutputDirectory() != null) {
 			args.add("-d");
-			args.add(getDestinationDirectory().getAbsolutePath());
+			args.add(getBinaryOutputDirectory().getAbsolutePath());
 		} else {
 			args.add("-d");
 			args.add("none");
@@ -904,13 +914,13 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 	protected void initInputClassLoader() {
 		ClassLoader cl = Thread.currentThread().getContextClassLoader();
-		if (buildOnlyOutdatedFiles && getDestinationDirectory() != null) {
+		if (buildOnlyOutdatedFiles && getBinaryOutputDirectory() != null) {
 			CompilerClassLoader ccl = getCompilerClassLoader(cl);
 			if (ccl == null) {
 				try {
-					Launcher.LOGGER.debug("setting classloader for " + getDestinationDirectory().toURI().toURL());
+					Launcher.LOGGER.debug("setting classloader for " + getBinaryOutputDirectory().toURI().toURL());
 					Thread.currentThread().setContextClassLoader(new CompilerClassLoader(new URL[] {
-									getDestinationDirectory().toURI().toURL()
+									getBinaryOutputDirectory().toURI().toURL()
 							}, factory.getEnvironment().getInputClassLoader()));
 				} catch (Exception e) {
 					Launcher.LOGGER.error(e.getMessage(), e);

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -78,12 +78,22 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 	@Override
 	public File getOutputDirectory() {
+		return getSourceOutputDirectory();
+	}
+
+	@Override
+	public void setSourceOutputDirectory(File outputDirectory) {
+		this.outputDirectory = outputDirectory;
+	}
+
+	@Override
+	public File getSourceOutputDirectory() {
 		return outputDirectory;
 	}
 
 	@Override
 	public void setOutputDirectory(File outputDirectory) {
-		this.outputDirectory = outputDirectory;
+		setSourceOutputDirectory(outputDirectory);
 	}
 
 	/**

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -33,14 +33,14 @@ public class LauncherTest extends TestCase {
 
 		JavaOutputProcessor processor = (JavaOutputProcessor) environment.getDefaultFileGenerator();
 		Assert.assertTrue(processor.getPrinter() instanceof DefaultJavaPrettyPrinter);
-		
+
 		// now assertions on the model builder
 		final SpoonModelBuilder builder = launcher.getModelBuilder();
-		assertEquals(new File("spooned"), builder.getOutputDirectory());
+		assertEquals(new File("spooned"), builder.getSourceOutputDirectory());
 		assertEquals(0, builder.getInputSources().size());
 		assertEquals("UTF-8", builder.getEncoding());
 	}
-	
+
 	@Test
 	public void testInitEnvironment() throws Exception {
 
@@ -50,7 +50,7 @@ public class LauncherTest extends TestCase {
 		launcher.processArguments();
 
 		final Environment environment = launcher.getEnvironment();
-		
+
 		// Verify if the environment is correct.
 		Assert.assertTrue(environment.isVerbose());
 		Assert.assertTrue(environment.isAutoImports());
@@ -59,10 +59,10 @@ public class LauncherTest extends TestCase {
 		Assert.assertEquals(42, environment.getTabulationSize());
 		Assert.assertEquals(5, environment.getComplianceLevel());
 		Assert.assertFalse(environment.isCopyResources());
-		 
+
 		final SpoonModelBuilder builder = launcher.getModelBuilder();
-		assertEquals(new File("spooned2"), builder.getOutputDirectory());
-		
+		assertEquals(new File("spooned2"), builder.getSourceOutputDirectory());
+
 		// the input directories
 		List<File> inputSources = new ArrayList<>(builder.getInputSources());
 		assertEquals(new File("src/main/java").toURI(), inputSources.get(0).toURI());

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -144,4 +144,14 @@ public class APITest {
 		assertNotNull(actual.getMethodsByName("prepareMojito").get(0));
 		assertNotNull(actual.getMethodsByName("makeMojito").get(0));
 	}
+
+	@Test
+	public void testOutputOfSpoon() throws Exception {
+		final SpoonAPI launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses");
+		launcher.setOutputDirectory("./target/spoon/test/output/");
+		launcher.run();
+
+		assertTrue(new File("./target/spoon/test/output/").exists());
+	}
 }

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -15,6 +15,7 @@ import spoon.Launcher;
 import spoon.SpoonAPI;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -148,11 +149,25 @@ public class APITest {
 
 	@Test
 	public void testOutputOfSpoon() throws Exception {
+		final File sourceOutput = new File("./target/spoon/test/output/");
 		final SpoonAPI launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses");
-		launcher.setSourceOutputDirectory("./target/spoon/test/output/");
+		launcher.setSourceOutputDirectory(sourceOutput);
 		launcher.run();
 
-		assertTrue(new File("./target/spoon/test/output/").exists());
+		assertTrue(sourceOutput.exists());
+	}
+
+	@Test
+	public void testDestinationOfSpoon() throws Exception {
+		final File binaryOutput = new File("./target/spoon/test/binary/");
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setShouldCompile(true);
+		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses");
+		launcher.setSourceOutputDirectory("./target/spooned");
+		launcher.setBinaryOutputDirectory(binaryOutput);
+		launcher.run();
+
+		assertTrue(binaryOutput.exists());
 	}
 }

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -29,7 +29,7 @@ public class APITest {
 		// and asserts there is no exception
 		SpoonAPI spoon = new Launcher();
 		spoon.addInputResource("src/test/resources/spoon/test/api");
-		spoon.getEnvironment().getDefaultFileGenerator().setOutputDirectory(new File("target/spooned/apitest"));
+		spoon.setSourceOutputDirectory("target/spooned");
 		spoon.run();
 		Factory factory = spoon.getFactory();
 		for (CtPackage p : factory.Package().getAll()) {
@@ -134,6 +134,7 @@ public class APITest {
 	public void testAddProcessorMethodInSpoonAPI() throws Exception {
 		final SpoonAPI launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses");
+		launcher.setSourceOutputDirectory("./target/spooned");
 		final AwesomeProcessor processor = new AwesomeProcessor();
 		launcher.addProcessor(processor);
 		launcher.run();
@@ -149,7 +150,7 @@ public class APITest {
 	public void testOutputOfSpoon() throws Exception {
 		final SpoonAPI launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses");
-		launcher.setOutputDirectory("./target/spoon/test/output/");
+		launcher.setSourceOutputDirectory("./target/spoon/test/output/");
 		launcher.run();
 
 		assertTrue(new File("./target/spoon/test/output/").exists());

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -146,6 +146,7 @@ public class ImportTest {
 		final Launcher launcher = new Launcher();
 		launcher.run(new String[] {
 				"-i", "./src/test/java/spoon/test/imports/testclasses",
+				"-o", "./target/spooned",
 				"--with-imports"
 		});
 		final CtClass<ImportTest> aClass = launcher.getFactory().Class().get(ChildClass.class);

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -150,6 +150,7 @@ public class IntercessionTest {
 		final Launcher launcher = new Launcher();
 		launcher.run(new String[] {
 				"-i", "./src/main/java",
+				"-o", "./target/spooned",
 				"--source-classpath", systemClassPath
 		});
 		final Factory factory = launcher.getFactory();

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -36,7 +36,7 @@ public class LambdaTest {
 		compiler = launcher.createCompiler(this.factory);
 
 		compiler.setSourceOutputDirectory(TestUtils.getSpoonedDirectory(getClass()));
-		compiler.setDestinationDirectory(TestUtils.getBuildDirectory(getClass()));
+		compiler.setBinaryOutputDirectory(TestUtils.getBuildDirectory(getClass()));
 		compiler.addInputSource(new File("./src/test/java/spoon/test/lambda/testclasses/"));
 		compiler.build();
 		compiler.generateProcessedSourceFiles(OutputType.COMPILATION_UNITS);

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -35,7 +35,7 @@ public class LambdaTest {
 		factory.getEnvironment().setComplianceLevel(8);
 		compiler = launcher.createCompiler(this.factory);
 
-		compiler.setOutputDirectory(TestUtils.getSpoonedDirectory(getClass()));
+		compiler.setSourceOutputDirectory(TestUtils.getSpoonedDirectory(getClass()));
 		compiler.setDestinationDirectory(TestUtils.getBuildDirectory(getClass()));
 		compiler.addInputSource(new File("./src/test/java/spoon/test/lambda/testclasses/"));
 		compiler.build();

--- a/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
+++ b/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
@@ -39,7 +39,7 @@ public class MethodReferenceTest {
 		factory.getEnvironment().setDefaultFileGenerator(launcher.createOutputWriter(sourceOutputDir, factory.getEnvironment()));
 		final SpoonCompiler compiler = launcher.createCompiler(factory);
 
-		compiler.setOutputDirectory(sourceOutputDir);
+		compiler.setSourceOutputDirectory(sourceOutputDir);
 		compiler.addInputSource(new File("./src/test/java/spoon/test/methodreference/testclasses/"));
 		compiler.build();
 		compiler.generateProcessedSourceFiles(OutputType.CLASSES);

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -68,7 +68,7 @@ public class PackageTest {
 		factory.getEnvironment().setAutoImports(false);
 		SpoonCompiler compiler = launcher.createCompiler(factory);
 		compiler.addInputSource(new File("./src/test/java/spoon/test/pkg/testclasses/"));
-		compiler.setOutputDirectory(new File("./target/spooned/"));
+		compiler.setSourceOutputDirectory(new File("./target/spooned/"));
 		compiler.build();
 		compiler.generateProcessedSourceFiles(OutputType.CLASSES);
 

--- a/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
+++ b/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
@@ -55,7 +55,7 @@ public class StaticAccessTest {
         File tmpdir = new File("target/spooned/staticFieldAccess");
         tmpdir.mkdirs();
         //    tmpdir.deleteOnExit();
-        compiler.setOutputDirectory(tmpdir);
+        compiler.setSourceOutputDirectory(tmpdir);
         compiler.generateProcessedSourceFiles(OutputType.COMPILATION_UNITS);
 
         // try to reload generated datas

--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -46,7 +46,7 @@ public class VisibilityTest {
 		final Factory factory = launcher.getFactory();
 		final SpoonCompiler compiler = launcher.createCompiler();
 		compiler.addInputSource(new File("./src/test/java/spoon/test/visibility/testclasses/"));
-		compiler.setOutputDirectory(sourceOutputDir);
+		compiler.setSourceOutputDirectory(sourceOutputDir);
 		compiler.build();
 		compiler.generateProcessedSourceFiles(OutputType.CLASSES);
 


### PR DESCRIPTION
- Creates 4 new methods in SpoonAPI : `setSourceOutputDirectory(String | File)` and `setBinaryOutputDirectory(String | File)`.
- Creates 4 new methods in SpoonModelBuilder : `set/getSourceOutputDirectory()` and `set/getBinaryOutputDirectory()`.
- Deprecates older methods.
- Adds 2 test cases for the source output and the binary output.