### PR TITLE
Add missing scanning of CtExecutableReference's parameters in CtScanner

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -379,6 +379,7 @@ public abstract class CtScanner implements CtVisitor {
 		enter(reference);
 		scan(reference.getDeclaringType());
 		scan(reference.getType());
+		scan(reference.getParameters());
 		scan(reference.getActualTypeArguments());
 		scan(reference.getAnnotations());
 		scan(reference.getComments());


### PR DESCRIPTION
Sorry I'm lazy to add a test for this because this is obviously a missing AST scanning branch, the test is going to be trivial from the source: "yes, we actually didn't visit execRef's parameters".