### PR TITLE
Pre post order

### DIFF
--- a/src/main/java/spoon/processing/AbstractManualProcessor.java
+++ b/src/main/java/spoon/processing/AbstractManualProcessor.java
@@ -31,6 +31,8 @@ public abstract class AbstractManualProcessor implements Processor<CtElement> {
 
 	Factory factory;
 
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
+
 	/**
 	 * Empty constructor only for all processors (invoked by Spoon).
 	 */
@@ -64,6 +66,25 @@ public abstract class AbstractManualProcessor implements Processor<CtElement> {
 	 */
 	public final TraversalStrategy getTraversalStrategy() {
 		return TraversalStrategy.POST_ORDER;
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 
 	public void init() {

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -40,6 +40,8 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 
 	Set<Class<? extends CtElement>> processedElementTypes = new HashSet<Class<? extends CtElement>>();
 
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
+
 	/**
 	 * Empty constructor only for all processors (invoked by Spoon).
 	 */
@@ -111,6 +113,25 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 
 	public TraversalStrategy getTraversalStrategy() {
 		return TraversalStrategy.POST_ORDER;
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 
 	public void init() {

--- a/src/main/java/spoon/processing/Processor.java
+++ b/src/main/java/spoon/processing/Processor.java
@@ -37,6 +37,30 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	TraversalStrategy getTraversalStrategy();
 
 	/**
+	 * Returns the current traversal state of the processor assigned by using
+	 * {@link #setTraversalState(TraversalStrategy)}. The returned state is
+	 * either {@link TraversalStrategy#PRE_ORDER} or
+	 * {@link TraversalStrategy#POST_ORDER}. The default state is
+	 * {@link TraversalStrategy#POST_ORDER} making sure this method never
+	 * returns {@code null}.
+	 *
+	 * @return	The current traversal state, never {@code null}.
+	 */
+	TraversalStrategy getTraversalState();
+
+	/**
+	 * Sets the current traversal state of the processor. The given state must
+	 * either be {@link TraversalStrategy#PRE_ORDER} or
+	 * {@link TraversalStrategy#POST_ORDER}.
+	 *
+	 * @param state	The current traversal state.
+	 * @throws IllegalArgumentException	If {@code state} is {@code null} or
+	 * 				neither {@link TraversalStrategy#PRE_ORDER} nor
+	 * 				{@link TraversalStrategy#POST_ORDER}.
+	 */
+	void setTraversalState(TraversalStrategy state);
+
+	/**
 	 * Gets the environment of this processor.
 	 */
 	Environment getEnvironment();

--- a/src/main/java/spoon/processing/TraversalStrategy.java
+++ b/src/main/java/spoon/processing/TraversalStrategy.java
@@ -37,6 +37,12 @@ public enum TraversalStrategy {
 	 * elements before the parents. This implies that child elements that are
 	 * removed by a processor will still be processed before they are removed.
 	 */
-	POST_ORDER
+	POST_ORDER,
 
+	/**
+	 * When this strategy is selected, the processor will traverse the parent
+	 * elements before and after the children. Thus, it's a combination of
+	 * {@link #PRE_ORDER} and {@link #POST_ORDER}.
+	 */
+	PRE_POST_ORDER
 }

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -18,6 +18,7 @@ package spoon.reflect.visitor;
 
 import java.lang.annotation.Annotation;
 
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayRead;
 import spoon.reflect.code.CtArrayWrite;
@@ -94,6 +95,28 @@ import spoon.reflect.reference.CtUnboundVariableReference;
  *  See {@link CtScanner} for a much more powerful implementation of CtVisitor.
  */
 public abstract class CtAbstractVisitor implements CtVisitor {
+
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
+	}
+
 	@Override
 	public <A extends Annotation> void visitCtAnnotation(
 			CtAnnotation<A> annotation) {

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
@@ -122,6 +123,8 @@ import java.util.Collection;
  * abstract element of the AST and a visit method for each element of the AST.
  */
 public abstract class CtInheritanceScanner implements CtVisitor {
+
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
 
 	/**
 	 * Default constructor.
@@ -854,5 +857,24 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	}
 
 	public void scanCtCodeSnippet(CtCodeSnippet snippet) {
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtArrayRead;
@@ -104,6 +105,9 @@ import java.util.Collection;
  * Is used by the processing and filtering engine.
  */
 public abstract class CtScanner implements CtVisitor {
+
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
+
 	/**
 	 * Default constructor.
 	 */
@@ -787,5 +791,24 @@ public abstract class CtScanner implements CtVisitor {
 		scan(f.getTypeCasts());
 		scan(f.getTarget());
 		exit(f);
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitor.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayRead;
 import spoon.reflect.code.CtArrayWrite;
@@ -97,6 +98,31 @@ import java.lang.annotation.Annotation;
  * element of the AST.
  */
 public interface CtVisitor {
+
+	/**
+	 * Returns the current traversal state of the visitor assigned by using
+	 * {@link #setTraversalState(TraversalStrategy)}. The returned state is
+	 * either {@link TraversalStrategy#PRE_ORDER} or
+	 * {@link TraversalStrategy#POST_ORDER}. The default state is
+	 * {@link TraversalStrategy#POST_ORDER} making sure this method never
+	 * returns {@code null}.
+	 *
+	 * @return	The current traversal state, never {@code null}.
+	 */
+	TraversalStrategy getTraversalState();
+
+	/**
+	 * Sets the current traversal state of the visitor. The given state must
+	 * either be {@link TraversalStrategy#PRE_ORDER} or
+	 * {@link TraversalStrategy#POST_ORDER}.
+	 *
+	 * @param state	The current traversal state.
+	 * @throws IllegalArgumentException	If {@code state} is {@code null} or
+	 * 				neither {@link TraversalStrategy#PRE_ORDER} nor
+	 * 				{@link TraversalStrategy#POST_ORDER}.
+	 */
+	void setTraversalState(TraversalStrategy state);
+
 	/**
 	 * Visits an annotation.
 	 */

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -18,6 +18,7 @@ package spoon.reflect.visitor;
 
 import org.apache.log4j.Level;
 import spoon.compiler.Environment;
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
@@ -125,6 +126,8 @@ import java.util.Stack;
  * A visitor for generating Java code from the program compile-time model.
  */
 public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
+
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
 
 	/**
 	 * Java file extension (.java).
@@ -2311,5 +2314,24 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	public <T> void visitCtUnboundVariableReference(CtUnboundVariableReference<T> reference) {
 		write(reference.getSimpleName());
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 }

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.eval;
 
+import spoon.processing.TraversalStrategy;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
@@ -119,6 +120,8 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 	boolean flowEnded = false;
 
 	CtCodeElement result;
+
+	private TraversalStrategy traversalState = TraversalStrategy.POST_ORDER;
 
 	Number convert(CtTypeReference<?> type, Number n) {
 		if ((type.getActualClass() == int.class) || (type.getActualClass() == Integer.class)) {
@@ -832,5 +835,24 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 	@Override
 	public <T> void visitCtSuperAccess(CtSuperAccess<T> f) {
 		setResult(f.getFactory().Core().clone(f));
+	}
+
+	@Override
+	public TraversalStrategy getTraversalState() {
+		return traversalState;
+	}
+
+	@Override
+	public void setTraversalState(TraversalStrategy state) {
+		if (state == null) {
+			throw new IllegalArgumentException(
+					"The given state must not be null");
+		} else if (state != TraversalStrategy.PRE_ORDER &&
+				state != TraversalStrategy.POST_ORDER) {
+			throw new IllegalArgumentException(
+					"The given state must either be 'PRE_ORDER' or" +
+							"'POST_ORDER'");
+		}
+		traversalState = state;
 	}
 }

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -87,19 +87,19 @@ public class ProcessingVisitor extends CtScanner {
 			// Setup the traversal state of the processor before using
 			// isToBeProcessed.
 			p.setTraversalState(TraversalStrategy.PRE_ORDER);
-			// Setup our own traversal state in order to determine the state
-			// within the visit methods.
-			setTraversalState(TraversalStrategy.PRE_ORDER);
 			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}
+			// Setup our own traversal state in order to determine the state
+			// within the visit methods.
+			setTraversalState(TraversalStrategy.PRE_ORDER);
+			super.scan(e);
 		}
-		super.scan(e); // process children
-		// The same applies for POST_ORDER.
 		if (p.getTraversalStrategy() == TraversalStrategy.POST_ORDER ||
 				p.getTraversalStrategy() == TraversalStrategy.PRE_POST_ORDER) {
-			p.setTraversalState(TraversalStrategy.POST_ORDER);
 			setTraversalState(TraversalStrategy.POST_ORDER);
+			super.scan(e);
+			p.setTraversalState(TraversalStrategy.POST_ORDER);
 			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -78,17 +78,24 @@ public class ProcessingVisitor extends CtScanner {
 		if (e == null) {
 			return;
 		}
-		Processor<CtElement> p = (Processor<CtElement>) processor;
-		if (p.getTraversalStrategy() == TraversalStrategy.PRE_ORDER
-				&& canBeProcessed(p, e)) {
-			if (p.isToBeProcessed(e)) {
+		final Processor<CtElement> p = (Processor<CtElement>) processor;
+		// Since the method 'isToBeProcessed' is part of the Processor class
+		// and, thus, could make usage of the traversal state, we have to make
+		// sure the state is setup correctly before using this method.
+		if (p.getTraversalStrategy() == TraversalStrategy.PRE_ORDER ||
+				p.getTraversalStrategy() == TraversalStrategy.PRE_POST_ORDER) {
+			// Setup the traversal state before using isToBeProcessed.
+			p.setTraversalState(TraversalStrategy.PRE_ORDER);
+			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}
 		}
-		super.scan(e);
-		if (p.getTraversalStrategy() == TraversalStrategy.POST_ORDER
-				&& canBeProcessed(p, e)) {
-			if (p.isToBeProcessed(e)) {
+		super.scan(e); // process children
+		// The same applies for POST_PROCESS.
+		if (p.getTraversalStrategy() == TraversalStrategy.POST_ORDER ||
+				p.getTraversalStrategy() == TraversalStrategy.PRE_POST_ORDER) {
+			p.setTraversalState(TraversalStrategy.POST_ORDER);
+			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}
 		}

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -84,17 +84,22 @@ public class ProcessingVisitor extends CtScanner {
 		// sure the state is setup correctly before using this method.
 		if (p.getTraversalStrategy() == TraversalStrategy.PRE_ORDER ||
 				p.getTraversalStrategy() == TraversalStrategy.PRE_POST_ORDER) {
-			// Setup the traversal state before using isToBeProcessed.
+			// Setup the traversal state of the processor before using
+			// isToBeProcessed.
 			p.setTraversalState(TraversalStrategy.PRE_ORDER);
+			// Setup our own traversal state in order to determine the state
+			// within the visit methods.
+			setTraversalState(TraversalStrategy.PRE_ORDER);
 			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}
 		}
 		super.scan(e); // process children
-		// The same applies for POST_PROCESS.
+		// The same applies for POST_ORDER.
 		if (p.getTraversalStrategy() == TraversalStrategy.POST_ORDER ||
 				p.getTraversalStrategy() == TraversalStrategy.PRE_POST_ORDER) {
 			p.setTraversalState(TraversalStrategy.POST_ORDER);
+			setTraversalState(TraversalStrategy.POST_ORDER);
 			if (canBeProcessed(p, e) && p.isToBeProcessed(e)) {
 				p.process(e);
 			}


### PR DESCRIPTION
This pr is just a suggestion to handle the feature requested of #557. The general idea is to extend the Processor and CtVisitor class in order to provide a state that can be used to determine if the process/visit method has been called from pre- or from post-order step. The state attribute ensures backward compatibility as the usage of it is optional. Unfortunately, I had to create some code duplications (the setter of the state). Maybe you should enhance the class hierarchy in order to prevent such duplications. Nonetheless, this should not (and actually is not) part of this pr. I'm unsure if calling process twice leads to errors. If yes, we could just remove it as the visit methods are the one I want to get executed twice, before and after. However, running the tests results to an error in spoon.test.intercession.IntercessionTest.testSettersAreAllGood line 202. Maybe you know whats going on here. All other tests pass.