### PR TITLE
feat(signature): Specify the display for executable ref.

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -32,6 +32,8 @@ public interface CtExecutableReference<T> extends CtReference, CtGenericElementR
 
 	String CONSTRUCTOR_NAME = "<init>";
 
+	String UNKNOWN_TYPE = "<unknown>";
+
 	/**
 	 * Tells if this is a reference to a constructor.
 	 */

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -298,7 +298,11 @@ public class SignaturePrinter implements CtVisitor {
 		write("(");
 		if (reference.getParameters().size() > 0) {
 			for (CtTypeReference<?> param : reference.getParameters()) {
-				scan(param);
+				if (param != null && !"null".equals(param.getSimpleName())) {
+					scan(param);
+				} else {
+					write(CtExecutableReference.UNKNOWN_TYPE);
+				}
 				write(", ");
 			}
 			clearLast();


### PR DESCRIPTION
When we are in noclasspath and don't have the information
about arguments of CtExecutableReference, we display
<unknown> in arguments.

Closes #454