### PR TITLE
fix LauncherTest, which fails on MS Windows

### DIFF
--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -63,7 +63,7 @@ public class LauncherTest {
 
 		// the input directories
 		List<File> inputSources = new ArrayList<>(builder.getInputSources());
-		assertTrue(inputSources.get(0).getPath().contains("src/main/java"));
+		assertTrue(inputSources.get(0).getPath().replace('\\', '/').contains("src/main/java"));
 		assertEquals("UTF-16", builder.getEncoding());
 
 	}


### PR DESCRIPTION
MS Windows uses backslash in file system path therefore this:
assertTrue(inputSources.get(0).getPath().contains("src/main/java"));
always fails on MS Windows