### PR TITLE
test bug CtClass.getSuperClass() returns invalid CtTypeReference

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -96,6 +96,12 @@ public interface CtTypeInformation {
 	boolean isGenerics();
 
 	/**
+	 * @param type
+	 * @return true if this Type is visible in class type
+	 */
+	boolean isVisibleIn(CtTypeReference<?> type);
+
+	/**
 	 * Returns true if the referenced type is a sub-type of the given type.
 	 */
 	boolean isSubtypeOf(CtTypeReference<?> type);

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -106,6 +106,7 @@ import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.printer.CommentOffset;
 import spoon.reflect.visitor.printer.ElementPrinterHelper;
 import spoon.reflect.visitor.printer.PrinterHelper;
+import spoon.support.SpoonClassNotFoundException;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
@@ -1616,11 +1617,30 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				if (!withGenerics) {
 					context.ignoreGenerics = true;
 				}
-				scan(ref.getDeclaringType());
-				if (!withGenerics) {
-					context.ignoreGenerics = ign;
+				CtTypeReference<?> declTypeRef = ref.getDeclaringType();
+				boolean isVisible = true;
+				try {
+					if (context.currentTopLevel != null && declTypeRef.isVisibleIn(context.currentTopLevel.getReference()) == false) {
+						//the declTypeRef is not visible in actually printed class
+						isVisible = false;
+					}
+				} catch (SpoonClassNotFoundException e) {
+					//ignore that we cannot detect visibility of the referred class. It is more probable that it is visible so
+					isVisible = true;
 				}
-				printer.write(".");
+
+				if (isVisible) {
+					/*
+					 * add scope of declaring class only if it is visible here. If it is not visible,
+					 * then we should continue, because the nested class might still be visible.
+					 * See ImportTest.testSpoonWithImports() class InnerClassProtected, which is visible in ClientClass
+					 */
+					scan(ref.getDeclaringType());
+					if (!withGenerics) {
+						context.ignoreGenerics = ign;
+					}
+					printer.write(".");
+				}
 			}
 			elementPrinterHelper.writeAnnotations(ref);
 			if (ref.isLocalType()) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -26,10 +26,8 @@ import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalTypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.MemberTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MissingTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
@@ -62,8 +60,6 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -618,21 +614,6 @@ class JDTTreeBuilderHelper {
 		}
 
 		if (type instanceof CtClass) {
-			if (typeDeclaration.superclass != null && typeDeclaration.superclass.resolvedType != null && typeDeclaration.enclosingType != null && !new String(
-					typeDeclaration.superclass.resolvedType.qualifiedPackageName()).equals(new String(typeDeclaration.binding.qualifiedPackageName()))) {
-
-				// Sorry for this hack but see the test case ImportTest#testImportOfAnInnerClassInASuperClassPackage.
-				// JDT isn't smart enough to return me a super class available. So, I modify their AST when
-				// superclasses aren't in the same package and when their visibilities are "default".
-				List<ModifierKind> modifiers = Arrays.asList(ModifierKind.PUBLIC, ModifierKind.PROTECTED);
-				final TypeBinding resolvedType = typeDeclaration.superclass.resolvedType;
-				if ((resolvedType instanceof MemberTypeBinding || resolvedType instanceof BinaryTypeBinding)//
-						&& resolvedType.enclosingType() != null && typeDeclaration.enclosingType.superclass != null//
-						&& Collections.disjoint(modifiers, getModifiers(resolvedType.enclosingType().modifiers))) {
-					typeDeclaration.superclass.resolvedType = jdtTreeBuilder.new SpoonReferenceBinding(typeDeclaration.superclass.resolvedType.sourceName(),
-							(ReferenceBinding) typeDeclaration.enclosingType.superclass.resolvedType);
-				}
-			}
 			if (typeDeclaration.superclass != null) {
 				((CtClass) type).setSuperclass(jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope));
 			}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -363,6 +363,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		}
 	}
 
+
 	@Override
 	public CtTypeReference<T> getReference() {
 		return getFactory().Type().createReference(this);
@@ -470,6 +471,36 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@Override
 	public boolean isGenerics() {
 		return false;
+	}
+
+	@Override
+	public boolean isVisibleIn(CtTypeReference<?> type) {
+		if (modifiers.contains(ModifierKind.PUBLIC)) {
+			return true;
+		}
+		if (modifiers.contains(ModifierKind.PROTECTED)) {
+			if (type.isSubtypeOf(this.getReference())) {
+				//is visible in subtypes
+				return true;
+			} //else it is visible in same package, like package protected
+		}
+		if (modifiers.contains(ModifierKind.PRIVATE)) {
+			//it is visible in scope of the same class only
+			return getTopLevelType(this.getReference()).getQualifiedName().equals(type.getQualifiedName());
+		}
+		//package protected
+		if (getTopLevelType(this.getReference()).getPackage().getSimpleName().equals(getTopLevelType(type).getPackage().getSimpleName())) {
+			//visible only in scope of the same package
+			return true;
+		}
+		return false;
+	}
+	//TODO we should move it into some better place
+	public static CtTypeReference<?> getTopLevelType(CtTypeReference<?> type) {
+		if (type.getDeclaringType() != null) {
+			type = type.getDeclaringType();
+		}
+		return type;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -33,6 +33,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.SpoonClassNotFoundException;
 import spoon.support.reflect.declaration.CtElementImpl;
+import spoon.support.reflect.declaration.CtTypeImpl;
 import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.util.RtHelper;
 
@@ -551,6 +552,31 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	@Override
 	public boolean isGenerics() {
+		return false;
+	}
+
+	@Override
+	public boolean isVisibleIn(CtTypeReference<?> type) {
+		Set<ModifierKind> modifiers = getModifiers();
+
+		if (modifiers.contains(ModifierKind.PUBLIC)) {
+			return true;
+		}
+		if (modifiers.contains(ModifierKind.PROTECTED)) {
+			if (type.isSubtypeOf(this)) {
+				//is visible in subtypes
+				return true;
+			} //else it is visible in same package, like package protected
+		}
+		if (modifiers.contains(ModifierKind.PRIVATE)) {
+			//it is visible in scope of the same class only
+			return CtTypeImpl.getTopLevelType(this).getQualifiedName().equals(type.getQualifiedName());
+		}
+		//package protected
+		if (CtTypeImpl.getTopLevelType(this).getPackage().getSimpleName().equals(CtTypeImpl.getTopLevelType(type).getPackage().getSimpleName())) {
+			//visible only in scope of the same package
+			return true;
+		}
 		return false;
 	}
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -295,6 +295,23 @@ public class ImportTest {
 				+ "    public class ArrayList extends java.util.ArrayList {    }" + newLine
 				+ "}", aClass.toString());
 	}
+	
+	@Test
+	public void testAccessToNestedClass() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {
+				"-i", "./src/test/java/spoon/test/imports/testclasses", "--with-imports"
+		});
+		launcher.buildModel();
+		final CtClass<ImportTest> aClass = launcher.getFactory().Class().get(ClientClass.class.getName()+"$InnerClass");
+		assertEquals(ClientClass.class.getName()+"$InnerClass", aClass.getQualifiedName()); 
+		final CtTypeReference<?> parentClass = aClass.getSuperclass();
+		//comment next line and parentClass.getActualClass(); will fail anyway
+		assertEquals("spoon.test.imports.testclasses.internal.SuperClass$InnerClassProtected", parentClass.getQualifiedName()); 
+		Class<?> actualClass = parentClass.getActualClass();
+		assertEquals("spoon.test.imports.testclasses.internal.SuperClass$InnerClassProtected", actualClass.getName()); 
+	}
+	
 
 	private Factory getFactory(String...inputs) {
 		final Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -65,7 +65,7 @@ public class ImportTest {
 		String expected = "spoon.test.imports.testclasses.ClientClass.InnerClass";
 		assertEquals(expected, innerClass.getReference().toString());
 
-		expected = "spoon.test.imports.testclasses.internal.ChildClass.InnerClassProtected";
+		expected = "spoon.test.imports.testclasses.internal.SuperClass.InnerClassProtected";
 		assertEquals(expected, innerClass.getSuperclass().toString());
 	}
 
@@ -86,7 +86,7 @@ public class ImportTest {
 		String expected = "visibility.YamlRepresenter.RepresentConfigurationSection";
 		assertEquals(expected, innerClass.getReference().toString());
 
-		expected = "org.yaml.snakeyaml.representer.Representer.RepresentMap";
+		expected = "org.yaml.snakeyaml.representer.SafeRepresenter.RepresentMap";
 		assertEquals(expected, innerClass.getSuperclass().toString());
 	}
 
@@ -157,6 +157,7 @@ public class ImportTest {
 		assertEquals(2, imports.size());
 		final Collection<CtTypeReference<?>> imports1 = importScanner.computeImports(anotherClass);
 		assertEquals(1, imports1.size());
+		assertTrue(anotherClass.toString().indexOf("InnerClass extends InnerClassProtected")>0);
 		final Collection<CtTypeReference<?>> imports2 = importScanner.computeImports(classWithInvocation);
 		assertEquals("Spoon ignores the arguments of CtInvocations", 1, imports2.size());
 	}


### PR DESCRIPTION
Added test  `spoon.test.imports.ImportTest.testAccessToNestedClass` which reproduces #959