### PR TITLE
fix(access): Writes correctly field access in anonymous type.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -2565,6 +2565,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			fa.setVariable(ref);
 
 			if (qualifiedNameReference.binding != null
+					&& !((FieldBinding) qualifiedNameReference.binding).declaringClass.isAnonymousType()
 					&& qualifiedNameReference.tokens.length - 1 == ((FieldBinding) qualifiedNameReference.binding).declaringClass.compoundName.length) {
 				// We get the binding information when we specify the complete fully qualified name of the delcaring class.
 				final ReferenceBinding declaringClass = ((FieldBinding) qualifiedNameReference.binding).declaringClass;

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -2,6 +2,7 @@ package spoon.test.fieldaccesses;
 
 import org.junit.Test;
 import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.declaration.CtElement;
@@ -13,6 +14,7 @@ import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.TestUtils;
+import spoon.test.fieldaccesses.testclasses.Panini;
 
 import java.util.List;
 import java.util.logging.Logger;
@@ -152,5 +154,16 @@ public class FieldAccessTest {
 
 		String expectedLambda = "() -> {\n" + "    spoon.test.fieldaccesses.MyClass.LOG.info(\"bla\");\n" + "}";
 		assertEquals(expectedLambda, logFieldAccess.getParent(CtLambda.class).toString());
+	}
+
+	@Test
+	public void testFieldAccessInAnonymousClass() throws Exception {
+		final Factory factory = TestUtils.build(Panini.class);
+		final CtType<Panini> panini = factory.Type().get(Panini.class);
+
+		final CtFieldRead fieldInAnonymous = panini.getElements(new TypeFilter<>(CtFieldRead.class)).get(0);
+		assertEquals("ingredient", fieldInAnonymous.getTarget().toString());
+		assertEquals("next", fieldInAnonymous.getVariable().getSimpleName());
+		assertEquals("ingredient.next", fieldInAnonymous.toString());
 	}
 }

--- a/src/test/java/spoon/test/fieldaccesses/testclasses/Panini.java
+++ b/src/test/java/spoon/test/fieldaccesses/testclasses/Panini.java
@@ -1,0 +1,22 @@
+package spoon.test.fieldaccesses.testclasses;
+
+public class Panini {
+
+	public Sandwich m() {
+		return new Sandwich() {
+			Ingredient ingredient;
+			@Override
+			int m() {
+				return ingredient.next;
+			}
+		};
+	}
+
+	abstract class Sandwich {
+		abstract int m();
+	}
+
+	class Ingredient {
+		int next;
+	}
+}


### PR DESCRIPTION
Fix bug introduced by [this commit](https://github.com/INRIA/spoon/commit/0413f94fb680884f7dba05e2ebba54dd6510ea1c?diff=unified) about field read access.