### PR TITLE
Refactor - use JDTBasedSpoonCompiler.buildModel()

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -379,14 +379,7 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 		}
 		CompilationUnitDeclaration[] units = batchCompiler.getUnits(filesToBuild);
 		// here we build the model
-		JDTTreeBuilder builder = new JDTTreeBuilder(factory);
-		for (int i = 0; i < units.length; i++) {
-			CompilationUnitDeclaration unit = units[i];
-			unit.traverse(builder, unit.scope);
-			if (getFactory().getEnvironment().isCommentsEnabled()) {
-				new JDTCommentBuilder(unit, factory).build();
-			}
-		}
+		buildModel(units);
 
 		return probs.size() == 0;
 	}
@@ -440,16 +433,19 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 		}
 
 		// here we build the model in the template factory
+		buildModel(units);
+
+		return probs.size() == 0;
+	}
+
+	protected void buildModel(CompilationUnitDeclaration[] units) {
 		JDTTreeBuilder builder = new JDTTreeBuilder(factory);
-		for (int i = 0; i < units.length; i++) {
-			CompilationUnitDeclaration unit = units[i];
+		for (CompilationUnitDeclaration unit : units) {
 			unit.traverse(builder, unit.scope);
 			if (getFactory().getEnvironment().isCommentsEnabled()) {
 				new JDTCommentBuilder(unit, factory).build();
 			}
 		}
-
-		return probs.size() == 0;
 	}
 
 	protected void generateProcessedSourceFilesUsingTypes(Filter<CtType<?>> typeFilter) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -114,14 +114,7 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 		}
 
 		// here we build the model
-		JDTTreeBuilder builder = new JDTTreeBuilder(factory);
-		for (CompilationUnitDeclaration unit : units) {
-			unit.traverse(builder, unit.scope);
-			//process comments too
-			if (getFactory().getEnvironment().isCommentsEnabled()) {
-				new JDTCommentBuilder(unit, factory).build();
-			}
-		}
+		buildModel(units);
 
 		return getProblems().size() == 0;
 	}


### PR DESCRIPTION
New method  JDTBasedSpoonCompiler.buildModel() was created and called on 3 places instead of 3 times implemented/copied code.

This PR depends on #930