### PR TITLE
refactor(api): Deprecates process method for a new one.

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -594,7 +594,7 @@ public class Launcher implements SpoonAPI {
 	 * <li>Template model building in the given factory (if any template source
 	 * is given): {@link SpoonCompiler#build()}.</li>
 	 * <li>Model processing with the list of given processors if any:
-	 * {@link SpoonCompiler#process(List)}.</li>
+	 * {@link SpoonCompiler#instantiateAndProcess(List)}.</li>
 	 * <li>Processed Source code printing and generation (can be disabled with
 	 * {@link OutputType#NO_OUTPUT}):
 	 * {@link SpoonCompiler#generateProcessedSourceFiles(OutputType)}.</li>
@@ -668,7 +668,7 @@ public class Launcher implements SpoonAPI {
 	@Override
 	public void process() {
 		long tstart = System.currentTimeMillis();
-		modelBuilder.process(getProcessorTypes());
+		modelBuilder.instantiateAndProcess(getProcessorTypes());
 		modelBuilder.process(getProcessors());
 		getEnvironment().debugMessage("model processed in " + (System.currentTimeMillis() - tstart) + " ms");
 	}

--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -17,15 +17,15 @@
 
 package spoon;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
 import spoon.compiler.SpoonResource;
 import spoon.processing.Processor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Responsible for building a spoon model from Java source code.
@@ -34,7 +34,7 @@ import spoon.reflect.factory.Factory;
  * The Spoon model (see {@link Factory} is built from input sources given as
  * files. Use {@link #build()} to create the Spoon model.
  * Once the model is built and stored in the factory, it
- * can be processed by using a {@link #process(List)}.
+ * can be processed by using a {@link #instantiateAndProcess(List)}.
  * </p>
  *
  * <p>
@@ -146,8 +146,16 @@ public interface SpoonModelBuilder {
 
 	/**
 	 * Processes the Java model with the given processors.
+	 * @see #instantiateAndProcess(List)
 	 */
+	@Deprecated
 	void process(List<String> processorTypes);
+
+	/**
+	 * Takes a list of fully qualified name processors and instantiates them to process
+	 * the Java model.
+	 */
+	void instantiateAndProcess(List<String> processors);
 
 	/**
 	 * Processes the Java model with the given processors.

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -915,11 +915,16 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 	@Override
 	public void process(List<String> processorTypes) {
+		instantiateAndProcess(processorTypes);
+	}
+
+	@Override
+	public void instantiateAndProcess(List<String> processors) {
 		initInputClassLoader();
 
 		// processing (consume all the processors)
 		ProcessingManager processing = new QueueProcessingManager(factory);
-		for (String processorName : processorTypes) {
+		for (String processorName : processors) {
 			processing.addProcessor(processorName);
 			factory.getEnvironment().debugMessage("Loaded processor " + processorName + ".");
 		}

--- a/src/test/java/spoon/test/properties/PropertiesTest.java
+++ b/src/test/java/spoon/test/properties/PropertiesTest.java
@@ -29,7 +29,7 @@ public class PropertiesTest {
 						));
 		compiler.build();
 
-		compiler.process(Arrays.asList(SimpleProcessor.class.getName()));
+		compiler.instantiateAndProcess(Arrays.asList(SimpleProcessor.class.getName()));
 		assertEquals(factory.getEnvironment().getErrorCount(), 0);
 	}
 

--- a/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
+++ b/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
@@ -1,13 +1,7 @@
 package spoon.test.staticFieldAccess;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.Arrays;
-
 import org.junit.Before;
 import org.junit.Test;
-
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.compiler.SpoonCompiler;
@@ -15,6 +9,11 @@ import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+
+import java.io.File;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
 
 
 public class StaticAccessTest {
@@ -49,7 +48,7 @@ public class StaticAccessTest {
 
     @Test
     public void testProcessAndCompile() throws Exception{
-        compiler.process(Arrays.asList(InsertBlockProcessor.class.getName()));
+        compiler.instantiateAndProcess(Arrays.asList(InsertBlockProcessor.class.getName()));
 
         // generate files
         File tmpdir = new File("target/spooned/staticFieldAccess");


### PR DESCRIPTION
In SpoonModelBuilder, we had two methods very semilar in their
signature. To avoid confusing these methods, we deprecates one of
them with a method name more explicit.