### PR TITLE
improves performance of VirtualFolder.getAllFiles()

### DIFF
--- a/src/main/java/spoon/support/compiler/FileSystemFile.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFile.java
@@ -35,7 +35,11 @@ public class FileSystemFile implements SpoonFile {
 
 	public FileSystemFile(File file) {
 		super();
-		this.file = file;
+		try {
+			this.file = file.getCanonicalFile();
+		} catch (IOException e) {
+			throw new SpoonException(e);
+		}
 	}
 
 	public InputStream getContent() {
@@ -94,11 +98,7 @@ public class FileSystemFile implements SpoonFile {
 
 	@Override
 	public File toFile() {
-		try {
-		return file.getCanonicalFile();
-		} catch (IOException e) {
-			throw new SpoonException(e);
-		}
+		return file;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/FileSystemFolder.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFolder.java
@@ -18,7 +18,6 @@ package spoon.support.compiler;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +36,11 @@ public class FileSystemFolder implements SpoonFolder {
 		if (!file.isDirectory()) {
 			throw new SpoonException("Not a directory " + file);
 		}
-		this.file = file;
+		try {
+			this.file = file.getCanonicalFile();
+		} catch (Exception e) {
+			throw new SpoonException(e);
+		}
 	}
 
 	public FileSystemFolder(String path) {
@@ -114,13 +117,8 @@ public class FileSystemFolder implements SpoonFolder {
 	}
 
 	public String getPath() {
-		try {
-			return file.getCanonicalPath();
-		} catch (Exception e) {
-			Launcher.LOGGER.error(e.getMessage(), e);
 			return file.getPath();
 		}
-	}
 
 	@Override
 	public boolean isArchive() {
@@ -134,11 +132,7 @@ public class FileSystemFolder implements SpoonFolder {
 
 	@Override
 	public File toFile() {
-		try {
-			return file.getCanonicalFile();
-		} catch (IOException e) {
-			throw new SpoonException(e);
-		}
+		return file;
 	}
 
 	@Override


### PR DESCRIPTION
Contains
1. test which measures performance of VirtualFolder.getAllFiles() 
2. test which measures performance of VirtualFolder.getSubFolders() 
3. code which improves that performance.

The performance improvement consists of these changes:
1. FileSystemFile calls slow File.getCanonicalFile() only once in constructor. It is not called later. I hope it breaks nothing. Please check it.
2. FileSystemFolder calls slow File.getCanonicalFile() only once in constructor. It is not called later. I hope it breaks nothing. Please check it.
3.  VirtualFolder getAllFiles() and getSubFolders() uses helper HashSet to collect distinct set of files

Note: Before the test needed 80s on 900 files. After performance fix it needs 0.2s
Note: The usage of helper HashSet would be enough to fix performance of VirtualFolder getAllFiles() and getSubFolders(), but FileSystemFile.toFile() and FileSystemFolder.toFile() and getPath() is probably called on other places in Spoon too, therefore I suggest to take both changes.
