### PR TITLE
Replace CtClass.constructors model from Set to List

### DIFF
--- a/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
+++ b/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
@@ -37,6 +37,9 @@ public final class ModelElementContainerDefaultCapacities {
      * than ArrayList's default of 10.
      */
 
+	// JDK 7 average is 1.467
+	public static final int CONSTRUCTORS_DEFAULT_CAPACITY = 2;
+
 	// JDK 7 average is 1.063 (methods), 1.207 (constructors)
 	public static final int PARAMETERS_CONTAINER_DEFAULT_CAPACITY = 2;
 

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -17,7 +17,6 @@
 package spoon.reflect.declaration;
 
 import java.util.List;
-import java.util.Set;
 
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtTypeReference;
@@ -48,7 +47,7 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	 * Returns the constructors of this class. This includes the default
 	 * constructor if this class has no constructors explicitly declared.
 	 */
-	Set<CtConstructor<T>> getConstructors();
+	List<CtConstructor<T>> getConstructors();
 
 	/**
 	 * Sets the anonymous blocks of this class.
@@ -74,7 +73,7 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	/**
 	 * Sets the constructors for this class.
 	 */
-	<C extends CtClass<T>> C setConstructors(Set<CtConstructor<T>> constructors);
+	<C extends CtClass<T>> C setConstructors(List<CtConstructor<T>> constructors);
 
 	/**
 	 * Adds a constructor to this class.

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -34,10 +34,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.ANONYMOUS_EXECUTABLES_CONTAINER_DEFAULT_CAPACITY;
+import static spoon.reflect.ModelElementContainerDefaultCapacities.CONSTRUCTORS_DEFAULT_CAPACITY;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtClass}.
@@ -49,7 +48,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 
 	List<CtAnonymousExecutable> anonymousExecutables = emptyList();
 
-	Set<CtConstructor<T>> constructors = emptySet();
+	List<CtConstructor<T>> constructors = emptyList();
 
 	CtTypeReference<?> superClass;
 
@@ -80,7 +79,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public Set<CtConstructor<T>> getConstructors() {
+	public List<CtConstructor<T>> getConstructors() {
 		return constructors;
 	}
 
@@ -120,9 +119,9 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public <C extends CtClass<T>> C setConstructors(Set<CtConstructor<T>> constructors) {
-		if (this.constructors == CtElementImpl.<CtConstructor<T>>emptySet()) {
-			this.constructors = new TreeSet<CtConstructor<T>>();
+	public <C extends CtClass<T>> C setConstructors(List<CtConstructor<T>> constructors) {
+		if (this.constructors == CtElementImpl.<CtConstructor<T>>emptyList()) {
+			this.constructors = new ArrayList<CtConstructor<T>>(constructors.size());
 		}
 		this.constructors.clear();
 		for (CtConstructor<T> constructor : constructors) {
@@ -133,12 +132,9 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 
 	@Override
 	public <C extends CtClass<T>> C addConstructor(CtConstructor<T> constructor) {
-		if (constructors == CtElementImpl.<CtConstructor<T>>emptySet()) {
-			constructors = new TreeSet<CtConstructor<T>>();
+		if (constructors == CtElementImpl.<CtConstructor<T>>emptyList()) {
+			constructors = new ArrayList<CtConstructor<T>>(CONSTRUCTORS_DEFAULT_CAPACITY);
 		}
-		// this needs to be done because of the set that needs the constructor's
-		// signature : we should use lists!!!
-		// TODO: CHANGE SETS TO LIST TO AVOID HAVING TO DO THIS
 		constructor.setParent(this);
 		constructors.add(constructor);
 		return (C) this;
@@ -149,7 +145,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 		if (!constructors.isEmpty()) {
 			if (constructors.size() == 1) {
 				if (constructors.contains(constructor)) {
-					constructors = CtElementImpl.<CtConstructor<T>>emptySet();
+					constructors = CtElementImpl.<CtConstructor<T>>emptyList();
 				}
 			} else {
 				constructors.remove(constructor);

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -64,6 +64,7 @@ import spoon.template.TemplateParameter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Iterator;
 import java.util.TreeSet;
 
 class SkipException extends SpoonException {
@@ -186,9 +187,10 @@ public class SubstitutionVisitor extends CtScanner {
 					ctClass.removeMethod(m);
 				}
 			}
-			for (CtConstructor<?> c : new TreeSet<CtConstructor<?>>(ctClass.getConstructors())) {
+			for (Iterator<CtConstructor<T>> it = ctClass.getConstructors().iterator(); it.hasNext();) {
+				CtConstructor<?> c = it.next();
 				if (c.getAnnotation(Local.class) != null) {
-					ctClass.getConstructors().remove(c);
+					it.remove();
 				}
 			}
 			for (CtField<?> field : new TreeSet<CtField<?>>(ctClass.getFields())) {

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -233,7 +233,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		}
 	}
 
-	class CtClassConstructorsReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
+	class CtClassConstructorsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
 		private spoon.reflect.declaration.CtClass element;
 
 		CtClassConstructorsReplaceListener(spoon.reflect.declaration.CtClass element) {
@@ -241,7 +241,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		}
 
 		@java.lang.Override
-		public void set(java.util.Set replace) {
+		public void set(java.util.List replace) {
 			this.element.setConstructors(replace);
 		}
 	}
@@ -1295,7 +1295,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(ctClass.getAnonymousExecutables(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassAnonymousExecutablesReplaceListener(ctClass));
 		replaceInSetIfExist(ctClass.getNestedTypes(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeNestedTypesReplaceListener(ctClass));
 		replaceInListIfExist(ctClass.getFields(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassFieldsReplaceListener(ctClass));
-		replaceInSetIfExist(ctClass.getConstructors(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassConstructorsReplaceListener(ctClass));
+		replaceInListIfExist(ctClass.getConstructors(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassConstructorsReplaceListener(ctClass));
 		replaceInSetIfExist(ctClass.getMethods(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeMethodsReplaceListener(ctClass));
 		replaceInListIfExist(ctClass.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(ctClass));
 	}
@@ -1334,7 +1334,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(ctEnum.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(ctEnum));
 		replaceInSetIfExist(ctEnum.getSuperInterfaces(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeInformationSuperInterfacesReplaceListener(ctEnum));
 		replaceInListIfExist(ctEnum.getFields(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassFieldsReplaceListener(ctEnum));
-		replaceInSetIfExist(ctEnum.getConstructors(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassConstructorsReplaceListener(ctEnum));
+		replaceInListIfExist(ctEnum.getConstructors(), new spoon.support.visitor.replace.ReplacementVisitor.CtClassConstructorsReplaceListener(ctEnum));
 		replaceInSetIfExist(ctEnum.getMethods(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeMethodsReplaceListener(ctEnum));
 		replaceInSetIfExist(ctEnum.getNestedTypes(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeNestedTypesReplaceListener(ctEnum));
 		replaceInListIfExist(ctEnum.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(ctEnum));

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -260,7 +260,7 @@ public class AnnotationTest {
 		assertEquals(CtAnnotatedElementType.PARAMETER, annotations.get(0).getAnnotatedElementType());
 
 		// load constructor of the clazz and check annotated element type of the constructor annotation
-		Set<? extends CtConstructor<?>> constructors = clazz.getConstructors();
+		List<? extends CtConstructor<?>> constructors = clazz.getConstructors();
 		assertEquals(1, constructors.size());
 
 		CtConstructor<?> constructor = constructors.iterator().next();

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -11,6 +11,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.test.ctClass.testclasses.Foo;
 import spoon.test.ctClass.testclasses.Pozole;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -98,7 +99,7 @@ public class CtClassTest {
 
 		assertEquals("1Cook", cook.getSimpleName());
 		assertEquals("spoon.test.ctClass.testclasses.Pozole$1Cook", cook.getQualifiedName());
-		final Set<? extends CtConstructor<?>> constructors = cook.getConstructors();
+		final List<? extends CtConstructor<?>> constructors = cook.getConstructors();
 		final String expectedConstructor = "public Cook() {" + System.lineSeparator() + "}";
 		assertEquals(expectedConstructor, constructors.toArray(new CtConstructor[constructors.size()])[0].toString());
 		assertEquals("final java.lang.Class<Cook> cookClass = Cook.class", cook.getMethod("m").getBody().getStatement(0).toString());


### PR DESCRIPTION
`// TODO: CHANGE SETS TO LIST TO AVOID HAVING TO DO THIS` says for itself, and I also encountered this issue in my use cases.

Generally, it seems hardly ever sensible to have any AST children node collections as Sets. Because finally it's AST user responsibility to generate correct code.  I think, framework shouldn't be "too smart" trying to do something for us in terms of Java source code semantics, i. e. making constructors/methods unique. It will be a java compiler error, finally, if we have two identical methods/constructors in a class body. On the other hand, pattern clone method -> insert into method list -> update list of arguments, body.. is pretty reasonable, but it is ruled out by the current Set<CtMethod> (and constructors, regaring this PR).

Though all collections should be Lists (IMO), even for lists we should probably check that some element (java object) is not inserted twice into any list. Because it is definitely a programmic error (like addressed by #645 ) and could lead to hard to find bugs, if replace/clone/traverse takes place.