### PR TITLE
chore: Updates travis to the new architecture and change mvn cmd.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: java
 
-install: mvn test javadoc:javadoc site
+sudo: false
+
+install: mvn verify javadoc:javadoc site
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
Now, Travis is using containers to build projects. To use this
new architecture, we must add "sudo: false". That's all.
And we change the mvn command from test to verify to apply
checkstyle plugin in travis builds.