### PR TITLE
fix: Circular references with generic types.

### DIFF
--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -40,4 +40,6 @@ public interface Factory {
 	EvalFactory Eval(); // used 4 times
 
 	ConstructorFactory Constructor(); // used 3 times
+
+	InternalFactory Internal();
 }

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -17,11 +17,6 @@
 
 package spoon.reflect.factory;
 
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-
 import spoon.compiler.Environment;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtAnnotationType;
@@ -35,7 +30,13 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.support.DefaultCoreFactory;
+import spoon.support.DefaultInternalFactory;
 import spoon.support.StandardEnvironment;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * Implements {@link Factory}
@@ -251,6 +252,16 @@ public class FactoryImpl implements Factory, Serializable {
 			type = new TypeFactory(this);
 		}
 		return type;
+	}
+
+	private transient InternalFactory internal;
+
+	@Override
+	public InternalFactory Internal() {
+		if (internal == null) {
+			internal = new DefaultInternalFactory(this);
+		}
+		return internal;
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/factory/InternalFactory.java
+++ b/src/main/java/spoon/reflect/factory/InternalFactory.java
@@ -1,0 +1,15 @@
+package spoon.reflect.factory;
+
+import spoon.reflect.internal.CtCircularTypeReference;
+
+/**
+ * This interface defines the creation methods for internal nodes of the
+ * meta-model. These nodes are available in the AST provided by Spoon
+ * but their creation should be used only in internal of Spoon.
+ */
+public interface InternalFactory {
+	/**
+	 * Creates a circular type reference.
+	 */
+	<T> CtCircularTypeReference createCircularTypeReference();
+}

--- a/src/main/java/spoon/reflect/internal/CtCircularTypeReference.java
+++ b/src/main/java/spoon/reflect/internal/CtCircularTypeReference.java
@@ -1,0 +1,16 @@
+package spoon.reflect.internal;
+
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * When we build a {@link CtTypeReference}, we can have a circular when
+ * we got this kind of generic type: {@code <T extends Comparable<? super T>>}.
+ * In this case, where we are at the last T, we come back at the first
+ * one and we are in a circular.
+ *
+ * Now, the last T is a CtCircularTypeReference and we stop the circular
+ * when we build the generic or when we scan an AST given.
+ */
+public interface CtCircularTypeReference extends CtTypeParameterReference {
+}

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -63,6 +63,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtLocalVariableReference;
@@ -385,6 +386,11 @@ public abstract class CtAbstractVisitor implements CtVisitor {
 
 	@Override
 	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
 
 	}
 

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -97,6 +97,7 @@ import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
@@ -761,6 +762,11 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtGenericElementReference(e);
 		scanCtTypeAnnotableReference(e);
 		scanCtVisitable(e);
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference e) {
+		visitCtTypeParameterReference(e);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -17,9 +17,6 @@
 
 package spoon.reflect.visitor;
 
-import java.lang.annotation.Annotation;
-import java.util.Collection;
-
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtArrayRead;
@@ -65,8 +62,8 @@ import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.declaration.CtAnnotation;
@@ -84,6 +81,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtLocalVariableReference;
@@ -93,6 +91,9 @@ import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtUnboundVariableReference;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
 
 /**
  * This visitor implements a deep-search scan on the metamodel.
@@ -681,6 +682,10 @@ public abstract class CtScanner implements CtVisitor {
 		scan(reference.getDeclaringType());
 		scanReferences(reference.getActualTypeArguments());
 		exitReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitor.java
@@ -79,6 +79,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtLocalVariableReference;
@@ -387,6 +388,11 @@ public interface CtVisitor {
 	 * Visits a reference to a type.
 	 */
 	<T> void visitCtTypeReference(CtTypeReference<T> reference);
+
+	/**
+	 * Visits a circular reference.
+	 */
+	<T> void visitCtCircularTypeReference(CtCircularTypeReference reference);
 
 	/**
 	 * Visits a type access.

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -17,16 +17,6 @@
 
 package spoon.reflect.visitor;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Stack;
-
 import org.apache.log4j.Level;
 import spoon.compiler.Environment;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -77,8 +67,8 @@ import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.code.UnaryOperatorKind;
@@ -105,6 +95,7 @@ import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
@@ -119,6 +110,16 @@ import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.support.reflect.cu.CtLineElementComparator;
 import spoon.support.util.SortedList;
 import spoon.support.visitor.SignaturePrinter;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Stack;
 
 /**
  * A visitor for generating Java code from the program compile-time model.
@@ -1826,6 +1827,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (!context.ignoreGenerics) {
 			writeActualTypeArguments(ref);
 		}
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+		visitCtTypeReference(reference);
 	}
 
 	private <T> boolean hasDeclaringTypeWithGenerics(CtTypeReference<T> reference) {

--- a/src/main/java/spoon/support/DefaultInternalFactory.java
+++ b/src/main/java/spoon/support/DefaultInternalFactory.java
@@ -1,0 +1,21 @@
+package spoon.support;
+
+import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.InternalFactory;
+import spoon.reflect.internal.CtCircularTypeReference;
+import spoon.support.reflect.internal.CtCircularTypeReferenceImpl;
+
+public class DefaultInternalFactory implements InternalFactory {
+	Factory mainFactory;
+
+	public DefaultInternalFactory(Factory factory) {
+		mainFactory = factory;
+	}
+
+	@Override
+	public <T> CtCircularTypeReference createCircularTypeReference() {
+		CtCircularTypeReference e = new CtCircularTypeReferenceImpl();
+		e.setFactory(mainFactory);
+		return e;
+	}
+}

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -90,6 +90,7 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.eval.PartialEvaluator;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
@@ -717,6 +718,11 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 	}
 
 	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+		throw new RuntimeException("Unknow Element");
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
 		throw new RuntimeException("Unknow Element");
 	}
 

--- a/src/main/java/spoon/support/reflect/internal/CtCircularTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/internal/CtCircularTypeReferenceImpl.java
@@ -1,0 +1,12 @@
+package spoon.support.reflect.internal;
+
+import spoon.reflect.internal.CtCircularTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.reflect.reference.CtTypeParameterReferenceImpl;
+
+public class CtCircularTypeReferenceImpl extends CtTypeParameterReferenceImpl implements CtCircularTypeReference {
+	@Override
+	public void accept(CtVisitor visitor) {
+		visitor.visitCtCircularTypeReference(this);
+	}
+}

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -82,6 +82,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtLocalVariableReference;
@@ -619,6 +620,11 @@ public class SignaturePrinter implements CtVisitor {
 
 	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
 		write(reference.getQualifiedName());
+	}
+
+	@Override
+	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+		visitCtTypeReference(reference);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/reference/testclasses/Tacos.java
+++ b/src/test/java/spoon/test/reference/testclasses/Tacos.java
@@ -1,0 +1,10 @@
+package spoon.test.reference.testclasses;
+
+import java.util.Comparator;
+
+public class Tacos {
+	@SuppressWarnings({ "unchecked", "rawtypes"})
+	public final void toSortedList() {
+		Comparator.naturalOrder();
+	}
+}


### PR DESCRIPTION
When you have an invocation to a method with this
kind of reference : <T extends Comparable<? extends T>>,
you got a circular reference and a StackOverflowException.
With this PR, we add a cache which detects circular references
in JDTTreeBuilder and uses this information in
CtScanner and DefaultJavaPrettyPrinter.

Closes #368