### PR TITLE
Fixed array[index] on RHS of assignment being considered ArrayWrite

### DIFF
--- a/src/test/java/spoon/test/variable/AccessTest.java
+++ b/src/test/java/spoon/test/variable/AccessTest.java
@@ -122,7 +122,7 @@ public class AccessTest {
 									  }
 								  });
 
-		assertEquals(1, arraysRead.size());
+		assertEquals(2, arraysRead.size());
 
 		final List<CtArrayWrite<?>> arraysWrite =
 				Query.getElements(factory,
@@ -146,7 +146,7 @@ public class AccessTest {
 									  }
 								  });
 
-		assertEquals(2, arraysAccess.size());
+		assertEquals(3, arraysAccess.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/variable/testclasses/ArrayAccessSample.java
+++ b/src/test/java/spoon/test/variable/testclasses/ArrayAccessSample.java
@@ -2,7 +2,7 @@ package spoon.test.variable.testclasses;
 
 public class ArrayAccessSample {
 	public void method(String[] s) {
-		s[0] = "tacos";
+		s[0] = s[0];
 		System.err.println(s[0]);
 	}
 }


### PR DESCRIPTION
Introduces test to validate if s[0] = s[1] has one write and one read.
Fixes the problem of considering all Ct{Variable, Field, Array}Access with an CtAssignment as a parent as Writes.

This is fixed by creating a context variable assigned that is turned on on the LHS of the assignment only.