### PR TITLE
refactor: Use get/setType methods with executable in CtInvocation.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -317,7 +317,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			}
 
 			if (e instanceof CtTypedElement && node instanceof Expression) {
-				if (((CtTypedElement<?>) e).getType() == null) {
+				if (((CtTypedElement<?>) e).getType() == null && !(e instanceof CtInvocation)) {
 					((CtTypedElement<Object>) e).setType(references.getTypeReference(((Expression) node).resolvedType));
 				}
 			}
@@ -2045,7 +2045,6 @@ public class JDTTreeBuilder extends ASTVisitor {
 		CtExecutableReference<Object> er = references.getExecutableReference(explicitConstructor.binding);
 		inv.setExecutable(er);
 		inv.getExecutable().setType((CtTypeReference<Object>) inv.getExecutable().getDeclaringType());
-		inv.setType(inv.getExecutable().getType());
 
 		if (explicitConstructor.genericTypeArguments() != null) {
 			inv.getExecutable().setActualTypeArguments(references.getBoundedTypesReferences(explicitConstructor.genericTypeArguments()));
@@ -2343,9 +2342,6 @@ public class JDTTreeBuilder extends ASTVisitor {
 				}
 				inv.setExecutable(ref);
 			}
-			// inv
-			// .setType(references
-			// .getTypeReference(messageSend.binding.returnType));
 			context.enter(inv, messageSend);
 			if (!(messageSend.receiver.getClass().equals(ThisReference.class))) {
 				messageSend.receiver.traverse(this, scope);

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -17,21 +17,22 @@
 
 package spoon.support.reflect.code;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities
-		.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
+import java.util.ArrayList;
+import java.util.List;
+
+import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 
 public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>>
 		implements CtInvocation<T> {
@@ -137,5 +138,15 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 		} else {
 			super.replace(element);
 		}
+	}
+
+	@Override
+	public CtTypeReference<T> getType() {
+		return getExecutable() == null ? null : getExecutable().getType();
+	}
+
+	@Override
+	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+		throw new UnsupportedOperationException("Uses getExecutable().setType(CtTypeReference<T>)");
 	}
 }

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -531,7 +531,6 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
 		CtInvocation<T> i = invocation.getFactory().Core().createInvocation();
-		i.setType(invocation.getType());
 		i.setExecutable(invocation.getExecutable());
 		boolean constant = true;
 		i.setTarget(evaluate(i, invocation.getTarget()));


### PR DESCRIPTION
In CtInvocation#getType(), we use getExecutable().getType.
In CtInvocation#setType(), we throw an UnsupportedOperationException.

Closes #418