### PR TITLE
Avoid NullPointerException in CtExecutableReferenceImpl.

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -139,7 +139,8 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtExecutable<T> getDeclaration() {
-		return getCtExecutable(getDeclaringType().getDeclaration());
+		final CtTypeReference<?> typeRef = getDeclaringType();
+		return typeRef == null ? null : getCtExecutable(typeRef.getDeclaration());
 	}
 
 	@Override

--- a/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
+++ b/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
@@ -1,0 +1,43 @@
+package spoon.reflect.declaration;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.visitor.CtScanner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * @author Marcel Steinbeck
+ */
+public class UnknownDeclarationTest {
+
+    private static class ExecutableReferenceVisitor extends CtScanner {
+
+        int referenceCounter = 0;
+
+        @Override
+        public <T> void visitCtExecutableReference(final CtExecutableReference<T> reference) {
+            final CtExecutable executable = reference.getDeclaration();
+            assertNull(executable);
+            referenceCounter++;
+        }
+    }
+
+    @Test
+    public void testUnknownCalls() {
+        final Launcher runLaunch = new Launcher();
+        runLaunch.getEnvironment().setNoClasspath(true);
+        runLaunch.addInputResource("./src/test/resources/noclasspath/UnknownCalls.java");
+        runLaunch.buildModel();
+
+        final CtPackage rootPackage = runLaunch.getFactory().Package().getRootPackage();
+        final ExecutableReferenceVisitor visitor = new ExecutableReferenceVisitor();
+        visitor.scan(rootPackage);
+        // super constructor to Object +
+        // UnknownClass constructor +
+        // UnknownClass method
+        assertEquals(3, visitor.referenceCounter);
+    }
+}

--- a/src/test/resources/noclasspath/UnknownCalls.java
+++ b/src/test/resources/noclasspath/UnknownCalls.java
@@ -1,0 +1,14 @@
+import test.UnknownClass;
+
+public class UnknownCalls {
+
+    public static void main(final String[] args) {
+        UnknownClass[] ucs = new UnknownClass[10];
+        for (int i = 0; i < ucs.length; i++) {
+            // unknown constructor call
+            ucs[i] = new UnknownClass();
+            // unknown method call
+            ucs[i].anUnknownMethod();
+        }
+    }
+}


### PR DESCRIPTION
According to JavaDoc, `getDeclaringType()` may return null. Until now,
`getDeclaration`, does not handle the null case and, therefore, may
throw a NullPointerException. This exception is thrown most likely in
noclasspath mode.  Fixes #808.