### PR TITLE
add interface CtBodyHolder

### DIFF
--- a/src/main/java/spoon/reflect/code/CtBodyHolder.java
+++ b/src/main/java/spoon/reflect/code/CtBodyHolder.java
@@ -16,33 +16,15 @@
  */
 package spoon.reflect.code;
 
+import spoon.reflect.declaration.CtElement;
+
 /**
- * This code element defines a <code>catch</code> of a <code>try</code>.
- *
- * @see spoon.reflect.code.CtTry
+ * This abstract code element defines an element, which contains a body
  */
-public interface CtCatch extends CtCodeElement, CtBodyHolder {
+public interface CtBodyHolder extends CtElement {
 
 	/**
-	 * Gets the catch's parameter (a throwable).
+	 * Gets the body of this element
 	 */
-	CtCatchVariable<? extends Throwable> getParameter();
-
-	/**
-	 * Sets the catch's parameter (a throwable).
-	 */
-	<T extends CtCatch> T setParameter(CtCatchVariable<? extends Throwable> parameter);
-
-	/**
-	 * Gets the catch's body.
-	 */
-	CtBlock<?> getBody();
-
-	/**
-	 * Sets the catch's body.
-	 */
-	<T extends CtCatch> T setBody(CtBlock<?> body);
-
-	@Override
-	CtCatch clone();
+	CtStatement getBody();
 }

--- a/src/main/java/spoon/reflect/code/CtBodyHolder.java
+++ b/src/main/java/spoon/reflect/code/CtBodyHolder.java
@@ -27,4 +27,9 @@ public interface CtBodyHolder extends CtElement {
 	 * Gets the body of this element
 	 */
 	CtStatement getBody();
+
+	/**
+	 * Sets the body of this element.
+	 */
+	<T extends CtBodyHolder> T setBody(CtStatement body);
 }

--- a/src/main/java/spoon/reflect/code/CtBodyHolder.java
+++ b/src/main/java/spoon/reflect/code/CtBodyHolder.java
@@ -30,6 +30,7 @@ public interface CtBodyHolder extends CtElement {
 
 	/**
 	 * Sets the body of this element.
+	 * If body is not a block, it is wrapped in a CtBlock which is semantically equivalent and eases transformation afterwards if required.
 	 */
 	<T extends CtBodyHolder> T setBody(CtStatement body);
 }

--- a/src/main/java/spoon/reflect/code/CtCatch.java
+++ b/src/main/java/spoon/reflect/code/CtCatch.java
@@ -36,12 +36,14 @@ public interface CtCatch extends CtCodeElement, CtBodyHolder {
 	/**
 	 * Gets the catch's body.
 	 */
+	@Override
 	CtBlock<?> getBody();
 
 	/**
-	 * Sets the catch's body.
+	 * Sets the catch's body. The instance of CtBlock makes sense too
 	 */
-	<T extends CtCatch> T setBody(CtBlock<?> body);
+	@Override
+	<T extends CtBodyHolder> T setBody(CtStatement body);
 
 	@Override
 	CtCatch clone();

--- a/src/main/java/spoon/reflect/code/CtCatch.java
+++ b/src/main/java/spoon/reflect/code/CtCatch.java
@@ -39,12 +39,6 @@ public interface CtCatch extends CtCodeElement, CtBodyHolder {
 	@Override
 	CtBlock<?> getBody();
 
-	/**
-	 * Sets the catch's body. The instance of CtBlock makes sense too
-	 */
-	@Override
-	<T extends CtBodyHolder> T setBody(CtStatement body);
-
 	@Override
 	CtCatch clone();
 }

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -26,12 +26,14 @@ public interface CtLoop extends CtStatement, TemplateParameter<Void>, CtBodyHold
 	/**
 	 * Gets the body of this loop.
 	 */
+	@Override
 	CtStatement getBody();
 
 	/**
-	 * Sets the body of this loop.
+	 * Sets the body of this loop. The instance of CtBlock makes sense too
 	 */
-	<T extends CtLoop> T setBody(CtStatement body);
+	@Override
+	<T extends CtBodyHolder> T setBody(CtStatement body);
 
 	@Override
 	CtLoop clone();

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -29,12 +29,6 @@ public interface CtLoop extends CtStatement, TemplateParameter<Void>, CtBodyHold
 	@Override
 	CtStatement getBody();
 
-	/**
-	 * Sets the body of this loop. The instance of CtBlock makes sense too
-	 */
-	@Override
-	<T extends CtBodyHolder> T setBody(CtStatement body);
-
 	@Override
 	CtLoop clone();
 }

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -21,7 +21,7 @@ import spoon.template.TemplateParameter;
 /**
  * This abstract code element defines a loop.
  */
-public interface CtLoop extends CtStatement, TemplateParameter<Void> {
+public interface CtLoop extends CtStatement, TemplateParameter<Void>, CtBodyHolder {
 
 	/**
 	 * Gets the body of this loop.

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -55,12 +55,14 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	/**
 	 * Sets the tried body.
 	 */
+	@Override
 	CtBlock<?> getBody();
 
 	/**
-	 * Sets the tried body.
+	 * Sets the tried body. The instance of CtBlock makes sense too
 	 */
-	<T extends CtTry> T setBody(CtBlock<?> body);
+	@Override
+	<T extends CtBodyHolder> T setBody(CtStatement body);
 
 	/**
 	 * Gets the <i>finalizer</i> block of this <code>try</code> (

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -30,7 +30,7 @@ import java.util.List;
  *     } catch (Exception ignore) {}
  * </pre>
  */
-public interface CtTry extends CtStatement, TemplateParameter<Void> {
+public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolder {
 
 	/**
 	 * Gets the <i>catchers</i> of this <code>try</code>.

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -53,16 +53,10 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	boolean removeCatcher(CtCatch catcher);
 
 	/**
-	 * Sets the tried body.
+	 * Gets the tried body.
 	 */
 	@Override
 	CtBlock<?> getBody();
-
-	/**
-	 * Sets the tried body. The instance of CtBlock makes sense too
-	 */
-	@Override
-	<T extends CtBodyHolder> T setBody(CtStatement body);
 
 	/**
 	 * Gets the <i>finalizer</i> block of this <code>try</code> (

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -53,7 +53,7 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	boolean removeCatcher(CtCatch catcher);
 
 	/**
-	 * Gets the tried body.
+	 * Gets the try body.
 	 */
 	@Override
 	CtBlock<?> getBody();

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
@@ -16,8 +16,9 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.UnsettableProperty;
 
@@ -43,7 +44,7 @@ public interface CtAnnotationMethod<T> extends CtMethod<T> {
 
 	@Override
 	@UnsettableProperty
-	<B extends T, T1 extends CtExecutable<T>> T1 setBody(CtBlock<B> body);
+	<T1 extends CtBodyHolder> T1 setBody(CtStatement body);
 
 	@Override
 	@UnsettableProperty

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -17,6 +17,7 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
@@ -28,7 +29,7 @@ import java.util.Set;
  * This element represents an executable element such as a method, a
  * constructor, or an anonymous block.
  */
-public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R> {
+public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBodyHolder {
 
 	/**
 	 * The separator for a string representation of an executable.
@@ -46,7 +47,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R> {
 	/**
 	 * Gets the body expression.
 	 */
-	<B extends R> CtBlock<B> getBody();
+	CtBlock<R> getBody();
 
 	/**
 	 * Sets the body expression.

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -52,12 +52,6 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	CtBlock<R> getBody();
 
 	/**
-	 * Sets the body expression. The instance of CtBlock makes sense too
-	 */
-	@Override
-	<T extends CtBodyHolder> T setBody(CtStatement body);
-
-	/**
 	 * Gets the parameters list.
 	 */
 	List<CtParameter<?>> getParameters();

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -18,7 +18,6 @@ package spoon.reflect.declaration;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
-import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -18,6 +18,7 @@ package spoon.reflect.declaration;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
@@ -47,12 +48,14 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	/**
 	 * Gets the body expression.
 	 */
+	@Override
 	CtBlock<R> getBody();
 
 	/**
-	 * Sets the body expression.
+	 * Sets the body expression. The instance of CtBlock makes sense too
 	 */
-	<B extends R, T extends CtExecutable<R>> T setBody(CtBlock<B> body);
+	@Override
+	<T extends CtBodyHolder> T setBody(CtStatement body);
 
 	/**
 	 * Gets the parameters list.

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -508,6 +508,25 @@ public class CodeFactory extends SubFactory {
 	}
 
 	/**
+	 * Accepts instance of CtStatement or CtBlock.
+	 * If element is CtStatement, then it creates wrapping CtBlock, which contains the element
+	 * If element is CtBlock, then it directly returns that element
+	 * If element is null, then it returns null.
+	 * note: It must not create empty CtBlock - as expected in CtCatch, CtExecutable, CtLoop and CtTry setBody implementations
+	 * @param element
+	 * @return CtBlock instance
+	 */
+	public <T extends CtStatement> CtBlock<?> getOrCreateCtBlock(T element) {
+		if (element == null) {
+			return null;
+		}
+		if (element instanceof CtBlock<?>) {
+			return (CtBlock<?>) element;
+		}
+		return this.createCtBlock(element);
+	}
+
+	/**
 	 * Creates a throw.
 	 *
 	 * @param thrownExp

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -22,24 +22,21 @@ import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCase;
-import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtIf;
-import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.code.CtSwitch;
-import spoon.reflect.code.CtTry;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
@@ -436,14 +433,8 @@ class JDTCommentBuilder {
 	 * @return body of element or null if this element has no body
 	 */
 	static CtElement getBody(CtElement e) {
-		if (e instanceof CtLoop) {
-			return ((CtLoop) e).getBody();
-		} else if (e instanceof CtExecutable) {
-			return ((CtExecutable<?>) e).getBody();
-		} else if (e instanceof CtTry) {
-			return ((CtTry) e).getBody();
-		} else if (e instanceof CtCatch) {
-			return ((CtCatch) e).getBody();
+		if (e instanceof CtBodyHolder) {
+			return ((CtBodyHolder) e).getBody();
 		}
 		return null;
 	}

--- a/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
@@ -17,8 +17,10 @@
 package spoon.support.reflect.code;
 
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.visitor.CtVisitor;
 
 public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
@@ -44,7 +46,8 @@ public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 	}
 
 	@Override
-	public <T extends CtCatch> T setBody(CtBlock<?> body) {
+	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+		CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 		if (body != null) {
 			body.setParent(this);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -18,8 +18,10 @@ package spoon.support.reflect.code;
 
 import spoon.SpoonException;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLambda;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
@@ -65,7 +67,8 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	}
 
 	@Override
-	public <B extends T, C extends CtExecutable<T>> C setBody(CtBlock<B> body) {
+	public <C extends CtBodyHolder> C setBody(CtStatement statement) {
+		CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 		if (expression != null && body != null) {
 			throw new SpoonException("A lambda can't have two bodys.");
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -60,8 +60,8 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <B extends T> CtBlock<B> getBody() {
-		return (CtBlock<B>) body;
+	public CtBlock<T> getBody() {
+		return (CtBlock<T>) body;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtLoop;
@@ -34,7 +35,8 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CtBodyHolder> T setBody(CtStatement body) {
+	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+		CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 		if (body != null) {
 			body.setParent(this);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtStatement;
@@ -31,8 +32,9 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 		return body;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CtLoop> T setBody(CtStatement body) {
+	public <T extends CtBodyHolder> T setBody(CtStatement body) {
 		if (body != null) {
 			body.setParent(this);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -17,8 +17,10 @@
 package spoon.support.reflect.code;
 
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCodeElement;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtVisitor;
@@ -99,7 +101,8 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	@Override
-	public <T extends CtTry> T setBody(CtBlock<?> body) {
+	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+		CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 		if (body != null) {
 			body.setParent(this);
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Set;
 
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.reference.CtExecutableReference;
@@ -55,7 +57,8 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 	}
 
 	@Override
-	public <B extends R, T extends CtExecutable<R>> T setBody(CtBlock<B> body) {
+	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+		CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 		if (body != null) {
 			body.setParent(this);
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -50,8 +50,8 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <B extends R> CtBlock<B> getBody() {
-		return (CtBlock<B>) body;
+	public CtBlock<R> getBody() {
+		return (CtBlock<R>) body;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -202,9 +202,9 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtExecutableBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private final spoon.reflect.declaration.CtExecutable element;
+		private final spoon.reflect.code.CtBodyHolder element;
 
-		CtExecutableBodyReplaceListener(spoon.reflect.declaration.CtExecutable element) {
+		CtExecutableBodyReplaceListener(spoon.reflect.code.CtBodyHolder element) {
 			this.element = element;
 		}
 
@@ -535,9 +535,9 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtCatchBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private final spoon.reflect.code.CtCatch element;
+		private final spoon.reflect.code.CtBodyHolder element;
 
-		CtCatchBodyReplaceListener(spoon.reflect.code.CtCatch element) {
+		CtCatchBodyReplaceListener(spoon.reflect.code.CtBodyHolder element) {
 			this.element = element;
 		}
 
@@ -747,9 +747,9 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtLoopBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private final spoon.reflect.code.CtLoop element;
+		private final spoon.reflect.code.CtBodyHolder element;
 
-		CtLoopBodyReplaceListener(spoon.reflect.code.CtLoop element) {
+		CtLoopBodyReplaceListener(spoon.reflect.code.CtBodyHolder element) {
 			this.element = element;
 		}
 
@@ -1571,9 +1571,9 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtTryBodyReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtBlock> {
-		private final spoon.reflect.code.CtTry element;
+		private final spoon.reflect.code.CtBodyHolder element;
 
-		CtTryBodyReplaceListener(spoon.reflect.code.CtTry element) {
+		CtTryBodyReplaceListener(spoon.reflect.code.CtBodyHolder element) {
 			this.element = element;
 		}
 

--- a/src/test/java/spoon/test/ctBodyHolder/CtBodyHolderTest.java
+++ b/src/test/java/spoon/test/ctBodyHolder/CtBodyHolderTest.java
@@ -1,0 +1,147 @@
+package spoon.test.ctBodyHolder;
+
+import static org.junit.Assert.*;
+import static spoon.testing.utils.ModelUtils.build;
+
+import org.junit.Test;
+
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
+import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtTry;
+import spoon.reflect.code.CtWhile;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.factory.Factory;
+import spoon.test.ctBodyHolder.testclasses.CWBStatementTemplate;
+import spoon.test.ctBodyHolder.testclasses.ClassWithBodies;
+
+public class CtBodyHolderTest
+{
+    @Test
+    public void testConstructor() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(1, cwbClass.getConstructors().size());
+        CtConstructor<?> constructor =  cwbClass.getConstructor();
+        checkCtBody(constructor, "constructor_body", 1);
+    }
+
+    @Test
+    public void testMethod() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(2, cwbClass.getMethods().size());
+        CtMethod<?> method =  cwbClass.getMethod("method");
+        checkCtBody(method, "method_body", 0);
+    }
+
+    @Test
+    public void testTryCatch() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(2, cwbClass.getMethods().size());
+        CtMethod<?> method =  cwbClass.getMethod("method2");
+        CtBlock<?> methodBody = method.getBody();
+        assertTrue(methodBody.getStatement(0) instanceof CtTry);
+        CtTry tryStmnt = (CtTry)methodBody.getStatement(0);
+        checkCtBody(tryStmnt, "try_body", 0);
+        assertEquals(1, tryStmnt.getCatchers().size());
+        assertTrue(tryStmnt.getCatchers().get(0) instanceof CtCatch);
+        checkCtBody(tryStmnt.getCatchers().get(0), "catch_body", 0);
+    }
+
+    @Test
+    public void testForWithStatement() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(2, cwbClass.getMethods().size());
+        CtMethod<?> method =  cwbClass.getMethod("method2");
+        CtBlock<?> methodBody = method.getBody();
+        assertTrue(methodBody.getStatement(1) instanceof CtFor);
+        CtFor forStmnt = (CtFor)methodBody.getStatement(1);
+        checkCtBody(forStmnt, "for_statemnt", 0);
+    }
+
+    @Test
+    public void testForWithBlock() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(2, cwbClass.getMethods().size());
+        CtMethod<?> method =  cwbClass.getMethod("method2");
+        CtBlock<?> methodBody = method.getBody();
+        assertTrue(methodBody.getStatement(2) instanceof CtFor);
+        CtFor forStmnt = (CtFor)methodBody.getStatement(2);
+        checkCtBody(forStmnt, "for_block", 0);
+    }
+
+    @Test
+    public void testWhileWithBlock() throws Exception {
+        Factory factory = build(ClassWithBodies.class, CWBStatementTemplate.class);
+        CtClass<?> cwbClass = (CtClass<?>) factory.Type().get(ClassWithBodies.class);
+        assertEquals(2, cwbClass.getMethods().size());
+        CtMethod<?> method =  cwbClass.getMethod("method2");
+        CtBlock<?> methodBody = method.getBody();
+        assertTrue(methodBody.getStatement(3) instanceof CtWhile);
+        CtWhile whileStmnt = (CtWhile)methodBody.getStatement(3);
+        checkCtBody(whileStmnt, "while_block", 0);
+    }
+
+    private void checkCtBody(CtBodyHolder p_bodyHolder, String p_constant, int off)
+	{
+		CtStatement body = p_bodyHolder.getBody();
+		assertTrue(body instanceof CtBlock<?>);
+		
+		CtBlock<?> block = (CtBlock)body;
+		assertEquals(1+off, block.getStatements().size());
+		
+		assertTrue(block.getStatement(off) instanceof CtAssignment);
+		
+		CtAssignment assignment = block.getStatement(off);
+		assertEquals(p_constant, ((CtLiteral<String>)assignment.getAssignment().partiallyEvaluate()).getValue());
+		
+		Factory f = body.getFactory();
+		
+		CtStatement newStat = new CWBStatementTemplate("xx").apply(body.getParent(CtType.class));
+		try {
+			newStat.getParent();
+			fail();
+		} catch(ParentNotInitializedException e) {
+			//expected exception
+		}
+		//try to set statement and get CtBlock
+		p_bodyHolder.setBody(newStat);
+		CtBlock newBlock = (CtBlock)p_bodyHolder.getBody();
+		assertSame(p_bodyHolder, newBlock.getParent());
+		assertSame(newBlock, newStat.getParent());
+
+		//try to set CtBlock and get the same CtBlock
+		CtStatement newStat2 = newStat.clone();
+		try {
+			newStat2.getParent();
+			fail();
+		} catch(ParentNotInitializedException e) {
+			//expected exception
+		}
+		CtBlock newBlock2 = f.Code().createCtBlock(newStat2);
+		assertSame(newBlock2, newStat2.getParent());
+		try {
+			newBlock2.getParent();
+			fail();
+		} catch(ParentNotInitializedException e) {
+			//expected exception
+		}
+
+		p_bodyHolder.setBody(newBlock2);
+		assertSame(newBlock2, p_bodyHolder.getBody());
+		assertSame(p_bodyHolder, newBlock2.getParent());
+		assertSame(newBlock2, newStat2.getParent());
+	}
+}

--- a/src/test/java/spoon/test/ctBodyHolder/testclasses/CWBStatementTemplate.java
+++ b/src/test/java/spoon/test/ctBodyHolder/testclasses/CWBStatementTemplate.java
@@ -1,0 +1,22 @@
+package spoon.test.ctBodyHolder.testclasses;
+
+import spoon.template.Parameter;
+import spoon.template.StatementTemplate;
+
+public class CWBStatementTemplate extends StatementTemplate
+{
+	@Parameter
+	String value;
+
+	public CWBStatementTemplate(String val)
+	{
+		value = val;
+	}
+
+	@Override
+	public void statement() throws Throwable
+	{
+		System.out.println(value);
+	}
+
+}

--- a/src/test/java/spoon/test/ctBodyHolder/testclasses/ClassWithBodies.java
+++ b/src/test/java/spoon/test/ctBodyHolder/testclasses/ClassWithBodies.java
@@ -1,0 +1,29 @@
+package spoon.test.ctBodyHolder.testclasses;
+
+public class ClassWithBodies
+{
+	String var;
+	
+	public ClassWithBodies()
+	{
+		var = "constructor_body";
+	}
+	
+	public void method() {
+		var = "method_body";
+	}
+	public void method2() {
+		try {
+			var = "try_body";
+		} catch(Exception e) {
+			var = "catch_body";
+		}
+		for(int i=0; i<10; i++) var="for_statemnt";
+		for(int i=0; i<10; i++) {
+			var="for_block";
+		}
+		while(1+1>var.length()) {
+			var="while_block";
+		}
+	}
+}

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -58,7 +58,9 @@ public class FactoryTest {
 		final CoreFactory specialCoreFactory = new DefaultCoreFactory() {
 			@Override
 			public <T> CtMethod<T> createMethod() {
-				return new MyCtMethod<T>();
+				MyCtMethod<T> m = new MyCtMethod<T>();
+				m.setFactory(getMainFactory());
+				return m;
 			}
 		};
 


### PR DESCRIPTION
Note! I had to rollback `CtExecutable.getBody` declaration made by 

> GerardPaligot <gerard.paligot@gmail.com> on 7.8.15 14:20

to make it compilable with new `CtBodyHolder`. I have not found a way how to declare `CtBodyHolder` to have it compilable with origin `CtExecutable.getBody` declaration.

I have no idea whether my changes are correct. It might have some impact to Spoon templates!