### PR TITLE
improves performance of CtElementImpl.equals()

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -109,6 +109,12 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (this == o) {
 			return true;
 		}
+		if (o == null) {
+			return false;
+		}
+		if (getClass().equals(o.getClass()) == false) {
+			return false;
+		}
 		boolean ret = EqualsVisitor.equals(this, (CtElement) o);
 		// neat online testing of core Java contract
 		if (ret && !factory.getEnvironment().checksAreSkipped() && this.hashCode() != o.hashCode()) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -112,7 +112,14 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (o == null) {
 			return false;
 		}
-		if (getClass().equals(o.getClass()) == false) {
+		Class<?> thisClass = getClass();
+		Class<?> thatClass = o.getClass();
+
+		if (thisClass != thatClass && thisClass.isAssignableFrom(thatClass) == false && thatClass.isAssignableFrom(thisClass) == false) {
+			/*
+			 * the classes are different. And they are not assignable to the other
+			 * Note: it must not return false for CtModelImpl$CtRootPackage and CtPackageImpl
+			 */
 			return false;
 		}
 		boolean ret = EqualsVisitor.equals(this, (CtElement) o);


### PR DESCRIPTION
This method is called very often so it makes sense to add fast checks
for null and check that classes are equal, otherwise the ClassCastException is thrown and caught internally and it is slow.

I do not know how to make a test for that, but during build of model with 6000 files it spent 43 seconds in CtElementImpl.equals(), while after fix it measured 0s in java VisualVM sampler