### PR TITLE
fix bug: NPE when compilation units array contains null elements

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -17,6 +17,7 @@
 package spoon.support.compiler.jdt;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
 
 import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.ICompilerRequestor;
@@ -72,6 +73,12 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 			requestor.acceptResult(unit.compilationResult);
 		}
 
-		return this.unitsToProcess;
+		ArrayList<CompilationUnitDeclaration> unitsToReturn = new ArrayList<CompilationUnitDeclaration>();
+		for (CompilationUnitDeclaration cud : this.unitsToProcess) {
+			if (cud != null) {
+				unitsToReturn.add(cud);
+			}
+		}
+		return unitsToReturn.toArray(new CompilationUnitDeclaration[unitsToReturn.size()]);
 	}
 }


### PR DESCRIPTION
Fix a bug in TreeBuilderCompiler.buildUnits() where a retured array is
longer then expected and the extra spaces are null. The method is updated
to use the **totalUnits** instance variable as the true element count in
the **unitsToProcess** array instead of the length of the array itself.

This bug broke processing of classes using method JDTBatchCompiler.getUnits() and
expecting every element in the returned array to be non-null.  The problem came up
when trying to process the source for a large GWT project.