### PR TITLE
fix: filter out some JDT errors on noclasspath

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -621,7 +621,12 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 				throw new ModelBuildingException(message);
 			} else {
 				// in noclasspath mode, errors are only reported
-				environment.report(null, problem.isError() ? Level.ERROR : Level.WARN, message);
+				// but undefined import, type, and name errors are irrelevant
+				int problemId = problem.getID();
+				if (problemId != IProblem.UndefinedType && problemId != IProblem.UndefinedName
+						&& problemId != IProblem.ImportNotFound) {
+					environment.report(null, Level.WARN, message);
+				}
 			}
 		}
 


### PR DESCRIPTION
Errors of type `UndefinedType`, `UndefinedName` and `ImportNotFound` are irrelevant for noclasspath mode, they are not logged anymore.

Closes #788

