### PR TITLE
support of comments in snippet

### DIFF
--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -25,6 +25,7 @@ import spoon.reflect.cu.Import;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.support.reflect.cu.ImportImpl;
 
 /**
@@ -64,8 +65,10 @@ public class CompilationUnitFactory extends SubFactory {
 	public CompilationUnit create(String filePath) {
 		CompilationUnit cu = cachedCompilationUnits.get(filePath);
 		if (cu == null) {
-			if ("".equals(filePath)) {
+			if (filePath.startsWith(JDTSnippetCompiler.SNIPPET_FILENAME_PREFIX)) {
 				cu = factory.Core().createVirtualCompilationUnit();
+				//put the virtual compilation unit of code snippet into cache too, so the JDTCommentBuilder can found it
+				cachedCompilationUnits.put(filePath, cu);
 				return cu;
 			}
 			cu = factory.Core().createCompilationUnit();
@@ -73,6 +76,16 @@ public class CompilationUnitFactory extends SubFactory {
 			cachedCompilationUnits.put(filePath, cu);
 		}
 		return cu;
+	}
+
+	/**
+	 * Removes compilation unit from the cache and returns it
+	 * Used by JDTSnippetCompiler to remove processed snippet from the cache
+	 * @param filePath
+	 * @return a cached compilation unit or null
+	 */
+	public CompilationUnit remove(String filePath) {
+		return cachedCompilationUnits.remove(filePath);
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -84,7 +84,7 @@ public class CompilationUnitFactory extends SubFactory {
 	 * @param filePath
 	 * @return a cached compilation unit or null
 	 */
-	public CompilationUnit remove(String filePath) {
+	public CompilationUnit removeFromCache(String filePath) {
 		return cachedCompilationUnits.remove(filePath);
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -47,6 +47,7 @@ import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -174,7 +175,8 @@ class JDTCommentBuilder {
 	private void insertCommentInAST(final CtComment comment) {
 		CtElement commentParent = findCommentParent(comment);
 		if (commentParent == null) {
-			if (spoonUnit.getFile().getName().equals(DefaultJavaPrettyPrinter.JAVA_PACKAGE_DECLARATION)) {
+			File file = spoonUnit.getFile();
+			if (file != null && file.getName().equals(DefaultJavaPrettyPrinter.JAVA_PACKAGE_DECLARATION)) {
 				spoonUnit.getDeclaredPackage().addComment(comment);
 			} else {
 				comment.setCommentType(CtComment.CommentType.FILE);

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -73,7 +73,7 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 			//remove snippet compilation unit from the cache (to clear memory) and remember it so client can use it
 			for (SpoonFile spoonFile : allFiles) {
 				if (spoonFile.getName().startsWith(SNIPPET_FILENAME_PREFIX)) {
-					snippetCompilationUnit = factory.CompilationUnit().remove(spoonFile.getName());
+					snippetCompilationUnit = factory.CompilationUnit().removeFromCache(spoonFile.getName());
 				}
 			}
 		}


### PR DESCRIPTION
The comments in snippet was always ignored. This PR includes this:

- Test case which fails when comments are lost in snippet
- Implementation of comments in snippet
- new method `CompilationUnit JDTSnippetCompiler.getSnippetCompilationUnit()`, which returns CompilationUnit of the compilet snippet. Note: I had to remember the CompilationUnit of the snippet in the CompilationUnit cache, otherwise JDTCommentBuilder was not able to add comments. And at the end I removed that CU from the cache ... so it is now possible to access that CU from the JDTSnippetCompiler too.

It is the first chunk of changes suggested by PR #929