### PR TITLE
fix(parent): Avoid NPE with CtElement#hasParent(CtElement)

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -22,6 +22,7 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtReference;
@@ -358,7 +359,7 @@ public abstract class CtElementImpl implements CtElement, Serializable, Comparab
 
 	@Override
 	public boolean hasParent(CtElement candidate) throws ParentNotInitializedException {
-		return getParent() == candidate || getParent().hasParent(candidate);
+		return !CtPackage.TOP_LEVEL_PACKAGE_NAME.equals(getFactory().getModel().getRootPackage().getSimpleName()) && (getParent() == candidate || getParent().hasParent(candidate));
 	}
 
 	@Override

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -36,9 +36,11 @@ import spoon.test.replace.testclasses.Tacos;
 import java.util.Stack;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class ParentTest {
@@ -124,12 +126,12 @@ public class ParentTest {
 		assertNotNull(pack2);
 		assertEquals(CtPackage.TOP_LEVEL_PACKAGE_NAME, panini.getPackage().getSimpleName());
 		CtPackage pack1 = factory.Package().getRootPackage();
-		
+
 		// the factory are not the same
 		assertNotEquals(factory, launcher.getFactory());
 		// so the root packages are not deeply equals
 		assertNotEquals(pack1, pack2);
-		
+
 		final CtTypeReference<?> burritos = panini.getReferences(new ReferenceTypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
 			@Override
 			public boolean matches(CtTypeReference<?> reference) {
@@ -278,4 +280,20 @@ public class ParentTest {
 		assertNotEquals(statement, statementParent);
 	}
 
+	@Test
+	public void testHasParent() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/reference-package/Panini.java");
+		launcher.setSourceOutputDirectory("./target/trash");
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.run();
+
+		try {
+			final CtType<Object> aPanini = launcher.getFactory().Type().get("Panini");
+			assertNotNull(aPanini);
+			assertFalse(aPanini.hasParent(aPanini.getFactory().Core().createAnnotation()));
+		} catch (NullPointerException e) {
+			fail();
+		}
+	}
 }


### PR DESCRIPTION
Closes #679