### PR TITLE
Infered generic type

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -2346,9 +2346,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 					e.traverse(this, scope);
 				}
 			}
-			if (messageSend.genericTypeArguments() != null) {
-				for (TypeBinding typeBinding : messageSend.genericTypeArguments()) {
-					inv.getExecutable().addActualTypeArgument(references.getTypeReference(typeBinding));
+			if (messageSend.typeArguments != null) {
+				for (TypeReference typeBinding : messageSend.typeArguments) {
+					inv.getExecutable().addActualTypeArgument(references.getTypeReference(typeBinding.resolvedType));
 				}
 			}
 			context.popArgument(inv);


### PR DESCRIPTION
The  ```<T> ``` at https://github.com/apache/commons-lang/blob/740c0f95fbd99cb7c07bcf7c54bc077c3ab27bd1/src/main/java/org/apache/commons/lang3/SerializationUtils.java#L267 is automatically inferred to  ```Object ``` by JTD. 

Thus the JDT method ```messageSend.genericTypeArguments()``` return the class  ```Object ``` and not  ```<T> ```. This implies that the Spoon AST is not correct.

This PR fix the Spoon AST but I cannot reproduce this error with a test.

Fill free to complete this PR with a test.