### PR TITLE
Fixes potential NullPointerException in JDTTreeBuilderQuery.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -131,6 +131,9 @@ class JDTTreeBuilderQuery {
 	static ImportReference searchPackage(char[][] packageName, CompilationUnitDeclaration[] unitsToProcess) {
 		for (CompilationUnitDeclaration unit : unitsToProcess) {
 			final ImportReference currentPackage = unit.currentPackage;
+			if (currentPackage == null) {
+				continue;
+			}
 			final char[][] tokens = currentPackage.tokens;
 			if (packageName.length > tokens.length) {
 				continue;


### PR DESCRIPTION
Unfortunately, I can't give you an example as I didn't manage to create a minimal version exploiting this error. However, it should be obvious that `currentPackage` may be null.