### PR TITLE
Improvements to collections: Make CtElementImpl.emptyList() and emptySet() DIFFERENT objects

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -37,6 +37,7 @@ import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -194,7 +195,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 		}
 		CtPackageReference pack = ((CtTypeReference<?>) imports
 				.get(simpleType.getSimpleName())).getPackage();
-		Collection<CtTypeReference<?>> refs = new ArrayList<CtTypeReference<?>>();
+		List<CtTypeReference<?>> refs = new ArrayList<CtTypeReference<?>>();
 		for (CtTypeReference<?> ref : imports.values()) {
 			// ignore non-top-level type
 			if (ref.getPackage() != null) {
@@ -208,7 +209,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 				}
 			}
 		}
-		return Collections.unmodifiableCollection(refs);
+		return Collections.unmodifiableList(refs);
 	}
 
 	/**

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -222,7 +222,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 					if (!Modifier.isFinal(f.getModifiers()) && !Modifier.isStatic(f.getModifiers())) {
 						if (fieldValue instanceof Collection) {
 							Collection<Object> c;
-							if (fieldValue == CtElementImpl.emptyCollection() || fieldValue == CtElementImpl.emptySet()) {
+							if (fieldValue == CtElementImpl.emptyList() || fieldValue == CtElementImpl.emptySet()) {
 								c = (Collection<Object>) fieldValue;
 							} else {
 								c = (Collection<Object>) fieldValue.getClass().getMethod("clone").invoke(fieldValue);

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -29,6 +29,7 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.support.reflect.declaration.CtElementImpl;
+import spoon.support.util.EmptyIterator;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -201,6 +202,9 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 
 	@Override
 	public Iterator<CtStatement> iterator() {
+		if (getStatements().isEmpty()) {
+			return EmptyIterator.instance();
+		}
 		// we have to both create a defensive object and an unmodifiable list
 		// with only Collections.unmodifiableList you can modify the defensive object
 		// with only new ArrayList it breaks the encapsulation

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -30,7 +30,6 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
@@ -148,7 +147,7 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 
 	@Override
 	public List<CtTypeReference<?>> getActualTypeArguments() {
-		return Collections.unmodifiableList(actualTypeArguments);
+		return unmodifiableList(actualTypeArguments);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -29,7 +29,6 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -79,7 +78,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@Override
 	public List<CtParameter<?>> getParameters() {
-		return Collections.unmodifiableList(parameters);
+		return unmodifiableList(parameters);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -239,7 +239,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 		for (CtExecutable<?> c : getConstructors()) {
 			l.add(c.getReference());
 		}
-		return Collections.unmodifiableCollection(l);
+		return Collections.unmodifiableList(l);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -33,6 +33,8 @@ import spoon.reflect.visitor.ModelConsistencyChecker;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.ReferenceFilter;
 import spoon.reflect.visitor.filter.AnnotationFilter;
+import spoon.support.util.EmptyClearableList;
+import spoon.support.util.EmptyClearableSet;
 import spoon.support.visitor.EqualVisitor;
 import spoon.support.visitor.HashcodeVisitor;
 import spoon.support.visitor.SignaturePrinter;
@@ -62,79 +64,27 @@ public abstract class CtElementImpl implements CtElement, Serializable, Comparab
 	protected static final Logger LOGGER = Logger.getLogger(CtElementImpl.class);
 	public static final String ERROR_MESSAGE_TO_STRING = "Error in printing the node. One parent isn't initialized!";
 
-	// we don't use Collections.unmodifiableList and Collections.unmodifiableSet
-	// because we need clear() for all set* methods
-	// and UnmodifiableList and unmodifiableCollection are not overridable (not visible grrrr)
-	private static class UnModifiableCollection extends ArrayList<Object> implements Set<Object> {
-		private static final long serialVersionUID = 1L;
-
-		@Override
-		public Object set(int index, Object element) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void add(int index, Object element) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Object remove(int index) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean addAll(int index, Collection<? extends Object> c) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public <T> T[] toArray(T[] a) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean add(java.lang.Object e) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean containsAll(Collection<?> c) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean addAll(Collection<?> c) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean retainAll(Collection<?> c) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean removeAll(Collection<?> c) {
-			throw new UnsupportedOperationException();
-		}
-	}
-
-	private static final Set<Object> EMPTY_SET = new UnModifiableCollection();
-	private static final Set<Object> EMPTY_LIST = new UnModifiableCollection();
-
-	@SuppressWarnings("unchecked")
 	public static <T> List<T> emptyList() {
-		return (List<T>) EMPTY_LIST;
+		return EmptyClearableList.instance();
 	}
 
-	@SuppressWarnings("unchecked")
 	public static <T> Set<T> emptySet() {
-		return (Set<T>) EMPTY_SET;
+		return EmptyClearableSet.instance();
 	}
 
-	@SuppressWarnings("unchecked")
+	public static <T> List<T> unmodifiableList(List<T> list) {
+		return list.isEmpty() ? Collections.<T>emptyList() : Collections.unmodifiableList(list);
+	}
+
+	/**
+	 * Returns an empty collection.
+	 * @param <T> type of elements
+	 * @return an empty collection
+	 * @deprecated use {@link #emptyList()} or {@link #emptySet()} instead
+	 */
+	@Deprecated
 	public static <T> Collection<T> emptyCollection() {
-		return (Collection<T>) EMPTY_LIST;
+		return emptyList();
 	}
 
 	public String getSignature() {
@@ -225,7 +175,7 @@ public abstract class CtElementImpl implements CtElement, Serializable, Comparab
 	}
 
 	public List<CtAnnotation<? extends Annotation>> getAnnotations() {
-		return Collections.unmodifiableList(annotations);
+		return unmodifiableList(annotations);
 	}
 
 	public String getDocComment() {
@@ -460,7 +410,7 @@ public abstract class CtElementImpl implements CtElement, Serializable, Comparab
 
 	@Override
 	public List<CtComment> getComments() {
-		return Collections.unmodifiableList(comments);
+		return unmodifiableList(comments);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.reference.CtExecutableReference;
@@ -51,12 +52,15 @@ public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> 
 
 	@Override
 	public Collection<CtExecutableReference<?>> getDeclaredExecutables() {
-		List<CtExecutableReference<?>> l =
-				new ArrayList<CtExecutableReference<?>>(super.getDeclaredExecutables());
-		for (CtTypeReference<?> sup : getSuperInterfaces()) {
+		Set<CtTypeReference<?>> superInterfaces = getSuperInterfaces();
+		if (superInterfaces.isEmpty()) {
+			return super.getDeclaredExecutables();
+		}
+		List<CtExecutableReference<?>> l = new ArrayList<CtExecutableReference<?>>(super.getDeclaredExecutables());
+		for (CtTypeReference<?> sup : superInterfaces) {
 			l.addAll(sup.getAllExecutables());
 		}
-		return Collections.unmodifiableCollection(l);
+		return Collections.unmodifiableList(l);
 	}
 
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -415,11 +415,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public Collection<CtFieldReference<?>> getDeclaredFields() {
+		if (getFields().isEmpty()) {
+			return Collections.emptyList();
+		}
 		List<CtFieldReference<?>> l = new ArrayList<CtFieldReference<?>>(getFields().size());
 		for (CtField<?> f : getFields()) {
 			l.add(f.getReference());
 		}
-		return Collections.unmodifiableCollection(l);
+		return Collections.unmodifiableList(l);
 	}
 
 	/**
@@ -685,11 +688,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public Collection<CtExecutableReference<?>> getDeclaredExecutables() {
+		if (getMethods().isEmpty()) {
+			return Collections.emptyList();
+		}
 		List<CtExecutableReference<?>> l = new ArrayList<CtExecutableReference<?>>(getMethods().size());
 		for (CtExecutable<?> m : getMethods()) {
 			l.add(m.getReference());
 		}
-		return Collections.unmodifiableCollection(l);
+		return Collections.unmodifiableList(l);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -37,7 +37,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -181,11 +180,15 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl
 
 	@Override
 	public List<CtTypeReference<?>> getParameters() {
-		return Collections.unmodifiableList(parameters);
+		return unmodifiableList(parameters);
 	}
 
 	@Override
 	public <C extends CtExecutableReference<T>> C setParameters(List<CtTypeReference<?>> parameters) {
+		if (parameters.isEmpty()) {
+			this.parameters = CtElementImpl.emptyList();
+			return (C) this;
+		}
 		if (this.parameters == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.parameters = new ArrayList<CtTypeReference<?>>();
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_BOUNDS_CONTAINER_DEFAULT_CAPACITY;
@@ -37,7 +36,7 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 
 	@Override
 	public List<CtTypeReference<?>> getBounds() {
-		return Collections.unmodifiableList(bounds);
+		return unmodifiableList(bounds);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/util/EmptyClearableList.java
+++ b/src/main/java/spoon/support/util/EmptyClearableList.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.util;
+
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.NoSuchElementException;
+import java.util.RandomAccess;
+
+public final class EmptyClearableList<E> extends AbstractList<E> implements RandomAccess, Serializable {
+	private static final long serialVersionUID = 0L;
+
+	private static final EmptyClearableList<Object> EMPTY_LIST = new EmptyClearableList<Object>();
+
+	public static <T> List<T> instance() {
+		return (List<T>) EMPTY_LIST;
+	}
+
+	private EmptyClearableList() {
+	}
+
+	@Override
+	public void clear() {
+		// do nothing
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return EmptyIterator.instance();
+	}
+
+	@Override
+	public ListIterator<E> listIterator() {
+		return (ListIterator<E>) EmptyListIterator.EMPTY_LIST_ITERATOR;
+	}
+
+	@Override
+	public int size() {
+		return 0;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
+
+	@Override
+	public boolean contains(Object obj) {
+		return false;
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return c.isEmpty();
+	}
+
+	@Override
+	public Object[] toArray() {
+		return new Object[0];
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		if (a.length > 0) {
+			a[0] = null;
+		}
+		return a;
+	}
+
+	@Override
+	public E get(int index) {
+		throw new IndexOutOfBoundsException("Index: " + index);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return (o instanceof List) && ((List<?>) o).isEmpty();
+	}
+
+	@Override
+	public int hashCode() {
+		return 1;
+	}
+
+	// Preserves singleton property
+	private Object readResolve() {
+		return EMPTY_LIST;
+	}
+
+	private static final class EmptyListIterator<E> extends EmptyIterator<E> implements ListIterator<E> {
+		static final EmptyListIterator<Object> EMPTY_LIST_ITERATOR = new EmptyListIterator<Object>();
+
+		@Override
+		public boolean hasPrevious() {
+			return false;
+		}
+
+		@Override
+		public E previous() {
+			throw new NoSuchElementException();
+		}
+
+		@Override
+		public int nextIndex() {
+			return 0;
+		}
+
+		@Override
+		public int previousIndex() {
+			return -1;
+		}
+
+		@Override
+		public void set(E e) {
+			throw new IllegalStateException();
+		}
+
+		@Override
+		public void add(E e) {
+			throw new UnsupportedOperationException();
+		}
+	}
+}

--- a/src/main/java/spoon/support/util/EmptyClearableSet.java
+++ b/src/main/java/spoon/support/util/EmptyClearableSet.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.util;
+
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+public final class EmptyClearableSet<E> extends AbstractSet<E> implements Serializable {
+	private static final long serialVersionUID = 0L;
+
+	private static final EmptyClearableSet<Object> EMPTY_SET = new EmptyClearableSet<Object>();
+
+	public static <T> Set<T> instance() {
+		return (Set<T>) EMPTY_SET;
+	}
+
+	private EmptyClearableSet() {
+	}
+
+	@Override
+	public void clear() {
+		// do nothing
+	}
+
+	@Override
+	public Iterator<E> iterator() {
+		return EmptyIterator.instance();
+	}
+
+	@Override
+	public int size() {
+		return 0;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
+
+	@Override
+	public boolean contains(Object obj) {
+		return false;
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return c.isEmpty();
+	}
+
+	@Override
+	public Object[] toArray() {
+		return new Object[0];
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		if (a.length > 0) {
+			a[0] = null;
+		}
+		return a;
+	}
+
+	// Preserves singleton property
+	private Object readResolve() {
+		return EMPTY_SET;
+	}
+}

--- a/src/main/java/spoon/support/util/EmptyIterator.java
+++ b/src/main/java/spoon/support/util/EmptyIterator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class EmptyIterator<E> implements Iterator<E> {
+	private static final EmptyIterator<Object> EMPTY_ITERATOR = new EmptyIterator<Object>();
+
+	public static <T> Iterator<T> instance() {
+		return (Iterator<T>) EMPTY_ITERATOR;
+	}
+
+	EmptyIterator() {
+	}
+
+	@Override
+	public boolean hasNext() {
+		return false;
+	}
+
+	@Override
+	public E next() {
+		throw new NoSuchElementException();
+	}
+
+	@Override
+	public void remove() {
+		throw new IllegalStateException();
+	}
+}


### PR DESCRIPTION
... because otherwise they cannot conform both java.util.List and java.util.Set equals()/hashCode() contract; never use Collections.unmodifiableCollection() (if wrapping list or set) because it narrows possible use on the client side without actual need; try to avoid creating unmodifiableList/Set(children) wrapper when the wrapped children is already an empty collection