### PR TITLE
fix: Circular references with generic types.

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -18,6 +18,7 @@
 package spoon.reflect.reference;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * This interface defines a reference to a
@@ -29,6 +30,11 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 	 * Gets the bounds (aka generics) of the referenced parameter.
 	 */
 	List<CtTypeReference<?>> getBounds();
+
+	/**
+	 * Gets the bounds (aka generics) of the referenced parameter with the circular information.
+	 */
+	Map<CtTypeReference<?>, Boolean> getBoundsWithCircular();
 
 	/**
 	 * Returns {@code true} if the bounds are upper bounds.
@@ -49,6 +55,11 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 	 * Adds a bound.
 	 */
 	<T extends CtTypeParameterReference> T addBound(CtTypeReference<?> bound);
+
+	/**
+	 * Adds a bound with the posibility to mark it as a circular reference.
+	 */
+	<T extends CtTypeParameterReference> T addBound(CtTypeReference<?> bound, boolean isCircular);
 
 	/**
 	 * Removes a bound.

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -17,9 +17,6 @@
 
 package spoon.reflect.visitor;
 
-import java.lang.annotation.Annotation;
-import java.util.Collection;
-
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtArrayRead;
@@ -65,8 +62,8 @@ import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.declaration.CtAnnotation;
@@ -93,6 +90,10 @@ import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtUnboundVariableReference;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Map;
 
 /**
  * This visitor implements a deep-search scan on the metamodel.
@@ -671,7 +672,11 @@ public abstract class CtScanner implements CtVisitor {
 		scan(ref.getPackage());
 		scan(ref.getDeclaringType());
 		scanReferences(ref.getActualTypeArguments());
-		scanReferences(ref.getBounds());
+		for (Map.Entry<CtTypeReference<?>, Boolean> entry : ref.getBoundsWithCircular().entrySet()) {
+			if (!entry.getValue()) {
+				scan(entry.getKey());
+			}
+		}
 		exitReference(ref);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -17,16 +17,6 @@
 
 package spoon.reflect.visitor;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Stack;
-
 import org.apache.log4j.Level;
 import spoon.compiler.Environment;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -77,8 +67,8 @@ import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.code.UnaryOperatorKind;
@@ -119,6 +109,16 @@ import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.support.reflect.cu.CtLineElementComparator;
 import spoon.support.util.SortedList;
 import spoon.support.visitor.SignaturePrinter;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Stack;
 
 /**
  * A visitor for generating Java code from the program compile-time model.
@@ -1790,8 +1790,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			} else {
 				write(" super ");
 			}
-			for (CtTypeReference<?> b : ref.getBounds()) {
-				scan(b);
+			for (Map.Entry<CtTypeReference<?>, Boolean> entry : ref.getBoundsWithCircular().entrySet()) {
+				if (!entry.getValue()) {
+					scan(entry.getKey());
+				} else {
+					write(entry.getKey().getQualifiedName());
+				}
 				write(" & ");
 			}
 			removeLastChar();

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -17,19 +17,6 @@
 
 package spoon.support.compiler.jdt;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.CASTS_CONTAINER_DEFAULT_CAPACITY;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
-import java.util.TreeMap;
-import java.util.TreeSet;
-
 import org.apache.log4j.Logger;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
@@ -151,7 +138,6 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.VariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.WildcardBinding;
-
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
@@ -224,6 +210,20 @@ import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.reference.CtUnboundVariableReferenceImpl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static spoon.reflect.ModelElementContainerDefaultCapacities.CASTS_CONTAINER_DEFAULT_CAPACITY;
 
 /**
  * A visitor for iterating through the parse tree.
@@ -439,8 +439,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			return ref;
 		}
 
-		// Map<TypeBinding, CtTypeReference<?>> bindingCache = new
-		// HashMap<TypeBinding, CtTypeReference<?>>();
+		Map<TypeBinding, CtTypeReference> bindingCache = new HashMap<TypeBinding, CtTypeReference>();
 
 		public <T> CtTypeReference<T> getTypeReference(TypeBinding binding, TypeReference ref) {
 			CtTypeReference<T> ctRef = getTypeReference(binding);
@@ -544,7 +543,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 				}
 				if (bounds && b.superInterfaces != null && b.superInterfaces != Binding.NO_SUPERINTERFACES) {
 					bounds = false;
-					// bindingCache.put(binding, ref);
+					bindingCache.put(binding, ref);
 					for (int i = 0, length = b.superInterfaces.length; i < length; i++) {
 						TypeBinding tb = b.superInterfaces[i];
 						((CtTypeParameterReference) ref).addBound(getTypeReference(tb));
@@ -574,7 +573,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 				}
 
 				if (((WildcardBinding) binding).bound != null && ref instanceof CtTypeParameterReference) {
-					((CtTypeParameterReference) ref).addBound(getTypeReference(((WildcardBinding) binding).bound));
+					if (bindingCache.containsKey(((WildcardBinding) binding).bound)) {
+						((CtTypeParameterReference) ref).addBound(bindingCache.get(((WildcardBinding) binding).bound), true);
+					} else {
+						((CtTypeParameterReference) ref).addBound(getTypeReference(((WildcardBinding) binding).bound));
+					}
 				}
 			} else if (binding instanceof LocalTypeBinding) {
 				if (!JDTTreeBuilder.this.context.isGenericTypeExplicit) {
@@ -639,7 +642,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			} else {
 				throw new RuntimeException("Unknown TypeBinding: " + binding.getClass() + " " + binding);
 			}
-			// bindingCache.remove(binding);
+			bindingCache.remove(binding);
 			addTypeAnnotationFromBindingToReference(binding, ref);
 			return (CtTypeReference<T>) ref;
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -17,13 +17,6 @@
 
 package spoon.support.reflect.reference;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
-
-import java.lang.reflect.AnnotatedElement;
-import java.util.ArrayList;
-import java.util.List;
-
 import spoon.reflect.reference.CtGenericElementReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -31,11 +24,20 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY;
+import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
+
 public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object>
 		implements CtTypeParameterReference {
 	private static final long serialVersionUID = 1L;
 
-	List<CtTypeReference<?>> bounds = CtElementImpl.emptyList();
+	Map<CtTypeReference<?>, Boolean> bounds = new HashMap<CtTypeReference<?>, Boolean>(TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY);
 
 	boolean upper = true;
 
@@ -50,6 +52,11 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object>
 
 	@Override
 	public List<CtTypeReference<?>> getBounds() {
+		return new ArrayList<CtTypeReference<?>>(bounds.keySet());
+	}
+
+	@Override
+	public Map<CtTypeReference<?>, Boolean> getBoundsWithCircular() {
 		return bounds;
 	}
 
@@ -60,7 +67,9 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object>
 
 	@Override
 	public <T extends CtTypeParameterReference> T setBounds(List<CtTypeReference<?>> bounds) {
-		this.bounds = bounds;
+		for (CtTypeReference<?> bound : bounds) {
+			this.bounds.put(bound, false);
+		}
 		return (T) this;
 	}
 
@@ -115,10 +124,13 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object>
 
 	@Override
 	public <T extends CtTypeParameterReference> T addBound(CtTypeReference<?> bound) {
-		if (bounds == CtElementImpl.<CtTypeReference<?>>emptyList()) {
-			bounds = new ArrayList<CtTypeReference<?>>(TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY);
-		}
-		bounds.add(bound);
+		bounds.put(bound, false);
+		return (T) this;
+	}
+
+	@Override
+	public <T extends CtTypeParameterReference> T addBound(CtTypeReference<?> bound, boolean isCircular) {
+		bounds.put(bound, isCircular);
 		return (T) this;
 	}
 

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -5,22 +5,28 @@ import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
+import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Lionel Seinturier
@@ -178,6 +184,41 @@ public class TypeReferenceTest {
 
 		assertNotEquals(firstRef.toString(), secondRef.toString());
 		assertNotEquals(firstRef, secondRef);
+	}
+
+	@Test
+	public void testRecursiveTypeReference() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses/Tacos.java");
+		launcher.setSourceOutputDirectory("./target/spoon-test");
+		launcher.run();
+
+		final CtInvocation<?> inv = Query.getElements(launcher.getFactory(), new TypeFilter<CtInvocation<?>>(CtInvocation.class) {
+			@Override
+			public boolean matches(CtInvocation<?> element) {
+				return !element.getExecutable().isConstructor() && super.matches(element);
+			}
+		}).get(0);
+
+		assertNotNull(inv.getExecutable());
+		final CtTypeReference<?> returnType = inv.getExecutable().getType();
+		assertNotNull(returnType);
+		assertEquals(1, returnType.getActualTypeArguments().size());
+
+		final CtTypeParameterReference genericType = (CtTypeParameterReference) returnType.getActualTypeArguments().get(0);
+		assertNotNull(genericType);
+		assertEquals(1, genericType.getBounds().size());
+
+		final CtTypeReference<?> extendsGeneric = genericType.getBounds().get(0);
+		assertNotNull(extendsGeneric);
+		assertEquals(1, extendsGeneric.getActualTypeArguments().size());
+
+		final CtTypeParameterReference genericExtends = (CtTypeParameterReference) extendsGeneric.getActualTypeArguments().get(0);
+		assertNotNull(genericExtends);
+		assertEquals(1, genericExtends.getBounds().size());
+		for (Map.Entry<CtTypeReference<?>, Boolean> bound : genericExtends.getBoundsWithCircular().entrySet()) {
+			assertTrue(bound.getValue());
+		}
 	}
 
 	class A {

--- a/src/test/java/spoon/test/reference/testclasses/Tacos.java
+++ b/src/test/java/spoon/test/reference/testclasses/Tacos.java
@@ -1,0 +1,10 @@
+package spoon.test.reference.testclasses;
+
+import java.util.Comparator;
+
+public class Tacos<U> {
+	@SuppressWarnings({ "unchecked", "rawtypes"})
+	public final void toSortedList() {
+		Comparator.naturalOrder();
+	}
+}


### PR DESCRIPTION
> With this PR, we can apply Spoon on RxJava. :)

When you have an invocation to a method with this
kind of reference : <T extends Comparable<? extends T>>,
you got a circular reference and a StackOverflowException.
With this PR, we add a cache which detects circular references
in JDTTreeBuilder and uses this information in
CtScanner and DefaultJavaPrettyPrinter.

Closes #368