### PR TITLE
fix(executable): fix the method ExecutableFactory#createReference

### DIFF
--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -25,15 +25,16 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import static java.util.Arrays.asList;
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 
 /**
@@ -104,12 +105,14 @@ public class ExecutableFactory extends SubFactory {
 				refs[i++] = param.getType().clone();
 			}
 		}
+		String executableName = e.getSimpleName();
 		if (e instanceof CtMethod) {
-			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(), ((CtMethod<T>) e).getType().clone(), e.getSimpleName(), refs);
+			boolean isStatic = ((CtMethod) e).hasModifier(ModifierKind.STATIC);
+			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(), isStatic, ((CtMethod<T>) e).getType().clone(), executableName, refs);
 		} else if (e instanceof CtLambda) {
-			return createReference(e.getParent(CtType.class).getReference(), e.getType(), e.getSimpleName(), refs);
+			return createReference(e.getParent(CtType.class).getReference(), e.getType(), executableName, refs);
 		} else if (e instanceof CtAnonymousExecutable) {
-			return createReference(((CtAnonymousExecutable) e).getDeclaringType().getReference(), e.getType().clone(), e.getSimpleName());
+			return createReference(((CtAnonymousExecutable) e).getDeclaringType().getReference(), e.getType().clone(), executableName);
 		}
 		return createReference(((CtConstructor<T>) e).getDeclaringType().getReference(), ((CtConstructor<T>) e).getType().clone(), CtExecutableReference.CONSTRUCTOR_NAME, refs);
 	}
@@ -127,13 +130,7 @@ public class ExecutableFactory extends SubFactory {
 	 * 		list of parameter's types
 	 */
 	public <T> CtExecutableReference<T> createReference(CtTypeReference<?> declaringType, CtTypeReference<T> type, String methodName, CtTypeReference<?>... parameterTypes) {
-		CtExecutableReference<T> methodRef = factory.Core().createExecutableReference();
-		methodRef.setDeclaringType(declaringType);
-		methodRef.setSimpleName(methodName);
-		methodRef.setType(type);
-		List<CtTypeReference<?>> l = new ArrayList<>(asList(parameterTypes));
-		methodRef.setParameters(l);
-		return methodRef;
+		return createReference(declaringType, false, type, methodName, parameterTypes);
 	}
 
 	/**
@@ -151,14 +148,7 @@ public class ExecutableFactory extends SubFactory {
 	 * 		list of parameter's types
 	 */
 	public <T> CtExecutableReference<T> createReference(CtTypeReference<?> declaringType, boolean isStatic, CtTypeReference<T> type, String methodName, CtTypeReference<?>... parameterTypes) {
-		CtExecutableReference<T> methodRef = factory.Core().createExecutableReference();
-		methodRef.setStatic(isStatic);
-		methodRef.setDeclaringType(declaringType);
-		methodRef.setSimpleName(methodName);
-		methodRef.setType(type);
-		List<CtTypeReference<?>> l = new ArrayList<>(asList(parameterTypes));
-		methodRef.setParameters(l);
-		return methodRef;
+		return createReference(declaringType, isStatic, type, methodName, Arrays.asList(parameterTypes));
 	}
 
 	/**

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -5,8 +5,10 @@ import spoon.Launcher;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.executable.testclasses.A;
 import spoon.test.executable.testclasses.Pozole;
 import spoon.testing.utils.ModelUtils;
 
@@ -39,5 +41,38 @@ public class ExecutableTest {
 	public void testBlockInExecutable() throws Exception {
 		final CtType<Pozole> aPozole = ModelUtils.buildClass(Pozole.class);
 		assertTrue(aPozole.getMethod("m").getBody().getStatement(1) instanceof CtBlock);
+	}
+
+	@Test
+	public void testGetReference() throws Exception {
+		final CtType<A> aClass = ModelUtils.buildClass(A.class);
+
+		String methodName = "getInt1";
+		CtExecutableReference<?> methodRef = aClass.getMethod(methodName).getReference();
+		assertEquals(false, methodRef.isFinal());
+		assertEquals(true, methodRef.isStatic());
+		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
+		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
+
+		methodName = "getInt2";
+		methodRef = aClass.getMethod(methodName).getReference();
+		assertEquals(true, methodRef.isFinal());
+		assertEquals(true, methodRef.isStatic());
+		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
+		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
+
+		methodName = "getInt3";
+		methodRef = aClass.getMethod(methodName).getReference();
+		assertEquals(true, methodRef.isFinal());
+		assertEquals(false, methodRef.isStatic());
+		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
+		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
+
+		methodName = "getInt4";
+		methodRef = aClass.getMethod(methodName).getReference();
+		assertEquals(false, methodRef.isFinal());
+		assertEquals(false, methodRef.isStatic());
+		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
+		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
 	}
 }

--- a/src/test/java/spoon/test/executable/testclasses/A.java
+++ b/src/test/java/spoon/test/executable/testclasses/A.java
@@ -1,0 +1,19 @@
+package spoon.test.executable.testclasses;
+
+public class A {
+	public static int getInt1() {
+		return 1;
+	}
+
+	public final static int getInt2() {
+		return 2;
+	}
+
+	public final int getInt3() {
+		return 3;
+	}
+
+	public int getInt4() {
+		return 4;
+	}
+}


### PR DESCRIPTION
The method `ExecutableFactory#createReference` now supports static method.

Fix #817 