### PR TITLE
fix(prettyprinter): only the imports of the last type were considered

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -111,10 +111,12 @@ import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A visitor for generating Java code from the program compile-time model.
@@ -1729,9 +1731,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	@Override
 	public void calculate(CompilationUnit sourceCompilationUnit, List<CtType<?>> types) {
 		this.sourceCompilationUnit = sourceCompilationUnit;
-		Collection<CtTypeReference<?>> imports = Collections.emptyList();
+		Set<CtTypeReference<?>> imports = new HashSet<>();
 		for (CtType<?> t : types) {
-			imports = computeImports(t);
+			imports.addAll(computeImports(t));
 		}
 		elementPrinterHelper.writeHeader(types, imports);
 		for (CtType<?> t : types) {

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -3,12 +3,14 @@ package spoon.test.prettyprinter;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.compiler.Environment;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
@@ -21,6 +23,8 @@ import spoon.test.prettyprinter.testclasses.AClass;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -265,5 +269,20 @@ public class DefaultPrettyPrinterTest {
 
 		assertEquals(nl + nl + "package foo;" + nl + nl + nl + "class Bar {}" + nl + nl,
 				IOUtils.toString(new FileInputStream(javaFile), "UTF-8"));
+	}
+
+	@Test
+	public void importsFromMultipleTypesSupported() {
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/A.java");
+		launcher.run();
+		Environment env = launcher.getEnvironment();
+		env.setAutoImports(true);
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(env);
+		printer.calculate(null, Arrays.asList(
+			launcher.getFactory().Class().get("spoon.test.prettyprinter.testclasses.A"),
+			launcher.getFactory().Class().get("spoon.test.prettyprinter.testclasses.B")
+		));
+		assertTrue(printer.getResult().contains("import java.util.ArrayList;"));
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/testclasses/A.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/A.java
@@ -1,0 +1,11 @@
+package spoon.test.prettyprinter.testclasses;
+
+import java.util.ArrayList;
+
+class A {
+	ArrayList<String> list = new ArrayList<>();
+}
+
+class B {
+
+}


### PR DESCRIPTION
When pretty printing several Java types with auto-import, only the imports of the last type were considered.

This fix permits to gather all the imports of all the types.