### PR TITLE
Solution for access path problem

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -118,9 +118,6 @@ public interface CtTypeInformation {
 	 *
 	 * getSuperClass().getDeclaration()/getTypeDeclaration() returns the corresponding CtType (if in the source folder of Spoon).
 	 *
-	 * However, getSuperClass().getDeclaration() returns null in very rare cases if the superclass does not use a simple name or a fully-qualified
-	 * name based on packages, but rather an access path.
-	 *
 	 * @return the class type directly extended by this class, or null if there
 	 *         is none
 	 */

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -150,6 +150,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	/**
 	 * Returns this, or top level type of this, if this is an inner type
 	 */
+	@DerivedProperty
 	CtTypeReference<?> getTopLevelType();
 
 	/**

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -153,7 +153,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	CtTypeReference<?> getTopLevelType();
 
 	/**
-	 * Computes nearest access path parent from this type to nestedType.
+	 * Computes nearest access path parent from contextType to this type.
 	 *
 	 * Normally the declaring type can be used as access path. For example in this class hierarchy
 	 * <pre>
@@ -177,7 +177,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * The C.getAccessParentFrom(X) will return D, because D can be used to access C in scope of X.
 	 *
 	 * @param contextType - the type where the access path should be visible or null if we do not care about visibility
-	 * @return type reference which can be used to access nestedType.
+	 * @return type reference which can be used to access this type in scope of contextType.
 	 */
 	CtTypeReference<?> getAccessType(CtTypeReference<?> contextType);
 }

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -23,6 +23,7 @@ import spoon.reflect.declaration.CtTypeInformation;
 import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
 
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -138,4 +139,46 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	@Override
 	@DerivedProperty
 	CtTypeReference<?> getSuperclass();
+
+	/**
+	 * Checks visibility based on public, protected, package protected and private modifiers of type
+	 * @param type
+	 * @return true if this can access that type
+	 */
+	boolean canAccess(CtTypeReference<?> type);
+
+	/**
+	 * Returns this or top level type of this if this is an inner type
+	 */
+	CtTypeReference<?> getTopLevelType();
+
+	/**
+	 * Computes shortest access path from this type to nestedType.
+	 *
+	 * Normally the declaring type can be used as access path. For example in this class hierarchy
+	 * <pre>
+	 * class A {
+	 *    class B {
+	 *       class C {}
+	 *    }
+	 * }
+	 * </pre>
+	 *
+	 * The C.getAccessPathFrom(null) will return [A,B]<br>
+	 * But when some class (A or B) on the access path is not visible in type X, then we must found an alternative path.
+	 * For example in case like:
+	 * <pre>
+	 * class D extends B {
+	 * }
+	 * class X extends D {
+	 * 	 class F extends C
+	 * }
+	 * </pre>
+	 * The C.getAccessPathFrom(X) will return D
+	 *
+	 * @param startType - the type where the access path should be visible or null if we do not care about visibility
+	 * @return list of type references. The first is top level type and next are nested types, which can be used to access nestedType.
+	 * The nestedType is not included in returned list.
+	 */
+	List<CtTypeReference<?>> getAccessPathFrom(CtTypeReference<?> startType);
 }

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -148,7 +148,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	boolean canAccess(CtTypeReference<?> type);
 
 	/**
-	 * Returns this or top level type of this if this is an inner type
+	 * Returns this, or top level type of this, if this is an inner type
 	 */
 	CtTypeReference<?> getTopLevelType();
 

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -23,7 +23,6 @@ import spoon.reflect.declaration.CtTypeInformation;
 import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
 
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -154,7 +153,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	CtTypeReference<?> getTopLevelType();
 
 	/**
-	 * Computes shortest access path from this type to nestedType.
+	 * Computes nearest access path parent from this type to nestedType.
 	 *
 	 * Normally the declaring type can be used as access path. For example in this class hierarchy
 	 * <pre>
@@ -165,9 +164,9 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * }
 	 * </pre>
 	 *
-	 * The C.getAccessPathFrom(null) will return [A,B]<br>
+	 * The C.getAccessParentFrom(null) will return B, because B can be used to access C, using code like <code>B.C</code><br>
 	 * But when some class (A or B) on the access path is not visible in type X, then we must found an alternative path.
-	 * For example in case like:
+	 * For example in case like, when A and B are invisible, e.g because of modifier <code>protected</code>:
 	 * <pre>
 	 * class D extends B {
 	 * }
@@ -175,11 +174,10 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * 	 class F extends C
 	 * }
 	 * </pre>
-	 * The C.getAccessPathFrom(X) will return D
+	 * The C.getAccessParentFrom(X) will return D, because D can be used to access C in scope of X.
 	 *
-	 * @param startType - the type where the access path should be visible or null if we do not care about visibility
-	 * @return list of type references. The first is top level type and next are nested types, which can be used to access nestedType.
-	 * The nestedType is not included in returned list.
+	 * @param contextType - the type where the access path should be visible or null if we do not care about visibility
+	 * @return type reference which can be used to access nestedType.
 	 */
-	List<CtTypeReference<?>> getAccessPathFrom(CtTypeReference<?> startType);
+	CtTypeReference<?> getAccessType(CtTypeReference<?> contextType);
 }

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1689,10 +1689,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				if (!withGenerics) {
 					context.ignoreGenerics = true;
 				}
-				printAccessPath(ref.getAccessPathFrom(context.getCurrentTypeOrInnerTypeReferenceInBody()));
+				scan(ref.getAccessType(context.getCurrentTypeOrInnerTypeReferenceInBody()));
 				if (!withGenerics) {
 					context.ignoreGenerics = ign;
 				}
+				printer.write(".");
 			}
 			//?? are these annotations on correct place ??
 			elementPrinterHelper.writeAnnotations(ref);
@@ -1716,17 +1717,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			context.ignoreEnclosingClass = false;
 			elementPrinterHelper.writeActualTypeArguments(ref);
 			context.ignoreEnclosingClass = old;
-		}
-	}
-
-	private void printAccessPath(List<CtTypeReference<?>> accessPath) {
-		for (int i = 0; i < accessPath.size(); i++) {
-			if (i == 0) {
-				scan(accessPath.get(i));
-			} else {
-				printer.write(accessPath.get(i).getSimpleName());
-			}
-			printer.write(".");
 		}
 	}
 

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -115,7 +115,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 			if (reference.getDeclaringType() == null) {
 				addImport(reference);
 			} else {
-				addImport(reference.getDeclaringType());
+				addImport(reference.getAccessType(targetType));
 			}
 		}
 		super.visitCtTypeReference(reference);

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -54,6 +54,8 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 			"ProcessHandle", "StackWalker", "StackFramePermission");
 
 	private Map<String, CtTypeReference<?>> imports = new TreeMap<>();
+	//top declaring type of that import
+	private CtTypeReference<?> targetType;
 	private Map<String, Boolean> namesPresentInJavaLang = new HashMap<>();
 
 	@Override
@@ -175,14 +177,19 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	@Override
 	public Collection<CtTypeReference<?>> computeImports(CtType<?> simpleType) {
 		imports.clear();
+		//look for top declaring type of that simpleType
+		targetType = simpleType.getReference().getTopLevelType();
 		addImport(simpleType.getReference());
 		scan(simpleType);
-		return getImports(simpleType);
+		return getImports();
 	}
 
 	@Override
 	public void computeImports(CtElement element) {
 		imports.clear();
+		//look for top declaring type of that element
+		CtType<?> type = element.getParent(CtType.class);
+		targetType = type == null ? null : type.getReference().getTopLevelType();
 		scan(element);
 	}
 
@@ -203,12 +210,11 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	 * @param simpleType
 	 * @return Collection of {@link spoon.reflect.reference.CtTypeReference}
 	 */
-	private Collection<CtTypeReference<?>> getImports(
-			CtType<?> simpleType) {
+	private Collection<CtTypeReference<?>> getImports() {
 		if (imports.isEmpty()) {
 			return Collections.EMPTY_LIST;
 		}
-		CtPackageReference pack = simpleType.getPackage().getReference();
+		CtPackageReference pack = targetType.getPackage();
 		List<CtTypeReference<?>> refs = new ArrayList<>();
 		for (CtTypeReference<?> ref : imports.values()) {
 			// ignore non-top-level type
@@ -245,6 +251,12 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 				return false;
 			}
 		}
+		if (targetType != null && targetType.canAccess(ref) == false) {
+			//ref type is not visible in targetType we must not add import for it, java compiler would fail on that.
+			return false;
+		}
+		//note: we must add the type refs from the same package too, to assure that isImported(typeRef) returns true for them
+		//these type refs are removed in #getImports()
 		imports.put(ref.getSimpleName(), ref);
 		return true;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -26,10 +26,8 @@ import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalTypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.MemberTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MissingTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
@@ -62,8 +60,6 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -618,21 +614,6 @@ class JDTTreeBuilderHelper {
 		}
 
 		if (type instanceof CtClass) {
-			if (typeDeclaration.superclass != null && typeDeclaration.superclass.resolvedType != null && typeDeclaration.enclosingType != null && !new String(
-					typeDeclaration.superclass.resolvedType.qualifiedPackageName()).equals(new String(typeDeclaration.binding.qualifiedPackageName()))) {
-
-				// Sorry for this hack but see the test case ImportTest#testImportOfAnInnerClassInASuperClassPackage.
-				// JDT isn't smart enough to return me a super class available. So, I modify their AST when
-				// superclasses aren't in the same package and when their visibilities are "default".
-				List<ModifierKind> modifiers = Arrays.asList(ModifierKind.PUBLIC, ModifierKind.PROTECTED);
-				final TypeBinding resolvedType = typeDeclaration.superclass.resolvedType;
-				if ((resolvedType instanceof MemberTypeBinding || resolvedType instanceof BinaryTypeBinding)//
-						&& resolvedType.enclosingType() != null && typeDeclaration.enclosingType.superclass != null//
-						&& Collections.disjoint(modifiers, getModifiers(resolvedType.enclosingType().modifiers))) {
-					typeDeclaration.superclass.resolvedType = jdtTreeBuilder.new SpoonReferenceBinding(typeDeclaration.superclass.resolvedType.sourceName(),
-							(ReferenceBinding) typeDeclaration.enclosingType.superclass.resolvedType);
-				}
-			}
 			if (typeDeclaration.superclass != null) {
 				((CtClass) type).setSuperclass(jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope));
 			}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -661,15 +661,15 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	}
 
 	@Override
-	public List<CtTypeReference<?>> getAccessPathFrom(CtTypeReference<?> startType) {
+	public CtTypeReference<?> getAccessType(CtTypeReference<?> contextType) {
 		CtTypeReference<?> declType = this.getDeclaringType();
 		if (declType == null) {
 			throw new SpoonException("The nestedType is expected, but it is: " + getQualifiedName());
 		}
-		if (startType != null && startType.canAccess(declType) == false) {
+		if (contextType != null && contextType.canAccess(declType) == false) {
 			//search for visible declaring type
 			CtTypeReference<?> visibleDeclType = null;
-			CtTypeReference<?> type = startType;
+			CtTypeReference<?> type = contextType;
 			//search which type or declaring type of startType extends from nestedType
 			while (visibleDeclType == null && type != null) {
 				visibleDeclType = getLastVisibleSuperClassExtendingFrom(type, declType);
@@ -682,11 +682,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 			}
 			declType = visibleDeclType;
 		}
-		//now we have declType which is visible in startType type
-		List<CtTypeReference<?>> accessPath = new ArrayList();
-		//collect access path from top to the may be nested declType
-		addAccessPathTo(accessPath, declType);
-		return accessPath;
+		return declType;
 	}
 
 	/**
@@ -712,16 +708,6 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 				adept = type;
 			}
 		}
-	}
-
-	private void addAccessPathTo(List<CtTypeReference<?>> accessPath, CtTypeReference<?> type) {
-		CtTypeReference<?> declType = type.getDeclaringType();
-		if (declType != null) {
-			//there is a declaring type. Add its access path
-			addAccessPathTo(accessPath, declType);
-		}
-		//then add itself
-		accessPath.add(type);
 	}
 
 	boolean isShadow;

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -656,6 +656,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 			if (parentType == null) {
 				return type;
 			}
+			type = parentType;
 		}
 	}
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -357,6 +357,32 @@ public class ImportTest {
 		assertEquals("spoon.test.imports.testclasses.internal.SuperClass$InnerClassProtected", actualClass.getName()); 
 	}
 	
+	@Test
+	public void testAccessType() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {
+				"-i", "./src/test/java/spoon/test/imports/testclasses", "--with-imports"
+		});
+		launcher.buildModel();
+		final CtClass<ImportTest> aInnerClass = launcher.getFactory().Class().get(ClientClass.class.getName()+"$InnerClass");
+		final CtClass<ImportTest> aSuperClass = launcher.getFactory().Class().get("spoon.test.imports.testclasses.internal.SuperClass");
+		assertEquals(ClientClass.class.getName()+"$InnerClass", aInnerClass.getQualifiedName());
+		
+		//Check that access type of ClientClass$InnerClass in undefined context is ClientClass
+		assertEquals(ClientClass.class.getName(), aInnerClass.getReference().getAccessType(null).getQualifiedName());
+		//Check that access type of ClientClass$InnerClass in package protected class is still ClientClass
+		assertEquals(ClientClass.class.getName(), aInnerClass.getReference().getAccessType(aSuperClass.getReference()).getQualifiedName());
+		
+		final CtTypeReference<?> innerClassProtected = aInnerClass.getSuperclass();
+		//check that parentClass is SuperClass$InnerClassProtected
+		assertEquals("spoon.test.imports.testclasses.internal.SuperClass$InnerClassProtected", innerClassProtected.getQualifiedName()); 
+		//Check that access type of SuperClass$InnerClassProtected in undefined context is SuperClass
+		assertEquals("spoon.test.imports.testclasses.internal.SuperClass", innerClassProtected.getAccessType(null).getQualifiedName());
+		//Check that access type of SuperClass$InnerClassProtected in ClientClass context is ChildClass
+		assertEquals("spoon.test.imports.testclasses.internal.ChildClass", innerClassProtected.getAccessType(launcher.getFactory().Class().createReference(ClientClass.class)).getQualifiedName());
+		//Check that access type of SuperClass$InnerClassProtected in ClientClass$InnerClass context is ChildClass
+		assertEquals("spoon.test.imports.testclasses.internal.ChildClass", innerClassProtected.getAccessType(aInnerClass.getReference()).getQualifiedName());
+	}
 
 	private Factory getFactory(String...inputs) {
 		final Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -433,7 +433,7 @@ public class TargetedExpressionTest {
 	public void testClassDeclaredInALambda() throws Exception {
 		// contract: A class can be declared in a lambda expression where we use final fields.
 		final CtType<Tapas> type = buildClass(Tapas.class);
-		final List<CtFieldAccess<?>> elements = new SortedList(new CtLineElementComparator());
+		final List<CtFieldAccess> elements = new SortedList(new CtLineElementComparator());
 		elements.addAll(type.getElements(new TypeFilter<>(CtFieldAccess.class)));
 		assertEquals(3, elements.size());
 


### PR DESCRIPTION
After short googling, I have not found any java specification about access path yet (so I am really not a guru for that), anyway I understood that:

> C1: Spoon needs access path from class A to super class B to be able to print the declaration of the class A correctly.

> C2: There is no other place, where access path is needed

> C3: Access path from class A to class B is not the qualified name of class B. 

> C4: the class B can have many access paths ~ one for each inheritance branch, but there is always only one qualified name of class B.

> C5: the access path cannot be used to load the class using class loader. It can be done only using qualified name.

Please correct me, if I am wrong.

The solution I would like to discuss consists of S1 and S2:

> S1: To remove the hack in JDTTreeBuilderHelper

It causes:
- the qualified name of the nested class is correct again, and can be used to load the class using class loader
- the relations `nestedType.getDeclaringType()` and `declaringType.getNestedTypes()` are consistent again

> S2: To compute the access path from class A to class B during pretty printing

I am sure, that you get this idea too. Could you explain me what is the problem? And if computation of access path is problem, then could you show me the case where it is problem?

Thank You! And and have a nice dreams :-)