### PR TITLE
test for thisAccess like this.field and not SomeClass.this.field

### DIFF
--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -23,6 +23,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Query;
@@ -413,5 +414,19 @@ public class FieldAccessTest {
 		factory.getEnvironment().setAutoImports(true);
 
 		assertEquals("this.size = size", pizza.getElements(new TypeFilter<>(CtAssignment.class)).get(0).toString());
+	}
+
+	@Test
+	public void testThisDotFieldAccessAutoNotImplicit() throws Exception {
+		Factory factory = build(Pizza.class);
+		CtClass<?> pizza = factory.Class().get(Pizza.class);
+		factory.getEnvironment().setAutoImports(true);
+
+		CtMethod<?> m = pizza.getMethod("addSize", factory.Type().INTEGER_PRIMITIVE);
+		CtParameter<?> param = m.getParameters().get(0);
+		param.setSimpleName("size");
+		m.getElements((CtParameterReference<?> e)-> "plus".equals(e.getSimpleName())).forEach((CtParameterReference<?> e)->e.setSimpleName("size"));
+		//the printer detects the name conflict between field name and parameter name and should use explicit thisAccess automatically  
+		assertEquals("this.size = (this.size) + size", m.getElements(new TypeFilter<>(CtAssignment.class)).get(0).toString());
 	}
 }

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -3,6 +3,7 @@ package spoon.test.fieldaccesses;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtArrayWrite;
+import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
@@ -30,6 +31,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.fieldaccesses.testclasses.B;
 import spoon.test.fieldaccesses.testclasses.Kuu;
 import spoon.test.fieldaccesses.testclasses.Panini;
+import spoon.test.fieldaccesses.testclasses.Pizza;
 import spoon.test.fieldaccesses.testclasses.Pozole;
 import spoon.test.fieldaccesses.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
@@ -394,5 +396,22 @@ public class FieldAccessTest {
 
 		assertEquals("A.myField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(0).toString());
 		assertEquals("finalField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(1).toString());
+	}
+	
+	@Test
+	public void testThisDotFieldAccess() throws Exception {
+		Factory factory = build(Pizza.class);
+		CtClass<?> pizza = factory.Class().get(Pizza.class);
+
+		assertEquals("this.size = size", pizza.getElements(new TypeFilter<>(CtAssignment.class)).get(0).toString());
+	}
+
+	@Test
+	public void testThisDotFieldAccessWithAutoImport() throws Exception {
+		Factory factory = build(Pizza.class);
+		CtClass<?> pizza = factory.Class().get(Pizza.class);
+		factory.getEnvironment().setAutoImports(true);
+
+		assertEquals("this.size = size", pizza.getElements(new TypeFilter<>(CtAssignment.class)).get(0).toString());
 	}
 }

--- a/src/test/java/spoon/test/fieldaccesses/testclasses/Pizza.java
+++ b/src/test/java/spoon/test/fieldaccesses/testclasses/Pizza.java
@@ -1,0 +1,10 @@
+package spoon.test.fieldaccesses.testclasses;
+
+public class Pizza
+{
+	int size;
+
+	void setSize(int size) {
+		this.size = size;
+	}
+}

--- a/src/test/java/spoon/test/fieldaccesses/testclasses/Pizza.java
+++ b/src/test/java/spoon/test/fieldaccesses/testclasses/Pizza.java
@@ -7,4 +7,12 @@ public class Pizza
 	void setSize(int size) {
 		this.size = size;
 	}
+
+	int getSize(int size) {
+		return size;
+	}
+
+	void addSize(int plus) {
+		size = size + plus;
+	}
 }

--- a/src/test/java/spoon/test/fieldaccesses/testclasses/internal/Foo.java
+++ b/src/test/java/spoon/test/fieldaccesses/testclasses/internal/Foo.java
@@ -1,9 +1,18 @@
 package spoon.test.fieldaccesses.testclasses.internal;
 
-public abstract class Foo extends Bar.Inner {
+import java.util.ArrayList;
+import java.util.List;
+
+public class Foo extends Bar.Inner {
 	class Test {
 		class Test2 {
-
 		}
+	}
+	public static class Fails {
+        public final List<String> keyValues = new ArrayList<>();
+        
+        public Fails() {
+        	keyValues.add("");
+        }
 	}
 }


### PR DESCRIPTION
I guess the issue #826 created by @leventov is about the problem, which is reproducable by 2 new tests of this PR

The problem, which I feel too is that in the source class like
```java
package spoon.test.fieldaccesses.testclasses;
public class Pizza {
	int size;
	void setSize(int size) {
		this.size = size;
	}
}
```

The spoon produces field access `this.size` in these two wrong forms 

if `factory.getEnvironment().setAutoImports(true)` then it is
> Pizza.this.size = size

if `factory.getEnvironment().setAutoImports(false)` then it is
> spoon.test.fieldaccesses.testclasses.Pizza.this.size = size

But I would prefer to print `this.size` in all cases.