### PR TITLE
refactor: avoid creation of JDT hacking TMP files

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -399,16 +399,9 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 
 		JDTBatchCompiler batchCompiler = createBatchCompiler(new FileCompilerConfig(templates));
 
-		File f = null;
 		String[] templateClasspath = new String[0];
 		if (getTemplateClasspath() != null && getTemplateClasspath().length > 0) {
 			templateClasspath = getTemplateClasspath();
-			for (SpoonFolder file : templates.getSubFolders()) {
-				if (file.isArchive()) {
-					// JDT bug HACK
-					f = createTmpJavaFile(file.getFileSystemParent());
-				}
-			}
 		}
 
 		String[] args;
@@ -426,10 +419,6 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 		getFactory().getEnvironment().debugMessage("template build args: " + Arrays.toString(args));
 		batchCompiler.configure(args);
 		CompilationUnitDeclaration[] units = batchCompiler.getUnits();
-
-		if (f != null && f.exists()) {
-			f.delete();
-		}
 
 		// here we build the model in the template factory
 		buildModel(units);
@@ -526,26 +515,6 @@ public class JDTBasedSpoonCompiler implements SpoonCompiler {
 				Launcher.LOGGER.error(e.getMessage(), e);
 			}
 		}
-	}
-
-	// this function is used to hack the JDT compiler...
-	protected File createTmpJavaFile(File folder) {
-		File f;
-		try {
-			f = File.createTempFile("Tmp", ".java", folder);
-		} catch (IOException e1) {
-			throw new SpoonException(e1);
-		}
-		if (f.exists()) {
-			return f;
-		}
-		try {
-			FileUtils.writeStringToFile(f, "class Tmp {}");
-			f.deleteOnExit();
-		} catch (Exception e) {
-			Launcher.LOGGER.error(e.getMessage(), e);
-		}
-		return f;
 	}
 
 	protected void keepOutdatedFiles(List<SpoonFile> files, Collection<File> outputFiles) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -16,7 +16,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -88,7 +87,6 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 		}
 		JDTBatchCompiler batchCompiler = createBatchCompiler(new FileCompilerConfig(sources));
 
-		File source = createTmpJavaFile(new File("."));
 		String[] args;
 		if (jdtBuilder == null) {
 			String[] sourceClasspath = getSourceClasspath();
@@ -96,7 +94,13 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 					.classpathOptions(new ClasspathOptions().encoding(this.encoding).classpath(sourceClasspath)) //
 					.complianceOptions(new ComplianceOptions().compliance(javaCompliance)) //
 					.advancedOptions(new AdvancedOptions().preserveUnusedVars().continueExecution().enableJavadoc()) //
-					.sources(new SourceOptions().sources(source.getPath())) //
+					/*
+					 * compiler requires some sources, otherwise it does not pass batchCompiler.configure(args) well
+					 * But it does not checks if the file really exists.
+					 * The CompilationUnits are delivered to compiler in different way,
+					 * so it is just a trick to initialize other Compiler configurations well
+					 */
+					.sources(new SourceOptions().sources("./Tmp.java")) //
 					.build();
 		} else {
 			args = jdtBuilder.build();
@@ -107,10 +111,6 @@ public class JDTSnippetCompiler extends JDTBasedSpoonCompiler {
 		batchCompiler.configure(args);
 
 		CompilationUnitDeclaration[] units = batchCompiler.getUnits();
-
-		if (source.exists()) {
-			source.delete();
-		}
 
 		// here we build the model
 		buildModel(units);


### PR DESCRIPTION
I am trying to unify compilation process of snippets, templates and sources. I have found these facts:

## JDTBasedSpoonCompiler buildSources and buildTemplates
- `JDTBasedSpoonCompiler.createTmpJavaFile(folder)` always creates empty file. **So nobody needs content of that file.**
- `JDTBasedSpoonCompiler` methods `buildSources` and `buildTemplates` does the same - compiles java files and fills the model. Just the classpath and files are different. But all other things related to compilation are same!
So there is no reason why `buildTemplates` is creating a temporary file next to zip or jar archives, while `buildSources` does not need that. 
This TMP file creation code is anyway wrong, it actually might produce many empty tmp files and deletes only one of them!
There is no test case, which would fail, if creation of tmp files here is omitted. 
The code is here since commit 39562eb27c0f533cc3a7055a05b7e344b6f29e6f (nearly 3 years old) and at this time there was used different version of JDT compiler. So there is high chance that JDT bug is already fixed.

So I suggest to get rid of the creation of these temporary files in `buildTemplates`. And if it really fails by somebody then we can get the stacktrace and can create a test case and can fix it **correctly**. But actually it looks like useless code, which just makes things more complicated.

## JDTSnippetCompiler buildSources
this method creates temporary file too. I have found that JDT compilation does not need existing file. It is enough to provide there **some** source path and it passes too.
