### PR TITLE
fix bug #921 Duplicity in package-info.java when templates are used

### DIFF
--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -76,9 +76,13 @@ public interface SpoonModelBuilder {
 	 */
 	boolean build(JDTBuilder builder);
 
-	/** The types of compilable elements */
+	/** The types of compilable elements
+	 * FILES - compiles the java files from the file system, which were registered by {@see SpoonModelBuilder#addInputSource()} and {@see SpoonModelBuilder#addTemplateSource(File)}
+	 * CTTYPES - compiles virtual java files, which are dynamically generated from the all top level classes of the CtModel by {@see DefaultJavaPrettyPrinter}
+	 * UNITS - compiles the java files, which are specified later by JDTBasedSpoonCompiler.build. This InputType cannot be used by compile.
+	 */
 	enum InputType {
-		FILES, CTTYPES
+		FILES, CTTYPES, UNITS
 	}
 
 

--- a/src/main/java/spoon/support/compiler/jdt/ConfigurableCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/ConfigurableCompiler.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2006-2016 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
 package spoon.support.compiler.jdt;
 
 import java.io.OutputStream;

--- a/src/main/java/spoon/support/compiler/jdt/ConfigurableCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/ConfigurableCompiler.java
@@ -1,0 +1,54 @@
+package spoon.support.compiler.jdt;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
+
+import spoon.SpoonException;
+import spoon.compiler.SpoonFile;
+
+public class ConfigurableCompiler extends JDTBatchCompiler {
+	protected CompilationUnit[] compilationUnits;
+
+	public ConfigurableCompiler(JDTBasedSpoonCompiler p_jdtCompiler) {
+		super(p_jdtCompiler);
+	}
+
+	public ConfigurableCompiler(JDTBasedSpoonCompiler p_jdtCompiler, OutputStream p_outWriter, OutputStream p_errWriter) {
+		super(p_jdtCompiler, p_outWriter, p_errWriter);
+	}
+
+	@Override
+	public CompilationUnit[] getCompilationUnits() {
+		return compilationUnits;
+	}
+
+	public void setCompilationUnits(CompilationUnit[] compilationUnits) {
+		this.compilationUnits = compilationUnits;
+	}
+
+	public void setInputFiles(List<SpoonFile> files) {
+		List<CompilationUnit> culist = new ArrayList<>(files.size());
+		for (SpoonFile f : files) {
+			if (filesToBeIgnored.contains(f.getPath())) {
+				continue;
+			}
+			try {
+				String fName = "";
+				if (f.isActualFile()) {
+					fName = f.getPath();
+				} else {
+					fName = f.getName();
+				}
+				culist.add(new CompilationUnit(IOUtils.toCharArray(f
+						.getContent(), jdtCompiler.encoding), fName, null));
+			} catch (Exception e) {
+				throw new SpoonException(e);
+			}
+		}
+		this.compilationUnits = culist.toArray(new CompilationUnit[0]);
+	}
+}

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -67,7 +67,7 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 		if (sources.getAllJavaFiles().isEmpty()) {
 			return true;
 		}
-		JDTBatchCompiler batchCompiler = createBatchCompiler(InputType.FILES);
+		JDTBatchCompiler batchCompiler = createBatchCompiler(sources.getAllJavaFiles());
 
 		File source = createTmpJavaFile(new File("."));
 		String[] args;

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
+import spoon.compiler.Environment;
 import spoon.compiler.SpoonCompiler;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtComment;
@@ -20,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.Assert.assertThat;
+import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class PackageTest {
 	@Test
@@ -100,5 +102,21 @@ public class PackageTest {
 		assertEquals(CtComment.CommentType.INLINE, aPackage.getComments().get(2).getCommentType());
 
 		assertThat(aPackage).isEqualTo(ModelUtils.build(new File("./target/spooned/package/spoon/test/pkg/testclasses/internal")).Package().get("spoon.test.pkg.testclasses.internal"));
+	}
+	
+	@Test
+	public void testAnnotationInPackageInfoWhenTemplatesCompiled() throws Exception {
+		final Launcher launcher = new Launcher();
+		Environment environment = launcher.getEnvironment();
+		
+		environment.setAutoImports(true);
+		environment.setCommentEnabled(true);
+		launcher.addInputResource("./src/test/java/spoon/test/pkg/package-info.java");
+		launcher.setSourceOutputDirectory("./target/spooned/packageAndTemplate");
+//		SpoonResourceHelper.resources("./src/test/java/spoon/test/pkg/test_templates").forEach(r->launcher.addTemplateResource(r));
+		launcher.addTemplateResource(SpoonResourceHelper.createResource(new File("./src/test/java/spoon/test/pkg/test_templates/FakeTemplate.java")));
+		launcher.buildModel();
+		launcher.prettyprint();
+		canBeBuilt("./target/spooned/packageAndTemplate/spoon/test/pkg/package-info.java", 8);
 	}
 }

--- a/src/test/java/spoon/test/pkg/test_templates/FakeTemplate.java
+++ b/src/test/java/spoon/test/pkg/test_templates/FakeTemplate.java
@@ -1,0 +1,10 @@
+package spoon.test.pkg.test_templates;
+
+import spoon.template.ExtensionTemplate;
+
+public class FakeTemplate extends ExtensionTemplate
+{
+	public FakeTemplate()
+	{
+	}
+}


### PR DESCRIPTION
This is next part of #929. It assures that `JDTBasedSpoonCompiler.build()` compiles sources and templates only once. Before it was compiled twice, therefore the annotations were duplicated.

I had to add new `InputType.UNITS` to tell the `createBatchCompiler` method that it should create JDTBatchCompiler which let's us configure to be compiled files.

I do not like this solution, because public `InputType.UNITS` is there just for internal purposes and it makes no sense for `JDTBasedSpoonCompiler.compile()` ... so it is confusing... But I was not able to found beter way without changing of contract of createBatchCompiler method, which is may be used by clients to filter files and directories.

@monperrus if you agree that `InputType.UNITS` is wrong, then please refactor `createBatchCompiler` and related tests by some way, so it can be used in simpler way.

I vote for removing support of filtering by folders and files (test `testFilterResourcesDir` and `testFilterResourcesFile()`)by overwriting of protected method ... this is not good because protect function becomes a "public API"