### PR TITLE
Fix a defect in CtScanner.visitCtAnnotation(): annotation values trav…

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -152,9 +152,7 @@ public abstract class CtScanner implements CtVisitor {
 		enter(annotation);
 		scan(annotation.getAnnotationType());
 		scan(annotation.getAnnotations());
-		for (Object o : annotation.getElementValues().values()) {
-			scan(o);
-		}
+		scan(annotation.getElementValues().values());
 		exit(annotation);
 	}
 


### PR DESCRIPTION
…ersal should be delegated to scan(), fixes #603