### PR TITLE
simplify JDTBatchCompiler.getUnits(). Reuse existing CU

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -16,7 +16,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
@@ -127,25 +126,8 @@ abstract class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.
 									new DefaultProblemFactory(Locale.getDefault())),
 							false);
 
-			// finding the corresponding content
-			// works for both real files and virtual files
-			char[] content = null;
-			String unitFileName = new String(unit.getFileName());
-			for (SpoonFile f : files) {
-				if (f.getName().equals(unitFileName)) {
-					try {
-						content = IOUtils.toCharArray(f.getContent());
-					} catch (Exception e) {
-						throw new SpoonException(e);
-					}
-				}
-			}
-			ICompilationUnit sourceUnit =
-					new CompilationUnit(
-							content,
-							unitFileName,
-							"", //$NON-NLS-1$
-							compilerOptions.defaultEncoding);
+			//reuse the source compilation unit
+			ICompilationUnit sourceUnit = unit.compilationResult.compilationUnit;
 
 			final CompilationResult compilationResult = new CompilationResult(sourceUnit, 0, 0, compilerOptions.maxProblemsPerUnit);
 			CompilationUnitDeclaration tmpDeclForComment = parser.dietParse(sourceUnit, compilationResult);


### PR DESCRIPTION
The compilation is done in two phases.
1) treeBuilderCompiler.buildUnits()
2) parser.dietParse() this call is processed for each result of the `treeBuilderCompiler.buildUnits()` and needs a CompilationUnit with the same name ... it is the same file which was used to produce the `unit` ... so we can use the CompilationUnit which is directly stored here `unit.compilationResult.compilationUnit`

I would like to have this change because

1) it makes code more readable
2) it makes clear that same compilation unit is used. Before the treeBuilderCompiler.buildUnits() worked with different input files, then parser.dietParse() ... it took me several hours until I recognized that both inputs should be always same.
3) the parameter `files` of the method `CompilationUnitDeclaration[] getUnits(List<SpoonFile> files)` is now unused, so we can remove it in next PR
