### PR TITLE
improves performance of FindCommentParentScanner

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -23,19 +23,23 @@ import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtIf;
+import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtTry;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
@@ -48,7 +52,6 @@ import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 
 import java.io.File;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -407,16 +410,8 @@ class JDTCommentBuilder {
 				if (element.isImplicit()) {
 					return;
 				}
-				CtElement body;
-				try {
-					Method getBody = element.getClass().getMethod("getBody");
-					body = (CtElement) getBody.invoke(element);
-					if (body != null) {
-						if (body.getPosition() == null) {
-							body = null;
-						}
-					}
-				} catch (Exception e) {
+				CtElement body = getBody(element);
+				if (body != null && body.getPosition() == null) {
 					body = null;
 				}
 				if (element.getPosition() != null
@@ -434,6 +429,23 @@ class JDTCommentBuilder {
 				comment.getPosition().getSourceEnd());
 		findCommentParentScanner.scan(spoonUnit.getDeclaredTypes());
 		return findCommentParentScanner.commentParent;
+	}
+
+	/**
+	 * @param element
+	 * @return body of element or null if this element has no body
+	 */
+	static CtElement getBody(CtElement e) {
+		if (e instanceof CtLoop) {
+			return ((CtLoop) e).getBody();
+		} else if (e instanceof CtExecutable) {
+			return ((CtExecutable<?>) e).getBody();
+		} else if (e instanceof CtTry) {
+			return ((CtTry) e).getBody();
+		} else if (e instanceof CtCatch) {
+			return ((CtCatch) e).getBody();
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
The collecting of comments seems to be slow in method 

``` java
JDTCommentBuilder$FindCommentParentScanner.scan(CtElement) 
...
element.getClass().getMethod("getBody")
```

Reason: Java reflection is slow. Throwing exception is slow. 

Solution: Cache the getBody method of classes in HashMap
I do not know how to make a test for that. But I see the visible improvement in building time of the model.
