### PR TITLE
Fix anonymous classname and CtClass.getConstructor

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1002,7 +1002,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 	private String computeAnonymousName(SourceTypeBinding binding) {
 		final String poolName = String.valueOf(binding.constantPoolName());
 		final int lastIndexSeparator = poolName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR);
-		return poolName.substring(lastIndexSeparator + 1, lastIndexSeparator + 2);
+		return poolName.substring(lastIndexSeparator + 1, poolName.length());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -69,8 +69,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 		for (CtConstructor<T> c : constructors) {
 			boolean cont = c.getParameters().size() == parameterTypes.length;
 			for (int i = 0; cont && (i < c.getParameters().size()) && (i < parameterTypes.length); i++) {
-				if (!c.getParameters().get(i).getType().getQualifiedName()
-						.equals(parameterTypes[i].getQualifiedName())) {
+				if (!parameterTypes[i].equals(c.getParameters().get(i).getType())) {
 					cont = false;
 				}
 			}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -166,13 +166,16 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		}
 		if (!isPrimitive() && isAnonymous()) {
 			final CtType<?> rootType = getFactory().Type().get(getDeclaringType().getQualifiedName());
-			final CtNewClass elements = rootType.getElements(new AbstractFilter<CtNewClass<?>>(CtNewClass.class) {
+			final List<CtNewClass<T>> elements = rootType.getElements(new AbstractFilter<CtNewClass<T>>(CtNewClass.class) {
 				@Override
-				public boolean matches(CtNewClass<?> element) {
-					return getSimpleName().equals(element.getAnonymousClass().getSimpleName());
+				public boolean matches(CtNewClass<T> element) {
+					return getQualifiedName().equals(element.getAnonymousClass().getQualifiedName());
 				}
-			}).get(0);
-			return elements.getAnonymousClass();
+			});
+			if (elements.size()  == 0) {
+				return null;
+			}
+			return (CtType<T>) elements.get(0).getAnonymousClass();
 		}
 		return null;
 	}

--- a/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
@@ -13,6 +13,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.TestUtils;
 import spoon.test.constructorcallnewclass.testclasses.Bar;
 import spoon.test.constructorcallnewclass.testclasses.Foo;
+import spoon.test.constructorcallnewclass.testclasses.Foo2;
 
 import java.util.List;
 
@@ -123,5 +124,20 @@ public class NewClassTest {
 
 	private void assertType(Class<?> typeExpected, CtNewClass<?> newClass) {
 		assertEquals("New class is typed by the class of the constructor", typeExpected, newClass.getType().getActualClass());
+	}
+
+	@Test
+	public void testMoreThan9NewClass() throws Exception {
+		final Factory build = TestUtils.build(Foo2.class);
+		final CtClass<?> foo = (CtClass<?>) build.Type().get(Foo2.class);
+		List<CtNewClass<?>> elements = foo.getElements(new AbstractFilter<CtNewClass<?>>(CtNewClass.class) {
+			@Override
+			public boolean matches(CtNewClass<?> element) {
+				return true;
+			}
+		});
+		assertEquals(13, elements.size());
+		assertEquals(Foo2.class.getCanonicalName() + "$12", elements.get(11).getAnonymousClass().getQualifiedName());
+		assertEquals(Foo2.class.getCanonicalName() + "$12$1", elements.get(12).getAnonymousClass().getQualifiedName());
 	}
 }

--- a/src/test/java/spoon/test/constructorcallnewclass/testclasses/Foo2.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/testclasses/Foo2.java
@@ -1,0 +1,97 @@
+package spoon.test.constructorcallnewclass.testclasses;
+
+/**
+ * Created by thomas on 14/10/15.
+ */
+public class Foo2 {
+
+    public void exec() {
+        AbstractClass abstractClass1 = new AbstractClass(1) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass2 = new AbstractClass(1) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass3 = new AbstractClass(2) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass4 = new AbstractClass(3) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass5 = new AbstractClass(4) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass6 = new AbstractClass(6) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass7 = new AbstractClass(7) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass8 = new AbstractClass(8) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass9 = new AbstractClass(9) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass10 = new AbstractClass(10) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+        AbstractClass abstractClass11 = new AbstractClass(11) {
+            @Override
+            public double getValue(double[] value) {
+                return 0;
+            }
+        };
+
+        AbstractClass abstractClass12 = new AbstractClass(12) {
+            @Override
+            public double getValue(double[] value) {
+                return new AbstractClass(12) {
+                    @Override
+                    public double getValue(double[] value) {
+                        return 0;
+                    }
+                }.getValue(value);
+            }
+        };
+    }
+
+    private abstract class AbstractClass {
+        private int i;
+        AbstractClass(int i) {
+            this.i=i;
+        }
+
+        public abstract double getValue(double[] value);
+    }
+}

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -1,0 +1,36 @@
+package spoon.test.ctClass;
+
+import org.junit.Assert;
+import org.junit.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtArrayTypeReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.test.TestUtils;
+import spoon.test.ctClass.testclasses.Foo;
+
+public class CtClassTest {
+
+    @Test
+    public void getConstructor() throws Exception {
+        final Factory build = TestUtils.build(Foo.class);
+        final CtClass<?> foo = (CtClass<?>) build.Type().get(Foo.class);
+
+        Assert.assertEquals(3, foo.getConstructors().size());
+
+        CtTypeReference<Object> typeString = build.Code().createCtTypeReference(String.class);
+        CtConstructor<?> constructor = foo.getConstructor(typeString);
+        Assert.assertEquals(typeString, constructor.getParameters().get(0).getType());
+
+        CtArrayTypeReference<Object> typeStringArray = build.Core().createArrayTypeReference();
+        typeStringArray.setComponentType(typeString);
+        constructor = foo.getConstructor(typeStringArray);
+        Assert.assertEquals(typeStringArray, constructor.getParameters().get(0).getType());
+
+        CtArrayTypeReference<Object> typeStringArrayArray = build.Core().createArrayTypeReference();
+        typeStringArrayArray.setComponentType(typeStringArray);
+        constructor = foo.getConstructor(typeStringArrayArray);
+        Assert.assertEquals(typeStringArrayArray, constructor.getParameters().get(0).getType());
+    }
+}

--- a/src/test/java/spoon/test/ctClass/testclasses/Foo.java
+++ b/src/test/java/spoon/test/ctClass/testclasses/Foo.java
@@ -1,0 +1,18 @@
+package spoon.test.ctClass.testclasses;
+
+/**
+ * Created by thomas on 14/10/15.
+ */
+public class Foo {
+    Foo(String arg) {
+
+    }
+
+    Foo(String[] arg) {
+
+    }
+
+    Foo(String[][] arg) {
+
+    }
+}


### PR DESCRIPTION
The anonymous classname was not correct when there are more than 9 anonymous per class.

The method CtClass.getConstructor did not return the correct constructor when there are serveral contructors with array/matrix parameter.