### PR TITLE
refactors the three responsibilities of equal/hashcode/signature

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -81,7 +81,12 @@ public interface CtElement extends FactoryAccessor, CtVisitable {
 
 	/**
 	 * Gets the signature of the element.
+	 * Has been introduced for CtMethod, see chapter "8.4.2 Method Signature" of the Java specification.
+	 * Overtime, has been badly exploited.
+	 *
+ 	 * Deprecated, will be moved in {@link CtExecutable}, in order to follow the Java specification
 	 */
+	@Deprecated
 	String getSignature();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -103,4 +103,9 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R> {
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	boolean removeThrownType(CtTypeReference<? extends Throwable> throwType);
+
+	/**
+	 * Gets the signature of this method or constructor as specified by chapter "8.4.2 Method Signature" of the Java specification
+	 */
+	String getSignature();
 }

--- a/src/main/java/spoon/reflect/factory/MethodFactory.java
+++ b/src/main/java/spoon/reflect/factory/MethodFactory.java
@@ -116,7 +116,6 @@ public class MethodFactory extends ExecutableFactory {
 	public <T> CtMethod<T> create(CtType<?> target, Set<ModifierKind> modifiers, CtTypeReference<T> returnType, String name, List<CtParameter<?>> parameters,
 			Set<CtTypeReference<? extends Throwable>> thrownTypes) {
 		CtMethod<T> method = factory.Core().createMethod();
-		target.addMethod(method);
 		if (modifiers != null) {
 			method.setModifiers(modifiers);
 		}
@@ -128,6 +127,7 @@ public class MethodFactory extends ExecutableFactory {
 		if (thrownTypes != null) {
 			method.setThrownTypes(thrownTypes);
 		}
+		target.addMethod(method);
 		return method;
 	}
 

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.visitor;
 
+import java.lang.annotation.Annotation;
+
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayRead;
 import spoon.reflect.code.CtArrayWrite;
@@ -87,8 +89,6 @@ import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtUnboundVariableReference;
-
-import java.lang.annotation.Annotation;
 
 /** Provides an empty implementation of CtVIsitor.
  *  See {@link CtScanner} for a much more powerful implementation of CtVisitor.

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -168,15 +168,6 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	}
 
 	/**
-	 * Generically scans a meta-model element reference.
-	 */
-	public void scan(CtReference reference) {
-		if (reference != null) {
-			reference.accept(this);
-		}
-	}
-
-	/**
 	 * Scans an abstract invocation.
 	 */
 	public <T> void scanCtAbstractInvocation(CtAbstractInvocation<T> a) {

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -501,10 +501,10 @@ public abstract class CtScanner implements CtVisitor {
 	public <T> void visitCtMethod(CtMethod<T> m) {
 		enter(m);
 		scan(m.getAnnotations());
+		scan(m.getFormalTypeParameters());
 		scan(m.getType());
 		scan(m.getParameters());
 		scan(m.getThrownTypes());
-		scan(m.getFormalTypeParameters());
 		scan(m.getBody());
 		exit(m);
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -36,16 +36,6 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 		super();
 	}
 
-	@Override
-	public int hashCode() {
-		return toString().hashCode();
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		return object instanceof CtReference && compareTo((CtReference) object) == 0;
-	}
-
 	protected abstract AnnotatedElement getActualAnnotatedElement();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
@@ -56,21 +56,6 @@ public abstract class CtVariableReferenceImpl<T> extends CtReferenceImpl
 	}
 
 	@Override
-	public boolean equals(Object object) {
-		if (!(object instanceof CtVariableReference)) {
-			return false;
-		}
-		CtVariableReference<?> ref = (CtVariableReference<?>) object;
-		return this.type.equals(ref.getType())
-				&& simplename.equals(ref.getSimpleName());
-	}
-
-	@Override
-	public int hashCode() {
-		return super.hashCode();
-	}
-
-	@Override
 	protected AnnotatedElement getActualAnnotatedElement() {
 		// this is never available through reflection
 		return null;

--- a/src/main/java/spoon/support/visitor/EqualVisitor.java
+++ b/src/main/java/spoon/support/visitor/EqualVisitor.java
@@ -1,0 +1,671 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import java.lang.annotation.Annotation;
+
+import spoon.reflect.code.CtAnnotationFieldAccess;
+import spoon.reflect.code.CtArrayAccess;
+import spoon.reflect.code.CtArrayRead;
+import spoon.reflect.code.CtArrayWrite;
+import spoon.reflect.code.CtAssert;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.code.CtCodeSnippetExpression;
+import spoon.reflect.code.CtCodeSnippetStatement;
+import spoon.reflect.code.CtConditional;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtContinue;
+import spoon.reflect.code.CtDo;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtFieldWrite;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.code.CtForEach;
+import spoon.reflect.code.CtIf;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtLambda;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtNewArray;
+import spoon.reflect.code.CtNewClass;
+import spoon.reflect.code.CtOperatorAssignment;
+import spoon.reflect.code.CtReturn;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtStatementList;
+import spoon.reflect.code.CtSuperAccess;
+import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtSynchronized;
+import spoon.reflect.code.CtThisAccess;
+import spoon.reflect.code.CtThrow;
+import spoon.reflect.code.CtTry;
+import spoon.reflect.code.CtTryWithResource;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.CtVariableWrite;
+import spoon.reflect.code.CtWhile;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtAnnotationType;
+import spoon.reflect.declaration.CtAnonymousExecutable;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtEnum;
+import spoon.reflect.declaration.CtEnumValue;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.internal.CtCircularTypeReference;
+import spoon.reflect.internal.CtImplicitArrayTypeReference;
+import spoon.reflect.internal.CtImplicitTypeReference;
+import spoon.reflect.reference.CtArrayTypeReference;
+import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtLocalVariableReference;
+import spoon.reflect.reference.CtPackageReference;
+import spoon.reflect.reference.CtParameterReference;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtUnboundVariableReference;
+import spoon.reflect.visitor.CtScanner;
+import spoon.support.reflect.declaration.CtElementImpl;
+
+/**
+ * Responsible for computing a deep representation of the object. Used by {@link CtElementImpl#equals(Object)} for deep equality.
+ *
+ *  Can also be seen as a super fast toString (without requiring to be valid java code)
+ **/
+public class EqualVisitor extends CtScanner {
+
+	StringBuffer representation;
+
+	public EqualVisitor() {
+		super();
+		reset();
+	}
+
+	public String getRepresentation() {
+		return representation.toString();
+	}
+
+	public void reset() {
+		representation = new StringBuffer();
+	}
+
+	protected EqualVisitor write(String value) {
+		representation.append(value);
+		return this;
+	}
+
+	@Override
+	public <A extends Annotation> void visitCtAnnotation(
+			CtAnnotation<A> annotation) {
+		write("@");
+		if (annotation.getAnnotationType() != null) {
+			write(annotation.getAnnotationType().getQualifiedName());
+		}
+	}
+
+	@Override
+	public <A extends Annotation> void visitCtAnnotationType(
+			CtAnnotationType<A> annotationType) {
+		write("@interface ");
+		write(annotationType.getQualifiedName());
+		super.visitCtAnnotationType(annotationType);
+	}
+
+	@Override
+	public void visitCtAnonymousExecutable(CtAnonymousExecutable e) {
+		scan(e.getBody());
+	}
+
+	@Override
+	public <T, E extends CtExpression<?>> void visitCtArrayAccess(CtArrayAccess<T, E> arrayAccess) {
+		printCtArrayAccess(arrayAccess);
+	}
+
+	@Override
+	public <T> void visitCtArrayRead(CtArrayRead<T> arrayRead) {
+		printCtArrayAccess(arrayRead);
+	}
+
+	@Override
+	public <T> void visitCtArrayWrite(CtArrayWrite<T> arrayWrite) {
+		printCtArrayAccess(arrayWrite);
+	}
+
+	private <T, E extends CtExpression<?>> void printCtArrayAccess(CtArrayAccess<T, E> arrayAccess) {
+		scan(arrayAccess.getTarget());
+		write("[");
+		scan(arrayAccess.getIndexExpression());
+		write("]");
+	}
+
+	@Override
+	public <T> void visitCtArrayTypeReference(CtArrayTypeReference<T> reference) {
+		scan(reference.getComponentType());
+		write("[]");
+	}
+
+	@Override
+	public <T> void visitCtImplicitArrayTypeReference(CtImplicitArrayTypeReference<T> reference) {
+		visitCtArrayTypeReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtAssert(CtAssert<T> asserted) {
+		representation.append("assert ");
+		scan(asserted.getAssertExpression());
+		representation.append(":");
+		scan(asserted.getExpression());
+	}
+
+	@Override
+	public <T, A extends T> void visitCtAssignment(
+			CtAssignment<T, A> assignement) {
+		for (CtTypeReference<?> ref : assignement.getTypeCasts()) {
+			write("(");
+			scan(ref);
+			write(")");
+		}
+		write("(");
+		scan(assignement.getAssigned());
+		write(" = ");
+		scan(assignement.getAssignment());
+		write(")");
+	}
+
+	@Override
+	public <T> void visitCtBinaryOperator(CtBinaryOperator<T> operator) {
+		scan(operator.getLeftHandOperand());
+		write(operator.getKind().toString());
+		scan(operator.getRightHandOperand());
+	}
+
+	@Override
+	public <R> void visitCtBlock(CtBlock<R> block) {
+		representation.append("{\n");
+		for (CtStatement s : block.getStatements()) {
+			scan(s);
+			representation.append(";\n");
+		}
+		representation.append("}");
+	}
+
+	@Override
+	public void visitCtBreak(CtBreak breakStatement) {
+		write("break ");
+		if (breakStatement.getTargetLabel() != null) {
+			write(breakStatement.getTargetLabel());
+		}
+	}
+
+	@Override
+	public <E> void visitCtCase(CtCase<E> caseStatement) {
+		write("case (");
+		scan(caseStatement.getCaseExpression());
+		for (CtStatement statement : caseStatement.getStatements()) {
+			scan(statement);
+		}
+		write(")");
+	}
+
+	@Override
+	public void visitCtCatch(CtCatch catchBlock) {
+		write("catch (");
+		scan(catchBlock.getParameter().getType());
+		write(")");
+	}
+
+	@Override
+	public <T> void visitCtClass(CtClass<T> ctClass) {
+		write("class ").write(ctClass.getQualifiedName());
+		super.visitCtClass(ctClass);
+	}
+
+	@Override
+	public <T> void visitCtConditional(CtConditional<T> conditional) {
+		scan(conditional.getCondition());
+		write("?");
+		scan(conditional.getThenExpression());
+		write(":");
+		scan(conditional.getElseExpression());
+	}
+
+	@Override
+	public <T> void visitCtConstructor(CtConstructor<T> c) {
+		write("<init>");
+		write("(");
+		for (CtParameter<?> p : c.getParameters()) {
+			scan(p.getType());
+			write(",");
+		}
+		write(")");
+		scan(c.getAnnotations());
+		scan(c.getBody());
+	}
+
+	@Override
+	public void visitCtContinue(CtContinue continueStatement) {
+		representation.append("continue ");
+		scan(continueStatement.getLabelledStatement());
+	}
+
+	@Override
+	public void visitCtDo(CtDo doLoop) {
+		write("do ");
+		scan(doLoop.getBody());
+		write(" while (");
+		scan(doLoop.getLoopingExpression());
+		write(")");
+	}
+
+	@Override
+	public <T extends Enum<?>> void visitCtEnum(CtEnum<T> ctEnum) {
+		write("enum ").write(ctEnum.getQualifiedName());
+		super.visitCtEnum(ctEnum);
+	}
+
+	@Override
+	public <T> void visitCtExecutableReference(CtExecutableReference<T> reference) {
+		SignaturePrinter p = new SignaturePrinter();
+		p.visitCtExecutableReference(reference);
+		write(p.getSignature());
+		write("");
+	}
+
+	@Override
+	public <T> void visitCtField(CtField<T> f) {
+		scan(f.getType());
+		write(" ").write(f.getSimpleName());
+		super.visitCtField(f);
+	}
+
+	@Override
+	public <T> void visitCtEnumValue(CtEnumValue<T> enumValue) {
+		visitCtField(enumValue);
+	}
+
+	@Override
+	public <T> void visitCtThisAccess(CtThisAccess<T> thisAccess) {
+		write("this");
+	}
+
+	@Override
+	public <T> void visitCtAnnotationFieldAccess(
+			CtAnnotationFieldAccess<T> annotationFieldAccess) {
+		scan(annotationFieldAccess.getTarget());
+	}
+
+	@Override
+	public <T> void visitCtFieldReference(CtFieldReference<T> reference) {
+		if (reference.getType() != null) {
+			write(reference.getType().getQualifiedName());
+		} else {
+			write("<no type>");
+		}
+		write(" ");
+		if (reference.getDeclaringType() != null) {
+			write(reference.getDeclaringType().getQualifiedName());
+			write(CtField.FIELD_SEPARATOR);
+		}
+		write(reference.getSimpleName());
+	}
+
+	@Override
+	public void visitCtFor(CtFor forLoop) {
+		write("for (");
+		for (CtStatement s : forLoop.getForInit()) {
+			scan(s);
+			write(",");
+		}
+		write(";");
+		scan(forLoop.getExpression());
+		write(";");
+		for (CtStatement s : forLoop.getForUpdate()) {
+			scan(s);
+			write(",");
+		}
+		write(")");
+		scan(forLoop.getBody());
+	}
+
+	@Override
+	public void visitCtForEach(CtForEach foreach) {
+		write("for (");
+		scan(foreach.getVariable());
+		write(":");
+		scan(foreach.getExpression());
+		write(")");
+		scan(foreach.getBody());
+	}
+
+	@Override
+	public void visitCtIf(CtIf ifElement) {
+		write("if (");
+		scan(ifElement.getCondition());
+		write(") then ");
+		scan((CtStatement) ifElement.getThenStatement());
+		write(" else ");
+		scan((CtStatement) ifElement.getElseStatement());
+	}
+
+	@Override
+	public <T> void visitCtInterface(CtInterface<T> intrface) {
+		write("interface ");
+		write(intrface.getQualifiedName());
+		super.visitCtInterface(intrface);
+	}
+
+	@Override
+	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
+		write("(");
+		scan(invocation.getExecutable());
+		write("(");
+		for (int i = 0; i < invocation.getArguments().size(); i++) {
+			CtExpression<?> arg_i = invocation.getArguments().get(i);
+			scan(arg_i);
+			if (i != (invocation.getArguments().size() - 1)) {
+				write(",");
+			}
+		}
+		write(")");
+		write(")");
+	}
+
+	@Override
+	public <T> void visitCtLiteral(CtLiteral<T> literal) {
+		if (literal.getValue() != null) {
+			write(literal.toString());
+		} else {
+			write("null");
+		}
+	}
+
+	@Override
+	public <T> void visitCtLocalVariable(CtLocalVariable<T> localVariable) {
+		write(localVariable.getSimpleName());
+	}
+
+	@Override
+	public <T> void visitCtLocalVariableReference(
+			CtLocalVariableReference<T> reference) {
+		if (reference.getType() != null) {
+			write(reference.getType().getQualifiedName()).write(" ");
+		}
+		write(reference.getSimpleName());
+
+	}
+
+	@Override
+	public <T> void visitCtCatchVariable(CtCatchVariable<T> catchVariable) {
+		write(catchVariable.getSimpleName());
+	}
+
+	@Override
+	public <T> void visitCtCatchVariableReference(CtCatchVariableReference<T> reference) {
+		scan(reference.getDeclaration());
+	}
+
+	@Override
+	public <T> void visitCtMethod(CtMethod<T> m) {
+		SignaturePrinter p = new SignaturePrinter();
+		p.visitCtMethod(m);
+		write(p.getSignature());
+		write(" ");
+		scan(m.getAnnotations());
+		scan(m.getBody());
+	}
+
+	@Override
+	public <T> void visitCtNewArray(CtNewArray<T> newArray) {
+		write("new ");
+		scan(newArray.getType());
+		for (CtExpression<?> c : newArray.getDimensionExpressions()) {
+			write("[");
+			scan(c);
+			write("]");
+		}
+		write("{");
+		for (CtExpression<?> e : newArray.getElements()) {
+			scan(e);
+			write(",");
+		}
+		write("}");
+	}
+
+	@Override
+	public <T> void visitCtConstructorCall(CtConstructorCall<T> ctConstructorCall) {
+		write("new ");
+		scan(ctConstructorCall.getExecutable());
+	}
+
+	@Override
+	public <T> void visitCtNewClass(CtNewClass<T> newClass) {
+		write("new ");
+		scan(newClass.getExecutable());
+		scan(newClass.getAnonymousClass());
+	}
+
+	@Override
+	public <T> void visitCtLambda(CtLambda<T> lambda) {
+		write("(");
+		scan(lambda.getType());
+		write(") (");
+		if (!lambda.getParameters().isEmpty()) {
+			for (CtParameter<?> parameter : lambda.getParameters()) {
+				scan(parameter);
+				write(",");
+			}
+		}
+		write(")");
+	}
+
+	@Override
+	public <T> void visitCtCodeSnippetExpression(
+			CtCodeSnippetExpression<T> expression) {
+		write(expression.getValue());
+	}
+
+	@Override
+	public void visitCtCodeSnippetStatement(CtCodeSnippetStatement statement) {
+		write(statement.getValue());
+	}
+
+	@Override
+	public <T, A extends T> void visitCtOperatorAssignment(
+			CtOperatorAssignment<T, A> assignment) {
+		scan(assignment.getAssigned());
+		write(assignment.getKind().toString());
+		scan(assignment.getAssignment());
+	}
+
+	@Override
+	public void visitCtPackage(CtPackage ctPackage) {
+		write("package " + ctPackage.getQualifiedName());
+		super.visitCtPackage(ctPackage);
+	}
+
+	@Override
+	public void visitCtPackageReference(CtPackageReference reference) {
+		write(reference.getSimpleName());
+	}
+
+	@Override
+	public <T> void visitCtParameter(CtParameter<T> parameter) {
+		scan(parameter.getType());
+		write(" ");
+		write(parameter.getSimpleName());
+	}
+
+	@Override
+	public <T> void visitCtParameterReference(CtParameterReference<T> reference) {
+		scan(reference.getType());
+		write(" ");
+		write(reference.getSimpleName());
+	}
+
+	@Override
+	public <R> void visitCtReturn(CtReturn<R> returnStatement) {
+		write("return ");
+		scan(returnStatement.getReturnedExpression());
+	}
+
+	@Override
+	public <R> void visitCtStatementList(CtStatementList statements) {
+		for (CtStatement s : statements.getStatements()) {
+			scan(s);
+			write(";\n");
+		}
+	}
+
+	@Override
+	public <E> void visitCtSwitch(CtSwitch<E> switchStatement) {
+		write("switch(");
+		scan(switchStatement.getSelector());
+		write(")");
+		for (CtCase<?> c : switchStatement.getCases()) {
+			scan(c);
+		}
+	}
+
+	@Override
+	public void visitCtSynchronized(CtSynchronized synchro) {
+		write("synchronized (");
+		scan(synchro.getExpression());
+		write(") ");
+		scan(synchro.getBlock());
+	}
+
+	@Override
+	public void visitCtThrow(CtThrow throwStatement) {
+		write("throw ");
+		scan(throwStatement.getThrownExpression());
+	}
+
+	@Override
+	public void visitCtTry(CtTry tryBlock) {
+		write("try {\n");
+		scan(tryBlock.getBody());
+		for (CtCatch c : tryBlock.getCatchers()) {
+			scan(c);
+		}
+		scan(tryBlock.getFinalizer());
+	}
+
+	@Override
+	public void visitCtTryWithResource(CtTryWithResource tryWithResource) {
+		write("try (");
+		for (CtLocalVariable<?> resource : tryWithResource.getResources()) {
+			scan(resource);
+		}
+		write(") {\n");
+		scan(tryWithResource.getBody());
+		for (CtCatch c : tryWithResource.getCatchers()) {
+			scan(c);
+		}
+		scan(tryWithResource.getFinalizer());
+	}
+
+	@Override
+	public void visitCtTypeParameter(CtTypeParameter typeParameter) {
+		write("<");
+		write(typeParameter.getSimpleName());
+		write(">");
+	}
+
+	@Override
+	public void visitCtTypeParameterReference(CtTypeParameterReference ref) {
+		write(ref.getQualifiedName());
+		if (ref.getBounds() != null && !ref.getBounds().isEmpty()) {
+			for (CtTypeReference<?> b : ref.getBounds()) {
+				scan(b);
+				write(", ");
+			}
+		}
+	}
+
+	@Override
+	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+		write(reference.getQualifiedName());
+		write(" ");
+	}
+
+	@Override
+	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
+		visitCtTypeReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
+		visitCtTypeReference(reference);
+	}
+
+	@Override
+	public <T> void visitCtTypeAccess(CtTypeAccess<T> typeAccess) {
+		write(typeAccess.getAccessedType().getQualifiedName());
+	}
+
+	@Override
+	public <T> void visitCtUnaryOperator(CtUnaryOperator<T> operator) {
+		scan(operator.getOperand());
+		write(operator.getKind().toString());
+	}
+
+
+	@Override
+	public <T> void visitCtVariableWrite(CtVariableWrite<T> variableWrite) {
+		scan(variableWrite.getVariable());
+	}
+
+	@Override
+	public void visitCtWhile(CtWhile whileLoop) {
+		write("while (");
+		scan(whileLoop.getLoopingExpression());
+		write(")");
+		scan(whileLoop.getBody());
+	}
+
+	@Override
+	public <T> void visitCtUnboundVariableReference(
+			CtUnboundVariableReference<T> reference) {
+		write(reference.getSimpleName());
+	}
+
+	@Override
+	public <T> void visitCtFieldRead(CtFieldRead<T> fieldRead) {
+		scan(fieldRead.getVariable());
+	}
+
+	@Override
+	public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
+		scan(fieldWrite.getVariable());
+	}
+
+	@Override
+	public <T> void visitCtSuperAccess(CtSuperAccess<T> f) {
+		write(f.getType().getQualifiedName() + ".super");
+	}
+}

--- a/src/main/java/spoon/support/visitor/HashcodeVisitor.java
+++ b/src/main/java/spoon/support/visitor/HashcodeVisitor.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.visitor.CtInheritanceScanner;
+
+/** Responsible for computing CtElement.hashCode().
+ * Version that is fast and compatible with EqualVisitor
+ */
+public class HashcodeVisitor extends CtInheritanceScanner {
+
+	private int hashCode = 0;
+
+	@Override
+	public void scanCtNamedElement(CtNamedElement e) {
+		hashCode += e.getSimpleName().hashCode();
+	}
+
+	@Override
+	public void scan(CtElement element) {
+		hashCode += 1;
+		super.scan(element);;
+	}
+
+	public int getHasCode() {
+		return hashCode;
+	}
+
+}

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -16,275 +16,33 @@
  */
 package spoon.support.visitor;
 
-import spoon.reflect.code.CtAnnotationFieldAccess;
-import spoon.reflect.code.CtArrayAccess;
-import spoon.reflect.code.CtArrayRead;
-import spoon.reflect.code.CtArrayWrite;
-import spoon.reflect.code.CtAssert;
-import spoon.reflect.code.CtAssignment;
-import spoon.reflect.code.CtBinaryOperator;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBreak;
-import spoon.reflect.code.CtCase;
-import spoon.reflect.code.CtCatch;
-import spoon.reflect.code.CtCatchVariable;
-import spoon.reflect.code.CtCodeSnippetExpression;
-import spoon.reflect.code.CtCodeSnippetStatement;
-import spoon.reflect.code.CtConditional;
-import spoon.reflect.code.CtConstructorCall;
-import spoon.reflect.code.CtContinue;
-import spoon.reflect.code.CtDo;
-import spoon.reflect.code.CtExecutableReferenceExpression;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtFieldRead;
-import spoon.reflect.code.CtFieldWrite;
-import spoon.reflect.code.CtFor;
-import spoon.reflect.code.CtForEach;
-import spoon.reflect.code.CtIf;
-import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtLambda;
-import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtNewArray;
-import spoon.reflect.code.CtNewClass;
-import spoon.reflect.code.CtOperatorAssignment;
-import spoon.reflect.code.CtReturn;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtStatementList;
-import spoon.reflect.code.CtSuperAccess;
-import spoon.reflect.code.CtSwitch;
-import spoon.reflect.code.CtSynchronized;
-import spoon.reflect.code.CtThisAccess;
-import spoon.reflect.code.CtThrow;
-import spoon.reflect.code.CtTry;
-import spoon.reflect.code.CtTryWithResource;
-import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
-import spoon.reflect.code.CtVariableWrite;
-import spoon.reflect.code.CtWhile;
-import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtAnnotationType;
-import spoon.reflect.declaration.CtAnonymousExecutable;
-import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtEnum;
-import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
-import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.internal.CtCircularTypeReference;
-import spoon.reflect.internal.CtImplicitArrayTypeReference;
-import spoon.reflect.internal.CtImplicitTypeReference;
 import spoon.reflect.reference.CtArrayTypeReference;
-import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
-import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.reference.CtLocalVariableReference;
-import spoon.reflect.reference.CtPackageReference;
-import spoon.reflect.reference.CtParameterReference;
-import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.reference.CtUnboundVariableReference;
-import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.CtInheritanceScanner;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
+/** Responsible for computing signatures for elements where a signature exists (CtType, CtMethod and CtPackage).
+ * Otherwise returns the empty string  */
+public class SignaturePrinter extends  CtInheritanceScanner {
 
-public class SignaturePrinter implements CtVisitor {
-
-	StringBuffer signature;
-
-	public SignaturePrinter() {
-		super();
-		reset();
-	}
+	final StringBuffer signature = new StringBuffer();
 
 	public String getSignature() {
 		return signature.toString();
 	}
 
-	public void reset() {
-		signature = new StringBuffer();
-	}
-
-	public void scan(CtElement e) {
-		if (e != null) {
-			e.accept(this);
-		}
-	}
-
-	public void scan(CtReference e) {
-		if (e != null) {
-			e.accept(this);
-		}
-	}
-
-	protected SignaturePrinter write(String value) {
-		signature.append(value);
-		return this;
-	}
-
-	private SignaturePrinter clearLast() {
-		signature.deleteCharAt(signature.length() - 1);
-		return this;
-	}
-
-	public <A extends Annotation> void visitCtAnnotation(
-			CtAnnotation<A> annotation) {
-		write("@");
-		if (annotation.getAnnotationType() != null) {
-			write(annotation.getAnnotationType().getQualifiedName());
-		}
-	}
-
-	public <A extends Annotation> void visitCtAnnotationType(
-			CtAnnotationType<A> annotationType) {
-		write("@interface ");
-		write(annotationType.getQualifiedName());
-	}
-
-	public void visitCtAnonymousExecutable(CtAnonymousExecutable e) {
-		scan(e.getBody());
-	}
-
-	public <T, E extends CtExpression<?>> void visitCtArrayAccess(CtArrayAccess<T, E> arrayAccess) {
-		printCtArrayAccess(arrayAccess);
-	}
-
 	@Override
-	public <T> void visitCtArrayRead(CtArrayRead<T> arrayRead) {
-		printCtArrayAccess(arrayRead);
-	}
-
-	@Override
-	public <T> void visitCtArrayWrite(CtArrayWrite<T> arrayWrite) {
-		printCtArrayAccess(arrayWrite);
-	}
-
-	public <T, E extends CtExpression<?>> void printCtArrayAccess(CtArrayAccess<T, E> arrayAccess) {
-		scan(arrayAccess.getTarget());
-		write("[");
-		scan(arrayAccess.getIndexExpression());
-		write("]");
-	}
-
 	public <T> void visitCtArrayTypeReference(CtArrayTypeReference<T> reference) {
 		scan(reference.getComponentType());
 		write("[]");
 	}
 
 	@Override
-	public <T> void visitCtImplicitArrayTypeReference(CtImplicitArrayTypeReference<T> reference) {
-		visitCtArrayTypeReference(reference);
-	}
-
-	public <T> void visitCtAssert(CtAssert<T> asserted) {
-		signature.append("assert ");
-		scan(asserted.getAssertExpression());
-		signature.append(":");
-		scan(asserted.getExpression());
-	}
-
-	public <T, A extends T> void visitCtAssignment(
-			CtAssignment<T, A> assignement) {
-		for (CtTypeReference<?> ref : assignement.getTypeCasts()) {
-			write("(");
-			scan(ref);
-			write(")");
-		}
-		write("(");
-		scan(assignement.getAssigned());
-		write(" = ");
-		scan(assignement.getAssignment());
-		write(")");
-	}
-
-	public <T> void visitCtBinaryOperator(CtBinaryOperator<T> operator) {
-		scan(operator.getLeftHandOperand());
-		write(operator.getKind().toString());
-		scan(operator.getRightHandOperand());
-	}
-
-	public <R> void visitCtBlock(CtBlock<R> block) {
-		signature.append("{\n");
-		for (CtStatement s : block.getStatements()) {
-			scan(s);
-			signature.append(";\n");
-		}
-		signature.append("}");
-	}
-
-	public void visitCtBreak(CtBreak breakStatement) {
-		write("break ");
-		if (breakStatement.getTargetLabel() != null) {
-			write(breakStatement.getTargetLabel());
-		}
-	}
-
-	public <E> void visitCtCase(CtCase<E> caseStatement) {
-		write("case (");
-		scan(caseStatement.getCaseExpression());
-		for (CtStatement statement : caseStatement.getStatements()) {
-			scan(statement);
-		}
-		write(")");
-	}
-
-	public void visitCtCatch(CtCatch catchBlock) {
-		write("catch (");
-		scan(catchBlock.getParameter().getType());
-		write(")");
-	}
-
-	public <T> void visitCtClass(CtClass<T> ctClass) {
-		write("class ").write(ctClass.getQualifiedName());
-	}
-
-	public <T> void visitCtConditional(CtConditional<T> conditional) {
-		scan(conditional.getCondition());
-		write("?");
-		scan(conditional.getThenExpression());
-		write(":");
-		scan(conditional.getElseExpression());
-	}
-
-	public <T> void visitCtConstructor(CtConstructor<T> c) {
-		write(c.getDeclaringType().getQualifiedName());
-		write("(");
-		for (CtParameter<?> p : c.getParameters()) {
-			scan(p.getType());
-			write(",");
-		}
-		if (!c.getParameters().isEmpty()) {
-			clearLast();
-		}
-		write(")");
-	}
-
-	public void visitCtContinue(CtContinue continueStatement) {
-		signature.append("continue ");
-		scan(continueStatement.getLabelledStatement());
-	}
-
-	public void visitCtDo(CtDo doLoop) {
-		write("do ");
-		scan(doLoop.getBody());
-		write(" while (");
-		scan(doLoop.getLoopingExpression());
-		write(")");
-	}
-
-	public <T extends Enum<?>> void visitCtEnum(CtEnum<T> ctEnum) {
-		write("enum ").write(ctEnum.getQualifiedName());
-	}
-
 	public <T> void visitCtExecutableReference(CtExecutableReference<T> reference) {
 		scan(reference.getDeclaringType());
 
@@ -304,141 +62,68 @@ public class SignaturePrinter implements CtVisitor {
 				}
 				write(", ");
 			}
-			clearLast();
-			clearLast();
-		}
-		write(")");
-	}
-
-	public <T> void visitCtField(CtField<T> f) {
-		scan(f.getType());
-		write(" ").write(f.getSimpleName());
-	}
-
-	@Override
-	public <T> void visitCtEnumValue(CtEnumValue<T> enumValue) {
-		visitCtField(enumValue);
-	}
-
-	public <T> void visitCtThisAccess(CtThisAccess<T> thisAccess) {
-		write(thisAccess.getType().getQualifiedName() + ".this");
-	}
-
-	public <T> void visitCtAnnotationFieldAccess(
-			CtAnnotationFieldAccess<T> annotationFieldAccess) {
-		scan(annotationFieldAccess.getTarget());
-	}
-
-	public <T> void visitCtFieldReference(CtFieldReference<T> reference) {
-		if (reference.getType() != null) {
-			write(reference.getType().getQualifiedName());
-		} else {
-			write("<no type>");
-		}
-		write(" ");
-		if (reference.getDeclaringType() != null) {
-			write(reference.getDeclaringType().getQualifiedName());
-			write(CtField.FIELD_SEPARATOR);
-		}
-		write(reference.getSimpleName());
-	}
-
-	public void visitCtFor(CtFor forLoop) {
-		write("for (");
-		for (CtStatement s : forLoop.getForInit()) {
-			scan(s);
-			write(",");
-		}
-		if (!forLoop.getForInit().isEmpty()) {
-			clearLast();
-		}
-		write(";");
-		scan(forLoop.getExpression());
-		write(";");
-		for (CtStatement s : forLoop.getForUpdate()) {
-			scan(s);
-			write(",");
-		}
-		if (!forLoop.getForUpdate().isEmpty()) {
-			clearLast();
-		}
-		write(")");
-		scan(forLoop.getBody());
-	}
-
-	public void visitCtForEach(CtForEach foreach) {
-		write("for (");
-		scan(foreach.getVariable());
-		write(":");
-		scan(foreach.getExpression());
-		write(")");
-		scan(foreach.getBody());
-	}
-
-	public void visitCtIf(CtIf ifElement) {
-		write("if (");
-		scan(ifElement.getCondition());
-		write(") then ");
-		scan((CtStatement) ifElement.getThenStatement());
-		write(" else ");
-		scan((CtStatement) ifElement.getElseStatement());
-	}
-
-	public <T> void visitCtInterface(CtInterface<T> intrface) {
-		write("interface ");
-		write(intrface.getQualifiedName());
-	}
-
-	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
-		write("(");
-		scan(invocation.getExecutable());
-		write("(");
-		for (int i = 0; i < invocation.getArguments().size(); i++) {
-			CtExpression<?> arg_i = invocation.getArguments().get(i);
-			scan(arg_i);
-			if (i != (invocation.getArguments().size() - 1)) {
-				write(",");
+			if (reference.getParameters().size() > 0) {
+				clearLast(); // ","
+				clearLast(); // space
 			}
 		}
 		write(")");
+	}
+
+	@Override
+	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+		write(reference.getQualifiedName());
+	}
+
+	@Override
+	public void visitCtTypeParameterReference(CtTypeParameterReference ref) {
+		write(ref.getQualifiedName());
+		if (ref.getBounds() != null && !ref.getBounds().isEmpty()) {
+			if (ref.isUpper()) {
+				write(" extends ");
+			} else {
+				write(" super ");
+			}
+			for (CtTypeReference<?> b: ref.getBounds()) {
+				scan(b);
+				write(",");
+			}
+			if (ref.getBounds().size() > 0) {
+				clearLast();
+			}
+		}
+	}
+
+	@Override
+	public <T> void visitCtConstructor(CtConstructor<T> c) {
+		write(c.getDeclaringType().getQualifiedName());
+		write("(");
+		for (CtParameter<?> p : c.getParameters()) {
+			scan(p.getType());
+			write(",");
+		}
+		if (c.getParameters().size() > 0) {
+			clearLast();
+		}
 		write(")");
 	}
 
-	public <T> void visitCtLiteral(CtLiteral<T> literal) {
-		if (literal.getValue() != null) {
-			write(literal.toString());
-		} else {
-			write("null");
-		}
-	}
 
-	public <T> void visitCtLocalVariable(CtLocalVariable<T> localVariable) {
-		write(localVariable.getSimpleName());
-	}
-
-	public <T> void visitCtLocalVariableReference(
-			CtLocalVariableReference<T> reference) {
-		write(reference.getType().getQualifiedName()).write(" ");
-		write(reference.getSimpleName());
-
-	}
 
 	@Override
-	public <T> void visitCtCatchVariable(CtCatchVariable<T> catchVariable) {
-		write(catchVariable.getSimpleName());
-	}
-
-	@Override
-	public <T> void visitCtCatchVariableReference(CtCatchVariableReference<T> reference) {
-		scan(reference.getDeclaration());
-	}
-
 	public <T> void visitCtMethod(CtMethod<T> m) {
 		if (!m.getFormalTypeParameters().isEmpty()) {
-			scan(m.getFormalTypeParameters());
-			write(" ");
+			write("<");
+			for (CtTypeReference ref: m.getFormalTypeParameters()) {
+				scan(ref);
+				write(",");
+			}
+			if (m.getFormalTypeParameters().size() > 0) {
+				clearLast();
+			}
+			write("> ");
 		}
-		scan(m.getType());
+		write(m.getType().getQualifiedName());
 		write(" ");
 		write(m.getSimpleName());
 		write("(");
@@ -452,250 +137,15 @@ public class SignaturePrinter implements CtVisitor {
 		write(")");
 	}
 
-	public void scan(List<CtTypeReference<?>> formalTypeParameters) {
-		if (formalTypeParameters != null && formalTypeParameters.size() > 0) {
-			write("<");
-			for (CtTypeReference<?> type : formalTypeParameters) {
-				write(type.getQualifiedName());
-				if (type instanceof CtTypeParameterReference) {
-					CtTypeParameterReference tmp = (CtTypeParameterReference) type;
-					if (tmp.getBounds() != null && tmp.getBounds().size() > 0) {
-						write(" extends ");
-						for (CtTypeReference<?> tmp2 : tmp.getBounds()) {
-							write(tmp2.getQualifiedName());
-						}
-						clearLast();
-					}
-				}
-				write(",");
-			}
-			clearLast();
-			write(">");
-		}
+	private SignaturePrinter clearLast() {
+		signature.deleteCharAt(signature.length() - 1);
+		return this;
 	}
 
-	public <T> void visitCtNewArray(CtNewArray<T> newArray) {
-		write("new ");
-		scan(newArray.getType());
-		for (CtExpression<?> c : newArray.getDimensionExpressions()) {
-			write("[");
-			scan(c);
-			write("]");
-		}
-		write("{");
-		for (CtExpression<?> e : newArray.getElements()) {
-			scan(e);
-			write(",");
-		}
-		if (!newArray.getElements().isEmpty()) {
-			clearLast();
-		}
-		write("}");
+
+	protected SignaturePrinter write(String value) {
+		signature.append(value);
+		return this;
 	}
 
-	@Override
-	public <T> void visitCtConstructorCall(CtConstructorCall<T> ctConstructorCall) {
-		write("new ");
-		scan(ctConstructorCall.getExecutable());
-	}
-
-	public <T> void visitCtNewClass(CtNewClass<T> newClass) {
-		write("new ");
-		scan(newClass.getExecutable());
-		scan(newClass.getAnonymousClass());
-	}
-
-	@Override
-	public <T> void visitCtLambda(CtLambda<T> lambda) {
-		write("(");
-		scan(lambda.getType());
-		write(") (");
-		if (!lambda.getParameters().isEmpty()) {
-			for (CtParameter<?> parameter : lambda.getParameters()) {
-				scan(parameter);
-				write(",");
-			}
-			clearLast();
-		}
-		write(")");
-	}
-
-	@Override
-	public <T, E extends CtExpression<?>> void visitCtExecutableReferenceExpression(
-			CtExecutableReferenceExpression<T, E> expression) {
-		write(expression.toString());
-	}
-
-	public <T> void visitCtCodeSnippetExpression(
-			CtCodeSnippetExpression<T> expression) {
-		write(expression.getValue());
-	}
-
-	public void visitCtCodeSnippetStatement(CtCodeSnippetStatement statement) {
-		write(statement.getValue());
-	}
-
-	public <T, A extends T> void visitCtOperatorAssignment(
-			CtOperatorAssignment<T, A> assignment) {
-		scan(assignment.getAssigned());
-		write(assignment.getKind().toString());
-		scan(assignment.getAssignment());
-	}
-
-	public void visitCtPackage(CtPackage ctPackage) {
-		write(ctPackage.getQualifiedName());
-	}
-
-	public void visitCtPackageReference(CtPackageReference reference) {
-		write(reference.getSimpleName());
-	}
-
-	public <T> void visitCtParameter(CtParameter<T> parameter) {
-		write(parameter.getSimpleName());
-	}
-
-	public <T> void visitCtParameterReference(CtParameterReference<T> reference) {
-		write(reference.getType().getQualifiedName()).write(" ");
-		write(reference.getSimpleName());
-	}
-
-	public <R> void visitCtReturn(CtReturn<R> returnStatement) {
-		write("return ");
-		scan(returnStatement.getReturnedExpression());
-	}
-
-	public <R> void visitCtStatementList(CtStatementList statements) {
-		for (CtStatement s : statements.getStatements()) {
-			scan(s);
-			write(";\n");
-		}
-	}
-
-	public <E> void visitCtSwitch(CtSwitch<E> switchStatement) {
-		write("switch(");
-		scan(switchStatement.getSelector());
-		write(")");
-		for (CtCase<?> c : switchStatement.getCases()) {
-			scan(c);
-		}
-	}
-
-	public void visitCtSynchronized(CtSynchronized synchro) {
-		write("synchronized (");
-		scan(synchro.getExpression());
-		write(") ");
-		scan(synchro.getBlock());
-	}
-
-	public void visitCtThrow(CtThrow throwStatement) {
-		write("throw ");
-		scan(throwStatement.getThrownExpression());
-	}
-
-	public void visitCtTry(CtTry tryBlock) {
-		write("try {\n");
-		scan(tryBlock.getBody());
-		for (CtCatch c : tryBlock.getCatchers()) {
-			scan(c);
-		}
-		scan(tryBlock.getFinalizer());
-	}
-
-	@Override
-	public void visitCtTryWithResource(CtTryWithResource tryWithResource) {
-		write("try (");
-		for (CtLocalVariable<?> resource : tryWithResource.getResources()) {
-			scan(resource);
-		}
-		write(") {\n");
-		scan(tryWithResource.getBody());
-		for (CtCatch c : tryWithResource.getCatchers()) {
-			scan(c);
-		}
-		scan(tryWithResource.getFinalizer());
-	}
-
-	public void visitCtTypeParameter(CtTypeParameter typeParameter) {
-		write("<");
-		write(typeParameter.getSimpleName());
-		write(">");
-	}
-
-	public void visitCtTypeParameterReference(CtTypeParameterReference ref) {
-		write(ref.getQualifiedName());
-		if (ref.getBounds() != null && !ref.getBounds().isEmpty()) {
-			if (ref.isUpper()) {
-				write(" extends ");
-			} else {
-				write(" super ");
-			}
-			for (CtTypeReference<?> b : ref.getBounds()) {
-				scan(b);
-				write(", ");
-			}
-			clearLast();
-			clearLast();
-		}
-	}
-
-	public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
-		write(reference.getQualifiedName());
-	}
-
-	@Override
-	public void visitCtCircularTypeReference(CtCircularTypeReference reference) {
-		visitCtTypeReference(reference);
-	}
-
-	@Override
-	public <T> void visitCtImplicitTypeReference(CtImplicitTypeReference<T> reference) {
-		visitCtTypeReference(reference);
-	}
-
-	@Override
-	public <T> void visitCtTypeAccess(CtTypeAccess<T> typeAccess) {
-		scan(typeAccess.getAccessedType());
-	}
-
-	public <T> void visitCtUnaryOperator(CtUnaryOperator<T> operator) {
-		scan(operator.getOperand());
-		write(operator.getKind().toString());
-	}
-
-	@Override
-	public <T> void visitCtVariableRead(CtVariableRead<T> variableRead) {
-		scan(variableRead.getVariable());
-	}
-
-	@Override
-	public <T> void visitCtVariableWrite(CtVariableWrite<T> variableWrite) {
-		scan(variableWrite.getVariable());
-	}
-
-	public void visitCtWhile(CtWhile whileLoop) {
-		write("while (");
-		scan(whileLoop.getLoopingExpression());
-		write(")");
-		scan(whileLoop.getBody());
-	}
-
-	public <T> void visitCtUnboundVariableReference(
-			CtUnboundVariableReference<T> reference) {
-		write(reference.getSimpleName());
-	}
-
-	@Override
-	public <T> void visitCtFieldRead(CtFieldRead<T> fieldRead) {
-		scan(fieldRead.getVariable());
-	}
-
-	@Override
-	public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
-		scan(fieldWrite.getVariable());
-	}
-
-	@Override
-	public <T> void visitCtSuperAccess(CtSuperAccess<T> f) {
-		write(f.getType().getQualifiedName() + ".super");
-	}
 }

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -1,20 +1,20 @@
 package spoon.reflect.declaration;
 
+import static org.junit.Assert.assertEquals;
+import static spoon.testing.utils.ModelUtils.build;
+
+import java.util.Set;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import spoon.reflect.declaration.testclasses.ExtendsObject;
 import spoon.reflect.declaration.testclasses.Subclass;
 import spoon.reflect.declaration.testclasses.Subinterface;
 import spoon.reflect.declaration.testclasses.TestInterface;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
-
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static spoon.testing.utils.ModelUtils.build;
 
 public class CtTypeInformationTest {
 	private Factory factory;
@@ -54,11 +54,8 @@ public class CtTypeInformationTest {
 		CtMethod<?> fooConcrete = type.getMethodsByName("foo").get(0);
 		CtMethod<?> fooAbstract = type2.getMethodsByName("foo").get(0);
 		assertEquals(fooConcrete.getSignature(), fooAbstract.getSignature());
-		// and they are in considered the same in a set
-		Set<CtMethod<?>> l = new HashSet<CtMethod<?>>();
-		l.add(fooConcrete);
-		l.add(fooAbstract);
-		assertEquals(1, l.size());
+		// yet they are different AST node
+		Assert.assertNotEquals(fooConcrete, fooAbstract);
 
 		assertEquals(type.getMethodsByName("foo").get(0).getSignature(),
 				type2.getMethodsByName("foo").get(0).getSignature());

--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -41,17 +41,15 @@ public class EqualTest {
 		CtInvocation<?> invo = (CtInvocation<?>) method.getBody().getStatement(0);
 
 		CtLiteral<?> argument1 = (CtLiteral<?>) invo.getArguments().get(0);
-
-		String signatureArg1= argument1.getSignature();
 		
-		assertEquals(realParam1 , signatureArg1);
+		assertEquals(realParam1 , argument1.toString());
 		
 		
 		CtReturn<?> returnStatement = (CtReturn<?>) method.getBody().getStatement(1);
 		
 		CtLiteral<?> returnExp = (CtLiteral<?>) returnStatement.getReturnedExpression();
 		
-		assertEquals(realParam1 , returnExp.getSignature() );
+		assertEquals(realParam1 , returnExp.toString() );
 		
 		try{
 			assertEquals(argument1, returnExp);

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -9,6 +9,7 @@ import static spoon.testing.utils.ModelUtils.createFactory;
 import java.io.File;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import spoon.Launcher;
@@ -20,6 +21,7 @@ import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThrow;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -57,7 +59,8 @@ public class IntercessionTest {
 								+ " String foo=\"toto\";" + "}" + "};")
 				.compile();
 		CtMethod<?> foo = (CtMethod<?>) clazz.getMethods().toArray()[0];
-
+		CtMethod<?> fooClone = factory.Core().clone(foo);
+		Assert.assertEquals(foo, fooClone);		
 		CtBlock<?> body = foo.getBody();
 		assertEquals(2, body.getStatements().size());
 
@@ -66,6 +69,35 @@ public class IntercessionTest {
 		body.insertEnd(returnStmt);
 		assertEquals(3, body.getStatements().size());
 		assertSame(returnStmt, body.getStatements().get(2));
+		
+		Assert.assertNotEquals(foo, fooClone);
+		
+	}
+
+	@Test
+	public void testEqualConstructor() {
+		CtClass<?> clazz = factory
+				.Code()
+				.createCodeSnippetStatement(
+						"" + "class X { public X() {} };")
+				.compile();
+		CtConstructor<?> foo = (CtConstructor<?>) clazz.getConstructors().toArray()[0];
+		CtConstructor<?> fooClone = factory.Core().clone(foo);
+		Assert.assertEquals(foo, fooClone);		
+		
+		CtBlock<?> body = foo.getBody();
+		
+		// there is an implicit call to super()
+		assertEquals(1, body.getStatements().size());
+		assertEquals("super()", body.getStatements().get(0).toString());
+
+		// adding a new statement;
+		CtStatement stmt = factory.Core().createCodeSnippetStatement();
+		body.insertEnd(stmt);
+		assertEquals(2, body.getStatements().size());
+		
+		// constructor are not equals anymore
+		Assert.assertNotEquals(foo, fooClone);		
 	}
 
 	@Test

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.Assertion;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
+
 import spoon.Launcher;
 import spoon.reflect.code.CtArrayWrite;
 import spoon.reflect.code.CtAssignment;
@@ -19,6 +20,7 @@ import spoon.test.parent.ParentTest;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.PrintStream;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -64,7 +66,9 @@ public class MainTest {
 
 		// scanners
 		checkContractCtScanner(pack);
+		
 	}
+
 
 	private void checkContractCtScanner(CtPackage pack) {
 		class Counter {

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -121,10 +121,16 @@ public class ParentTest {
 
 		final CtType<Object> panini = launcher.getFactory().Type().get("Panini");
 
-		assertNotNull(panini.getPackage().getParent());
+		CtPackage pack2 = (CtPackage) panini.getPackage().getParent();
+		assertNotNull(pack2);
 		assertEquals(CtPackage.TOP_LEVEL_PACKAGE_NAME, panini.getPackage().getSimpleName());
-		assertEquals(factory.Package().getRootPackage(), panini.getPackage().getParent());
-
+		CtPackage pack1 = factory.Package().getRootPackage();
+		
+		// the factory are not the same
+		assertNotEquals(factory, launcher.getFactory());
+		// so the root packages are not deeply equals
+		assertNotEquals(pack1, pack2);
+		
 		final CtTypeReference<?> burritos = panini.getReferences(new ReferenceTypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
 			@Override
 			public boolean matches(CtTypeReference<?> reference) {

--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -20,6 +20,7 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractReferenceFilter;
+import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
@@ -209,16 +210,20 @@ public class ExecutableReferenceGenericTest {
 
 	@Test
 	public void testExecutableReferences() throws Exception {
-		List<CtClass<?>> classes = Query.getElements(factory, new TypeFilter<CtClass<?>>(CtClass.class));
-
-		List<CtExecutableReference<?>> refsExecutableClass1 = Query.getReferences(classes.get(0),
+		// factory has loaded MyClass, MyClass2 and MyClass3
+		
+		CtClass<?> classMyClass = Query.getElements(factory, new NameFilter<CtClass>("MyClass")).get(0);
+		assertEquals("MyClass", classMyClass.getSimpleName());
+		List<CtExecutableReference<?>> refsExecutableClass1 = Query.getReferences(classMyClass,
 				new AbstractReferenceFilter<CtExecutableReference<?>>(CtExecutableReference.class) {
 					public boolean matches(CtExecutableReference<?> reference) {
 						return true;
 					}
 				});
 
-		List<CtExecutableReference<?>> refsExecutableClass2 = Query.getReferences(classes.get(1),
+		CtClass<?> classMyClass2 =  Query.getElements(factory, new NameFilter<CtClass>("MyClass2")).get(0);
+		assertEquals("MyClass2", classMyClass2.getSimpleName());
+		List<CtExecutableReference<?>> refsExecutableClass2 = Query.getReferences(classMyClass2,
 				new AbstractReferenceFilter<CtExecutableReference<?>>(CtExecutableReference.class) {
 					public boolean matches(CtExecutableReference<?> reference) {
 						return true;


### PR DESCRIPTION
Before:
The three responsibilities of equals/hashCode/signature were handled by the same code in SignaturePrinter,
with two major problems:
- no deep equality for package, class and method
- low performance of hashCode

Now:
The three responsibilities are handled by three different visitors:
- SignaturePrinter for signatures
- EqualVisitor for equal
- HashcodeVisitor for equal