### PR TITLE
fixed(prettyprint): parentheses are missing when pretty-pretting some ternary expressions

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -87,6 +87,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtArrayTypeReference;
@@ -543,11 +544,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (!(condition instanceof CtStatement)) {
 			elementPrinterHelper.writeComment(condition, CommentOffset.BEFORE);
 		}
-		boolean parent = false;
+		boolean parent;
 		try {
-			parent = (conditional.getParent() instanceof CtAssignment);
+			parent = conditional.getParent() instanceof CtAssignment || conditional.getParent() instanceof CtVariable;
 		} catch (ParentNotInitializedException ex) {
 			// nothing if we have no parent
+			parent = false;
 		}
 		if (parent) {
 			printer.write("(");

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -209,7 +209,7 @@ public class CommentTest {
 		assertEquals(createFakeComment(f, "comment after then CtConditional"), ctConditional.getThenExpression().getComments().get(1));
 		assertEquals(createFakeComment(f, "comment before else CtConditional"), ctConditional.getElseExpression().getComments().get(0));
 		assertEquals(createFakeComment(f, "comment after else CtConditional"), ctLocalVariable1.getComments().get(0));
-		assertEquals("java.lang.Double dou = i == 1// comment after condition CtConditional" + newLine
+		assertEquals("java.lang.Double dou = (i == 1)// comment after condition CtConditional" + newLine
 				+ " ? // comment before then CtConditional" + newLine
 				+ "null// comment after then CtConditional" + newLine
 				+ " : // comment before else CtConditional" + newLine

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -288,16 +288,14 @@ public class DefaultPrettyPrinterTest {
 	}
 
 	@Test
-	public void testTernaryParenthesesOnLocalVariable() throws SnippetCompilationError {
+	public void testTernaryParenthesesOnLocalVariable() {
 		// Spooning the code snippet
 		Launcher launcher = new Launcher();
 		CtCodeSnippetStatement snippet = launcher.getFactory().Code().createCodeSnippetStatement(
 			"final int foo = (new Object() instanceof Object ? new Object().equals(null) : new Object().equals(new Object())) ? 0 : new Object().hashCode();");
 		CtStatement compile = snippet.compile();
-
 		// Pretty-printing the Spooned code snippet and compiling the resulting code.
 		snippet = launcher.getFactory().Code().createCodeSnippetStatement(compile.toString());
-		// If it throws an exception, the printed code is not valid.
-		snippet.compile();
+		assertEquals(compile, snippet.compile());
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -7,10 +7,11 @@ import spoon.compiler.Environment;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
@@ -19,11 +20,11 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.JavaOutputProcessor;
+import spoon.support.compiler.SnippetCompilationError;
 import spoon.test.prettyprinter.testclasses.AClass;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -284,5 +285,20 @@ public class DefaultPrettyPrinterTest {
 			launcher.getFactory().Class().get("spoon.test.prettyprinter.testclasses.B")
 		));
 		assertTrue(printer.getResult().contains("import java.util.ArrayList;"));
+	}
+
+	@Test
+	public void testTernaryParenthesesOnLocalVariable() throws SnippetCompilationError {
+		// Spooning the code snippet
+		Launcher launcher = new Launcher();
+		CtCodeSnippetStatement snippet = launcher.getFactory().Code().createCodeSnippetStatement(
+			"final int foo = (new Object() instanceof Object ? new Object().equals(null) : new Object().equals(new Object())) ? 0 : new Object().hashCode();");
+		CtStatement compile = snippet.compile();
+
+		// Pretty-printing the Spooned code snippet and compiling the resulting code.
+		launcher = new Launcher();
+		snippet = launcher.getFactory().Code().createCodeSnippetStatement(compile.toString());
+		// If it throws an exception, the printed code is not valid.
+		snippet.compile();
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -296,7 +296,6 @@ public class DefaultPrettyPrinterTest {
 		CtStatement compile = snippet.compile();
 
 		// Pretty-printing the Spooned code snippet and compiling the resulting code.
-		launcher = new Launcher();
 		snippet = launcher.getFactory().Code().createCodeSnippetStatement(compile.toString());
 		// If it throws an exception, the printed code is not valid.
 		snippet.compile();


### PR DESCRIPTION
The current prettyprint of ternary expressions (CtConditional) adds parentheses around the condition only when the parent is an assignment. The added test show that parentheses are also required on variable declaration.

The test shows that the mandatory parentheses that originally surround the condition are removed when pretty-printing the spooned code. This leads to ambiguous code that does not compile.
The fix adds the parentheses when the parent is a variable declaration.

Maybe the parentheses should be always added.