### PR TITLE
fix(isAssignableFrom): deprecate a method that is totally confusing

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -103,7 +103,13 @@ public interface CtTypeInformation {
 	/**
 	 * Returns <code>true</code> if this referenced type is assignable from an
 	 * instance of the given type.
+	 *
+	 * Deprecated on Nov 19, 2016
+	 * Reasons for deprecation:
+	 * 1) it has the opposite behavior of java.lang.Class.isAssignableFrom, this is very confusing
+	 * 2) we already have {@link #isSubtypeOf(CtTypeReference)}
 	 */
+	@Deprecated
 	boolean isAssignableFrom(CtTypeReference<?> type);
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
@@ -40,7 +40,7 @@ public class OverriddenMethodFilter implements Filter<CtMethod<?>> {
 	public boolean matches(CtMethod<?> element) {
 		final CtType expectedParent = method.getParent(CtType.class);
 		final CtType<?> currentParent = element.getParent(CtType.class);
-		return expectedParent.isAssignableFrom(currentParent.getReference()) //
+		return expectedParent.isSubtypeOf(currentParent.getReference()) //
 				&& !currentParent.equals(expectedParent) //
 				&& method.getReference().isOverriding(element.getReference());
 	}

--- a/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
@@ -40,7 +40,7 @@ public class OverridingMethodFilter implements Filter<CtMethod<?>> {
 	public boolean matches(CtMethod<?> element) {
 		final CtType expectedParent = method.getParent(CtType.class);
 		final CtType<?> currentParent = element.getParent(CtType.class);
-		return currentParent.isAssignableFrom(expectedParent.getReference()) //
+		return currentParent.isSubtypeOf(expectedParent.getReference()) //
 				&& !currentParent.equals(expectedParent) //
 				&& element.getReference().isOverriding(method.getReference());
 	}

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -438,7 +438,7 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 			}
 		}
 		if (fieldAccess.getFactory().Type().createReference(Enum.class)
-				.isAssignableFrom(fieldAccess.getVariable().getDeclaringType())) {
+				.isSubtypeOf(fieldAccess.getVariable().getDeclaringType())) {
 			CtLiteral<CtFieldReference<?>> l = fieldAccess.getFactory().Core().createLiteral();
 			l.setValue(fieldAccess.getVariable());
 			setResult(l);
@@ -561,7 +561,7 @@ public class VisitorPartialEvaluator implements CtVisitor, PartialEvaluator {
 			// try to inline partial evaluation results for local calls
 			// (including to superclasses)
 			if ((executable != null) && (invocation.getType() != null) && invocation.getExecutable().getDeclaringType()
-					.isAssignableFrom(((CtType<?>) invocation.getParent(CtType.class)).getReference())) {
+					.isSubtypeOf(((CtType<?>) invocation.getParent(CtType.class)).getReference())) {
 				CtBlock<?> b = evaluate(invocation.getParent(), executable.getBody());
 				flowEnded = false;
 				CtStatement last = b.getStatements().get(b.getStatements().size() - 1);

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -204,7 +204,7 @@ public abstract class Parameters {
 			return (ref.getDeclaration() != null // we must have the source of
 					// this fieldref
 					&& ref.getDeclaration().getAnnotation(Parameter.class) != null) || (!((ref.getType() instanceof CtTypeParameterReference) || ref.getSimpleName().equals("this"))
-					&& getTemplateParameterType(ref.getFactory()).isAssignableFrom(ref.getType()));
+					&& getTemplateParameterType(ref.getFactory()).isSubtypeOf(ref.getType()));
 		} catch (RuntimeException e) {
 			// if (e.getCause() instanceof ClassNotFoundException) {
 			// return false;

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -474,7 +474,7 @@ public class SubstitutionVisitor extends CtScanner {
 				reference.setPackage(t.getPackage());
 				reference.setSimpleName(t.getSimpleName());
 				reference.setDeclaringType(t.getDeclaringType());
-			} else if (templateTypeRef.isAssignableFrom(reference)) {
+			} else if (templateTypeRef.isSubtypeOf(reference)) {
 				// this can only be a template inheritance case (to be verified)
 				CtTypeReference<?> sc = targetRef.getSuperclass();
 				if (sc != null) {

--- a/src/main/java/spoon/template/TemplateMatcher.java
+++ b/src/main/java/spoon/template/TemplateMatcher.java
@@ -154,7 +154,7 @@ public class TemplateMatcher {
 		for (Object tem : teList) {
 			if (variables.contains(tem) && (tem instanceof CtInvocation)) {
 				CtInvocation<?> listCand = (CtInvocation<?>) tem;
-				boolean ok = listCand.getFactory().Type().createReference(TemplateParameter.class).isAssignableFrom(listCand.getTarget().getType());
+				boolean ok = listCand.getFactory().Type().createReference(TemplateParameter.class).isSubtypeOf(listCand.getTarget().getType());
 				return ok ? listCand : null;
 			}
 			if (tem instanceof CtVariable) {

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcer.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcer.java
@@ -4,10 +4,13 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonAPI;
 import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.support.DefaultCoreFactory;
+import spoon.support.compiler.SnippetCompilationHelper;
 
 import java.util.TreeSet;
 
@@ -70,13 +73,13 @@ public class SpoonArchitectureEnforcer {
 		interfaces.addInputResource("src/main/java/spoon/reflect/declaration");
 		interfaces.addInputResource("src/main/java/spoon/reflect/code");
 		interfaces.addInputResource("src/main/java/spoon/reflect/reference");
+		interfaces.addInputResource("src/main/java/spoon/support/DefaultCoreFactory.java");
 		interfaces.buildModel();
 
-		for(CtType<?> t : implementations.getModel().getAllTypes()) {
+		for (CtType<?> t : implementations.getModel().getAllTypes()) {
 			String impl = t.getQualifiedName().replace(".support", "").replace("Impl", "");
 			CtType itf = interfaces.getFactory().Type().get(impl);
-			assertTrue(t.isAssignableFrom(itf.getReference()));
+			assertTrue(itf.isSubtypeOf(t.getReference()));
 		}
 	}
-
 }

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -561,8 +561,8 @@ public class CommentTest {
 			// we don't consider references
 			if (x.getSimpleName().endsWith("Reference")) { return; }
 
-			if (x.isAssignableFrom(launcher.getFactory().Type().get(CtStatement.class).getReference())
-					|| x.isAssignableFrom(launcher.getFactory().Type().get(CtExpression.class).getReference())
+			if (x.isSubtypeOf(launcher.getFactory().Type().get(CtStatement.class).getReference())
+					|| x.isSubtypeOf(launcher.getFactory().Type().get(CtExpression.class).getReference())
 					) {
 				if (x.getSimpleName().equals("CtCodeSnippetStatement")) { return; } // no meaningful snippet
 				if (x.getSimpleName().equals("CtCodeSnippetExpression")) { return; } // no meaningful snippet


### PR DESCRIPTION
 Reasons for deprecation:

* it has the opposite behavior of java.lang.Class.isAssignableFrom, this is very confusing
* we already have {@link #isSubtypeOf(CtTypeReference)}