### PR TITLE
fix(filter): fixes NPE in VariableAccessFilter when the getVariable()  is null (e.g. super)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
@@ -33,12 +33,15 @@ public class VariableAccessFilter<T extends CtVariableAccess<?>> implements Filt
 	 * 		the accessed variable
 	 */
 	public VariableAccessFilter(CtVariableReference<?> variable) {
+		if (variable == null) {
+			throw new IllegalArgumentException("The parameter variable cannot be null.");
+		}
 		this.variable = variable;
 	}
 
 	@Override
 	public boolean matches(T variableAccess) {
-		return variableAccess.getVariable().equals(variable);
+		return variable.equals(variableAccess.getVariable());
 	}
 
 }

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -12,6 +12,7 @@ import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
@@ -35,6 +36,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.declaration.CtMethodImpl;
 import spoon.test.filters.testclasses.AbstractTostada;
 import spoon.test.filters.testclasses.Antojito;
+import spoon.test.filters.testclasses.FieldAccessFilterTacos;
 import spoon.test.filters.testclasses.ITostada;
 import spoon.test.filters.testclasses.SubTostada;
 import spoon.test.filters.testclasses.Tacos;
@@ -47,6 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class FilterTest {
@@ -89,6 +92,18 @@ public class FilterTest {
 		CtFieldReference<?> ref = (CtFieldReference<?>)(elements.get(0)).getReference();
 		List<CtFieldAccess<?>> expressions = foo.getElements(new FieldAccessFilter(ref));
 		assertEquals(2, expressions.size());
+
+		final Factory build = build(FieldAccessFilterTacos.class);
+		final CtType<FieldAccessFilterTacos> fieldAccessFilterTacos = build.Type().get(FieldAccessFilterTacos.class);
+
+		try {
+			List<CtField> fields = fieldAccessFilterTacos.getElements(new TypeFilter<CtField>(CtField.class));
+			for (CtField ctField : fields) {
+				fieldAccessFilterTacos.getElements(new FieldAccessFilter(ctField.getReference()));
+			}
+		} catch (NullPointerException e) {
+			fail("FieldAccessFilter must not throw a NPE.");
+		}
 	}
 
 

--- a/src/test/java/spoon/test/filters/testclasses/FieldAccessFilterTacos.java
+++ b/src/test/java/spoon/test/filters/testclasses/FieldAccessFilterTacos.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.test.filters.testclasses;
+
+import java.util.ArrayList;
+
+public class FieldAccessFilterTacos extends ArrayList {
+	private int myfield = 0;
+
+	FieldAccessFilterTacos () {
+		super();
+		this.myfield = 0;
+	}
+
+	public void m() {
+		myfield = super.size();
+		Object o = super.get(myfield);
+	}
+}


### PR DESCRIPTION
close #639 