### PR TITLE
fix for https://github.com/INRIA/spoon/issues/793

### DIFF
--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -44,7 +44,7 @@ public class JavaReflectionTreeBuilderTest {
 		final CtEnum<TextStyle> anEnum = new JavaReflectionTreeBuilder(createFactory()).scan(TextStyle.class);
 		assertNotNull(anEnum);
 		assertEquals("java.time.format.TextStyle", anEnum.getQualifiedName());
-		assertNull(anEnum.getSuperclass());
+		assertNotNull(anEnum.getSuperclass());
 		assertTrue(anEnum.getFields().size() > 0);
 		assertTrue(anEnum.getEnumValues().size() > 0);
 		assertTrue(anEnum.getMethods().size() > 0);

--- a/src/test/java/spoon/test/reference/Enum.java
+++ b/src/test/java/spoon/test/reference/Enum.java
@@ -1,0 +1,11 @@
+package spoon.test.reference;
+
+public enum Enum {
+    A,
+    B,
+    C;
+    
+    public static Enum getFirst(){
+        return valueOf("A");
+    }
+}

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -147,8 +147,8 @@ public class ExecutableReferenceTest {
 			}
 		});
 	}
-    
-    @Test
+
+	@Test
 	public void testInvokeEnumMethod() {
 		final spoon.Launcher launcher = new spoon.Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/reference/Enum.java");
@@ -157,12 +157,12 @@ public class ExecutableReferenceTest {
 		launcher.buildModel();
 
 		CtInvocation invocation = launcher.getModel().getElements(new TypeFilter<CtInvocation>(CtInvocation.class) {
-            @Override
-            public boolean matches(CtInvocation element) {
-                return super.matches(element) 
-                    && element.getExecutable().getSimpleName().equals("valueOf");
-            }
-        }).get(0);
-        assertNotNull(invocation.getExecutable().getExecutableDeclaration());
-    }
+			@Override
+			public boolean matches(CtInvocation element) {
+				return super.matches(element) 
+					&& element.getExecutable().getSimpleName().equals("valueOf");
+			}
+		}).get(0);
+		assertNotNull(invocation.getExecutable().getExecutableDeclaration());
+	}
 }

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -147,4 +147,22 @@ public class ExecutableReferenceTest {
 			}
 		});
 	}
+    
+    @Test
+	public void testInvokeEnumMethod() {
+		final spoon.Launcher launcher = new spoon.Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/reference/Enum.java");
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.getEnvironment().setComplianceLevel(8);
+		launcher.buildModel();
+
+		CtInvocation invocation = launcher.getModel().getElements(new TypeFilter<CtInvocation>(CtInvocation.class) {
+            @Override
+            public boolean matches(CtInvocation element) {
+                return super.matches(element) 
+                    && element.getExecutable().getSimpleName().equals("valueOf");
+            }
+        }).get(0);
+        assertNotNull(invocation.getExecutable().getExecutableDeclaration());
+    }
 }

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -344,7 +344,7 @@ public class TypeReferenceTest {
 		final CtClass<Object> aClass = launcher.getFactory().Class().get("Demo2");
 		Set<CtTypeReference<?>> superInterfaces = aClass.getSuperInterfaces();
 		final CtTypeReference superInterface = superInterfaces.toArray(new CtTypeReference[superInterfaces.size()])[0];
-        assertEquals("Bar", superInterface.getSimpleName());
+		assertEquals("Bar", superInterface.getSimpleName());
 		assertEquals(2, superInterface.getActualTypeArguments().size());
 		final CtTypeReference<?> first = superInterface.getActualTypeArguments().get(0);
 		assertTrue(first instanceof CtTypeParameterReference);
@@ -523,14 +523,14 @@ public class TypeReferenceTest {
 		class Tacos<K extends A> {
 		}
 	}
-    
-    @Test
+	
+	@Test
 	public void testCorrectEnumParent() {
 		final Launcher launcher = new Launcher();
-        launcher.getEnvironment().setNoClasspath(true);
-        launcher.buildModel();
-        CtEnum e = launcher.getFactory().Enum().create("spoon.test.reference.EnumE");
-        CtTypeReference correctParent = launcher.getFactory().Type().createReference(java.lang.Enum.class);
-        assertEquals(correctParent, e.getReference().getSuperclass());
-    }
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.buildModel();
+		CtEnum e = launcher.getFactory().Enum().create("spoon.test.reference.EnumE");
+		CtTypeReference correctParent = launcher.getFactory().Type().createReference(java.lang.Enum.class);
+		assertEquals(correctParent, e.getReference().getSuperclass());
+	}
 }

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import spoon.reflect.declaration.CtEnum;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -343,7 +344,7 @@ public class TypeReferenceTest {
 		final CtClass<Object> aClass = launcher.getFactory().Class().get("Demo2");
 		Set<CtTypeReference<?>> superInterfaces = aClass.getSuperInterfaces();
 		final CtTypeReference superInterface = superInterfaces.toArray(new CtTypeReference[superInterfaces.size()])[0];
-		assertEquals("Bar", superInterface.getSimpleName());
+        assertEquals("Bar", superInterface.getSimpleName());
 		assertEquals(2, superInterface.getActualTypeArguments().size());
 		final CtTypeReference<?> first = superInterface.getActualTypeArguments().get(0);
 		assertTrue(first instanceof CtTypeParameterReference);
@@ -522,4 +523,14 @@ public class TypeReferenceTest {
 		class Tacos<K extends A> {
 		}
 	}
+    
+    @Test
+	public void testCorrectEnumParent() {
+		final Launcher launcher = new Launcher();
+        launcher.getEnvironment().setNoClasspath(true);
+        launcher.buildModel();
+        CtEnum e = launcher.getFactory().Enum().create("spoon.test.reference.EnumE");
+        CtTypeReference correctParent = launcher.getFactory().Type().createReference(java.lang.Enum.class);
+        assertEquals(correctParent, e.getReference().getSuperclass());
+    }
 }


### PR DESCRIPTION
Generating `values()` and `valueOf()` methods on request. Methods are not accessible through `getMethods()`, because they aren't declared, but are accessible through `getAllMethods()`