### PR TITLE
refactor JDTBatchCompiler.getUnits() unused parameter removed

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -369,7 +369,7 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 				keepOutdatedFiles(filesToBuild, new ArrayList<File>());
 			}
 		}
-		CompilationUnitDeclaration[] units = batchCompiler.getUnits(filesToBuild);
+		CompilationUnitDeclaration[] units = batchCompiler.getUnits();
 		// here we build the model
 		buildModel(units);
 
@@ -425,7 +425,7 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 		getFactory().getEnvironment().debugMessage("template build args: " + Arrays.toString(args));
 		batchCompiler.configure(args);
-		CompilationUnitDeclaration[] units = batchCompiler.getUnits(templates.getAllJavaFiles());
+		CompilationUnitDeclaration[] units = batchCompiler.getUnits();
 
 		if (f != null && f.exists()) {
 			f.delete();

--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -30,12 +30,10 @@ import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.core.util.CommentRecorderParser;
 import spoon.SpoonException;
-import spoon.compiler.SpoonFile;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -102,7 +100,7 @@ public class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Ma
 	/** Calls JDT to retrieve the list of compilation unit declarations.
 	 * Depends on the actual implementation of {@link #getCompilationUnits()}
 	 */
-	public CompilationUnitDeclaration[] getUnits(List<SpoonFile> files) {
+	public CompilationUnitDeclaration[] getUnits() {
 		startTime = System.currentTimeMillis();
 		INameEnvironment environment = this.jdtCompiler.environment;
 		if (environment == null) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -106,7 +106,7 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 
 		batchCompiler.configure(args);
 
-		CompilationUnitDeclaration[] units = batchCompiler.getUnits(sources.getAllJavaFiles());
+		CompilationUnitDeclaration[] units = batchCompiler.getUnits();
 
 		if (source.exists()) {
 			source.delete();

--- a/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
@@ -2,8 +2,6 @@ package spoon.support.compiler.jdt;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.List;
-
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -11,7 +9,6 @@ import org.junit.Test;
 
 import spoon.Launcher;
 import spoon.compiler.SpoonCompiler;
-import spoon.compiler.SpoonFile;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtClass;
@@ -29,7 +26,7 @@ public class ExtendedStringLiteralTest {
 					protected JDTBatchCompiler createBatchCompiler() {
 						return new JDTBatchCompiler(this) {
 							@Override
-							public CompilationUnitDeclaration[] getUnits(List<SpoonFile> files) {
+							public CompilationUnitDeclaration[] getUnits() {
 								startTime = System.currentTimeMillis();
 								INameEnvironment environment = this.jdtCompiler.environment;
 								if (environment == null) {


### PR DESCRIPTION
I suggest to remove unused parameter of JDTBatchCompiler.getUnits().