### PR TITLE
remove unused imports so the compilation in workspace passes

### DIFF
--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -30,7 +30,6 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -7,13 +7,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
-import java.util.Collection;
 import java.util.List;
 
 import org.junit.Test;
 
 import spoon.Launcher;
-import spoon.SpoonException;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
@@ -22,7 +20,6 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
-import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.reference.SpoonClassNotFoundException;

--- a/src/test/java/spoon/test/delete/DeleteTest.java
+++ b/src/test/java/spoon/test/delete/DeleteTest.java
@@ -10,7 +10,6 @@ import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;

--- a/src/test/java/spoon/test/generics/testclasses/Spaghetti.java
+++ b/src/test/java/spoon/test/generics/testclasses/Spaghetti.java
@@ -1,7 +1,5 @@
 package spoon.test.generics.testclasses;
 
-import java.util.ArrayList;
-
 @SuppressWarnings(value = { "unchecked" , "unused" , "rawtypes" })
 public class Spaghetti<B> {
     public interface This<K, V> {    }

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -35,7 +35,6 @@ import spoon.test.replace.testclasses.Tacos;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.Stack;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -20,7 +20,6 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.JavaOutputProcessor;
-import spoon.support.compiler.SnippetCompilationError;
 import spoon.test.prettyprinter.testclasses.AClass;
 
 import java.io.File;

--- a/src/test/java/spoon/test/template/CheckBound.java
+++ b/src/test/java/spoon/test/template/CheckBound.java
@@ -1,7 +1,6 @@
 package spoon.test.template;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class CheckBound {


### PR DESCRIPTION
There are some unused imports in tests. Please merge this fix, so my workspace does not report confusing errors.