### PR TITLE
fix: Parameters in a lambda expression.

### DIFF
--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -80,7 +80,6 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -403,11 +402,6 @@ public interface CoreFactory {
 	 * Creates a type reference.
 	 */
 	<T> CtTypeReference<T> createTypeReference();
-
-	/**
-	 * Creates a inference type reference.
-	 */
-	<T> CtImplicitTypeReference<T> createImplicitTypeReference();
 
 	/**
 	 * Creates a type access expression.

--- a/src/main/java/spoon/reflect/factory/InternalFactory.java
+++ b/src/main/java/spoon/reflect/factory/InternalFactory.java
@@ -1,6 +1,7 @@
 package spoon.reflect.factory;
 
 import spoon.reflect.internal.CtCircularTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 
 /**
  * This interface defines the creation methods for internal nodes of the
@@ -11,5 +12,10 @@ public interface InternalFactory {
 	/**
 	 * Creates a circular type reference.
 	 */
-	<T> CtCircularTypeReference createCircularTypeReference();
+	CtCircularTypeReference createCircularTypeReference();
+
+	/**
+	 * Creates a inference type reference.
+	 */
+	<T> CtImplicitTypeReference<T> createImplicitTypeReference();
 }

--- a/src/main/java/spoon/reflect/internal/CtImplicitTypeReference.java
+++ b/src/main/java/spoon/reflect/internal/CtImplicitTypeReference.java
@@ -1,13 +1,17 @@
-package spoon.reflect.reference;
+package spoon.reflect.internal;
+
+import spoon.reflect.reference.CtTypeReference;
 
 /**
  * This interface defines a reference to a {@link spoon.reflect.declaration.CtType} or sub-type
- * but when this type is implicit like given in the diamond operator.
+ * but when this type is implicit like given in the diamond operator or parameter of a lambda.
  *
  * <pre>
  * {@code
  *     // The type in the diamond operator of ArrayList is a CtImplicitTypeReference with a String.
  *     List<String> list = new ArrayList<>();
+ *
+ *     (e) -> {}
  * }
  * </pre>
  *

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -66,6 +66,7 @@ import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -390,7 +391,12 @@ public abstract class CtAbstractVisitor implements CtVisitor {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
 
 	}
 

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -101,6 +101,7 @@ import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -765,8 +766,13 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference e) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference e) {
 		visitCtTypeParameterReference(e);
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
+		visitCtTypeReference(reference);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -84,6 +84,7 @@ import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -685,7 +686,12 @@ public abstract class CtScanner implements CtVisitor {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
+		visitCtTypeReference(reference);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitor.java
@@ -82,6 +82,7 @@ import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -392,7 +393,12 @@ public interface CtVisitor {
 	/**
 	 * Visits a circular reference.
 	 */
-	<T> void visitCtCircularTypeReference(CtCircularTypeReference reference);
+	void visitCtCircularTypeReference(CtCircularTypeReference reference);
+
+	/**
+	 * Visits a reference to an implicit type.
+	 */
+	<T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference);
 
 	/**
 	 * Visits a type access.

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -99,7 +99,7 @@ import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
-import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -1830,8 +1830,13 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
 		visitCtTypeReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
+		// The type is implicit, we don't print it!
 	}
 
 	private <T> boolean hasDeclaringTypeWithGenerics(CtTypeReference<T> reference) {

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -1,12 +1,5 @@
 package spoon.reflect.visitor;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
-import java.util.TreeMap;
-
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtInvocation;
@@ -19,8 +12,16 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A scanner that calculates the imports for a given model.
@@ -140,7 +141,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 
 	@Override
 	public boolean isImported(CtTypeReference<?> ref) {
-		if (imports.containsKey(ref.getSimpleName())) {
+		if (!(ref instanceof CtImplicitTypeReference) && imports.containsKey(ref.getSimpleName())) {
 			CtTypeReference<?> exist = imports.get(ref.getSimpleName());
 			if (exist.getQualifiedName().equals(ref.getQualifiedName())) {
 				return true;

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -84,7 +84,6 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.reference.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -155,7 +154,6 @@ import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 import spoon.support.reflect.reference.CtCatchVariableReferenceImpl;
 import spoon.support.reflect.reference.CtExecutableReferenceImpl;
 import spoon.support.reflect.reference.CtFieldReferenceImpl;
-import spoon.support.reflect.reference.CtImplicitTypeReferenceImpl;
 import spoon.support.reflect.reference.CtLocalVariableReferenceImpl;
 import spoon.support.reflect.reference.CtPackageReferenceImpl;
 import spoon.support.reflect.reference.CtParameterReferenceImpl;
@@ -640,13 +638,6 @@ public class DefaultCoreFactory implements CoreFactory, Serializable {
 
 	public <T> CtTypeReference<T> createTypeReference() {
 		CtTypeReference<T> e = new CtTypeReferenceImpl<T>();
-		e.setFactory(getMainFactory());
-		return e;
-	}
-
-	@Override
-	public <T> CtImplicitTypeReference<T> createImplicitTypeReference() {
-		final CtImplicitTypeReferenceImpl<T> e = new CtImplicitTypeReferenceImpl<T>();
 		e.setFactory(getMainFactory());
 		return e;
 	}

--- a/src/main/java/spoon/support/DefaultInternalFactory.java
+++ b/src/main/java/spoon/support/DefaultInternalFactory.java
@@ -3,18 +3,27 @@ package spoon.support;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.InternalFactory;
 import spoon.reflect.internal.CtCircularTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.support.reflect.internal.CtCircularTypeReferenceImpl;
+import spoon.support.reflect.internal.CtImplicitTypeReferenceImpl;
 
 public class DefaultInternalFactory implements InternalFactory {
-	Factory mainFactory;
+	private final Factory mainFactory;
 
 	public DefaultInternalFactory(Factory factory) {
 		mainFactory = factory;
 	}
 
 	@Override
-	public <T> CtCircularTypeReference createCircularTypeReference() {
+	public CtCircularTypeReference createCircularTypeReference() {
 		CtCircularTypeReference e = new CtCircularTypeReferenceImpl();
+		e.setFactory(mainFactory);
+		return e;
+	}
+
+	@Override
+	public <T> CtImplicitTypeReference<T> createImplicitTypeReference() {
+		final CtImplicitTypeReferenceImpl<T> e = new CtImplicitTypeReferenceImpl<T>();
 		e.setFactory(mainFactory);
 		return e;
 	}

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -94,6 +94,7 @@ import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtGenericElementReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -722,7 +723,12 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+		throw new RuntimeException("Unknow Element");
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
 		throw new RuntimeException("Unknow Element");
 	}
 

--- a/src/main/java/spoon/support/reflect/internal/CtImplicitTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/internal/CtImplicitTypeReferenceImpl.java
@@ -1,11 +1,18 @@
-package spoon.support.reflect.reference;
+package spoon.support.reflect.internal;
 
-import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.reflect.reference.CtTypeReferenceImpl;
 
 public class CtImplicitTypeReferenceImpl<R> extends CtTypeReferenceImpl<R>
 		implements CtImplicitTypeReference<R> {
 	String name;
+
+	@Override
+	public void accept(CtVisitor visitor) {
+		visitor.visitCtImplicitTypeReference(this);
+	}
 
 	@Override
 	public <T extends CtReference> T setSimpleName(String simplename) {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -17,21 +17,6 @@
 
 package spoon.support.reflect.reference;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
-
 import spoon.Launcher;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtAnnotation;
@@ -51,6 +36,21 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.util.RtHelper;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static spoon.reflect.ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY;
+import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 
 public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeReference<T> {
 	private static final long serialVersionUID = 1L;
@@ -216,8 +216,8 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	@Override
 	public boolean isPrimitive() {
-		return (getSimpleName().equals("boolean") || getSimpleName().equals("byte") || getSimpleName().equals("double") || getSimpleName().equals("int") || getSimpleName().equals("short")
-				|| getSimpleName().equals("char") || getSimpleName().equals("long") || getSimpleName().equals("float") || getSimpleName().equals("void"));
+		return ("boolean".equals(getSimpleName()) || "byte".equals(getSimpleName()) || "double".equals(getSimpleName()) || "int".equals(getSimpleName()) || "short".equals(getSimpleName())
+				|| "char".equals(getSimpleName()) || "long".equals(getSimpleName()) || "float".equals(getSimpleName()) || "void".equals(getSimpleName()));
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -85,6 +85,7 @@ import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.internal.CtCircularTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
@@ -623,7 +624,12 @@ public class SignaturePrinter implements CtVisitor {
 	}
 
 	@Override
-	public <T> void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+		visitCtTypeReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
 		visitCtTypeReference(reference);
 	}
 

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -42,7 +42,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -29,6 +29,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -111,8 +112,10 @@ public class GenericsTest {
 		CtField<?> f = clazz.getFields().get(0);
 		CtConstructorCall<?> val = (CtConstructorCall<?>) f.getDefaultExpression();
 
-		// the diamond is resolved to String
-		assertEquals("java.lang.String", val.getType().getActualTypeArguments().get(0).toString());
+		// the diamond is resolved to String but we don't print it, so we use the fully qualified name.
+		assertTrue(val.getType().getActualTypeArguments().get(0) instanceof CtImplicitTypeReference);
+		assertEquals("", val.getType().getActualTypeArguments().get(0).toString());
+		assertEquals("java.lang.String", val.getType().getActualTypeArguments().get(0).getQualifiedName());
 		assertEquals("new java.util.ArrayList<>()",val.toString());
 	}
 

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -11,10 +11,12 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.test.TestUtils;
+import spoon.test.lambda.testclasses.Bar;
 import spoon.test.lambda.testclasses.Foo;
 
 import java.io.File;
@@ -26,6 +28,7 @@ import static org.junit.Assert.*;
 public class LambdaTest {
 	private Factory factory;
 	private CtType<Foo> foo;
+	private CtType<Bar> bar;
 	private SpoonCompiler compiler;
 
 	@Before
@@ -42,6 +45,7 @@ public class LambdaTest {
 		compiler.generateProcessedSourceFiles(OutputType.COMPILATION_UNITS);
 
 		foo = factory.Type().get(Foo.class);
+		bar = factory.Type().get(Bar.class);
 	}
 
 	@Test
@@ -67,7 +71,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)((spoon.test.lambda.testclasses.Foo.Person p) -> (p.age) > 10))",
+				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)(( p) -> (p.age) > 10))",
 				lambda);
 	}
 
@@ -86,7 +90,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((spoon.test.lambda.testclasses.Foo.CheckPersons)((spoon.test.lambda.testclasses.Foo.Person p1,spoon.test.lambda.testclasses.Foo.Person p2) -> ((p1.age) - (p2.age)) > 0))",
+				"((spoon.test.lambda.testclasses.Foo.CheckPersons)(( p1, p2) -> ((p1.age) - (p2.age)) > 0))",
 				lambda);
 	}
 
@@ -151,7 +155,7 @@ public class LambdaTest {
 		assertStatementBody(lambda);
 
 		assertIsWellPrinted(
-				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)((spoon.test.lambda.testclasses.Foo.Person p) -> {"
+				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)(( p) -> {"
 						+ System.lineSeparator()
 						+ "    p.doSomething();" + System.lineSeparator()
 						+ "    return (p.age) > 10;" + System.lineSeparator()
@@ -177,7 +181,7 @@ public class LambdaTest {
 			}
 		}).get(0);
 		final String expected =
-				"if (((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)((spoon.test.lambda.testclasses.Foo.Person p) -> (p.age) > 18)).test(new spoon.test.lambda.testclasses.Foo.Person(10))) {"
+				"if (((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>)(( p) -> (p.age) > 18)).test(new spoon.test.lambda.testclasses.Foo.Person(10))) {"
 						+ System.lineSeparator()
 						+ "    java.lang.System.err.println(\"Enjoy, you have more than 18.\");" + System
 						.lineSeparator()
@@ -188,6 +192,25 @@ public class LambdaTest {
 	@Test
 	public void testCompileLambdaGeneratedBySpoon() throws Exception {
 		TestUtils.canBeBuild(TestUtils.getSpoonedDirectory(getClass()), 8);
+	}
+
+	@Test
+	public void testTypeParameterOfLambdaWithoutType() throws Exception {
+		final CtLambda<?> lambda1 = bar.getElements(new NameFilter<CtLambda<?>>("lambda$1")).get(0);
+		assertEquals(1, lambda1.getParameters().size());
+		final CtParameter<?> ctParameterFirstLambda = lambda1.getParameters().get(0);
+		assertEquals("s", ctParameterFirstLambda.getSimpleName());
+		assertTrue(ctParameterFirstLambda.getType() instanceof CtImplicitTypeReference);
+		assertEquals("", ctParameterFirstLambda.getType().toString());
+		assertEquals("SingleSubscriber", ctParameterFirstLambda.getType().getSimpleName());
+
+		final CtLambda<?> lambda2 = bar.getElements(new NameFilter<CtLambda<?>>("lambda$2")).get(0);
+		assertEquals(2, lambda2.getParameters().size());
+		final CtParameter<?> ctParameterSecondLambda = lambda2.getParameters().get(0);
+		assertEquals("v", ctParameterSecondLambda.getSimpleName());
+		assertTrue(ctParameterSecondLambda.getType() instanceof CtImplicitTypeReference);
+		assertEquals("", ctParameterSecondLambda.getType().toString());
+		assertEquals("?", ctParameterSecondLambda.getType().getSimpleName());
 	}
 
 	private void assertTypedBy(Class<?> expectedType, CtTypeReference<?> type) {

--- a/src/test/java/spoon/test/lambda/testclasses/Bar.java
+++ b/src/test/java/spoon/test/lambda/testclasses/Bar.java
@@ -1,0 +1,32 @@
+package spoon.test.lambda.testclasses;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class Bar<T> {
+	public static <T> Bar<T> m(CompletableFuture<? extends T> future) {
+		Objects.requireNonNull(future);
+		return create(s -> {
+			future.whenComplete((v, e) -> {
+			});
+		});
+	}
+
+	public static <T> Bar<T> create(SingleOnSubscribe<T> onSubscribe) {
+		return new Bar<>();
+	}
+
+	public interface SingleOnSubscribe<T> extends Consumer<SingleSubscriber<? super T>> {
+	}
+
+	public interface SingleSubscriber<T> {
+		void onSubscribe(Disposable d);
+		void onSuccess(T value);
+		void onError(Throwable e);
+	}
+
+	public interface Disposable {
+		void dispose();
+	}
+}

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -17,7 +17,7 @@ import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtImplicitTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;


### PR DESCRIPTION
From now, we don't re-print type of parameters of lambda
if original sources don't specify it. We print the name
of these parameters and we save the expected type in the
AST.

Issue #368