### PR TITLE
Fix a bug in ImportScannerImpl.visitCtInvocation

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -63,12 +63,10 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 
 	@Override
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
-		// For a ctinvocation, we don't have to import declaring type
 		enter(invocation);
 		scan(invocation.getAnnotations());
 		scanReferences(invocation.getTypeCasts());
 		scan(invocation.getTarget());
-		scan(invocation.getExecutable());
 		scan(invocation.getArguments());
 		exit(invocation);
 	}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -20,6 +20,8 @@ import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.imports.testclasses.ClassWithInvocation;
 import spoon.test.imports.testclasses.ClientClass;
+import spoon.test.imports.testclasses.Mole;
+import spoon.test.imports.testclasses.Pozole;
 import spoon.test.imports.testclasses.SubClass;
 import spoon.test.imports.testclasses.internal.ChildClass;
 
@@ -207,6 +209,42 @@ public class ImportTest {
 
 		// Invocation for a static method without the declaring class specified, a return type and an import *.
 		assertCorrectInvocationWithLimit(new Expected().name("staticE").typeIsNull(false), elements.get(15));
+	}
+
+	@Test
+	public void testImportOfInvocationOfPrivateClass() throws Exception {
+		final Factory factory = getFactory(
+				"./src/test/java/spoon/test/imports/testclasses/internal2/Chimichanga.java",
+				"./src/test/java/spoon/test/imports/testclasses/Mole.java");
+
+		ImportScanner importContext = new ImportScannerImpl();
+		Collection<CtTypeReference<?>> imports = importContext.computeImports(factory.Class().get(Mole.class));
+
+		assertEquals(1, imports.size());
+		assertEquals("spoon.test.imports.testclasses.internal2.Chimichanga", imports.toArray()[0].toString());
+	}
+
+	@Test
+	public void testImportOfInvocationOfStaticMethod() throws Exception {
+		final Factory factory = getFactory(
+				"./src/test/java/spoon/test/imports/testclasses/internal2/Menudo.java",
+				"./src/test/java/spoon/test/imports/testclasses/Pozole.java");
+
+		ImportScanner importContext = new ImportScannerImpl();
+		Collection<CtTypeReference<?>> imports = importContext.computeImports(factory.Class().get(Pozole.class));
+
+		assertEquals(1, imports.size());
+		assertEquals("spoon.test.imports.testclasses.internal2.Menudo", imports.toArray()[0].toString());
+	}
+
+	private Factory getFactory(String...inputs) {
+		final Launcher launcher = new Launcher();
+		for (String input : inputs) {
+			launcher.addInputResource(input);
+		}
+		launcher.setSourceOutputDirectory("./target/trash");
+		launcher.run();
+		return launcher.getFactory();
 	}
 
 	private void assertCorrectInvocation(Expected expected, CtInvocation<?> ctInvocation) {

--- a/src/test/java/spoon/test/imports/testclasses/Mole.java
+++ b/src/test/java/spoon/test/imports/testclasses/Mole.java
@@ -1,0 +1,10 @@
+package spoon.test.imports.testclasses;
+
+import spoon.test.imports.testclasses.internal2.Chimichanga;
+
+public class Mole {
+	public void m() {
+		final Chimichanga chimichanga = new Chimichanga();
+		chimichanga.make();
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/Pozole.java
+++ b/src/test/java/spoon/test/imports/testclasses/Pozole.java
@@ -1,0 +1,9 @@
+package spoon.test.imports.testclasses;
+
+import spoon.test.imports.testclasses.internal2.Menudo;
+
+public class Pozole {
+	public void m1() {
+		Menudo.m();
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal2/Chimichanga.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal2/Chimichanga.java
@@ -1,0 +1,9 @@
+package spoon.test.imports.testclasses.internal2;
+
+public class Chimichanga extends Tostada {
+}
+
+class Tostada {
+	public void make() {
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal2/Menudo.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal2/Menudo.java
@@ -1,0 +1,6 @@
+package spoon.test.imports.testclasses.internal2;
+
+public class Menudo {
+	public static void m() {
+	}
+}


### PR DESCRIPTION
shouldn't import invoked method declaration classes