### PR TITLE
Lookup dynamically the declaration of all variable references

### DIFF
--- a/src/main/java/spoon/generating/replace/CtListener.java
+++ b/src/main/java/spoon/generating/replace/CtListener.java
@@ -19,7 +19,7 @@ package spoon.generating.replace;
 import spoon.reflect.declaration.CtElement;
 
 class CtListener implements ReplaceListener<CtElement> {
-	private CtElement element;
+	private final CtElement element;
 
 	CtListener(CtElement element) {
 		this.element = element;

--- a/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
@@ -22,12 +22,14 @@ import spoon.reflect.code.CtCatchVariable;
  * This interface defines a reference to {@link spoon.reflect.code.CtCatchVariable}.
  */
 public interface CtCatchVariableReference<T> extends CtVariableReference<T> {
+	@Override
 	CtCatchVariable<T> getDeclaration();
 
 	/**
 	 * Sets the catch variable declaration that corresponds to this catch
 	 * variable reference.
 	 */
+	@Deprecated
 	<C extends CtCatchVariableReference<T>> C setDeclaration(CtCatchVariable<T> declaration);
 
 	@Override

--- a/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
@@ -23,12 +23,14 @@ import spoon.reflect.code.CtLocalVariable;
  * {@link spoon.reflect.code.CtLocalVariable}.
  */
 public interface CtLocalVariableReference<T> extends CtVariableReference<T> {
+	@Override
 	CtLocalVariable<T> getDeclaration();
 
 	/**
 	 * Sets the local variable declaration that corresponds to this local
 	 * variable reference.
 	 */
+	@Deprecated
 	<C extends CtLocalVariableReference<T>> C setDeclaration(CtLocalVariable<T> declaration);
 
 	@Override

--- a/src/main/java/spoon/reflect/reference/CtParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtParameterReference.java
@@ -34,6 +34,7 @@ public interface CtParameterReference<T> extends CtVariableReference<T> {
 	 */
 	<C extends CtParameterReference<T>> C setDeclaringExecutable(CtExecutableReference<?> executable);
 
+	@Override
 	CtParameter<T> getDeclaration();
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1106,7 +1106,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			if (declaration == null) {
 				return true;
 			}
-			return variable.getDeclaration().getModifiers().contains(ModifierKind.FINAL);
+			return declaration.getModifiers().contains(ModifierKind.FINAL);
 		} catch (ParentNotInitializedException e) {
 			return false;
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -61,11 +61,14 @@ public class ContextBuilder {
 
 	boolean isGenericTypeExplicit = true;
 
+	boolean isBuildLambda = false;
+
 	boolean isLambdaParameterImplicitlyTyped = true;
 
 	boolean ignoreComputeImports = false;
 
 	boolean isTypeParameter = false;
+
 
 	/**
 	 * Stack of all parents elements

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -884,7 +884,10 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 
 		if (lambdaExpression.body() != null) {
+			final boolean isBuildLambdaBack = context.isBuildLambda;
+			context.isBuildLambda = true;
 			lambdaExpression.body().traverse(this, blockScope);
+			context.isBuildLambda = isBuildLambdaBack;
 		}
 
 		return false;
@@ -2288,9 +2291,15 @@ public class JDTTreeBuilder extends ASTVisitor {
 			} else {
 				va = factory.Core().createVariableRead();
 			}
-			CtLocalVariableReference ref = factory.Core().createLocalVariableReference();
-			ref.setSimpleName(new String(singleNameReference.token));
-			ref.setDeclaration((CtLocalVariable) this.context.getLocalVariableDeclaration(ref.getSimpleName()));
+			final String name = CharOperation.charToString(singleNameReference.token);
+			CtVariableReference ref;
+			if (context.isBuildLambda) {
+				ref = factory.Core().createParameterReference();
+			} else {
+				ref = factory.Core().createLocalVariableReference();
+				((CtLocalVariableReference) ref).setDeclaration((CtLocalVariable) this.context.getLocalVariableDeclaration(name));
+			}
+			ref.setSimpleName(name);
 			va.setVariable(ref);
 		}
 		if (va != null) {

--- a/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
@@ -16,7 +16,10 @@
  */
 package spoon.support.reflect.reference;
 
+import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 
@@ -36,6 +39,24 @@ public class CtCatchVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> 
 
 	@Override
 	public CtCatchVariable<T> getDeclaration() {
+		if (declaration == null) {
+			CtElement element = this;
+			String name = getSimpleName();
+			CtCatchVariable var;
+			try {
+				do {
+					CtCatch catchBlock = element.getParent(CtCatch.class);
+					if (catchBlock == null) {
+						return null;
+					}
+					var = catchBlock.getParameter();
+					element = catchBlock;
+				} while (!name.equals(var.getSimpleName()));
+			} catch (ParentNotInitializedException e) {
+				return null;
+			}
+			return var;
+		}
 		return declaration;
 	}
 

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -130,10 +130,14 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtField<T> getDeclaration() {
-		final CtField<T> ctField = fromDeclaringType();
+		final CtField<T> ctField = lookupDynamically();
 		if (ctField != null) {
 			return ctField;
 		}
+		return fromDeclaringType();
+	}
+
+	private CtField<T> lookupDynamically() {
 		CtElement element = this;
 		CtField optional = null;
 		String name = getSimpleName();

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -17,6 +17,10 @@
 package spoon.support.reflect.reference;
 
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtStatementList;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 
@@ -36,6 +40,25 @@ public class CtLocalVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> 
 
 	@Override
 	public CtLocalVariable<T> getDeclaration() {
+		if (declaration == null) {
+			CtElement element = this;
+			CtLocalVariable<T> optional = null;
+			String name = getSimpleName();
+			try {
+				do {
+					CtStatementList block = element.getParent(CtStatementList.class);
+					for (CtStatement ctStatement : block.getStatements()) {
+						if (ctStatement instanceof CtLocalVariable && ((CtLocalVariable) ctStatement).getSimpleName().equals(name)) {
+							optional = (CtLocalVariable) ctStatement;
+						}
+					}
+					element = block;
+				} while (optional == null);
+			} catch (ParentNotInitializedException e) {
+				return null;
+			}
+			return optional;
+		}
 		return declaration;
 	}
 

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -47,6 +47,9 @@ public class CtLocalVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> 
 			try {
 				do {
 					CtStatementList block = element.getParent(CtStatementList.class);
+					if (block == null) {
+						return null;
+					}
 					for (CtStatement ctStatement : block.getStatements()) {
 						if (ctStatement instanceof CtLocalVariable && ((CtLocalVariable) ctStatement).getSimpleName().equals(name)) {
 							optional = (CtLocalVariable) ctStatement;

--- a/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
@@ -43,10 +43,14 @@ public class CtParameterReferenceImpl<T> extends CtVariableReferenceImpl<T> impl
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtParameter<T> getDeclaration() {
-		final CtParameter<T> ctParameter = fromDeclaringExecutable();
+		final CtParameter<T> ctParameter = lookupDynamically();
 		if (ctParameter != null) {
 			return ctParameter;
 		}
+		return fromDeclaringExecutable();
+	}
+
+	private CtParameter<T> lookupDynamically() {
 		CtElement element = this;
 		CtParameter optional = null;
 		String name = getSimpleName();

--- a/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
@@ -16,8 +16,10 @@
  */
 package spoon.support.reflect.reference;
 
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -41,6 +43,33 @@ public class CtParameterReferenceImpl<T> extends CtVariableReferenceImpl<T> impl
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtParameter<T> getDeclaration() {
+		final CtParameter<T> ctParameter = fromDeclaringExecutable();
+		if (ctParameter != null) {
+			return ctParameter;
+		}
+		CtElement element = this;
+		CtParameter optional = null;
+		String name = getSimpleName();
+		try {
+			do {
+				CtExecutable executable = element.getParent(CtExecutable.class);
+				if (executable == null) {
+					return null;
+				}
+				for (CtParameter parameter : (List<CtParameter>) executable.getParameters()) {
+					if (name.equals(parameter.getSimpleName())) {
+						optional = parameter;
+					}
+				}
+				element = executable;
+			} while (optional == null);
+		} catch (ParentNotInitializedException e) {
+			return null;
+		}
+		return optional;
+	}
+
+	private CtParameter<T> fromDeclaringExecutable() {
 		CtExecutable<?> exec = executable.getDeclaration();
 		if (exec == null) {
 			return null;
@@ -51,8 +80,7 @@ public class CtParameterReferenceImpl<T> extends CtVariableReferenceImpl<T> impl
 				return (CtParameter<T>) p;
 			}
 		}
-		throw new IllegalStateException(
-				"Cannot found declaration for parameter " + getSimpleName());
+		return null;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -15,6 +15,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
+
 package spoon.support.visitor.replace;
 
 
@@ -25,7 +26,7 @@ package spoon.support.visitor.replace;
  */
 public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	class CtAbstractInvocationArgumentsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtAbstractInvocation element;
+		private final spoon.reflect.code.CtAbstractInvocation element;
 
 		CtAbstractInvocationArgumentsReplaceListener(spoon.reflect.code.CtAbstractInvocation element) {
 			this.element = element;
@@ -38,7 +39,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAbstractInvocationExecutableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtExecutableReference> {
-		private spoon.reflect.code.CtAbstractInvocation element;
+		private final spoon.reflect.code.CtAbstractInvocation element;
 
 		CtAbstractInvocationExecutableReplaceListener(spoon.reflect.code.CtAbstractInvocation element) {
 			this.element = element;
@@ -51,7 +52,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtActualTypeContainerActualTypeArgumentsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.reference.CtActualTypeContainer element;
+		private final spoon.reflect.reference.CtActualTypeContainer element;
 
 		CtActualTypeContainerActualTypeArgumentsReplaceListener(spoon.reflect.reference.CtActualTypeContainer element) {
 			this.element = element;
@@ -64,7 +65,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAnnotationAnnotationTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.declaration.CtAnnotation element;
+		private final spoon.reflect.declaration.CtAnnotation element;
 
 		CtAnnotationAnnotationTypeReplaceListener(spoon.reflect.declaration.CtAnnotation element) {
 			this.element = element;
@@ -77,7 +78,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAnnotationFieldAccessVariableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtFieldReference> {
-		private spoon.reflect.code.CtVariableAccess element;
+		private final spoon.reflect.code.CtVariableAccess element;
 
 		CtAnnotationFieldAccessVariableReplaceListener(spoon.reflect.code.CtVariableAccess element) {
 			this.element = element;
@@ -90,7 +91,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAnnotationValuesReplaceListener implements spoon.generating.replace.ReplaceMapListener<java.util.Map> {
-		private spoon.reflect.declaration.CtAnnotation element;
+		private final spoon.reflect.declaration.CtAnnotation element;
 
 		CtAnnotationValuesReplaceListener(spoon.reflect.declaration.CtAnnotation element) {
 			this.element = element;
@@ -103,7 +104,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtArrayAccessIndexExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtArrayAccess element;
+		private final spoon.reflect.code.CtArrayAccess element;
 
 		CtArrayAccessIndexExpressionReplaceListener(spoon.reflect.code.CtArrayAccess element) {
 			this.element = element;
@@ -116,7 +117,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtArrayTypeReferenceComponentTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtArrayTypeReference element;
+		private final spoon.reflect.reference.CtArrayTypeReference element;
 
 		CtArrayTypeReferenceComponentTypeReplaceListener(spoon.reflect.reference.CtArrayTypeReference element) {
 			this.element = element;
@@ -129,7 +130,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAssertAssertExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtAssert element;
+		private final spoon.reflect.code.CtAssert element;
 
 		CtAssertAssertExpressionReplaceListener(spoon.reflect.code.CtAssert element) {
 			this.element = element;
@@ -142,7 +143,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAssertExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtAssert element;
+		private final spoon.reflect.code.CtAssert element;
 
 		CtAssertExpressionReplaceListener(spoon.reflect.code.CtAssert element) {
 			this.element = element;
@@ -155,7 +156,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtAssignmentAssignedReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtAssignment element;
+		private final spoon.reflect.code.CtAssignment element;
 
 		CtAssignmentAssignedReplaceListener(spoon.reflect.code.CtAssignment element) {
 			this.element = element;
@@ -168,7 +169,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtBinaryOperatorLeftHandOperandReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtBinaryOperator element;
+		private final spoon.reflect.code.CtBinaryOperator element;
 
 		CtBinaryOperatorLeftHandOperandReplaceListener(spoon.reflect.code.CtBinaryOperator element) {
 			this.element = element;
@@ -181,7 +182,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtBinaryOperatorRightHandOperandReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtBinaryOperator element;
+		private final spoon.reflect.code.CtBinaryOperator element;
 
 		CtBinaryOperatorRightHandOperandReplaceListener(spoon.reflect.code.CtBinaryOperator element) {
 			this.element = element;
@@ -194,7 +195,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtCaseCaseExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtCase element;
+		private final spoon.reflect.code.CtCase element;
 
 		CtCaseCaseExpressionReplaceListener(spoon.reflect.code.CtCase element) {
 			this.element = element;
@@ -207,7 +208,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtCatchBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private spoon.reflect.code.CtCatch element;
+		private final spoon.reflect.code.CtCatch element;
 
 		CtCatchBodyReplaceListener(spoon.reflect.code.CtCatch element) {
 			this.element = element;
@@ -220,7 +221,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtCatchParameterReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtCatchVariable> {
-		private spoon.reflect.code.CtCatch element;
+		private final spoon.reflect.code.CtCatch element;
 
 		CtCatchParameterReplaceListener(spoon.reflect.code.CtCatch element) {
 			this.element = element;
@@ -233,7 +234,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtClassAnonymousExecutablesReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtClass element;
+		private final spoon.reflect.declaration.CtClass element;
 
 		CtClassAnonymousExecutablesReplaceListener(spoon.reflect.declaration.CtClass element) {
 			this.element = element;
@@ -246,7 +247,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtClassConstructorsReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtClass element;
+		private final spoon.reflect.declaration.CtClass element;
 
 		CtClassConstructorsReplaceListener(spoon.reflect.declaration.CtClass element) {
 			this.element = element;
@@ -259,7 +260,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtClassFieldsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtType element;
+		private final spoon.reflect.declaration.CtType element;
 
 		CtClassFieldsReplaceListener(spoon.reflect.declaration.CtType element) {
 			this.element = element;
@@ -272,7 +273,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtConditionalConditionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtConditional element;
+		private final spoon.reflect.code.CtConditional element;
 
 		CtConditionalConditionReplaceListener(spoon.reflect.code.CtConditional element) {
 			this.element = element;
@@ -285,7 +286,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtConditionalElseExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtConditional element;
+		private final spoon.reflect.code.CtConditional element;
 
 		CtConditionalElseExpressionReplaceListener(spoon.reflect.code.CtConditional element) {
 			this.element = element;
@@ -298,7 +299,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtConditionalThenExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtConditional element;
+		private final spoon.reflect.code.CtConditional element;
 
 		CtConditionalThenExpressionReplaceListener(spoon.reflect.code.CtConditional element) {
 			this.element = element;
@@ -311,7 +312,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtContinueLabelledStatementReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private spoon.reflect.code.CtContinue element;
+		private final spoon.reflect.code.CtContinue element;
 
 		CtContinueLabelledStatementReplaceListener(spoon.reflect.code.CtContinue element) {
 			this.element = element;
@@ -324,7 +325,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtDoLoopingExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtDo element;
+		private final spoon.reflect.code.CtDo element;
 
 		CtDoLoopingExpressionReplaceListener(spoon.reflect.code.CtDo element) {
 			this.element = element;
@@ -337,7 +338,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtElementAnnotationsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtElement element;
+		private final spoon.reflect.declaration.CtElement element;
 
 		CtElementAnnotationsReplaceListener(spoon.reflect.declaration.CtElement element) {
 			this.element = element;
@@ -350,7 +351,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtElementCommentsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtElement element;
+		private final spoon.reflect.declaration.CtElement element;
 
 		CtElementCommentsReplaceListener(spoon.reflect.declaration.CtElement element) {
 			this.element = element;
@@ -363,7 +364,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private spoon.reflect.declaration.CtExecutable element;
+		private final spoon.reflect.declaration.CtExecutable element;
 
 		CtExecutableBodyReplaceListener(spoon.reflect.declaration.CtExecutable element) {
 			this.element = element;
@@ -376,7 +377,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableParametersReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtExecutable element;
+		private final spoon.reflect.declaration.CtExecutable element;
 
 		CtExecutableParametersReplaceListener(spoon.reflect.declaration.CtExecutable element) {
 			this.element = element;
@@ -389,7 +390,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableReferenceDeclaringTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtExecutableReference element;
+		private final spoon.reflect.reference.CtExecutableReference element;
 
 		CtExecutableReferenceDeclaringTypeReplaceListener(spoon.reflect.reference.CtExecutableReference element) {
 			this.element = element;
@@ -402,7 +403,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableReferenceExpressionExecutableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtExecutableReference> {
-		private spoon.reflect.code.CtExecutableReferenceExpression element;
+		private final spoon.reflect.code.CtExecutableReferenceExpression element;
 
 		CtExecutableReferenceExpressionExecutableReplaceListener(spoon.reflect.code.CtExecutableReferenceExpression element) {
 			this.element = element;
@@ -415,7 +416,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableReferenceParametersReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.reference.CtExecutableReference element;
+		private final spoon.reflect.reference.CtExecutableReference element;
 
 		CtExecutableReferenceParametersReplaceListener(spoon.reflect.reference.CtExecutableReference element) {
 			this.element = element;
@@ -428,7 +429,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableReferenceTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtExecutableReference element;
+		private final spoon.reflect.reference.CtExecutableReference element;
 
 		CtExecutableReferenceTypeReplaceListener(spoon.reflect.reference.CtExecutableReference element) {
 			this.element = element;
@@ -441,7 +442,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExecutableThrownTypesReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtExecutable element;
+		private final spoon.reflect.declaration.CtExecutable element;
 
 		CtExecutableThrownTypesReplaceListener(spoon.reflect.declaration.CtExecutable element) {
 			this.element = element;
@@ -454,7 +455,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtExpressionTypeCastsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtExpression element;
+		private final spoon.reflect.code.CtExpression element;
 
 		CtExpressionTypeCastsReplaceListener(spoon.reflect.code.CtExpression element) {
 			this.element = element;
@@ -467,7 +468,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtFieldAccessVariableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtFieldReference> {
-		private spoon.reflect.code.CtVariableAccess element;
+		private final spoon.reflect.code.CtVariableAccess element;
 
 		CtFieldAccessVariableReplaceListener(spoon.reflect.code.CtVariableAccess element) {
 			this.element = element;
@@ -480,7 +481,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtFieldReferenceDeclaringTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtFieldReference element;
+		private final spoon.reflect.reference.CtFieldReference element;
 
 		CtFieldReferenceDeclaringTypeReplaceListener(spoon.reflect.reference.CtFieldReference element) {
 			this.element = element;
@@ -493,7 +494,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtForEachExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtForEach element;
+		private final spoon.reflect.code.CtForEach element;
 
 		CtForEachExpressionReplaceListener(spoon.reflect.code.CtForEach element) {
 			this.element = element;
@@ -506,7 +507,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtForEachVariableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtLocalVariable> {
-		private spoon.reflect.code.CtForEach element;
+		private final spoon.reflect.code.CtForEach element;
 
 		CtForEachVariableReplaceListener(spoon.reflect.code.CtForEach element) {
 			this.element = element;
@@ -519,7 +520,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtForExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtFor element;
+		private final spoon.reflect.code.CtFor element;
 
 		CtForExpressionReplaceListener(spoon.reflect.code.CtFor element) {
 			this.element = element;
@@ -532,7 +533,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtForForInitReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtFor element;
+		private final spoon.reflect.code.CtFor element;
 
 		CtForForInitReplaceListener(spoon.reflect.code.CtFor element) {
 			this.element = element;
@@ -545,7 +546,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtForForUpdateReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtFor element;
+		private final spoon.reflect.code.CtFor element;
 
 		CtForForUpdateReplaceListener(spoon.reflect.code.CtFor element) {
 			this.element = element;
@@ -558,7 +559,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtFormalTypeDeclarerFormalTypeParametersReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtFormalTypeDeclarer element;
+		private final spoon.reflect.declaration.CtFormalTypeDeclarer element;
 
 		CtFormalTypeDeclarerFormalTypeParametersReplaceListener(spoon.reflect.declaration.CtFormalTypeDeclarer element) {
 			this.element = element;
@@ -571,7 +572,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtIfConditionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtIf element;
+		private final spoon.reflect.code.CtIf element;
 
 		CtIfConditionReplaceListener(spoon.reflect.code.CtIf element) {
 			this.element = element;
@@ -584,7 +585,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtIfElseStatementReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private spoon.reflect.code.CtIf element;
+		private final spoon.reflect.code.CtIf element;
 
 		CtIfElseStatementReplaceListener(spoon.reflect.code.CtIf element) {
 			this.element = element;
@@ -597,7 +598,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtIfThenStatementReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private spoon.reflect.code.CtIf element;
+		private final spoon.reflect.code.CtIf element;
 
 		CtIfThenStatementReplaceListener(spoon.reflect.code.CtIf element) {
 			this.element = element;
@@ -610,7 +611,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtIntersectionTypeReferenceBoundsReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.reference.CtIntersectionTypeReference element;
+		private final spoon.reflect.reference.CtIntersectionTypeReference element;
 
 		CtIntersectionTypeReferenceBoundsReplaceListener(spoon.reflect.reference.CtIntersectionTypeReference element) {
 			this.element = element;
@@ -623,7 +624,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtLambdaExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtLambda element;
+		private final spoon.reflect.code.CtLambda element;
 
 		CtLambdaExpressionReplaceListener(spoon.reflect.code.CtLambda element) {
 			this.element = element;
@@ -636,7 +637,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtLoopBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private spoon.reflect.code.CtLoop element;
+		private final spoon.reflect.code.CtLoop element;
 
 		CtLoopBodyReplaceListener(spoon.reflect.code.CtLoop element) {
 			this.element = element;
@@ -649,7 +650,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtNewArrayDimensionExpressionsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtNewArray element;
+		private final spoon.reflect.code.CtNewArray element;
 
 		CtNewArrayDimensionExpressionsReplaceListener(spoon.reflect.code.CtNewArray element) {
 			this.element = element;
@@ -662,7 +663,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtNewArrayElementsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtNewArray element;
+		private final spoon.reflect.code.CtNewArray element;
 
 		CtNewArrayElementsReplaceListener(spoon.reflect.code.CtNewArray element) {
 			this.element = element;
@@ -675,7 +676,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtNewClassAnonymousClassReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.declaration.CtClass> {
-		private spoon.reflect.code.CtNewClass element;
+		private final spoon.reflect.code.CtNewClass element;
 
 		CtNewClassAnonymousClassReplaceListener(spoon.reflect.code.CtNewClass element) {
 			this.element = element;
@@ -688,7 +689,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtPackagePackagesReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtPackage element;
+		private final spoon.reflect.declaration.CtPackage element;
 
 		CtPackagePackagesReplaceListener(spoon.reflect.declaration.CtPackage element) {
 			this.element = element;
@@ -701,7 +702,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtPackageTypesReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtPackage element;
+		private final spoon.reflect.declaration.CtPackage element;
 
 		CtPackageTypesReplaceListener(spoon.reflect.declaration.CtPackage element) {
 			this.element = element;
@@ -714,7 +715,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtParameterReferenceDeclaringExecutableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtExecutableReference> {
-		private spoon.reflect.reference.CtParameterReference element;
+		private final spoon.reflect.reference.CtParameterReference element;
 
 		CtParameterReferenceDeclaringExecutableReplaceListener(spoon.reflect.reference.CtParameterReference element) {
 			this.element = element;
@@ -727,7 +728,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtRHSReceiverAssignmentReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtRHSReceiver element;
+		private final spoon.reflect.code.CtRHSReceiver element;
 
 		CtRHSReceiverAssignmentReplaceListener(spoon.reflect.code.CtRHSReceiver element) {
 			this.element = element;
@@ -740,7 +741,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtReturnReturnedExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtReturn element;
+		private final spoon.reflect.code.CtReturn element;
 
 		CtReturnReturnedExpressionReplaceListener(spoon.reflect.code.CtReturn element) {
 			this.element = element;
@@ -753,7 +754,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtStatementListStatementsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtStatementList element;
+		private final spoon.reflect.code.CtStatementList element;
 
 		CtStatementListStatementsReplaceListener(spoon.reflect.code.CtStatementList element) {
 			this.element = element;
@@ -766,7 +767,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtSwitchCasesReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtSwitch element;
+		private final spoon.reflect.code.CtSwitch element;
 
 		CtSwitchCasesReplaceListener(spoon.reflect.code.CtSwitch element) {
 			this.element = element;
@@ -779,7 +780,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtSwitchSelectorReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtSwitch element;
+		private final spoon.reflect.code.CtSwitch element;
 
 		CtSwitchSelectorReplaceListener(spoon.reflect.code.CtSwitch element) {
 			this.element = element;
@@ -792,7 +793,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtSynchronizedBlockReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private spoon.reflect.code.CtSynchronized element;
+		private final spoon.reflect.code.CtSynchronized element;
 
 		CtSynchronizedBlockReplaceListener(spoon.reflect.code.CtSynchronized element) {
 			this.element = element;
@@ -805,7 +806,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtSynchronizedExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtSynchronized element;
+		private final spoon.reflect.code.CtSynchronized element;
 
 		CtSynchronizedExpressionReplaceListener(spoon.reflect.code.CtSynchronized element) {
 			this.element = element;
@@ -818,7 +819,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTargetedExpressionTargetReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtTargetedExpression element;
+		private final spoon.reflect.code.CtTargetedExpression element;
 
 		CtTargetedExpressionTargetReplaceListener(spoon.reflect.code.CtTargetedExpression element) {
 			this.element = element;
@@ -831,7 +832,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtThrowThrownExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtThrow element;
+		private final spoon.reflect.code.CtThrow element;
 
 		CtThrowThrownExpressionReplaceListener(spoon.reflect.code.CtThrow element) {
 			this.element = element;
@@ -844,7 +845,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTryBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private spoon.reflect.code.CtTry element;
+		private final spoon.reflect.code.CtTry element;
 
 		CtTryBodyReplaceListener(spoon.reflect.code.CtTry element) {
 			this.element = element;
@@ -857,7 +858,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTryCatchersReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtTry element;
+		private final spoon.reflect.code.CtTry element;
 
 		CtTryCatchersReplaceListener(spoon.reflect.code.CtTry element) {
 			this.element = element;
@@ -870,7 +871,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTryFinalizerReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private spoon.reflect.code.CtTry element;
+		private final spoon.reflect.code.CtTry element;
 
 		CtTryFinalizerReplaceListener(spoon.reflect.code.CtTry element) {
 			this.element = element;
@@ -883,7 +884,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTryWithResourceResourcesReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.code.CtTryWithResource element;
+		private final spoon.reflect.code.CtTryWithResource element;
 
 		CtTryWithResourceResourcesReplaceListener(spoon.reflect.code.CtTryWithResource element) {
 			this.element = element;
@@ -896,7 +897,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeAccessAccessedTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.code.CtTypeAccess element;
+		private final spoon.reflect.code.CtTypeAccess element;
 
 		CtTypeAccessAccessedTypeReplaceListener(spoon.reflect.code.CtTypeAccess element) {
 			this.element = element;
@@ -909,7 +910,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeAccessTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.declaration.CtTypedElement element;
+		private final spoon.reflect.declaration.CtTypedElement element;
 
 		CtTypeAccessTypeReplaceListener(spoon.reflect.declaration.CtTypedElement element) {
 			this.element = element;
@@ -922,7 +923,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeFieldsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private spoon.reflect.declaration.CtType element;
+		private final spoon.reflect.declaration.CtType element;
 
 		CtTypeFieldsReplaceListener(spoon.reflect.declaration.CtType element) {
 			this.element = element;
@@ -935,7 +936,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeInformationSuperInterfacesReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtType element;
+		private final spoon.reflect.declaration.CtType element;
 
 		CtTypeInformationSuperInterfacesReplaceListener(spoon.reflect.declaration.CtType element) {
 			this.element = element;
@@ -948,7 +949,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeInformationSuperclassReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.declaration.CtClass element;
+		private final spoon.reflect.declaration.CtClass element;
 
 		CtTypeInformationSuperclassReplaceListener(spoon.reflect.declaration.CtClass element) {
 			this.element = element;
@@ -961,7 +962,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeMethodsReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtType element;
+		private final spoon.reflect.declaration.CtType element;
 
 		CtTypeMethodsReplaceListener(spoon.reflect.declaration.CtType element) {
 			this.element = element;
@@ -974,7 +975,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeNestedTypesReplaceListener implements spoon.generating.replace.ReplaceSetListener<java.util.Set> {
-		private spoon.reflect.declaration.CtType element;
+		private final spoon.reflect.declaration.CtType element;
 
 		CtTypeNestedTypesReplaceListener(spoon.reflect.declaration.CtType element) {
 			this.element = element;
@@ -987,7 +988,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeParameterReferenceBoundingTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtTypeParameterReference element;
+		private final spoon.reflect.reference.CtTypeParameterReference element;
 
 		CtTypeParameterReferenceBoundingTypeReplaceListener(spoon.reflect.reference.CtTypeParameterReference element) {
 			this.element = element;
@@ -1000,7 +1001,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeReferenceDeclaringTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtTypeReference element;
+		private final spoon.reflect.reference.CtTypeReference element;
 
 		CtTypeReferenceDeclaringTypeReplaceListener(spoon.reflect.reference.CtTypeReference element) {
 			this.element = element;
@@ -1013,7 +1014,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypeReferencePackageReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtPackageReference> {
-		private spoon.reflect.reference.CtTypeReference element;
+		private final spoon.reflect.reference.CtTypeReference element;
 
 		CtTypeReferencePackageReplaceListener(spoon.reflect.reference.CtTypeReference element) {
 			this.element = element;
@@ -1026,7 +1027,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtTypedElementTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.declaration.CtTypedElement element;
+		private final spoon.reflect.declaration.CtTypedElement element;
 
 		CtTypedElementTypeReplaceListener(spoon.reflect.declaration.CtTypedElement element) {
 			this.element = element;
@@ -1039,7 +1040,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtUnaryOperatorOperandReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtUnaryOperator element;
+		private final spoon.reflect.code.CtUnaryOperator element;
 
 		CtUnaryOperatorOperandReplaceListener(spoon.reflect.code.CtUnaryOperator element) {
 			this.element = element;
@@ -1052,7 +1053,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtVariableAccessVariableReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtVariableReference> {
-		private spoon.reflect.code.CtVariableAccess element;
+		private final spoon.reflect.code.CtVariableAccess element;
 
 		CtVariableAccessVariableReplaceListener(spoon.reflect.code.CtVariableAccess element) {
 			this.element = element;
@@ -1065,7 +1066,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtVariableDefaultExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.declaration.CtVariable element;
+		private final spoon.reflect.declaration.CtVariable element;
 
 		CtVariableDefaultExpressionReplaceListener(spoon.reflect.declaration.CtVariable element) {
 			this.element = element;
@@ -1078,7 +1079,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtVariableReferenceTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
-		private spoon.reflect.reference.CtVariableReference element;
+		private final spoon.reflect.reference.CtVariableReference element;
 
 		CtVariableReferenceTypeReplaceListener(spoon.reflect.reference.CtVariableReference element) {
 			this.element = element;
@@ -1091,7 +1092,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	class CtWhileLoopingExpressionReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtExpression> {
-		private spoon.reflect.code.CtWhile element;
+		private final spoon.reflect.code.CtWhile element;
 
 		CtWhileLoopingExpressionReplaceListener(spoon.reflect.code.CtWhile element) {
 			this.element = element;

--- a/src/test/java/spoon/test/reference/CloneReferenceTest.java
+++ b/src/test/java/spoon/test/reference/CloneReferenceTest.java
@@ -1,0 +1,85 @@
+package spoon.test.reference;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.reference.CtVariableReference;
+import spoon.reflect.visitor.CtScanner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertTrue;
+
+public class CloneReferenceTest {
+
+    @Test
+    public void testGetDeclarationAfterClone() throws Exception {
+        Launcher spoon = new Launcher();
+
+        List<String> names = Arrays.asList("f1", "f2", "a", "b", "x", "field", "param", "e");
+        spoon.addInputResource("./src/test/resources/noclasspath/A2.java");
+        spoon.getEnvironment().setComplianceLevel(8);
+        spoon.getEnvironment().setNoClasspath(true);
+        spoon.buildModel();
+
+
+        final CtClass<Object> a = spoon.getFactory().Class().get("A2");
+        // test before clone
+        for (String name : names) {
+            CtVariable var1 = findVariable(a, name);
+            CtVariable var2 = findReference(a, name).getDeclaration();
+            assertTrue(var1 == var2);
+        }
+
+        CtClass b = a.clone();
+
+        // test after clone
+        for (String name : names) {
+            CtVariable var1 = findVariable(b, name);
+            CtVariable var2 = findReference(b, name).getDeclaration();
+            assertTrue(var1 == var2);
+        }
+    }
+
+    class Finder<T> extends CtScanner {
+
+        private final Class<T> c;
+        private final Predicate<T> filter;
+        private T result;
+
+        public Finder(Class<T> c, Predicate<T> filter) {
+            this.c = c;
+            this.filter = filter;
+        }
+
+        @Override
+        public void scan(CtElement element) {
+            if (element != null && c.isAssignableFrom(element.getClass()) && filter.test((T) element)) {
+                result = (T) element;
+            } else {
+                super.scan(element);
+            }
+        }
+
+        public T find(CtElement root) {
+            scan(root);
+            return result;
+        }
+    }
+
+    public <T extends CtElement> T find(CtElement root, Class<T> c, Predicate<T> filter) {
+        return new Finder<>(c, filter).find(root);
+    }
+
+    public CtVariable findVariable(CtElement root, String name) {
+        return find(root, CtVariable.class, var -> name.equals(var.getSimpleName()));
+    }
+
+    public CtVariableReference findReference(CtElement root, String name) {
+        return find(root, CtVariableReference.class, ref -> name.equals(ref.getSimpleName()));
+    }
+}

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -16,6 +16,7 @@ import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.filter.AbstractReferenceFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.reference.testclasses.Pozole;
+import spoon.test.reference.testclasses.Tortillas;
 import spoon.testing.utils.ModelUtils;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
+import static spoon.testing.utils.ModelUtils.buildClass;
 
 public class VariableAccessTest {
 
@@ -135,6 +137,13 @@ public class VariableAccessTest {
 		assertTrue(localVarRef.getDeclaration() == declaration);
 		assertEquals(localVarRefCloned.getDeclaration(), declarationCloned);
 		assertTrue(localVarRefCloned.getDeclaration() == declarationCloned);
+	}
+
+	@Test
+	public void testReferences() throws Exception {
+		final CtType<Tortillas> aTortillas = buildClass(Tortillas.class);
+		final CtMethod<Object> make = aTortillas.getMethod("make", aTortillas.getFactory().Type().stringType());
+		System.out.println(make);
 	}
 
 	private CtMethod<Object> getMethod(Launcher launcher, CtClass<Object> a2) {

--- a/src/test/java/spoon/test/reference/testclasses/Tortillas.java
+++ b/src/test/java/spoon/test/reference/testclasses/Tortillas.java
@@ -1,0 +1,7 @@
+package spoon.test.reference.testclasses;
+
+public class Tortillas {
+	public void make(String string) {
+		String string1 = string;
+	}
+}

--- a/src/test/resources/noclasspath/A2.java
+++ b/src/test/resources/noclasspath/A2.java
@@ -1,0 +1,14 @@
+public class A2 {
+
+	int field;
+
+	public void b(int param) {
+		IntUnaryOperator f1 = x -> x;
+		IntBinaryOperator f2 = (a, b) -> a + b;
+		try {
+			System.out.println(f1.applyAsInt(f2.applyAsInt(field, param)));
+		} catch (RuntimeException e) {
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
This PR is a proposal for the issue #756.

On the issue, the solution proposed @fedorov-s-n was good but have 2 problems (specified by him): change the API and can throw an exception `ParentNotInitializeException` if the model isn't complete.

Me, I propose a solution widely inspired by @fedorov-s-n (big thanks to him) but I remove disadvantages: I haven't any change in the API and I handle the exception.

What do you think about it?