### PR TITLE
fix(noclasspath): tolerates missing annotation types

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -199,6 +199,9 @@ class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Main {
 				environment, getHandlingPolicy(), compilerOptions,
 				this.jdtCompiler.requestor, getProblemFactory(), this.out,
 				null);
+		if (jdtCompiler.getEnvironment().getNoClasspath()) {
+			treeBuilderCompiler.lookupEnvironment.mayTolerateMissingType = true;
+		}
 		CompilationUnitDeclaration[] units = treeBuilderCompiler
 				.buildUnits(getCompilationUnits(files));
 		for (int i = 0; i < units.length; i++) {


### PR DESCRIPTION
This PR does not contains any test because I did not succeed to reproduce the the failing scenario in the test environment.
The bug is related to this eclipse issue: https://bugs.eclipse.org/bugs/show_bug.cgi?id=388042

# Stackstrace

```bash
org.eclipse.jdt.internal.compiler.problem.AbortCompilation: Pb(324) The type javax.annotation.Nullable cannot be resolved. It is indirectly referenced from required .class files
	at org.eclipse.jdt.internal.compiler.problem.ProblemHandler.handle(ProblemHandler.java:135)
	at org.eclipse.jdt.internal.compiler.problem.ProblemHandler.handle(ProblemHandler.java:201)
	at org.eclipse.jdt.internal.compiler.problem.ProblemReporter.handle(ProblemReporter.java:2132)
	at org.eclipse.jdt.internal.compiler.problem.ProblemReporter.isClassPathCorrect(ProblemReporter.java:4162)
	at org.eclipse.jdt.internal.compiler.lookup.UnresolvedReferenceBinding.resolve(UnresolvedReferenceBinding.java:59)
	at org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.resolveType(BinaryTypeBinding.java:131)
	at org.eclipse.jdt.internal.compiler.lookup.UnresolvedAnnotationBinding.getAnnotationType(UnresolvedAnnotationBinding.java:24)
	at org.eclipse.jdt.core.dom.DefaultBindingResolver.getAnnotationInstance(DefaultBindingResolver.java:50)
	at org.eclipse.jdt.core.dom.MethodBinding.getParameterAnnotations(MethodBinding.java:153)
....
```