### PR TITLE
Optimize QueryVisitor: don't rely on ClassCastException as normal con…

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -36,9 +36,12 @@ public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 		this.type = (Class<T>) type;
 	}
 
+	public Class<T> getType() {
+		return type;
+	}
+
 	@Override
 	public boolean matches(T element) {
 		return type.isAssignableFrom(element.getClass());
 	}
-
 }


### PR DESCRIPTION
…trol flow, i. e. avoid frequent throws of ClassCastException, because it is expensive in JVM