### PR TITLE
[fix #431] Change the line number of all CtNamedElements

### DIFF
--- a/src/main/java/spoon/reflect/cu/SourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/SourcePosition.java
@@ -45,6 +45,7 @@ public interface SourcePosition {
 	/**
 	 * Gets the line in the source file (1 indexed). Prefer using
 	 * {@link #getSourceStart()}}.
+	 * For CtNamedElement the line is where the name is declared.
 	 */
 	int getLine();
 

--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -356,7 +356,7 @@ public interface CoreFactory {
 	 */
 	SourcePosition createSourcePosition(
 			CompilationUnit compilationUnit,
-			int start, int end, int[] lineSeparatorPositions);
+			int startDeclaration, int startSource, int end, int[] lineSeparatorPositions);
 
 	/**
 	 * Creates a statement list.

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -663,8 +663,8 @@ public class DefaultCoreFactory implements CoreFactory, Serializable {
 		this.mainFactory = mainFactory;
 	}
 
-	public SourcePosition createSourcePosition(CompilationUnit compilationUnit, int start, int end, int[] lineSeparatorPositions) {
-		return new SourcePositionImpl(compilationUnit, start, end, lineSeparatorPositions);
+	public SourcePosition createSourcePosition(CompilationUnit compilationUnit, int startDeclaration, int startSource, int end, int[] lineSeparatorPositions) {
+		return new SourcePositionImpl(compilationUnit, startDeclaration, startSource, end, lineSeparatorPositions);
 	}
 
 	public CompilationUnit createCompilationUnit() {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -191,6 +191,7 @@ import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
@@ -297,23 +298,25 @@ public class JDTTreeBuilder extends ASTVisitor {
 			// aststack.push(node);
 			if (compilationunitdeclaration != null) {
 				CoreFactory cf = factory.Core();
-				int sourceStart = node.sourceStart;
+				int sourceStartDeclaration = node.sourceStart;
+				int sourceStartSource = node.sourceStart;
 				int sourceEnd = node.sourceEnd;
 				if (node instanceof AbstractVariableDeclaration) {
-					sourceStart = ((AbstractVariableDeclaration) node).declarationSourceStart;
+					sourceStartDeclaration = ((AbstractVariableDeclaration) node).declarationSourceStart;
 					sourceEnd = ((AbstractVariableDeclaration) node).declarationSourceEnd;
 				} else if  (node instanceof TypeDeclaration) {
-					sourceStart = ((TypeDeclaration) node).declarationSourceStart;
+					sourceStartDeclaration = ((TypeDeclaration) node).declarationSourceStart;
 					sourceEnd = ((TypeDeclaration) node).declarationSourceEnd;
 				} else if ((e instanceof CtBlock) && (node instanceof AbstractMethodDeclaration)) {
-					sourceStart = ((AbstractMethodDeclaration) node).bodyStart - 1;
+					sourceStartDeclaration = ((AbstractMethodDeclaration) node).bodyStart - 1;
 					sourceEnd = ((AbstractMethodDeclaration) node).bodyEnd + 1;
 				} else if ((node instanceof AbstractMethodDeclaration)) {
 					if (((AbstractMethodDeclaration) node).bodyStart == 0) {
-						sourceStart = -1;
+						sourceStartDeclaration = -1;
+						sourceStartSource = -1;
 						sourceEnd = -1;
 					} else {
-						sourceStart = ((AbstractMethodDeclaration) node).declarationSourceStart;
+						sourceStartDeclaration = ((AbstractMethodDeclaration) node).declarationSourceStart;
 						sourceEnd = ((AbstractMethodDeclaration) node).declarationSourceEnd;
 					}
 				}
@@ -322,8 +325,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 						sourceEnd = ((Expression) node).statementEnd;
 					}
 				}
+				if (!(e instanceof CtNamedElement)) {
+					sourceStartSource = sourceStartDeclaration;
+				}
 				CompilationUnit cu = factory.CompilationUnit().create(new String(compilationunitdeclaration.getFileName()));
-				e.setPosition(cf.createSourcePosition(cu, sourceStart, sourceEnd, compilationunitdeclaration.compilationResult.lineSeparatorPositions));
+				e.setPosition(cf.createSourcePosition(cu, sourceStartDeclaration, sourceStartSource, sourceEnd, compilationunitdeclaration.compilationResult.lineSeparatorPositions));
 			}
 			ASTPair pair = stack.peek();
 			CtElement current = pair.element;
@@ -2672,7 +2678,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 					CompilationUnit cu = factory.CompilationUnit().create(new String(context.compilationunitdeclaration.getFileName()));
 					int sourceEnd = (int) (positions[i]);
 					final int[] lineSeparatorPositions = context.compilationunitdeclaration.compilationResult.lineSeparatorPositions;
-					fa.setPosition(factory.Core().createSourcePosition(cu, sourceStart, sourceEnd, lineSeparatorPositions));
+					fa.setPosition(factory.Core().createSourcePosition(cu, sourceStart, sourceStart, sourceEnd, lineSeparatorPositions));
 					fa = other;
 					i++;
 				}
@@ -2714,7 +2720,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 					CompilationUnit cu = factory.CompilationUnit().create(new String(context.compilationunitdeclaration.getFileName()));
 					int sourceEnd = (int) (positions[i]);
 					final int[] lineSeparatorPositions = context.compilationunitdeclaration.compilationResult.lineSeparatorPositions;
-					va.setPosition(factory.Core().createSourcePosition(cu, sourceStart, sourceEnd, lineSeparatorPositions));
+					va.setPosition(factory.Core().createSourcePosition(cu, sourceStart, sourceStart, sourceEnd, lineSeparatorPositions));
 					va = other;
 					i++;
 				}

--- a/src/main/java/spoon/support/reflect/cu/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/SourcePositionImpl.java
@@ -93,14 +93,15 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 
 	int[] lineSeparatorPositions;
 
-	private int sourceStart, sourceEnd;
+	private int sourceStart, sourceEnd, line;
 
-	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {
+	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStartDeclaration, int sourceStartSource, int sourceEnd, int[] lineSeparatorPositions) {
 		super();
 		this.compilationUnit = compilationUnit;
-		this.sourceStart = sourceStart;
+		this.sourceStart = sourceStartDeclaration;
 		this.sourceEnd = sourceEnd;
 		this.lineSeparatorPositions = lineSeparatorPositions;
+		this.line = searchLineNumber(lineSeparatorPositions, sourceStartSource);
 	}
 
 	public int getColumn() {
@@ -119,7 +120,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	}
 
 	public int getLine() {
-		return searchLineNumber(lineSeparatorPositions, sourceStart);
+		return line;
 	}
 
 	public int getEndLine() {

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -32,7 +32,7 @@ public class PositionTest {
 
 		SourcePosition position = foo.getPosition();
 
-		assertEquals(3, position.getLine());
+		assertEquals(4, position.getLine());
 		assertEquals(6, position.getEndLine());
 
 		assertEquals(42, position.getSourceStart());
@@ -99,6 +99,21 @@ public class PositionTest {
 		assertEquals(98, positionParam1.getSourceEnd());
 
 		assertEquals("int parm1", contentAtPosition(classContent, positionParam1));
+
+
+		CtMethod<?> method2 = foo.getMethodsByName("mWithDoc").get(0);
+		SourcePosition position2 = method2.getPosition();
+
+		assertEquals(13, position2.getLine());
+		assertEquals(15, position2.getEndLine());
+
+		assertEquals("/**\n"
+				+ "\t * Mathod with javadoc\n"
+				+ "\t * @param parm1 the parameter\n"
+				+ "\t */\n"
+				+ "\tint mWithDoc(int parm1) {\n"
+				+ "\t\treturn parm1;\n"
+				+ "\t}", contentAtPosition(classContent, position2));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/position/testclasses/FooMethod.java
+++ b/src/test/java/spoon/test/position/testclasses/FooMethod.java
@@ -5,4 +5,12 @@ public class FooMethod {
 	public static void m(int parm1) {
 		return;
 	}
+
+	/**
+	 * Mathod with javadoc
+	 * @param parm1 the parameter
+	 */
+	int mWithDoc(int parm1) {
+		return parm1;
+	}
 }


### PR DESCRIPTION
The line number of a ```CtNamedElement``` is now the line where the developer declares the name.