### PR TITLE
Added a method to know whether a given method is part of a CtType

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -216,6 +216,14 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	List<CtMethod<?>> getMethodsByName(String name);
 
 	/**
+	 * Searches in the type for the given method.
+	 * Super classes and implemented interfaces are considered.
+	 * @param method The method to search for in the class.
+	 * @return True: the type has the given method. False otherwise.
+	 */
+	boolean hasMethod(CtMethod<?> method);
+
+	/**
 	 * Sets the methods of this type.
 	 */
 	<C extends CtType<T>> C setMethods(Set<CtMethod<?>> methods);

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -218,6 +218,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	/**
 	 * Searches in the type for the given method.
 	 * Super classes and implemented interfaces are considered.
+	 * The matching criterion is that the signatures are identical.
 	 * @param method The method to search for in the class.
 	 * @return True: the type has the given method. False otherwise.
 	 */

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.declaration;
 
+import spoon.SpoonException;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtAnnotation;
@@ -739,6 +740,48 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		}
 		return result;
 	}
+
+
+	@Override
+	public boolean hasMethod(CtMethod<?> method) {
+		if (method == null) {
+			return false;
+		}
+
+		// Checking whether the parent is the calling type.
+		try {
+			if (method.getParent() == this) {
+				return true;
+			}
+		} catch (ParentNotInitializedException ex) {
+			// No matter, trying something else.
+		}
+
+		// Checking whether a super class has the method.
+		final CtTypeReference<?> superCl = getSuperclass();
+
+		try {
+			if (superCl != null && superCl.getTypeDeclaration().hasMethod(method)) {
+				return true;
+			}
+		} catch (SpoonException ex) {
+			// No matter, trying something else.
+		}
+
+		// Finally, checking whether an interface has the method.
+		for (CtTypeReference<?> interf : getSuperInterfaces()) {
+			try {
+				if (interf.getTypeDeclaration().hasMethod(method)) {
+					return true;
+				}
+			} catch (SpoonException ex) {
+				// No matter, trying something else.
+			}
+		}
+
+		return false;
+	}
+
 
 	@Override
 	public String getQualifiedName() {

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -748,18 +748,15 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			return false;
 		}
 
-		// Checking whether the parent is the calling type.
-		try {
-			if (method.getParent() == this) {
+		final String over = method.getSignature();
+		for (CtMethod<?> m : getMethods()) {
+			if (m.getSignature().equals(over)) {
 				return true;
 			}
-		} catch (ParentNotInitializedException ex) {
-			// No matter, trying something else.
 		}
 
 		// Checking whether a super class has the method.
 		final CtTypeReference<?> superCl = getSuperclass();
-
 		try {
 			if (superCl != null && superCl.getTypeDeclaration().hasMethod(method)) {
 				return true;

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -1,0 +1,65 @@
+package spoon.test.ctType;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static spoon.testing.utils.ModelUtils.createFactory;
+
+public class CtTypeTest {
+	@Test
+	public void testHasMethodInDirectMethod() {
+		CtClass<?> clazz = createFactory().Code().createCodeSnippetStatement(
+			"class X { public void foo() {} }").compile();
+		assertTrue(clazz.hasMethod(clazz.getMethods().iterator().next()));
+	}
+
+	@Test
+	public void testHasMethodNotHasMethod() {
+		Factory factory = createFactory();
+		CtClass<?> clazz = factory.Code().createCodeSnippetStatement(
+			"class X { public void foo() {} }").compile();
+		CtClass<?> clazz2 = factory.Code().createCodeSnippetStatement(
+			"class Y { public void foo2() {} }").compile();
+		assertFalse(clazz.hasMethod(clazz2.getMethods().iterator().next()));
+	}
+
+	@Test
+	public void testHasMethodOnNull() {
+		CtClass<?> clazz = createFactory().Code().createCodeSnippetStatement(
+			"class X { public void foo() {} }").compile();
+		assertFalse(clazz.hasMethod(null));
+	}
+
+	@Test
+	public void testHasMethodInSuperClass() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/ctType/testclasses/X.java");
+		launcher.run();
+
+		final CtClass<?> xClass = launcher.getFactory().Class().get("spoon.test.ctType.testclasses.X");
+		final CtClass<?> yClass = launcher.getFactory().Class().get("spoon.test.ctType.testclasses.Y");
+		final CtMethod<?> superMethod = xClass.getMethods().iterator().next();
+
+		assertTrue(yClass.hasMethod(superMethod));
+	}
+
+	@Test
+	public void testHasMethodInDefaultMethod() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/ctType/testclasses/X.java");
+		launcher.getEnvironment().setComplianceLevel(8);
+		launcher.run();
+
+		final CtClass<?> x = launcher.getFactory().Class().get("spoon.test.ctType.testclasses.W");
+		final CtInterface<?> z = launcher.getFactory().Interface().get("spoon.test.ctType.testclasses.Z");
+		final CtMethod<?> superMethod = z.getMethods().iterator().next();
+
+		assertTrue(x.hasMethod(superMethod));
+	}
+}

--- a/src/test/java/spoon/test/ctType/testclasses/X.java
+++ b/src/test/java/spoon/test/ctType/testclasses/X.java
@@ -1,0 +1,19 @@
+package spoon.test.ctType.testclasses;
+
+class X {
+	public void foo() {
+
+	}
+}
+
+class Y extends X {
+
+}
+
+interface Z {
+	void foo();
+}
+
+abstract class W implements Z {
+}
+


### PR DESCRIPTION
Hey all,
As suggested on the mailing list, here is a PR to add a method in CtType to know whether a given type has a method (inherited or not, abstract or implemented). Look at the Javadoc for more details. Let me know if you want me to change the behaviour of the added method (replacing PR 870).