### PR TITLE
Add getParent(Filter)

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -196,6 +196,12 @@ public interface CtElement extends FactoryAccessor, CtVisitable {
 	<P extends CtElement> P getParent(Class<P> parentType) throws ParentNotInitializedException;
 
 	/**
+	 * Gets the first parent that matches the filter.
+	 * If the receiver (this) matches the filter, it is also returned
+	 */
+	<E extends CtElement> E getParent(Filter<E> filter) throws ParentNotInitializedException;
+
+	/**
 	 * Manually sets the parent element of the current element.
 	 *
 	 * @param parent

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -33,7 +33,7 @@ public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 	 * Creates a filter with the type of the potentially matching elements.
 	 */
 	@SuppressWarnings("unchecked")
-	public AbstractFilter(Class<?> type) {
+	public AbstractFilter(Class<? super T> type) {
 		this.type = (Class<T>) type;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -346,6 +346,28 @@ public abstract class CtElementImpl implements CtElement, Serializable, Comparab
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E getParent(Filter<E> filter) throws ParentNotInitializedException {
+		E current = (E) this;
+		while (true) {
+			try {
+				while (current != null && !filter.matches(current)) {
+					current = (E) current.getParent();
+				}
+				break;
+			} catch (ClassCastException e) {
+				// expected, some elements are not of type
+				current = (E) current.getParent();
+			}
+		}
+
+		if (current != null && filter.matches(current)) {
+			return current;
+		}
+		return null;
+	}
+
+	@Override
 	public boolean hasParent(CtElement candidate) throws ParentNotInitializedException {
 		return getParent() == candidate || getParent().hasParent(candidate);
 	}

--- a/src/test/java/spoon/test/parent/Foo.java
+++ b/src/test/java/spoon/test/parent/Foo.java
@@ -20,4 +20,24 @@ class Foo {
 		}
 		return 0;
 	}
+
+	void m() {
+		String one, two, three;
+		one = two = three = "";
+		for(int k =0; k<0; k++) {
+
+		}
+	}
+
+	void internalClass() {
+		class T {
+			void m() {
+				new Object() {
+					void m() {
+						String one, two, three;
+					}
+				};
+			}
+		}
+	}
 }


### PR DESCRIPTION
This pull request adds the method ```getParent(Filter)``` in order to be able to select a specific parent.
The method ```return null``` if no match is found