### PR TITLE
fix: Avoid NPE in CtTypeReference#getAllExecutables.

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -402,7 +402,9 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 				l.add(consRef);
 			}
 			Class<?> sc = c.getSuperclass();
-			l.addAll(getFactory().Type().createReference(sc).getAllExecutables());
+			if (sc != null) {
+				l.addAll(getFactory().Type().createReference(sc).getAllExecutables());
+			}
 		} else {
 			return t.getAllExecutables();
 		}

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -3,12 +3,13 @@ package spoon.test.reference;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.Query;
-import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.reference.testclasses.Burritos;
 
 import java.util.List;
 
@@ -16,6 +17,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 public class ExecutableReferenceTest {
 	@Test
@@ -77,5 +79,21 @@ public class ExecutableReferenceTest {
 		assertNotEquals(staticExecutable, executableOneParameter);
 		assertEquals("Bar#m(java.lang.String)", staticExecutable.toString());
 		assertEquals("Bar.m(\"42\")", invocations.get(3).toString());
+	}
+
+	@Test
+	public void testSuperClassInGetAllExecutables() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses/");
+		launcher.setSourceOutputDirectory("./target/spoon-test");
+		launcher.run();
+
+		final CtClass<Burritos> aBurritos = launcher.getFactory().Class().get(Burritos.class);
+		final CtMethod<?> aMethod = aBurritos.getMethodsByName("m").get(0);
+		try {
+			aMethod.getType().getAllExecutables();
+		} catch (NullPointerException e) {
+			fail("We shoudn't have a NullPointerException when we call getAllExecutables.");
+		}
 	}
 }

--- a/src/test/java/spoon/test/reference/testclasses/Burritos.java
+++ b/src/test/java/spoon/test/reference/testclasses/Burritos.java
@@ -1,0 +1,7 @@
+package spoon.test.reference.testclasses;
+
+public class Burritos {
+	public Tacos m() {
+		return null;
+	}
+}


### PR DESCRIPTION
When the type reference doesn't have a parent, the method
throws a NPE.

Closes #409