### PR TITLE
refactor(template): Removes the second call to get the declaring class.

### DIFF
--- a/src/main/java/spoon/template/BlockTemplate.java
+++ b/src/main/java/spoon/template/BlockTemplate.java
@@ -49,9 +49,6 @@ public abstract class BlockTemplate extends AbstractTemplate<CtBlock<?>> {
 	public CtBlock<?> apply(CtType<?> targetType) {
 		CtClass<? extends BlockTemplate> c;
 		c = targetType.getFactory().Class().get(this.getClass());
-		if (c == null) {
-			c = targetType.getFactory().Class().get(this.getClass());
-		}
 		return Substitution.substitute(targetType, this, getBlock(c));
 	}
 

--- a/src/main/java/spoon/template/ExpressionTemplate.java
+++ b/src/main/java/spoon/template/ExpressionTemplate.java
@@ -66,11 +66,7 @@ public abstract class ExpressionTemplate<T> extends AbstractTemplate<CtExpressio
 		CtClass<? extends ExpressionTemplate<?>> c;
 		CtBlock<?> b;
 		c = targetType.getFactory().Class().get(this.getClass());
-		if (c == null) {
-			c = targetType.getFactory().Class().get(this.getClass());
-		}
-		b = Substitution
-				.substitute(targetType, this, getExpressionBlock(c));
+		b = Substitution.substitute(targetType, this, getExpressionBlock(c));
 		return ((CtReturn<T>) b.getStatements().get(0)).getReturnedExpression();
 	}
 

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -54,9 +54,6 @@ public abstract class StatementTemplate extends AbstractTemplate<CtStatement> {
 		}
 
 		c = factory.Class().get(this.getClass());
-		if (c == null) {
-			c = factory.Class().get(this.getClass());
-		}
 		// we substitute the first statement of method statement
 		CtStatement result = c.getMethod("statement").getBody().getStatements().get(0).clone();
 		new SubstitutionVisitor(factory, targetType, this).scan(result);


### PR DESCRIPTION
There are a lot of tests [here](https://github.com/INRIA/spoon/tree/master/src/test/java/spoon/test/template) for templates but everything seems okay when we remove the second call.

Maybe @petitpre knows historical reasons? But it seems no longer necessary.

Closes #754 
