### PR TITLE
Fixed nullpointer in hasTypeInImports.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -411,6 +411,8 @@ public class JDTTreeBuilder extends ASTVisitor {
 	private String hasTypeInImports(String typeName) {
 		if (typeName == null) {
 			return null;
+		} else if (context.compilationunitdeclaration.imports == null) {
+			return null;
 		}
 		for (ImportReference anImport : context.compilationunitdeclaration.imports) {
 			final String importType = CharOperation.charToString(anImport.getImportName()[anImport.getImportName().length - 1]);


### PR DESCRIPTION
I found that `hasTypeInImports` may throw a NullPointerException due to `context.compilationunitdeclaration.imports` being null. I'm not entirely sure if this is the correct place to fix the bug but at least this PR shows that there is one.