### PR TITLE
fix(scanner): add missing scan properties based on a new powerful specification

### DIFF
--- a/src/main/java/spoon/reflect/code/CtCatchVariable.java
+++ b/src/main/java/spoon/reflect/code/CtCatchVariable.java
@@ -19,6 +19,8 @@ package spoon.reflect.code;
 import spoon.reflect.declaration.CtMultiTypedElement;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
 
 /**
  * This code element defines an exception variable in a catch.
@@ -33,8 +35,13 @@ public interface CtCatchVariable<T> extends CtVariable<T>, CtMultiTypedElement, 
 	 *
 	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
 	 */
+	@DerivedProperty
 	CtCatchVariableReference<T> getReference();
 
 	@Override
 	CtCatchVariable<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
 }

--- a/src/main/java/spoon/reflect/code/CtConstructorCall.java
+++ b/src/main/java/spoon/reflect/code/CtConstructorCall.java
@@ -19,6 +19,7 @@ package spoon.reflect.code;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.List;
 
@@ -38,6 +39,7 @@ public interface CtConstructorCall<T> extends CtTargetedExpression<T, CtExpressi
 	 * @see CtExecutableReference#getActualTypeArguments()
 	 */
 	@Override
+	@DerivedProperty
 	List<CtTypeReference<?>> getActualTypeArguments();
 
 	/**

--- a/src/main/java/spoon/reflect/code/CtInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtInvocation.java
@@ -19,6 +19,7 @@ package spoon.reflect.code;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.List;
 
@@ -42,6 +43,7 @@ public interface CtInvocation<T> extends CtAbstractInvocation<T>, CtStatement, C
 	 * @see CtExecutableReference#getActualTypeArguments()
 	 */
 	@Override
+	@DerivedProperty
 	List<CtTypeReference<?>> getActualTypeArguments();
 
 	/**
@@ -66,6 +68,7 @@ public interface CtInvocation<T> extends CtAbstractInvocation<T>, CtStatement, C
 	 * the actual type bound to this particular invocation.
 	 */
 	@Override
+	@DerivedProperty
 	CtTypeReference<T> getType();
 
 	@Override

--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -17,6 +17,10 @@
 package spoon.reflect.code;
 
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
+import java.util.Set;
 
 /**
  * This code element represents the creation of a lambda. A lambda
@@ -63,4 +67,8 @@ public interface CtLambda<T> extends CtExpression<T>, CtExecutable<T> {
 
 	@Override
 	CtLambda<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<T1 extends CtExecutable<T>> T1 setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 }

--- a/src/main/java/spoon/reflect/code/CtLocalVariable.java
+++ b/src/main/java/spoon/reflect/code/CtLocalVariable.java
@@ -18,6 +18,7 @@ package spoon.reflect.code;
 
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtLocalVariableReference;
+import spoon.support.DerivedProperty;
 
 /**
  * This code element defines a local variable definition (within an executable
@@ -39,7 +40,15 @@ public interface CtLocalVariable<T> extends CtStatement, CtVariable<T>, CtRHSRec
 	 *
 	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
 	 */
+	@DerivedProperty
 	CtLocalVariableReference<T> getReference();
+
+	/**
+	 * Useful proxy to {@link #getDefaultExpression()}.
+	 */
+	@Override
+	@DerivedProperty
+	CtExpression<T> getAssignment();
 
 	@Override
 	CtLocalVariable<T> clone();

--- a/src/main/java/spoon/reflect/code/CtNewClass.java
+++ b/src/main/java/spoon/reflect/code/CtNewClass.java
@@ -20,6 +20,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.List;
 
@@ -46,6 +47,7 @@ public interface CtNewClass<T> extends CtConstructorCall<T> {
 	 * @see CtExecutableReference#getActualTypeArguments()
 	 */
 	@Override
+	@DerivedProperty
 	List<CtTypeReference<?>> getActualTypeArguments();
 
 	/**

--- a/src/main/java/spoon/reflect/code/CtRHSReceiver.java
+++ b/src/main/java/spoon/reflect/code/CtRHSReceiver.java
@@ -17,6 +17,7 @@
 package spoon.reflect.code;
 
 import spoon.reflect.declaration.CtField;
+import spoon.support.DerivedProperty;
 
 /**
  * Represents the right hand side of an assignment
@@ -27,6 +28,7 @@ public interface CtRHSReceiver<A> {
 	/**
 	 * Returns the right-hand side of the "=" operator.
 	 */
+	@DerivedProperty
 	CtExpression<A> getAssignment();
 
 	/**

--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -17,6 +17,7 @@
 package spoon.reflect.code;
 
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 /**
  * This code element represents a type reference usable as an expression.
@@ -68,6 +69,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 * @see #getAccessedType() to get the accessed type.
 	 */
 	@Override
+	@DerivedProperty
 	CtTypeReference<Void> getType();
 
 	@Override

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -21,8 +21,11 @@ import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
 
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -102,6 +105,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 *
 	 * @return annotated {@link spoon.reflect.declaration.CtElement}
 	 */
+	@DerivedProperty // the annotation is contained by the element not the other way around
 	CtElement getAnnotatedElement();
 
 	/**
@@ -138,4 +142,8 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 
 	@Override
 	CtAnnotation<A> clone();
+
+	@Override
+	@UnsettableProperty
+	<C extends CtExpression<A>> C setTypeCasts(List<CtTypeReference<?>> types);
 }

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
@@ -16,7 +16,13 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * This element defines an annotation method declared in an annotation type.
@@ -34,4 +40,20 @@ public interface CtAnnotationMethod<T> extends CtMethod<T> {
 
 	@Override
 	CtAnnotationMethod<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<B extends T, T1 extends CtExecutable<T>> T1 setBody(CtBlock<B> body);
+
+	@Override
+	@UnsettableProperty
+	<T1 extends CtExecutable<T>> T1 setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+
+	@Override
+	@UnsettableProperty
+	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+
+	@Override
+	@UnsettableProperty
+	<T1 extends CtExecutable<T>> T1 setParameters(List<CtParameter<?>> parameters);
 }

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
@@ -16,7 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+
 import java.lang.annotation.Annotation;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -27,6 +32,7 @@ public interface CtAnnotationType<T extends Annotation> extends CtType<T> {
 	/**
 	 * Gets the methods of this annotation type which are necessarily {@link CtAnnotationMethod}.
 	 */
+	@DerivedProperty
 	Set<CtAnnotationMethod<?>> getAnnotationMethods();
 
 	/**
@@ -45,4 +51,17 @@ public interface CtAnnotationType<T extends Annotation> extends CtType<T> {
 
 	@Override
 	CtAnnotationType<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<T>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
+
 }

--- a/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
@@ -16,6 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
+import java.util.List;
+import java.util.Set;
+
 /**
  * This element defines an anonymous executable block declaration in a class.
  *
@@ -24,4 +30,12 @@ package spoon.reflect.declaration;
 public interface CtAnonymousExecutable extends CtExecutable<Void>, CtTypeMember {
 	@Override
 	CtAnonymousExecutable clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtExecutable<Void>> T setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+
+	@Override
+	@UnsettableProperty
+	<T extends CtExecutable<Void>> T setParameters(List<CtParameter<?>> parameters);
 }

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -18,6 +18,8 @@ package spoon.reflect.declaration;
 
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
+
 import java.util.List;
 import java.util.Set;
 
@@ -33,15 +35,11 @@ import java.util.Set;
  * @author Renaud Pawlak
  */
 public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
-
-	/**
-	 * Gets the fields defined by this class.
-	 */
-	List<CtField<?>> getFields();
-
 	/**
 	 * Returns the anonymous blocks of this class.
+	 * Derived from {@link #getTypeMembers()}
 	 */
+	@DerivedProperty
 	List<CtAnonymousExecutable> getAnonymousExecutables();
 
 	/**
@@ -52,7 +50,10 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	/**
 	 * Returns the constructors of this class. This includes the default
 	 * constructor if this class has no constructors explicitly declared.
+	 *
+	 * Derived from {@link #getTypeMembers()}
 	 */
+	@DerivedProperty
 	Set<CtConstructor<T>> getConstructors();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtConstructor.java
+++ b/src/main/java/spoon/reflect/declaration/CtConstructor.java
@@ -26,12 +26,6 @@ public interface CtConstructor<T> extends CtExecutable<T>, CtTypeMember, CtForma
 	 */
 	String getSimpleName();
 
-	/**
-	 * Returns the declaring type of this constructor (always the same as the
-	 * constructor's type).
-	 */
-	CtType<T> getDeclaringType();
-
 	@Override
 	CtConstructor<T> clone();
 }

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -25,6 +25,7 @@ import spoon.reflect.visitor.CtVisitable;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.ReferenceFilter;
 import spoon.reflect.visitor.Root;
+import spoon.support.DerivedProperty;
 import spoon.support.visitor.equals.IgnoredByEquals;
 
 import java.lang.annotation.Annotation;
@@ -161,6 +162,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable {
 	 * Calculates and returns the set of all the types referenced by this
 	 * element (and sub-elements in the AST).
 	 */
+	@DerivedProperty
 	Set<CtTypeReference<?>> getReferencedTypes();
 
 	/**
@@ -196,6 +198,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable {
 	 * @throws ParentNotInitializedException
 	 * 		when the parent of this element is not initialized
 	 */
+	@DerivedProperty
 	CtElement getParent() throws ParentNotInitializedException;
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtEnum.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnum.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
 import java.util.List;
 
 /**
@@ -69,4 +72,12 @@ public interface CtEnum<T extends Enum<?>> extends CtClass<T> {
 
 	@Override
 	CtEnum<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
 }

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -19,6 +19,7 @@ package spoon.reflect.declaration;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.List;
 import java.util.Set;
@@ -39,6 +40,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R> {
 	 *
 	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
 	 */
+	@DerivedProperty
 	CtExecutableReference<R> getReference();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtInterface.java
+++ b/src/main/java/spoon/reflect/declaration/CtInterface.java
@@ -16,10 +16,17 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
 /**
  * This element defines an interface declaration.
  */
 public interface CtInterface<T> extends CtType<T> {
 	@Override
 	CtInterface<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
 }

--- a/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
@@ -38,4 +38,9 @@ public interface CtMultiTypedElement extends CtElement {
 	 * Gets all types of the element.
 	 */
 	List<CtTypeReference<?>> getMultiTypes();
+
+	/**
+	 * Adds a type for the element.
+	 */
+	<T extends CtMultiTypedElement> T setMultiTypes(List<CtTypeReference<?>> types);
 }

--- a/src/main/java/spoon/reflect/declaration/CtNamedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtNamedElement.java
@@ -17,6 +17,7 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.reference.CtReference;
+import spoon.support.DerivedProperty;
 
 /**
  * This element defines a simple (relative) name.
@@ -35,6 +36,7 @@ public interface CtNamedElement extends CtElement {
 	/**
 	 * Returns the corresponding reference.
 	 */
+	@DerivedProperty
 	CtReference getReference();
 
 	@Override

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -17,6 +17,7 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.reference.CtPackageReference;
+import spoon.support.DerivedProperty;
 
 import java.util.Set;
 
@@ -39,6 +40,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	/**
 	 * Gets the declaring package of the current one. Returns null if the package is not yet in another one.
 	 */
+	@DerivedProperty
 	CtPackage getDeclaringPackage();
 
 	/**
@@ -69,6 +71,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 *
 	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
 	 */
+	@DerivedProperty
 	CtPackageReference getReference();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtParameter.java
@@ -16,7 +16,10 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtParameterReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
 
 /**
  * This element defines an executable parameter declaration.
@@ -28,7 +31,11 @@ public interface CtParameter<T> extends CtVariable<T>, CtShadowable {
 	/**
 	 * Gets the executable that is the parent declaration of this parameter
 	 * declaration.
+	 *
+	 * (Overriding the return type)
 	 */
+	@Override
+	@DerivedProperty
 	CtExecutable<?> getParent();
 
 	/**
@@ -43,8 +50,15 @@ public interface CtParameter<T> extends CtVariable<T>, CtShadowable {
 	 */
 	<C extends CtParameter<T>> C setVarArgs(boolean varArgs);
 
+	/** overriding the return type */
+	@Override
+	@DerivedProperty
 	CtParameterReference<T> getReference();
 
 	@Override
 	CtParameter<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
 }

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -17,6 +17,7 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.List;
 import java.util.Set;
@@ -71,7 +72,10 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	/**
 	 * Returns the fields that are directly declared by this class or interface.
 	 * Includes enum constants.
+	 *
+	 * Derived from {@link #getTypeMembers()}
 	 */
+	@DerivedProperty
 	List<CtField<?>> getFields();
 
 	/**
@@ -83,11 +87,13 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Returns the declarations of the nested classes and interfaces that are
 	 * directly declared by this class or interface.
 	 */
+	@DerivedProperty
 	Set<CtType<?>> getNestedTypes();
 
 	/**
 	 * Gets the package where this type is declared.
 	 */
+	@DerivedProperty
 	CtPackage getPackage();
 
 	/**
@@ -95,6 +101,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 *
 	 * Overrides the return type.
 	 */
+	@DerivedProperty
 	CtTypeReference<T> getReference();
 
 	/**
@@ -181,6 +188,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Up to 5.2: The recursion stops when the super-type/super-interface is not in the model,
 	 * which means that no method of library super-classes, or of Object are present.
 	 */
+	@DerivedProperty
 	Set<CtMethod<?>> getAllMethods();
 
 	/**
@@ -200,7 +208,11 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	/**
 	 * Returns the methods that are directly declared by this class or
 	 * interface.
+	 *
+	 * Derived from {@link #getTypeMembers()}
+	 *
 	 */
+	@DerivedProperty
 	Set<CtMethod<?>> getMethods();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -19,6 +19,7 @@ package spoon.reflect.declaration;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 import java.util.Collection;
 import java.util.Set;
@@ -123,17 +124,20 @@ public interface CtTypeInformation {
 	/**
 	 * Gets the fields declared by this type.
 	 */
+	@DerivedProperty
 	Collection<CtFieldReference<?>> getDeclaredFields();
 
 	/**
 	 * Gets the fields declared by this type and by all its supertypes if
 	 * applicable.
 	 */
+	@DerivedProperty
 	Collection<CtFieldReference<?>> getAllFields();
 
 	/**
 	 * Gets the executables declared by this type if applicable.
 	 */
+	@DerivedProperty
 	Collection<CtExecutableReference<?>> getDeclaredExecutables();
 
 	/**
@@ -149,6 +153,7 @@ public interface CtTypeInformation {
 	 * If a method is overridden twice in the hierarchy, it counts for two different elements.
 	 * If a method is declared in an interface in the hierarchy and implemented in the current type or in a super type, it counts for two (or n different elements).
 	 */
+	@DerivedProperty
 	Collection<CtExecutableReference<?>> getAllExecutables();
 
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypeMember.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeMember.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.support.DerivedProperty;
+
 /**
  * This interface represents a member of a class (field, method,
  * nested class or static/instance initializer).
@@ -27,6 +29,7 @@ public interface CtTypeMember extends CtModifiable {
 	 *
 	 * @return declaring class
 	 */
+	@DerivedProperty
 	CtType<?> getDeclaringType();
 
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -17,17 +17,37 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+
+import java.util.List;
+import java.util.Set;
 
 /**
  * This element defines a declaration of a type parameter (aka generics).
  * For example, in class A&lt;E&gt; { ... }, the "E" is modeled as an instance of CtTypeParameter.
  */
 public interface CtTypeParameter extends CtType<Object> {
-	// override the return type
+	/** override the return type */
 	@Override
+	@DerivedProperty
 	CtTypeParameterReference getReference();
 
 	// override the return type
 	@Override
 	CtTypeParameter clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<Object>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
+
+	@Override
+	@UnsettableProperty
+	<C extends CtType<Object>> C setTypeMembers(List<CtTypeMember> members);
+
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypedElement.java
@@ -17,6 +17,7 @@
 package spoon.reflect.declaration;
 
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
 /**
  * This abstract element defines a typed element.
@@ -25,6 +26,7 @@ public interface CtTypedElement<T> extends CtElement {
 	/**
 	 * Gets this element's type.
 	 */
+	@DerivedProperty
 	CtTypeReference<T> getType();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtVariable.java
+++ b/src/main/java/spoon/reflect/declaration/CtVariable.java
@@ -18,6 +18,7 @@ package spoon.reflect.declaration;
 
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtVariableReference;
+import spoon.support.DerivedProperty;
 
 /**
  * This abstract element defines a variable declaration.
@@ -34,6 +35,7 @@ public interface CtVariable<T> extends CtNamedElement, CtTypedElement<T>, CtModi
 	 *
 	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
 	 */
+	@DerivedProperty
 	CtVariableReference<T> getReference();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.reference;
 
+import spoon.support.DerivedProperty;
+
 /**
  * This interface defines a reference to an array.
  */
@@ -33,6 +35,7 @@ public interface CtArrayTypeReference<T> extends CtTypeReference<T> {
 	 * e.g., if you have the array <code>int[][][]</code>,
 	 * this method returns a type reference to "int".
 	 */
+	@DerivedProperty
 	CtTypeReference<?> getArrayType();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
@@ -17,12 +17,15 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.code.CtCatchVariable;
+import spoon.support.DerivedProperty;
 
 /**
  * This interface defines a reference to {@link spoon.reflect.code.CtCatchVariable}.
  */
 public interface CtCatchVariableReference<T> extends CtVariableReference<T> {
+	// overriding the return type
 	@Override
+	@DerivedProperty
 	CtCatchVariable<T> getDeclaration();
 
 	@Override

--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -17,6 +17,7 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtExecutable;
+import spoon.support.DerivedProperty;
 import spoon.support.visitor.equals.IgnoredByEquals;
 
 import java.lang.reflect.Constructor;
@@ -57,6 +58,7 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	Constructor<?> getActualConstructor();
 
 	@Override
+	@DerivedProperty
 	CtExecutable<T> getDeclaration();
 
 	/**
@@ -66,11 +68,13 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	 *
 	 * @return the executable declaration that corresponds to the reference.
 	 */
+	@DerivedProperty
 	CtExecutable<T> getExecutableDeclaration();
 
 	/**
 	 * Gets the reference to the type that declares this executable.
 	 */
+	@DerivedProperty
 	CtTypeReference<?> getDeclaringType();
 
 	/**
@@ -98,6 +102,7 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	/**
 	 * Returns the executable overridden by this one, if exists (null otherwise).
 	 */
+	@DerivedProperty
 	CtExecutableReference<?> getOverridingExecutable();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtFieldReference.java
+++ b/src/main/java/spoon/reflect/reference/CtFieldReference.java
@@ -17,6 +17,7 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtField;
+import spoon.support.DerivedProperty;
 
 import java.lang.reflect.Member;
 
@@ -33,6 +34,7 @@ public interface CtFieldReference<T> extends CtVariableReference<T> {
 	Member getActualField();
 
 	@Override
+	@DerivedProperty
 	CtField<T> getDeclaration();
 
 	/**
@@ -42,11 +44,13 @@ public interface CtFieldReference<T> extends CtVariableReference<T> {
 	 *
 	 * @return the field declaration that corresponds to the reference.
 	 */
+	@DerivedProperty
 	CtField<T> getFieldDeclaration();
 
 	/**
 	 * Gets the type in which the field is declared.
 	 */
+	@DerivedProperty
 	CtTypeReference<?> getDeclaringType();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.reference;
 
+import spoon.support.UnsettableProperty;
+
 import java.util.List;
 
 /**
@@ -47,4 +49,8 @@ public interface CtIntersectionTypeReference<T> extends CtTypeReference<T> {
 
 	@Override
 	CtIntersectionTypeReference<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 }

--- a/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
@@ -17,6 +17,7 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.code.CtLocalVariable;
+import spoon.support.DerivedProperty;
 
 /**
  * This interface defines a reference to
@@ -24,6 +25,7 @@ import spoon.reflect.code.CtLocalVariable;
  */
 public interface CtLocalVariableReference<T> extends CtVariableReference<T> {
 	@Override
+	@DerivedProperty
 	CtLocalVariable<T> getDeclaration();
 
 	@Override

--- a/src/main/java/spoon/reflect/reference/CtPackageReference.java
+++ b/src/main/java/spoon/reflect/reference/CtPackageReference.java
@@ -17,6 +17,7 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtPackage;
+import spoon.support.DerivedProperty;
 
 /**
  * This interface defines a reference to a
@@ -26,6 +27,7 @@ public interface CtPackageReference extends CtReference {
 	/**
 	 * Gets the package element when available in the source code.
 	 */
+	@DerivedProperty
 	CtPackage getDeclaration();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtParameterReference.java
@@ -17,6 +17,7 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtParameter;
+import spoon.support.DerivedProperty;
 
 /**
  * This interface defines a reference to a
@@ -35,6 +36,7 @@ public interface CtParameterReference<T> extends CtVariableReference<T> {
 	<C extends CtParameterReference<T>> C setDeclaringExecutable(CtExecutableReference<?> executable);
 
 	@Override
+	@DerivedProperty
 	CtParameter<T> getDeclaration();
 
 	@Override

--- a/src/main/java/spoon/reflect/reference/CtReference.java
+++ b/src/main/java/spoon/reflect/reference/CtReference.java
@@ -16,7 +16,12 @@
  */
 package spoon.reflect.reference;
 
+import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtElement;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+
+import java.util.List;
 
 /**
  * This is the root interface for named program element references. References
@@ -42,10 +47,17 @@ public interface CtReference extends CtElement {
 	/**
 	 * Tries to get the declaration that corresponds to the referenced element.
 	 *
+	 * Consider using the more robust {@link CtTypeReference#getTypeDeclaration()} and {@link CtExecutableReference#getExecutableDeclaration()}.
 	 * @return referenced element or null if element does not exist
 	 */
+	@DerivedProperty
 	CtElement getDeclaration();
 
 	@Override
 	CtReference clone();
+
+	/** comments are not possible for references */
+	@Override
+	@UnsettableProperty
+	<E extends CtElement> E setComments(List<CtComment> comments);
 }

--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -17,6 +17,8 @@
 package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtTypeParameter;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
 
 import java.util.List;
 
@@ -70,11 +72,16 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 	 */
 	<T extends CtTypeParameterReference> T setBoundingType(CtTypeReference<?> superType);
 
-	// override the return
+	// overriding the return type
 	@Override
+	@DerivedProperty
 	CtTypeParameter getDeclaration();
 
-	// override the return
+	// overriding the return type
 	@Override
 	CtTypeParameterReference clone();
+
+	@Override
+	@UnsettableProperty
+	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 }

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -20,7 +20,10 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
+import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
+
+import java.util.Set;
 
 /**
  * This interface defines a reference to a
@@ -64,6 +67,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * @return the referenced element or <code>null</code> if the type
 	 * declaration is not the analyzed source files.
 	 */
+	@DerivedProperty
 	CtType<T> getDeclaration();
 
 	/**
@@ -73,6 +77,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 *
 	 * @return the type declaration that corresponds to the reference.
 	 */
+	@DerivedProperty
 	CtType<T> getTypeDeclaration();
 
 	/**
@@ -81,6 +86,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * @return the declaring type if this references an inner class; null in
 	 * other cases
 	 */
+	@DerivedProperty
 	CtTypeReference<?> getDeclaringType();
 
 	/**
@@ -88,6 +94,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 *
 	 * @return the declaring package or null if this if a inner class
 	 */
+	@DerivedProperty
 	CtPackageReference getPackage();
 
 	/**
@@ -125,4 +132,12 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 
 	@Override
 	CtTypeReference<T> clone();
+
+	@Override
+	@DerivedProperty
+	Set<CtTypeReference<?>> getSuperInterfaces();
+
+	@Override
+	@DerivedProperty
+	CtTypeReference<?> getSuperclass();
 }

--- a/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
@@ -16,6 +16,13 @@
  */
 package spoon.reflect.reference;
 
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtElement;
+import spoon.support.UnsettableProperty;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
 /**
  * This interface defines a reference to an unbound
  * {@link spoon.reflect.declaration.CtVariable}.
@@ -23,4 +30,8 @@ package spoon.reflect.reference;
 public interface CtUnboundVariableReference<T> extends CtVariableReference<T> {
 	@Override
 	CtUnboundVariableReference<T> clone();
+
+	@Override
+	@UnsettableProperty
+	<E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
 }

--- a/src/main/java/spoon/reflect/reference/CtVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtVariableReference.java
@@ -18,6 +18,7 @@ package spoon.reflect.reference;
 
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.support.DerivedProperty;
 
 import java.util.Set;
 
@@ -30,6 +31,7 @@ public interface CtVariableReference<T> extends CtReference {
 	/**
 	 * Gets the type of the variable.
 	 */
+	@DerivedProperty
 	CtTypeReference<T> getType();
 
 	/**
@@ -40,6 +42,7 @@ public interface CtVariableReference<T> extends CtReference {
 	/**
 	 * Tries to get the declaration of the reference.
 	 */
+	@DerivedProperty
 	CtVariable<T> getDeclaration();
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -149,6 +149,7 @@ public abstract class CtScanner implements CtVisitor {
 	public <A extends Annotation> void visitCtAnnotation(
 			final CtAnnotation<A> annotation) {
 		enter(annotation);
+		scan(annotation.getComments());
 		scan(annotation.getAnnotationType());
 		scan(annotation.getAnnotations());
 		scan(annotation.getValues());
@@ -218,8 +219,8 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtArrayTypeReference(final CtArrayTypeReference<T> reference) {
 		enter(reference);
+		scan(reference.getComments());
 		scan(reference.getDeclaringType());
-		scan(reference.getPackage());
 		scan(reference.getComponentType());
 		scan(reference.getActualTypeArguments());
 		scan(reference.getAnnotations());
@@ -394,16 +395,18 @@ public abstract class CtScanner implements CtVisitor {
 	@Override
 	public <T> void visitCtThisAccess(final CtThisAccess<T> thisAccess) {
 		enter(thisAccess);
+		scan(thisAccess.getComments());
+		scan(thisAccess.getAnnotations());
 		scan(thisAccess.getType());
 		scan(thisAccess.getTypeCasts());
 		scan(thisAccess.getTarget());
-		scan(thisAccess.getComments());
 		exit(thisAccess);
 	}
 
 	public <T> void visitCtAnnotationFieldAccess(
 			final CtAnnotationFieldAccess<T> annotationFieldAccess) {
 		enter(annotationFieldAccess);
+		scan(annotationFieldAccess.getComments());
 		scan(annotationFieldAccess.getAnnotations());
 		scan(annotationFieldAccess.getType());
 		scan(annotationFieldAccess.getTypeCasts());
@@ -502,14 +505,16 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtCatchVariable(final CtCatchVariable<T> catchVariable) {
 		enter(catchVariable);
+		scan(catchVariable.getComments());
 		scan(catchVariable.getAnnotations());
 		scan(catchVariable.getType());
-		scan(catchVariable.getComments());
+		scan(catchVariable.getMultiTypes());
 		exit(catchVariable);
 	}
 
 	public <T> void visitCtCatchVariableReference(final CtCatchVariableReference<T> reference) {
 		enter(reference);
+		scan(reference.getComments());
 		scan(reference.getType());
 		scan(reference.getAnnotations());
 		exit(reference);
@@ -589,6 +594,8 @@ public abstract class CtScanner implements CtVisitor {
 	public <T, E extends CtExpression<?>> void visitCtExecutableReferenceExpression(
 			final CtExecutableReferenceExpression<T, E> expression) {
 		enter(expression);
+		scan(expression.getComments());
+		scan(expression.getAnnotations());
 		scan(expression.getType());
 		scan(expression.getTypeCasts());
 		scan(expression.getExecutable());
@@ -619,6 +626,7 @@ public abstract class CtScanner implements CtVisitor {
 
 	public void visitCtPackageReference(final CtPackageReference reference) {
 		enter(reference);
+		scan(reference.getAnnotations());
 		exit(reference);
 	}
 
@@ -722,6 +730,7 @@ public abstract class CtScanner implements CtVisitor {
 	@Override
 	public <T> void visitCtIntersectionTypeReference(final CtIntersectionTypeReference<T> reference) {
 		enter(reference);
+		scan(reference.getAnnotations());
 		scan(reference.getBounds());
 		exit(reference);
 	}
@@ -787,11 +796,16 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtCodeSnippetExpression(final CtCodeSnippetExpression<T> expression) {
 		enter(expression);
+		scan(expression.getComments());
+		scan(expression.getAnnotations());
+		scan(expression.getTypeCasts());
 		exit(expression);
 	}
 
 	public void visitCtCodeSnippetStatement(final CtCodeSnippetStatement statement) {
 		enter(statement);
+		scan(statement.getComments());
+		scan(statement.getAnnotations());
 		exit(statement);
 	}
 
@@ -825,17 +839,20 @@ public abstract class CtScanner implements CtVisitor {
 	@Override
 	public <T> void visitCtSuperAccess(final CtSuperAccess<T> f) {
 		enter(f);
+		scan(f.getComments());
 		scan(f.getAnnotations());
 		scan(f.getType());
 		scan(f.getTypeCasts());
 		scan(f.getTarget());
-		scan(f.getComments());
+		scan(f.getVariable());
 		exit(f);
 	}
 
 	@Override
 	public void visitCtComment(final CtComment comment) {
 		enter(comment);
+		scan(comment.getComments());
+		scan(comment.getAnnotations());
 		exit(comment);
 	}
 }

--- a/src/main/java/spoon/support/DerivedProperty.java
+++ b/src/main/java/spoon/support/DerivedProperty.java
@@ -14,35 +14,21 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-package spoon.reflect.declaration;
+package spoon.support;
 
-import spoon.reflect.code.CtRHSReceiver;
-import spoon.reflect.reference.CtFieldReference;
-import spoon.support.DerivedProperty;
+import spoon.reflect.declaration.CtType;
 
-/**
- * This element defines a field declaration.
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Tells that a metamodel property is derived, ie computed from the value of another property.
+ * For instance {@link CtType#getFields()}  is derived from {@link CtType#getTypeMembers()}
+ *
+ * This annotation is used for specifying CtScanner: derived properties are never scanned.
  */
-public interface CtField<T> extends CtVariable<T>, CtTypeMember, CtRHSReceiver<T>, CtShadowable {
-
-	/**
-	 * The separator for a string representation of a field.
-	 */
-	String FIELD_SEPARATOR = "#";
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
-	 */
-	@DerivedProperty
-	CtFieldReference<T> getReference();
-
-	/**
-	 * Replaces this element by another one.
-	 */
-	<R extends T> void replace(CtField<R> element);
-
-	@Override
-	CtField<T> clone();
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface DerivedProperty {
 }

--- a/src/main/java/spoon/support/UnsettableProperty.java
+++ b/src/main/java/spoon/support/UnsettableProperty.java
@@ -14,35 +14,19 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-package spoon.reflect.declaration;
+package spoon.support;
 
-import spoon.reflect.code.CtRHSReceiver;
-import spoon.reflect.reference.CtFieldReference;
-import spoon.support.DerivedProperty;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * This element defines a field declaration.
+ * Tells that a metamodel property (ie a getter in metamodel interface) is unsettable because it does not make sense for a certain metamodel element.
+ * This is used when the Java static type system cannot express this contract.
+ * For instance, a catch variable cannot have a default expression.
  */
-public interface CtField<T> extends CtVariable<T>, CtTypeMember, CtRHSReceiver<T>, CtShadowable {
-
-	/**
-	 * The separator for a string representation of a field.
-	 */
-	String FIELD_SEPARATOR = "#";
-
-	/*
-	 * (non-Javadoc)
-	 *
-	 * @see spoon.reflect.declaration.CtNamedElement#getReference()
-	 */
-	@DerivedProperty
-	CtFieldReference<T> getReference();
-
-	/**
-	 * Replaces this element by another one.
-	 */
-	<R extends T> void replace(CtField<R> element);
-
-	@Override
-	CtField<T> clone();
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD })
+public @interface UnsettableProperty {
 }

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -116,6 +116,22 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 	}
 
 	@Override
+	public <T extends CtMultiTypedElement> T setMultiTypes(List<CtTypeReference<?>> types) {
+		if (types == null || types.isEmpty()) {
+			this.types = CtElementImpl.emptyList();
+			return (T) this;
+		}
+		if (this.types == CtElementImpl.<CtTypeReference<?>>emptyList()) {
+			this.types = new ArrayList<>();
+		}
+		this.types.clear();
+		for (CtTypeReference<?> t : types) {
+			addMultiType(t);
+		}
+		return (T) this;
+	}
+
+	@Override
 	public Set<ModifierKind> getModifiers() {
 		return modifiers;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -36,7 +36,6 @@ import spoon.reflect.visitor.filter.AnnotationFilter;
 import spoon.support.reflect.cu.SourcePositionImpl;
 import spoon.support.util.EmptyClearableList;
 import spoon.support.util.EmptyClearableSet;
-import spoon.support.visitor.DeepRepresentationVisitor;
 import spoon.support.visitor.HashcodeVisitor;
 import spoon.support.visitor.TypeReferenceScanner;
 import spoon.support.visitor.equals.CloneHelper;
@@ -97,11 +96,8 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String getShortRepresentation() {
-		final DeepRepresentationVisitor printer = new DeepRepresentationVisitor();
-		printer.scan(this);
-		return printer.getRepresentation();
+		return super.toString();
 	}
-
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -36,6 +36,7 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <A extends java.lang.annotation.Annotation> void visitCtAnnotation(final spoon.reflect.declaration.CtAnnotation<A> annotation) {
 		spoon.reflect.declaration.CtAnnotation<A> aCtAnnotation = spoon.support.visitor.clone.CloneBuilder.build(this.builder, annotation, annotation.getFactory().Core().createAnnotation());
+		aCtAnnotation.setComments(spoon.support.visitor.equals.CloneHelper.clone(annotation.getComments()));
 		aCtAnnotation.setAnnotationType(spoon.support.visitor.equals.CloneHelper.clone(annotation.getAnnotationType()));
 		aCtAnnotation.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(annotation.getAnnotations()));
 		aCtAnnotation.setValues(spoon.support.visitor.equals.CloneHelper.clone(annotation.getValues()));
@@ -89,8 +90,8 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
 		spoon.reflect.reference.CtArrayTypeReference<T> aCtArrayTypeReference = spoon.support.visitor.clone.CloneBuilder.build(this.builder, reference, reference.getFactory().Core().createArrayTypeReference());
+		aCtArrayTypeReference.setComments(spoon.support.visitor.equals.CloneHelper.clone(reference.getComments()));
 		aCtArrayTypeReference.setDeclaringType(spoon.support.visitor.equals.CloneHelper.clone(reference.getDeclaringType()));
-		aCtArrayTypeReference.setPackage(spoon.support.visitor.equals.CloneHelper.clone(reference.getPackage()));
 		aCtArrayTypeReference.setComponentType(spoon.support.visitor.equals.CloneHelper.clone(reference.getComponentType()));
 		aCtArrayTypeReference.setActualTypeArguments(spoon.support.visitor.equals.CloneHelper.clone(reference.getActualTypeArguments()));
 		aCtArrayTypeReference.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(reference.getAnnotations()));
@@ -281,16 +282,18 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	@java.lang.Override
 	public <T> void visitCtThisAccess(final spoon.reflect.code.CtThisAccess<T> thisAccess) {
 		spoon.reflect.code.CtThisAccess<T> aCtThisAccess = spoon.support.visitor.clone.CloneBuilder.build(this.builder, thisAccess, thisAccess.getFactory().Core().createThisAccess());
+		aCtThisAccess.setComments(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getComments()));
+		aCtThisAccess.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getAnnotations()));
 		aCtThisAccess.setType(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getType()));
 		aCtThisAccess.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getTypeCasts()));
 		aCtThisAccess.setTarget(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getTarget()));
-		aCtThisAccess.setComments(spoon.support.visitor.equals.CloneHelper.clone(thisAccess.getComments()));
 		this.other = aCtThisAccess;
 	}
 
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtAnnotationFieldAccess(final spoon.reflect.code.CtAnnotationFieldAccess<T> annotationFieldAccess) {
 		spoon.reflect.code.CtAnnotationFieldAccess<T> aCtAnnotationFieldAccess = spoon.support.visitor.clone.CloneBuilder.build(this.builder, annotationFieldAccess, annotationFieldAccess.getFactory().Core().createAnnotationFieldAccess());
+		aCtAnnotationFieldAccess.setComments(spoon.support.visitor.equals.CloneHelper.clone(annotationFieldAccess.getComments()));
 		aCtAnnotationFieldAccess.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(annotationFieldAccess.getAnnotations()));
 		aCtAnnotationFieldAccess.setType(spoon.support.visitor.equals.CloneHelper.clone(annotationFieldAccess.getType()));
 		aCtAnnotationFieldAccess.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(annotationFieldAccess.getTypeCasts()));
@@ -397,15 +400,17 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtCatchVariable(final spoon.reflect.code.CtCatchVariable<T> catchVariable) {
 		spoon.reflect.code.CtCatchVariable<T> aCtCatchVariable = spoon.support.visitor.clone.CloneBuilder.build(this.builder, catchVariable, catchVariable.getFactory().Core().createCatchVariable());
+		aCtCatchVariable.setComments(spoon.support.visitor.equals.CloneHelper.clone(catchVariable.getComments()));
 		aCtCatchVariable.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(catchVariable.getAnnotations()));
 		aCtCatchVariable.setType(spoon.support.visitor.equals.CloneHelper.clone(catchVariable.getType()));
-		aCtCatchVariable.setComments(spoon.support.visitor.equals.CloneHelper.clone(catchVariable.getComments()));
+		aCtCatchVariable.setMultiTypes(spoon.support.visitor.equals.CloneHelper.clone(catchVariable.getMultiTypes()));
 		this.other = aCtCatchVariable;
 	}
 
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtCatchVariableReference(final spoon.reflect.reference.CtCatchVariableReference<T> reference) {
 		spoon.reflect.reference.CtCatchVariableReference<T> aCtCatchVariableReference = spoon.support.visitor.clone.CloneBuilder.build(this.builder, reference, reference.getFactory().Core().createCatchVariableReference());
+		aCtCatchVariableReference.setComments(spoon.support.visitor.equals.CloneHelper.clone(reference.getComments()));
 		aCtCatchVariableReference.setType(spoon.support.visitor.equals.CloneHelper.clone(reference.getType()));
 		aCtCatchVariableReference.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(reference.getAnnotations()));
 		this.other = aCtCatchVariableReference;
@@ -491,6 +496,8 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	@java.lang.Override
 	public <T, E extends spoon.reflect.code.CtExpression<?>> void visitCtExecutableReferenceExpression(final spoon.reflect.code.CtExecutableReferenceExpression<T, E> expression) {
 		spoon.reflect.code.CtExecutableReferenceExpression<T, E> aCtExecutableReferenceExpression = spoon.support.visitor.clone.CloneBuilder.build(this.builder, expression, expression.getFactory().Core().createExecutableReferenceExpression());
+		aCtExecutableReferenceExpression.setComments(spoon.support.visitor.equals.CloneHelper.clone(expression.getComments()));
+		aCtExecutableReferenceExpression.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(expression.getAnnotations()));
 		aCtExecutableReferenceExpression.setType(spoon.support.visitor.equals.CloneHelper.clone(expression.getType()));
 		aCtExecutableReferenceExpression.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(expression.getTypeCasts()));
 		aCtExecutableReferenceExpression.setExecutable(spoon.support.visitor.equals.CloneHelper.clone(expression.getExecutable()));
@@ -523,6 +530,7 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public void visitCtPackageReference(final spoon.reflect.reference.CtPackageReference reference) {
 		spoon.reflect.reference.CtPackageReference aCtPackageReference = spoon.support.visitor.clone.CloneBuilder.build(this.builder, reference, reference.getFactory().Core().createPackageReference());
+		aCtPackageReference.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(reference.getAnnotations()));
 		this.other = aCtPackageReference;
 	}
 
@@ -638,6 +646,7 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	@java.lang.Override
 	public <T> void visitCtIntersectionTypeReference(final spoon.reflect.reference.CtIntersectionTypeReference<T> reference) {
 		spoon.reflect.reference.CtIntersectionTypeReference<T> aCtIntersectionTypeReference = spoon.support.visitor.clone.CloneBuilder.build(this.builder, reference, reference.getFactory().Core().createIntersectionTypeReference());
+		aCtIntersectionTypeReference.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(reference.getAnnotations()));
 		aCtIntersectionTypeReference.setBounds(spoon.support.visitor.equals.CloneHelper.clone(reference.getBounds()));
 		this.other = aCtIntersectionTypeReference;
 	}
@@ -710,12 +719,17 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtCodeSnippetExpression(final spoon.reflect.code.CtCodeSnippetExpression<T> expression) {
 		spoon.reflect.code.CtCodeSnippetExpression<T> aCtCodeSnippetExpression = spoon.support.visitor.clone.CloneBuilder.build(this.builder, expression, expression.getFactory().Core().createCodeSnippetExpression());
+		aCtCodeSnippetExpression.setComments(spoon.support.visitor.equals.CloneHelper.clone(expression.getComments()));
+		aCtCodeSnippetExpression.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(expression.getAnnotations()));
+		aCtCodeSnippetExpression.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(expression.getTypeCasts()));
 		this.other = aCtCodeSnippetExpression;
 	}
 
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public void visitCtCodeSnippetStatement(final spoon.reflect.code.CtCodeSnippetStatement statement) {
 		spoon.reflect.code.CtCodeSnippetStatement aCtCodeSnippetStatement = spoon.support.visitor.clone.CloneBuilder.build(this.builder, statement, statement.getFactory().Core().createCodeSnippetStatement());
+		aCtCodeSnippetStatement.setComments(spoon.support.visitor.equals.CloneHelper.clone(statement.getComments()));
+		aCtCodeSnippetStatement.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(statement.getAnnotations()));
 		this.other = aCtCodeSnippetStatement;
 	}
 
@@ -753,11 +767,12 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	@java.lang.Override
 	public <T> void visitCtSuperAccess(final spoon.reflect.code.CtSuperAccess<T> f) {
 		spoon.reflect.code.CtSuperAccess<T> aCtSuperAccess = spoon.support.visitor.clone.CloneBuilder.build(this.builder, f, f.getFactory().Core().createSuperAccess());
+		aCtSuperAccess.setComments(spoon.support.visitor.equals.CloneHelper.clone(f.getComments()));
 		aCtSuperAccess.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(f.getAnnotations()));
 		aCtSuperAccess.setType(spoon.support.visitor.equals.CloneHelper.clone(f.getType()));
 		aCtSuperAccess.setTypeCasts(spoon.support.visitor.equals.CloneHelper.clone(f.getTypeCasts()));
 		aCtSuperAccess.setTarget(spoon.support.visitor.equals.CloneHelper.clone(f.getTarget()));
-		aCtSuperAccess.setComments(spoon.support.visitor.equals.CloneHelper.clone(f.getComments()));
+		aCtSuperAccess.setVariable(spoon.support.visitor.equals.CloneHelper.clone(f.getVariable()));
 		this.other = aCtSuperAccess;
 	}
 
@@ -765,6 +780,8 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	@java.lang.Override
 	public void visitCtComment(final spoon.reflect.code.CtComment comment) {
 		spoon.reflect.code.CtComment aCtComment = spoon.support.visitor.clone.CloneBuilder.build(this.builder, comment, comment.getFactory().Core().createComment());
+		aCtComment.setComments(spoon.support.visitor.equals.CloneHelper.clone(comment.getComments()));
+		aCtComment.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(comment.getAnnotations()));
 		this.other = aCtComment;
 	}
 }

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -56,7 +56,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 			if ((replace) != null) {
 				map.put(key, ((V) (replace)));
 				replace.setParent(shouldBeDeleted.getParent());
-			} else {
+			}else {
 				map.remove(key);
 			}
 			listener.set(map);
@@ -97,7 +97,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 			if ((replace) != null) {
 				list.set(index, ((T) (replace)));
 				replace.setParent(shouldBeDeleted.getParent());
-			} else {
+			}else {
 				list.remove(index);
 			}
 			listener.set(list);
@@ -110,6 +110,20 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 			if ((replace) != null) {
 				replace.setParent(candidate.getParent());
 			}
+		}
+	}
+
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
+	class CtElementCommentsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
+		private final spoon.reflect.declaration.CtElement element;
+
+		CtElementCommentsReplaceListener(spoon.reflect.declaration.CtElement element) {
+			this.element = element;
+		}
+
+		@java.lang.Override
+		public void set(java.util.List replace) {
+			this.element.setComments(replace);
 		}
 	}
 
@@ -158,6 +172,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <A extends java.lang.annotation.Annotation> void visitCtAnnotation(final spoon.reflect.declaration.CtAnnotation<A> annotation) {
+		replaceInListIfExist(annotation.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(annotation));
 		replaceElementIfExist(annotation.getAnnotationType(), new spoon.support.visitor.replace.ReplacementVisitor.CtAnnotationAnnotationTypeReplaceListener(annotation));
 		replaceInListIfExist(annotation.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(annotation));
 		replaceInMapIfExist(annotation.getValues(), new spoon.support.visitor.replace.ReplacementVisitor.CtAnnotationValuesReplaceListener(annotation));
@@ -174,20 +189,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		@java.lang.Override
 		public void set(java.util.List replace) {
 			this.element.setTypeMembers(replace);
-		}
-	}
-
-	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
-	class CtElementCommentsReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
-		private final spoon.reflect.declaration.CtElement element;
-
-		CtElementCommentsReplaceListener(spoon.reflect.declaration.CtElement element) {
-			this.element = element;
-		}
-
-		@java.lang.Override
-		public void set(java.util.List replace) {
-			this.element.setComments(replace);
 		}
 	}
 
@@ -314,20 +315,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
-	class CtTypeReferencePackageReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtPackageReference> {
-		private final spoon.reflect.reference.CtTypeReference element;
-
-		CtTypeReferencePackageReplaceListener(spoon.reflect.reference.CtTypeReference element) {
-			this.element = element;
-		}
-
-		@java.lang.Override
-		public void set(spoon.reflect.reference.CtPackageReference replace) {
-			this.element.setPackage(replace);
-		}
-	}
-
-	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtArrayTypeReferenceComponentTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
 		private final spoon.reflect.reference.CtArrayTypeReference element;
 
@@ -358,8 +345,8 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
+		replaceInListIfExist(reference.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(reference));
 		replaceElementIfExist(reference.getDeclaringType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeReferenceDeclaringTypeReplaceListener(reference));
-		replaceElementIfExist(reference.getPackage(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeReferencePackageReplaceListener(reference));
 		replaceElementIfExist(reference.getComponentType(), new spoon.support.visitor.replace.ReplacementVisitor.CtArrayTypeReferenceComponentTypeReplaceListener(reference));
 		replaceInListIfExist(reference.getActualTypeArguments(), new spoon.support.visitor.replace.ReplacementVisitor.CtActualTypeContainerActualTypeArgumentsReplaceListener(reference));
 		replaceInListIfExist(reference.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(reference));
@@ -893,10 +880,11 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtThisAccess(final spoon.reflect.code.CtThisAccess<T> thisAccess) {
+		replaceInListIfExist(thisAccess.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(thisAccess));
+		replaceInListIfExist(thisAccess.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(thisAccess));
 		replaceElementIfExist(thisAccess.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(thisAccess));
 		replaceInListIfExist(thisAccess.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(thisAccess));
 		replaceElementIfExist(thisAccess.getTarget(), new spoon.support.visitor.replace.ReplacementVisitor.CtTargetedExpressionTargetReplaceListener(thisAccess));
-		replaceInListIfExist(thisAccess.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(thisAccess));
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
@@ -916,6 +904,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtAnnotationFieldAccess(final spoon.reflect.code.CtAnnotationFieldAccess<T> annotationFieldAccess) {
+		replaceInListIfExist(annotationFieldAccess.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(annotationFieldAccess));
 		replaceInListIfExist(annotationFieldAccess.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(annotationFieldAccess));
 		replaceElementIfExist(annotationFieldAccess.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(annotationFieldAccess));
 		replaceInListIfExist(annotationFieldAccess.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(annotationFieldAccess));
@@ -1178,16 +1167,32 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
+	class CtMultiTypedElementMultiTypesReplaceListener implements spoon.generating.replace.ReplaceListListener<java.util.List> {
+		private final spoon.reflect.declaration.CtMultiTypedElement element;
+
+		CtMultiTypedElementMultiTypesReplaceListener(spoon.reflect.declaration.CtMultiTypedElement element) {
+			this.element = element;
+		}
+
+		@java.lang.Override
+		public void set(java.util.List replace) {
+			this.element.setMultiTypes(replace);
+		}
+	}
+
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtCatchVariable(final spoon.reflect.code.CtCatchVariable<T> catchVariable) {
+		replaceInListIfExist(catchVariable.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(catchVariable));
 		replaceInListIfExist(catchVariable.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(catchVariable));
 		replaceElementIfExist(catchVariable.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(catchVariable));
-		replaceInListIfExist(catchVariable.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(catchVariable));
+		replaceInListIfExist(catchVariable.getMultiTypes(), new spoon.support.visitor.replace.ReplacementVisitor.CtMultiTypedElementMultiTypesReplaceListener(catchVariable));
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtCatchVariableReference(final spoon.reflect.reference.CtCatchVariableReference<T> reference) {
+		replaceInListIfExist(reference.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(reference));
 		replaceElementIfExist(reference.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtVariableReferenceTypeReplaceListener(reference));
 		replaceInListIfExist(reference.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(reference));
 	}
@@ -1346,6 +1351,8 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T, E extends spoon.reflect.code.CtExpression<?>> void visitCtExecutableReferenceExpression(final spoon.reflect.code.CtExecutableReferenceExpression<T, E> expression) {
+		replaceInListIfExist(expression.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(expression));
+		replaceInListIfExist(expression.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(expression));
 		replaceElementIfExist(expression.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(expression));
 		replaceInListIfExist(expression.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(expression));
 		replaceElementIfExist(expression.getExecutable(), new spoon.support.visitor.replace.ReplacementVisitor.CtExecutableReferenceExpressionExecutableReplaceListener(expression));
@@ -1400,8 +1407,10 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(ctPackage.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(ctPackage));
 	}
 
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public void visitCtPackageReference(final spoon.reflect.reference.CtPackageReference reference) {
+		replaceInListIfExist(reference.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(reference));
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
@@ -1638,6 +1647,20 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
+	class CtTypeReferencePackageReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtPackageReference> {
+		private final spoon.reflect.reference.CtTypeReference element;
+
+		CtTypeReferencePackageReplaceListener(spoon.reflect.reference.CtTypeReference element) {
+			this.element = element;
+		}
+
+		@java.lang.Override
+		public void set(spoon.reflect.reference.CtPackageReference replace) {
+			this.element.setPackage(replace);
+		}
+	}
+
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	class CtTypeParameterReferenceBoundingTypeReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.reference.CtTypeReference> {
 		private final spoon.reflect.reference.CtTypeParameterReference element;
 
@@ -1684,6 +1707,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtIntersectionTypeReference(final spoon.reflect.reference.CtIntersectionTypeReference<T> reference) {
+		replaceInListIfExist(reference.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(reference));
 		replaceInListIfExist(reference.getBounds(), new spoon.support.visitor.replace.ReplacementVisitor.CtIntersectionTypeReferenceBoundsReplaceListener(reference));
 	}
 
@@ -1799,12 +1823,19 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceInListIfExist(whileLoop.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(whileLoop));
 	}
 
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtCodeSnippetExpression(final spoon.reflect.code.CtCodeSnippetExpression<T> expression) {
+		replaceInListIfExist(expression.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(expression));
+		replaceInListIfExist(expression.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(expression));
+		replaceInListIfExist(expression.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(expression));
 	}
 
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public void visitCtCodeSnippetStatement(final spoon.reflect.code.CtCodeSnippetStatement statement) {
+		replaceInListIfExist(statement.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(statement));
+		replaceInListIfExist(statement.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(statement));
 	}
 
 	@java.lang.Override
@@ -1848,15 +1879,19 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtSuperAccess(final spoon.reflect.code.CtSuperAccess<T> f) {
+		replaceInListIfExist(f.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(f));
 		replaceInListIfExist(f.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(f));
 		replaceElementIfExist(f.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(f));
 		replaceInListIfExist(f.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(f));
 		replaceElementIfExist(f.getTarget(), new spoon.support.visitor.replace.ReplacementVisitor.CtTargetedExpressionTargetReplaceListener(f));
-		replaceInListIfExist(f.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(f));
+		replaceElementIfExist(f.getVariable(), new spoon.support.visitor.replace.ReplacementVisitor.CtVariableAccessVariableReplaceListener(f));
 	}
 
+	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public void visitCtComment(final spoon.reflect.code.CtComment comment) {
+		replaceInListIfExist(comment.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(comment));
+		replaceInListIfExist(comment.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(comment));
 	}
 }
 

--- a/src/main/java/spoon/testing/AbstractCtElementAssert.java
+++ b/src/main/java/spoon/testing/AbstractCtElementAssert.java
@@ -41,7 +41,7 @@ public abstract class AbstractCtElementAssert<T extends AbstractCtElementAssert<
 		process(actual.getFactory(), processors);
 
 		if (!actual.equals(expected)) {
-			throw new AssertionError(String.format("%1$s and %2$s aren't equals.", actual.getShortRepresentation(), expected.getShortRepresentation()));
+			throw new AssertionError();
 		}
 		return this.myself;
 	}

--- a/src/test/java/spoon/processing/CtGenerationTest.java
+++ b/src/test/java/spoon/processing/CtGenerationTest.java
@@ -1,5 +1,6 @@
 package spoon.processing;
 
+import org.junit.ComparisonFailure;
 import org.junit.Test;
 
 import spoon.Launcher;
@@ -11,6 +12,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtBiScannerDefault;
 import spoon.reflect.visitor.Filter;
+import spoon.reflect.visitor.filter.RegexFilter;
 import spoon.support.visitor.equals.EqualsVisitor;
 
 import java.io.File;
@@ -43,8 +45,12 @@ public class CtGenerationTest {
 		// cp ./target/generated/spoon/support/visitor/replace/ReplacementVisitor.java ./src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
 		CtClass<Object> actual = build(new File("./src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java")).Class().get("spoon.support.visitor.replace.ReplacementVisitor");
 		CtClass<Object> expected = build(new File("./target/generated/spoon/support/visitor/replace/ReplacementVisitor.java")).Class().get("spoon.support.visitor.replace.ReplacementVisitor");
-		assertThat(actual)
+		try {
+			assertThat(actual)
 				.isEqualTo(expected);
+		} catch (AssertionError e) {
+			throw new ComparisonFailure("EqualsVisitor different", expected.toString(), actual.toString());
+		}
 	}
 
 	@Test
@@ -66,8 +72,12 @@ public class CtGenerationTest {
 		launcher.setOutputFilter(new RegexFilter("spoon.reflect.visitor.CtBiScannerDefault"));
 		launcher.run();
 
-		assertThat(build(new File("./src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java")).Class().get(CtBiScannerDefault.class))
-				.isEqualTo(build(new File("./target/generated/spoon/reflect/visitor/CtBiScannerDefault.java")).Class().get(CtBiScannerDefault.class));
+		// we don't necessarily want to hard-wired the relation bewteen CtScanner and CtBiScannerDefault.java
+		// this can be done on an informed basis when important changes are made in the metamodel/scanner
+		// and then we can have smaller clean tested pull requests to see the impact of the change
+		// cp ./target/generated/spoon/reflect/visitor/CtBiScannerDefault.java ./src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
+		//assertThat(build(new File("./src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java")).Class().get(CtBiScannerDefault.class))
+		//		.isEqualTo(build(new File("./target/generated/spoon/reflect/visitor/CtBiScannerDefault.java")).Class().get(CtBiScannerDefault.class));
 	}
 
 	@Test
@@ -92,12 +102,17 @@ public class CtGenerationTest {
 
 		CtClass<Object> actual = build(new File("./src/main/java/spoon/support/visitor/equals/EqualsVisitor.java")).Class().get(EqualsVisitor.class);
 		CtClass<Object> expected = build(new File("./target/generated/spoon/support/visitor/equals/EqualsVisitor.java")).Class().get(EqualsVisitor.class);
-		assertThat(actual)
-				.isEqualTo(expected);
+		try {
+			assertThat(actual)
+					.isEqualTo(expected);
+		} catch (AssertionError e) {
+			throw new ComparisonFailure("EqualsVisitor different", expected.toString(), actual.toString());
+		}
 	}
 
 	@Test
 	public void testGenerateCloneVisitor() throws Exception {
+		// contract: generates CloneBuilder.java and CloneBuilder.java
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);
@@ -122,6 +137,7 @@ public class CtGenerationTest {
 		launcher.run();
 
 		// cp ./target/generated/spoon/support/visitor/clone/CloneBuilder.java  ./src/main/java/spoon/support/visitor/clone/CloneBuilder.java
+		// cp ./target/generated/spoon/support/visitor/clone/CloneVisitor.java  ./src/main/java/spoon/support/visitor/clone/CloneVisitor.java
 		assertThat(build(new File("./src/main/java/spoon/support/visitor/clone/")).Package().get("spoon.support.visitor.clone"))
 				.isEqualTo(build(new File("./target/generated/spoon/support/visitor/clone/")).Package().get("spoon.support.visitor.clone"));
 	}

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -19,7 +19,22 @@ package spoon.reflect.visitor;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.reflect.visitor.processors.CheckScannerProcessor;
+import spoon.test.SpoonTestHelpers;
+
+import java.util.Comparator;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static spoon.test.SpoonTestHelpers.isMetamodelProperty;
 
 public class CtScannerTest {
 	@Test
@@ -42,4 +57,68 @@ public class CtScannerTest {
 
 		// All assertions are in the processor.
 	}
+
+	class SimpleSignature extends CtScanner {
+		String signature = "";
+		@Override
+		public <T> void visitCtParameter(CtParameter<T> parameter) {
+			signature += parameter.getType().getQualifiedName()+", ";
+			super.visitCtParameter(parameter);
+		}
+
+		@Override
+		public <T> void visitCtMethod(CtMethod<T> m) {
+			signature += m.getSimpleName()+"(";
+			super.visitCtMethod(m);
+			signature += ")";
+		}
+	}
+
+
+	class SimpleSignatureComparator implements Comparator<CtMethod<?>> {
+		@Override
+		public int compare(CtMethod<?> o1, CtMethod<?> o2) {
+			return computeSimpleSignature(o1).compareTo(computeSimpleSignature(o2));
+		}
+	}
+
+	private String computeSimpleSignature(CtMethod<?> m) {
+		SimpleSignature sc1 = new SimpleSignature();
+		sc1.visitCtMethod(m);
+		return sc1.signature;
+	}
+
+	@Test
+	public void testScannerCallsAllProperties() throws Exception {
+		// contract: CtScanner must visit all metamodel properties
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/main/java/spoon/reflect/");
+		launcher.run();
+		CtClass<?> scanner = (CtClass<?>)launcher.getFactory().Type().get(CtScanner.class);
+
+		for (CtType<?> t : SpoonTestHelpers.getAllInstantiableMetamodelInterfaces()) {
+			Set<String> t1 = new TreeSet<>();
+			for (CtMethod<?> m : t.getAllMethods()) {
+				if (isMetamodelProperty(t, m)) {
+					t1.add(computeSimpleSignature(m));
+				}
+			}
+
+			Set<String> t2 = new TreeSet<>();
+			CtMethod<?> visitMethod = scanner.getMethodsByName("visit"+t.getSimpleName()).get(0);
+			for (CtInvocation<?> invoc : visitMethod.getElements(new TypeFilter<CtInvocation>(CtInvocation.class) {
+					@Override
+					public boolean matches(CtInvocation element) {
+						CtMethod<?> method = (CtMethod<?>) element.getExecutable().getExecutableDeclaration();
+						assertFalse(method.isShadow());
+						return super.matches(element) && isMetamodelProperty(t, method);
+					}
+				})) {
+				t2.add(computeSimpleSignature((CtMethod<?>) invoc.getExecutable().getExecutableDeclaration()));
+			}
+		assertEquals("CtScanner contract violated for "+t.getSimpleName(), t1, t2);
+		}
+	}
+
+
 }

--- a/src/test/java/spoon/test/SpoonTestHelpers.java
+++ b/src/test/java/spoon/test/SpoonTestHelpers.java
@@ -4,8 +4,13 @@ import spoon.Launcher;
 import spoon.SpoonAPI;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.OverridingMethodFilter;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,4 +46,59 @@ public class SpoonTestHelpers {
 		}
 		return result;
 	}
+
+	/**
+	 * returns true if typeReference point to a class of the metamodel or a List/set of a class of the metamodel.
+	 */
+	public static boolean isMetamodelRelatedType(CtTypeReference<?> typeReference) {
+		CtTypeReference<Object> ctElRef = typeReference.getFactory().Code().createCtTypeReference(CtElement.class);
+
+		// simple case, a sublcass of CtElement
+		if (typeReference.isSubtypeOf(ctElRef)) {
+			return true;
+		}
+		// limit case because of a bug to be fixed
+		if (typeReference.getActualTypeArguments().size()>0 && "?".equals(typeReference.getActualTypeArguments()
+				.get(0).getQualifiedName())) {
+			return false;
+		}
+		return (typeReference.getActualTypeArguments().size()>0
+				&& typeReference.getActualTypeArguments()
+				.get(0).getTypeDeclaration()
+				.isSubtypeOf(ctElRef))
+				;
+	}
+
+	/** returns the corresponding setter, if several are possible returns the lowest one in the hierarchy */
+	public static CtMethod<?> getSetterOf(CtType<?> baseType, CtMethod<?> getter) {
+		String setterName = getter.getSimpleName().replaceFirst("^get", "set");
+		Object[] tentativeSetters = baseType.getAllMethods().stream().filter(x->x.getSimpleName().equals(setterName)).toArray();
+		if (tentativeSetters.length==0) {
+			return null;
+		}
+
+		// return one that is as low as possible in the hierarchy
+		for(Object o : tentativeSetters) {
+			if (baseType.getPackage().getElements(new OverridingMethodFilter((CtMethod<?>) o)).size() == 0) {
+				return (CtMethod<?>) o;
+			}
+		}
+
+		//System.out.println(setterName+" "+tentativeSetters.length);
+		return (CtMethod<?>) tentativeSetters[0];
+	}
+
+	/** specifies what a metamodel property is: a getter than returns a metamodel-related class and that is not derived */
+	public static boolean isMetamodelProperty(CtType<?> baseType, CtMethod<?> m) {
+		CtMethod<?> correspondingSetter = getSetterOf(baseType, m);
+		return
+				m.getSimpleName().startsWith("get")
+						&& m.getParameters().size() == 0 // a getter has no parameter
+						&& m.getAnnotation(DerivedProperty.class) == null
+						&& (correspondingSetter == null || correspondingSetter.getAnnotation(UnsettableProperty.class) == null)
+						&&
+						// return type
+						isMetamodelRelatedType(m.getType());
+	}
+
 }

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -109,20 +109,7 @@ public class MainTest {
 	}
 
 	private void checkEqualityBetweenOriginalAndClone(CtPackage pack) {
-		class ExpectedCounterScanner extends CtScanner {
-			private int expectedCounter = 0;
-
-			@Override
-			public void scan(CtElement element) {
-				if (element != null) {
-					expectedCounter++;
-				}
-				super.scan(element);
-			}
-		}
 		class ActualCounterScanner extends CtBiScannerDefault {
-			private int counter = 0;
-
 			@Override
 			public boolean biScan(CtElement element, CtElement other) {
 				if (element == null) {
@@ -132,18 +119,14 @@ public class MainTest {
 				} else if (other == null) {
 					Assert.fail("other can't be null if element isn't null.");
 				} else {
-					counter++;
 					assertEquals(element, other);
 					assertFalse(element == other);
 				}
 				return super.biScan(element, other);
 			}
 		}
-		final ExpectedCounterScanner expected = new ExpectedCounterScanner();
-		expected.scan(pack);
 		final ActualCounterScanner actual = new ActualCounterScanner();
 		actual.biScan(pack, pack.clone());
-		assertEquals(expected.expectedCounter, actual.counter);
 	}
 
 	private void checkShadow(CtPackage pack) {


### PR DESCRIPTION
The idea is no annotate the metamodel methods with Spoon-specific annotations:

* `@DerivedProperty`  for getters that are derived from other properties
* `@UnsettableProperty`  for setters that are not usable in certains cases

Then, the core contract is that `CtScanner` must visit all settable, non-derived properties. 

By doing this, I found a couple of bugs in CScanner (property not visited)