### PR TITLE
remove unused printer code of visitCtCatchVariable

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1133,11 +1133,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (env.isPreserveLineNumbers()) {
 			printer.adjustPosition(catchVariable, sourceCompilationUnit);
 		}
-		if (!context.noTypeDecl) {
-			elementPrinterHelper.writeModifiers(catchVariable);
-			scan(catchVariable.getType());
-			printer.write(" ");
-		}
+		elementPrinterHelper.writeModifiers(catchVariable);
+		scan(catchVariable.getType());
+		printer.write(" ");
 		printer.write(catchVariable.getSimpleName());
 	}
 


### PR DESCRIPTION
I am learning how DefaultJavaPrettyPrinter works, to make #913 fast again and I have found some little unused code.
@GerardPaligot please review this, if it is really unused, or I misunderstood something.