### PR TITLE
introduces CtModel for #584

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -22,15 +22,18 @@ import com.martiansoftware.jsap.JSAPException;
 import com.martiansoftware.jsap.JSAPResult;
 import com.martiansoftware.jsap.Switch;
 import com.martiansoftware.jsap.stringparsers.FileStringParser;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.processing.Processor;
+import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -765,6 +768,11 @@ public class Launcher implements SpoonAPI {
 	@Override
 	public void setBinaryOutputDirectory(File outputDirectory) {
 		modelBuilder.setBinaryOutputDirectory(outputDirectory);
+	}
+
+	@Override
+	public CtModel getModel() {
+		return factory.getModel();
 	}
 
 }

--- a/src/main/java/spoon/SpoonAPI.java
+++ b/src/main/java/spoon/SpoonAPI.java
@@ -16,15 +16,16 @@
  */
 package spoon;
 
+import java.io.File;
+
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonCompiler;
 import spoon.processing.Processor;
+import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.Filter;
-
-import java.io.File;
 
 /**
  * Is the core entry point of Spoon. Implemented by Launcher.
@@ -144,4 +145,7 @@ public interface SpoonAPI {
 	 * Creates a new Spoon compiler (for building the model)
 	 */
 	SpoonCompiler createCompiler();
+
+	/** Returns the model built from the sources given via {@link #addInputResource(String)} */
+	CtModel getModel();
 }

--- a/src/main/java/spoon/reflect/CtModel.java
+++ b/src/main/java/spoon/reflect/CtModel.java
@@ -14,42 +14,35 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-package spoon.reflect.visitor.filter;
+package spoon.reflect;
 
+import java.util.Collection;
+import java.util.List;
+
+import spoon.processing.Processor;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.Filter;
 
-/**
- * Defines an abstract filter based on matching on the element types.
- *
- * Not necessary in simple cases thanks to the use of runtime reflection.
+/** represents a Java program, modeled by a set of compile-time (Ct) objects
+ * where each objects is a program element (for instance, a CtClass represents a class).
  */
-public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
+public interface CtModel {
 
-	private Class<T> type;
+	/** returns the root package */
+	CtPackage getRootPackage();
 
-	/**
-	 * Creates a filter with the type of the potentially matching elements.
-	 */
-	@SuppressWarnings("unchecked")
-	public AbstractFilter(Class<? super T> type) {
-		this.type = (Class<T>) type;
-	}
+	/** returns all top-level types of the model */
+	Collection<CtType<?>> getAllTypes();
 
-	/**
-	 * Creates a filter with the no typing constraint.
-	 */
-	@SuppressWarnings("unchecked")
-	public AbstractFilter() {
-		this.type = (Class<T>) CtElement.class;
-	}
+	/** returns all packages of the model */
+	Collection<CtPackage> getAllPackages();
 
-	public Class<T> getType() {
-		return type;
-	}
+	/** process this model with the given processor */
+	void processWith(Processor<?> processor);
 
-	@Override
-	public boolean matches(T element) {
-		return type.isAssignableFrom(element.getClass());
-	}
+	/** Returns all the model elements matching the filter. */
+	<E extends CtElement> List<E> getElements(Filter<E> filter);
+
 }

--- a/src/main/java/spoon/reflect/CtModelImpl.java
+++ b/src/main/java/spoon/reflect/CtModelImpl.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import spoon.processing.Processor;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.Filter;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.QueueProcessingManager;
+import spoon.support.reflect.declaration.CtElementImpl;
+import spoon.support.reflect.declaration.CtPackageImpl;
+
+public class CtModelImpl implements CtModel {
+
+	private static class CtRootPackage extends CtPackageImpl {
+		{
+			this.setSimpleName(CtPackage.TOP_LEVEL_PACKAGE_NAME);
+			this.setParent(new CtElementImpl() {
+				@Override
+				public void accept(CtVisitor visitor) {
+
+				}
+
+				@Override
+				public CtElement getParent() throws ParentNotInitializedException {
+					return null;
+				}
+							});
+		}
+
+		@Override
+		public String getSimpleName() {
+			return super.getSimpleName();
+		}
+
+		@Override
+		public String getQualifiedName() {
+			return "";
+		}
+
+		@Override
+		public String toString() {
+			return packs.size() + " packages";
+		}
+
+	}
+
+	private CtPackage rootPackage = new CtRootPackage();
+
+	public CtModelImpl(Factory f) {
+		rootPackage.setFactory(f);
+	}
+
+	@Override
+	public CtPackage getRootPackage() {
+		return rootPackage;
+	}
+
+
+	@Override
+	public Collection<CtType<?>> getAllTypes() {
+		List<CtType<?>> types = new ArrayList<CtType<?>>();
+		for (CtPackage pack : getAllPackages()) {
+			types.addAll(pack.getTypes());
+		}
+		return types;
+	}
+
+
+	@Override
+	public Collection<CtPackage> getAllPackages() {
+		return Collections.unmodifiableCollection(rootPackage.getElements(new TypeFilter<CtPackage>(CtPackage.class)));
+	}
+
+
+	@Override
+	public void processWith(Processor<?> processor) {
+		new QueueProcessingManager(rootPackage.getFactory()).process(getRootPackage());
+	}
+
+	@Override
+	public <E extends CtElement> List<E> getElements(Filter<E> filter) {
+		return getRootPackage().getElements(filter);
+	}
+
+}

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -37,7 +37,7 @@ public interface CtPackage extends CtNamedElement {
 	String TOP_LEVEL_PACKAGE_NAME = "unnamed package";
 
 	/**
-	 * Gets the declaring package of the current one.
+	 * Gets the declaring package of the current one. Returns null if the package is not yet in another one.
 	 */
 	CtPackage getDeclaringPackage();
 

--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -39,7 +39,7 @@ public class CompilationUnitFactory extends SubFactory {
 		super(factory);
 	}
 
-	Map<String, CompilationUnit> compilationUnits = new TreeMap<String, CompilationUnit>();
+	private transient Map<String, CompilationUnit> cachedCompilationUnits = new TreeMap<String, CompilationUnit>();
 
 	/**
 	 * Gets the compilation unit map.
@@ -47,7 +47,7 @@ public class CompilationUnitFactory extends SubFactory {
 	 * @return a map (path -&gt; {@link CompilationUnit})
 	 */
 	public Map<String, CompilationUnit> getMap() {
-		return compilationUnits;
+		return cachedCompilationUnits;
 	}
 
 	/**
@@ -62,7 +62,7 @@ public class CompilationUnitFactory extends SubFactory {
 	 * Creates or gets a compilation unit for a given file path.
 	 */
 	public CompilationUnit create(String filePath) {
-		CompilationUnit cu = compilationUnits.get(filePath);
+		CompilationUnit cu = cachedCompilationUnits.get(filePath);
 		if (cu == null) {
 			if ("".equals(filePath)) {
 				cu = factory.Core().createVirtualCompilationUnit();
@@ -70,7 +70,7 @@ public class CompilationUnitFactory extends SubFactory {
 			}
 			cu = factory.Core().createCompilationUnit();
 			cu.setFile(new File(filePath));
-			compilationUnits.put(filePath, cu);
+			cachedCompilationUnits.put(filePath, cu);
 		}
 		return cu;
 	}

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -17,6 +17,7 @@
 package spoon.reflect.factory;
 
 import spoon.compiler.Environment;
+import spoon.reflect.CtModel;
 
 /**
  * Provides the sub-factories required by Spoon.
@@ -26,6 +27,9 @@ import spoon.compiler.Environment;
  * Otherwise FactoryImpl is a default implementation.
  */
 public interface Factory {
+
+	/** returns the Spoon model that has been built with this factory or one of its subfactories */
+	CtModel getModel();
 
 	CoreFactory Core(); // used 238 times
 

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -16,7 +16,14 @@
  */
 package spoon.reflect.factory;
 
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
 import spoon.compiler.Environment;
+import spoon.reflect.CtModel;
+import spoon.reflect.CtModelImpl;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtClass;
@@ -31,11 +38,6 @@ import spoon.reflect.declaration.CtType;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.DefaultInternalFactory;
 import spoon.support.StandardEnvironment;
-
-import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
 
 /**
  * Implements {@link Factory}
@@ -214,7 +216,7 @@ public class FactoryImpl implements Factory, Serializable {
 		return methodF;
 	}
 
-	private PackageFactory packageF;
+	private transient PackageFactory packageF;
 
 	/**
 	 * The {@link CtPackage} sub-factory.
@@ -227,7 +229,7 @@ public class FactoryImpl implements Factory, Serializable {
 		return packageF;
 	}
 
-	private CompilationUnitFactory compilationUnit;
+	private transient CompilationUnitFactory compilationUnit;
 
 	/**
 	 * The {@link CompilationUnit} sub-factory.
@@ -319,5 +321,12 @@ public class FactoryImpl implements Factory, Serializable {
 			}
 			return symbol;
 		}
+	}
+
+	private final CtModel model = new CtModelImpl(this);
+
+	@Override
+	public CtModel getModel() {
+		return model;
 	}
 }

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -16,56 +16,21 @@
  */
 package spoon.reflect.factory;
 
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ParentNotInitializedException;
-import spoon.reflect.reference.CtPackageReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.reflect.declaration.CtElementImpl;
-import spoon.support.reflect.declaration.CtPackageImpl;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtPackageReference;
+
 /**
  * The {@link CtPackage} sub-factory.
  */
 public class PackageFactory extends SubFactory implements Serializable {
 	private static final long serialVersionUID = 1L;
-
-	private CtPackage rootPackage;
-
-	private static class CtRootPackage extends CtPackageImpl {
-		{
-			setSimpleName(CtPackage.TOP_LEVEL_PACKAGE_NAME);
-			setParent(new CtElementImpl() {
-				@Override
-				public void accept(CtVisitor visitor) {
-
-				}
-
-				@Override
-				public CtElement getParent() throws ParentNotInitializedException {
-					return null;
-				}
-			});
-		}
-
-		@Override
-		public String getSimpleName() {
-			return super.getSimpleName();
-		}
-
-		@Override
-		public String getQualifiedName() {
-			return "";
-		}
-
-	}
 
 	/**
 	 * Creates a new package sub-factory.
@@ -75,8 +40,6 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 */
 	public PackageFactory(Factory factory) {
 		super(factory);
-		rootPackage = new CtRootPackage();
-		rootPackage.setFactory(factory);
 	}
 
 	/**
@@ -101,16 +64,11 @@ public class PackageFactory extends SubFactory implements Serializable {
 		return createReference(pack.getName());
 	}
 
-	CtPackageReference topLevel;
-
 	/**
 	 * Returns a reference on the top level package.
 	 */
 	public CtPackageReference topLevel() {
-		if (topLevel == null) {
-			topLevel = createReference(CtPackage.TOP_LEVEL_PACKAGE_NAME);
-		}
-		return topLevel;
+		return factory.getModel().getRootPackage().getReference();
 	}
 
 	/**
@@ -146,7 +104,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 */
 	public CtPackage getOrCreate(String qualifiedName) {
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage last = rootPackage;
+		CtPackage last = factory.getModel().getRootPackage();
 
 		while (token.hasMoreElements()) {
 			String name = token.nextToken();
@@ -175,7 +133,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 			throw new RuntimeException("Invalid package name " + qualifiedName);
 		}
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage current = rootPackage;
+		CtPackage current = factory.getModel().getRootPackage();
 		if (token.hasMoreElements()) {
 			current = current.getPackage(token.nextToken());
 			while (token.hasMoreElements() && current != null) {
@@ -191,14 +149,14 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * packages and their sub-packages.
 	 */
 	public Collection<CtPackage> getAll() {
-		return getSubPackageList(rootPackage);
+		return factory.getModel().getAllPackages();
 	}
 
 	/**
 	 * Return the unnamed top-level package.
 	 */
 	public CtPackage getRootPackage() {
-		return rootPackage;
+		return factory.getModel().getRootPackage();
 	}
 
 	private List<CtPackage> getSubPackageList(CtPackage pack) {

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -35,8 +35,7 @@ import java.util.List;
  */
 public class TypeFactory extends SubFactory {
 
-	CtTypeReference<?> nullType;
-
+	public final CtTypeReference<?> NULL_TYPE = createReference(CtTypeReference.NULL_TYPE_NAME);
 	public final CtTypeReference<Void> VOID = createReference(Void.class);
 	public final CtTypeReference<String> STRING = createReference(String.class);
 	public final CtTypeReference<Boolean> BOOLEAN = createReference(Boolean.class);
@@ -63,10 +62,7 @@ public class TypeFactory extends SubFactory {
 	 * Returns a reference on the null type (type of null).
 	 */
 	public CtTypeReference<?> nullType() {
-		if (nullType == null) {
-			nullType = createReference(CtTypeReference.NULL_TYPE_NAME);
-		}
-		return nullType;
+		return NULL_TYPE;
 	}
 
 	/**
@@ -237,11 +233,7 @@ public class TypeFactory extends SubFactory {
 	 * Gets the list of all top-level created types.
 	 */
 	public List<CtType<?>> getAll() {
-		List<CtType<?>> types = new ArrayList<CtType<?>>();
-		for (CtPackage pack : factory.Package().getAll()) {
-			types.addAll(pack.getTypes());
-		}
-		return types;
+		return (List<CtType<?>>) factory.getModel().getAllTypes();
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -36,10 +36,18 @@ public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 		this.type = (Class<T>) type;
 	}
 
+	/**
+	 * Creates a filter with the no typing constraint.
+	 */
+	@SuppressWarnings("unchecked")
+	public AbstractFilter() {
+		this.type = (Class<T>) CtElement.class;
+	}
+
 	public Class<T> getType() {
 		return type;
 	}
-
+    
 	@Override
 	public boolean matches(T element) {
 		return type.isAssignableFrom(element.getClass());

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -80,6 +80,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.factory.CoreFactory;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.SubFactory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -177,18 +178,15 @@ import java.util.Stack;
  * This class implements a default core factory for Spoon's meta-model. This
  * implementation is done with regular Java classes (POJOs).
  */
-public class DefaultCoreFactory implements CoreFactory, Serializable {
+public class DefaultCoreFactory extends SubFactory implements CoreFactory, Serializable {
 
 	private static final long serialVersionUID = 1L;
-
-	// transient Stack<CtElement> cloningContext = new Stack<CtElement>();
-
-	Factory mainFactory;
 
 	/**
 	 * Default constructor.
 	 */
 	public DefaultCoreFactory() {
+		super(null);
 	}
 
 	public <T> T clone(T object) {
@@ -675,11 +673,11 @@ public class DefaultCoreFactory implements CoreFactory, Serializable {
 	}
 
 	public Factory getMainFactory() {
-		return mainFactory;
+		return factory;
 	}
 
 	public void setMainFactory(Factory mainFactory) {
-		this.mainFactory = mainFactory;
+		this.factory = mainFactory;
 	}
 
 	public SourcePosition createSourcePosition(CompilationUnit compilationUnit, int startDeclaration, int startSource, int end, int[] lineSeparatorPositions) {

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -25,7 +25,7 @@ public abstract class CtNamedElementImpl extends CtElementImpl implements CtName
 
 	private static final long serialVersionUID = 1L;
 
-	String simpleName;
+	String simpleName = "";
 
 	@Override
 	public CtReference getReference() {

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcer.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcer.java
@@ -1,0 +1,40 @@
+package spoon.test.architecture;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.SpoonAPI;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.visitor.filter.AbstractFilter;
+
+public class SpoonArchitectureEnforcer {
+
+	@Test
+	public void statelessFactory() throws Exception {
+		// the factories must be stateless
+		SpoonAPI spoon = new Launcher();
+		spoon.addInputResource("src/main/java/spoon/reflect/factory");
+		spoon.buildModel();
+		
+		for (CtType t : spoon.getFactory().Package().getRootPackage().getElements(new AbstractFilter<CtType>() {
+			@Override
+			public boolean matches(CtType element) {
+				return super.matches(element) 
+						&& element.getSimpleName().contains("Factory");
+			};
+		})) {
+			for (Object o : t.getFields()) {
+				CtField f=(CtField)o;
+				if (f.getSimpleName().equals("factory")) { continue; }
+				if (f.hasModifier(ModifierKind.FINAL) || f.hasModifier(ModifierKind.TRANSIENT) ) { continue; }
+				
+				fail("architectural constraint: a factory must be stateless");
+			}
+		}
+		
+	}
+}

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -1,28 +1,34 @@
 package spoon.test.factory;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static spoon.testing.utils.ModelUtils.build;
+import static spoon.testing.utils.ModelUtils.buildClass;
+
 import org.junit.Test;
+
 import spoon.Launcher;
-import spoon.reflect.code.CtExpression;
+import spoon.SpoonAPI;
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.CoreFactory;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
+import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.reflect.visitor.filter.NameFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
 import spoon.support.reflect.declaration.CtMethodImpl;
 import spoon.test.factory.testclasses.Foo;
-
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static spoon.testing.utils.ModelUtils.build;
-import static spoon.testing.utils.ModelUtils.buildClass;
 
 public class FactoryTest {
 
@@ -89,4 +95,87 @@ public class FactoryTest {
 		assertEquals(1, ((CtNewArray) foo.getAnnotations().get(0).getElementValues().get("classes")).getElements().size());
 		assertEquals("spoon.test.factory.testclasses.Foo.class", ((CtNewArray) foo.getAnnotations().get(0).getElementValues().get("classes")).getElements().get(0).toString());
 	}
+	
+	@Test
+	public void testCtModel() throws Exception {
+		SpoonAPI spoon = new Launcher();
+		spoon.addInputResource("src/test/java/spoon/test/factory/testclasses");
+		spoon.buildModel();
+		
+		CtModel model = spoon.getModel();
+		
+		// contains Foo and Foo.@Bar
+		assertEquals(1, model.getAllTypes().size());
+		
+		// [, spoon, spoon.test, spoon.test.factory, spoon.test.factory.testclasses]
+		assertEquals(5, model.getAllPackages().size());
+		
+		// add to itself is fine
+		model.getRootPackage().addPackage(model.getRootPackage());
+		assertEquals(1, model.getAllTypes().size());
+		assertEquals(5, model.getAllPackages().size());
+
+		model.getRootPackage().getPackage("spoon").addPackage(model.getRootPackage().getPackage("spoon"));
+		assertEquals(1, model.getAllTypes().size());
+		assertEquals(5, model.getAllPackages().size());
+
+		model.getRootPackage().addPackage(model.getRootPackage().getPackage("spoon"));
+		assertEquals(1, model.getAllTypes().size());
+		assertEquals(5, model.getAllPackages().size());
+
+		
+		CtPackage p = spoon.getFactory().Core().clone(model.getRootPackage().getElements(new NameFilter<CtPackage>("spoon")).get(0));
+		// if we change the implem, merge is impossible
+		CtField f = spoon.getFactory().Core().createField();
+		f.setSimpleName("foo");
+		f.setType(spoon.getFactory().Type().BYTE);
+		p.getElements(new NameFilter<CtPackage>("testclasses")).get(0).getType("Foo").addField(f);
+		try {
+			model.getRootPackage().addPackage(p);
+			fail("no exception thrown");
+		} catch (IllegalStateException success) {}
+	}
+
+	@Test
+	public void testIncrementalModel() throws Exception {
+
+		// Feed some inputResources to a spoon compiler
+		SpoonAPI spoon = new Launcher();
+		spoon.addInputResource("src/test/java/spoon/test/factory/testclasses");
+
+		// Build model
+		spoon.buildModel();
+		assertEquals(1, spoon.getModel().getAllTypes().size());
+		
+		// Do something with that model..
+		CtModel model = spoon.getModel();
+		model.processWith(new AbstractProcessor<CtMethod>() {
+			@Override
+			public void process(CtMethod element) {
+				element.setDefaultMethod(false);
+			}			
+		});
+
+		// Feed some new inputResources 
+		SpoonAPI spoon2 = new Launcher();
+		spoon2.addInputResource("src/test/java/spoon/test/factory/testclasses2");
+		
+		// Build models of newly added classes/packages 
+		spoon2.buildModel();
+		assertEquals(1, spoon2.getModel().getAllTypes().size());
+
+		// attach them to the existing model.
+		model.getRootPackage().addPackage(spoon2.getModel().getRootPackage());
+
+		// checking the results
+		assertEquals(6, model.getAllPackages().size());		
+		assertEquals(2, model.getAllTypes().size());
+		assertEquals(1, model.getRootPackage().getElements(new AbstractFilter<CtPackage>() {
+			@Override
+			public boolean matches(CtPackage element) {
+				return "spoon.test.factory.testclasses2".equals(element.getQualifiedName());
+			}
+		}).size());
+	}
+
 }

--- a/src/test/java/spoon/test/factory/testclasses2/Baz.java
+++ b/src/test/java/spoon/test/factory/testclasses2/Baz.java
@@ -1,0 +1,4 @@
+package spoon.test.factory.testclasses2;
+
+public class Baz {
+}

--- a/src/test/java/spoon/test/parent/ParentContractTest.java
+++ b/src/test/java/spoon/test/parent/ParentContractTest.java
@@ -5,6 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
+
+import spoon.SpoonException;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
@@ -20,6 +22,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.visitor.CtVisitable;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -130,7 +133,13 @@ public class ParentContractTest<T extends CtVisitable> {
 				// we check that setParent has been called
 				verify(mockedArgument).setParent((CtElement) receiver);
 			} catch (AssertionError e) {
-				Assert.fail("call setParent contract failed for "+setter.toString()+" "+e.toString());
+				Assert.fail("call setParent contract failed for "+setter.toString()+" "+e.toString());				
+			} catch (InvocationTargetException e) {
+				if (e.getCause() instanceof RuntimeException) {
+					throw e.getCause();
+				} else {
+					throw new SpoonException(e.getCause()); 
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently, the notion of "model" in Spoon is implicit, and the factory takes this role. However, it's not the way it should be. It's been a long time we wanted to introduce `CtModel`, #584 triggered it. 

The tentative interface is:
```
/** represents a Java program, modeled by a set of compile-time (Ct) objects
 * where each objects is a program element (for instance, a CtClass represents a class).
 */
public interface CtModel {

	/** returns the root package */
	CtPackage getRootPackage();

	/** returns all types of the model */
	Collection<CtType<?>> getAllTypes();

	/** returns all packages of the model */
	Collection<CtPackage> getAllPackages();

	/** process this model with the given processor */
	void processWith(Processor<?> processor);

}
```

The workflow of #584 is tested in `FactoryTest.testIncrementalModel`.

This has triggered cleaning the factory infrastructure.

One more commit is a utility constructor in `AbstractFilter`.

Done in AF145.
 