### PR TITLE
refactor(api): Uses actual types of executable ref in constructor call.

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -565,7 +565,6 @@ public abstract class CtScanner implements CtVisitor {
 		scan(ctConstructorCall.getTypeCasts());
 		scan(ctConstructorCall.getExecutable());
 		scan(ctConstructorCall.getTarget());
-		scan(ctConstructorCall.getActualTypeArguments());
 		scan(ctConstructorCall.getArguments());
 		scan(ctConstructorCall.getComments());
 		exit(ctConstructorCall);
@@ -577,7 +576,6 @@ public abstract class CtScanner implements CtVisitor {
 		scan(newClass.getTypeCasts());
 		scan(newClass.getExecutable());
 		scan(newClass.getTarget());
-		scan(newClass.getActualTypeArguments());
 		scan(newClass.getArguments());
 		scan(newClass.getAnonymousClass());
 		scan(newClass.getComments());

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -32,14 +32,12 @@ import spoon.support.reflect.declaration.CtElementImpl;
 import java.util.ArrayList;
 import java.util.List;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 
 public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>>
 		implements CtConstructorCall<T> {
 	private static final long serialVersionUID = 1L;
 
-	List<CtTypeReference<?>> actualTypeArguments = CtElementImpl.emptyList();
 	List<CtExpression<?>> arguments = emptyList();
 	CtExecutableReference<T> executable;
 	String label;
@@ -147,38 +145,28 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 
 	@Override
 	public List<CtTypeReference<?>> getActualTypeArguments() {
-		return unmodifiableList(actualTypeArguments);
+		return getExecutable() == null ? CtElementImpl.<CtTypeReference<?>>emptyList() : getExecutable().getActualTypeArguments();
 	}
 
 	@Override
 	public <T extends CtGenericElementReference> T setActualTypeArguments(List<CtTypeReference<?>> actualTypeArguments) {
-		if (this.actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
-			this.actualTypeArguments = new ArrayList<CtTypeReference<?>>(
-					CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
-		}
-		this.actualTypeArguments.clear();
-		for (CtTypeReference<?> actualTypeArgument : actualTypeArguments) {
-			addActualTypeArgument(actualTypeArgument);
+		if (getExecutable() != null) {
+			getExecutable().setActualTypeArguments(actualTypeArguments);
 		}
 		return (T) this;
 	}
 
 	@Override
-	public <T extends CtGenericElementReference> T addActualTypeArgument(
-			CtTypeReference<?> actualTypeArgument) {
-		if (actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
-			actualTypeArguments = new ArrayList<CtTypeReference<?>>(
-					CONSTRUCTOR_CALL_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+	public <T extends CtGenericElementReference> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+		if (getExecutable() != null) {
+			getExecutable().addActualTypeArgument(actualTypeArgument);
 		}
-		actualTypeArgument.setParent(this);
-		actualTypeArguments.add(actualTypeArgument);
 		return (T) this;
 	}
 
 	@Override
 	public boolean removeActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
-		return actualTypeArguments != CtElementImpl.<CtTypeReference<?>>emptyList()
-				&& actualTypeArguments.remove(actualTypeArgument);
+		return getExecutable() != null && getExecutable().removeActualTypeArgument(actualTypeArgument);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1486,7 +1486,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(ctConstructorCall.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(ctConstructorCall));
 		replaceElementIfExist(ctConstructorCall.getExecutable(), new spoon.support.visitor.replace.ReplacementVisitor.CtAbstractInvocationExecutableReplaceListener(ctConstructorCall));
 		replaceElementIfExist(ctConstructorCall.getTarget(), new spoon.support.visitor.replace.ReplacementVisitor.CtTargetedExpressionTargetReplaceListener(ctConstructorCall));
-		replaceInListIfExist(ctConstructorCall.getActualTypeArguments(), new spoon.support.visitor.replace.ReplacementVisitor.CtGenericElementReferenceActualTypeArgumentsReplaceListener(ctConstructorCall));
 		replaceInListIfExist(ctConstructorCall.getArguments(), new spoon.support.visitor.replace.ReplacementVisitor.CtAbstractInvocationArgumentsReplaceListener(ctConstructorCall));
 		replaceInListIfExist(ctConstructorCall.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(ctConstructorCall));
 	}
@@ -1496,7 +1495,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(newClass.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(newClass));
 		replaceElementIfExist(newClass.getExecutable(), new spoon.support.visitor.replace.ReplacementVisitor.CtAbstractInvocationExecutableReplaceListener(newClass));
 		replaceElementIfExist(newClass.getTarget(), new spoon.support.visitor.replace.ReplacementVisitor.CtTargetedExpressionTargetReplaceListener(newClass));
-		replaceInListIfExist(newClass.getActualTypeArguments(), new spoon.support.visitor.replace.ReplacementVisitor.CtGenericElementReferenceActualTypeArgumentsReplaceListener(newClass));
 		replaceInListIfExist(newClass.getArguments(), new spoon.support.visitor.replace.ReplacementVisitor.CtAbstractInvocationArgumentsReplaceListener(newClass));
 		replaceElementIfExist(newClass.getAnonymousClass(), new spoon.support.visitor.replace.ReplacementVisitor.CtNewClassAnonymousClassReplaceListener(newClass));
 		replaceInListIfExist(newClass.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(newClass));

--- a/src/test/java/spoon/test/parent/ParentContractTest.java
+++ b/src/test/java/spoon/test/parent/ParentContractTest.java
@@ -5,12 +5,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
-
 import spoon.SpoonException;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtNewClass;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtAnonymousExecutable;
@@ -117,8 +115,11 @@ public class ParentContractTest<T extends CtVisitable> {
 			if (o instanceof CtCatchVariable && "setDefaultExpression".equals(setter.getName())) continue;
 			if (o instanceof CtConstructor && "setType".equals(setter.getName())) continue;
 			if (o instanceof CtInvocation && "setType".equals(setter.getName())) continue;
-			if (o instanceof CtConstructorCall && "setType".equals(setter.getName())) continue;
-			if (o instanceof CtNewClass && "setType".equals(setter.getName())) continue;
+			if (o instanceof CtConstructorCall || CtConstructorCall.class.isAssignableFrom(o.getClass())) {
+				if ("setType".equals(setter.getName())) continue;
+				if ("setActualTypeArguments".equals(setter.getName())) continue;
+				if ("addActualTypeArgument".equals(setter.getName())) continue;
+			}
 			if (o instanceof CtAnonymousExecutable && ("addParameter".equals(setter.getName()) || "setParameters".equals(setter.getName()))) continue;
 			if (o instanceof CtAnonymousExecutable && ("addThrownType".equals(setter.getName()) || "setThrownTypes".equals(setter.getName()))) continue;
 			if (o instanceof CtAnonymousExecutable && "setType".equals(setter.getName())) continue;
@@ -133,12 +134,12 @@ public class ParentContractTest<T extends CtVisitable> {
 				// we check that setParent has been called
 				verify(mockedArgument).setParent((CtElement) receiver);
 			} catch (AssertionError e) {
-				Assert.fail("call setParent contract failed for "+setter.toString()+" "+e.toString());				
+				Assert.fail("call setParent contract failed for "+setter.toString()+" "+e.toString());
 			} catch (InvocationTargetException e) {
 				if (e.getCause() instanceof RuntimeException) {
 					throw e.getCause();
 				} else {
-					throw new SpoonException(e.getCause()); 
+					throw new SpoonException(e.getCause());
 				}
 			}
 		}


### PR DESCRIPTION
An interesting enhancement can be to add `CtGenericElementReference` on `CtInvocation` to write something like this : `ctInvocation.getActualTypeArguments()`. For now, you must  pass by the `CtExecutableReference`: `ctInvocation.getExecutable().getActualTypeArguments()`. It isn't really easy to use.

What do you think @monperrus?

Closes #599