### PR TITLE
fix: typecast on conditional

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
+++ b/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
@@ -189,6 +189,7 @@ public abstract class CtBiScannerDefault extends spoon.reflect.visitor.CtAbstrac
 		biScan(conditional.getThenExpression(), other.getThenExpression());
 		biScan(conditional.getElseExpression(), other.getElseExpression());
 		biScan(conditional.getComments(), other.getComments());
+		biScan(conditional.getTypeCasts(), other.getTypeCasts());
 		exit(conditional);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -316,6 +316,7 @@ public abstract class CtScanner implements CtVisitor {
 		scan(conditional.getThenExpression());
 		scan(conditional.getElseExpression());
 		scan(conditional.getComments());
+		scan(conditional.getTypeCasts());
 		exit(conditional);
 	}
 

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -192,6 +192,7 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 		aCtConditional.setThenExpression(spoon.support.visitor.equals.CloneHelper.clone(conditional.getThenExpression()));
 		aCtConditional.setElseExpression(spoon.support.visitor.equals.CloneHelper.clone(conditional.getElseExpression()));
 		aCtConditional.setComments(spoon.support.visitor.equals.CloneHelper.clone(conditional.getComments()));
+		aCtConditional.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(conditional.getTypeCasts()));
 		this.other = aCtConditional;
 	}
 

--- a/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
@@ -186,6 +186,7 @@ public class EqualsVisitor extends spoon.reflect.visitor.CtAbstractBiScanner {
 		biScan(conditional.getCondition(), other.getCondition());
 		biScan(conditional.getThenExpression(), other.getThenExpression());
 		biScan(conditional.getElseExpression(), other.getElseExpression());
+		biScan(conditional.getTypeCasts(), other.getTypeCasts());
 		exit(conditional);
 	}
 

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1307,6 +1307,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceElementIfExist(conditional.getThenExpression(), new spoon.support.visitor.replace.ReplacementVisitor.CtConditionalThenExpressionReplaceListener(conditional));
 		replaceElementIfExist(conditional.getElseExpression(), new spoon.support.visitor.replace.ReplacementVisitor.CtConditionalElseExpressionReplaceListener(conditional));
 		replaceInListIfExist(conditional.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(conditional));
+		replaceInListIfExist(conditional.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(conditional));
 	}
 
 	public <T> void visitCtConstructor(final spoon.reflect.declaration.CtConstructor<T> c) {

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -1,7 +1,10 @@
 package spoon.reflect.ast;
 
+import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.code.CtConditional;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
@@ -69,5 +72,31 @@ public class CloneTest {
 				return "CtElement".equals(intrface.getSimpleName());
 			}
 		}.scan(launcher.getModel().getRootPackage());
+	}
+
+	@Test
+	public void testCloneCastConditional() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.setSourceOutputDirectory("./target/trash");
+
+		launcher.addInputResource("./src/test/resources/spoon/test/visitor/ConditionalRes.java");
+
+		launcher.addProcessor(new AbstractProcessor<CtConditional<?>>() {
+			@Override
+			public void process(CtConditional<?> conditional) {
+				CtConditional clone = conditional.clone();
+				Assert.assertEquals(0, conditional.getTypeCasts().size());
+				Assert.assertEquals(0, clone.getTypeCasts().size());
+				Assert.assertEquals(conditional, clone);
+				conditional.addTypeCast(getFactory().Type().bytePrimitiveType());
+				Assert.assertEquals(1, conditional.getTypeCasts().size());
+				Assert.assertNotEquals(conditional, clone);
+				clone = conditional.clone();
+				Assert.assertEquals(conditional, clone);
+				Assert.assertEquals(1, clone.getTypeCasts().size());
+			}
+		});
+		launcher.run();
 	}
 }

--- a/src/test/resources/spoon/test/visitor/ConditionalRes.java
+++ b/src/test/resources/spoon/test/visitor/ConditionalRes.java
@@ -1,0 +1,5 @@
+public class ConditionalRes {
+
+	byte [] b = new byte [] { true ? 1 : 2};
+
+}


### PR DESCRIPTION
Hello, TypeCast on CtConditional are not cloned or used in equals. Here an example:

Snippet code:
```java
public class ConditionalRes {
	byte [] b = new byte [] { true ? 1 : 2};
}
```
Spoon code:
```java
@Test
public void testCloneCastConditional() throws Exception {
	final Launcher launcher = new Launcher();
	launcher.setSourceOutputDirectory("./target/trash");
	launcher.addInputResource("./src/test/resources/spoon/test/visitor/ConditionalRes.java");
	launcher.addProcessor(new AbstractProcessor<CtConditional<?>>() {
		@Override
		public void process(CtConditional<?> conditional) {
			conditional.addTypeCast(getFactory().Type().bytePrimitiveType());
			CtConditional clone = conditional.clone();
			System.out.println(conditional);
			System.out.println(clone);
			System.out.println(conditional.equals(clone));
		}
	});
	launcher.run();
}
```
Output:

>((byte) (true ? 1 : 2))
>true ? 1 : 2
>true

