### PR TITLE
fix(array): the qualified name of an array is not java.lang.reflect.Array

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -25,12 +25,6 @@ import java.lang.reflect.Array;
 public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTypeReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	public static final String ARRAY_SIMPLE_NAME = Array.class.getSimpleName();
-	/**
-	 * getCanonicalName() is an _expensive_ operation, result should be cached
-	 */
-	public static final String ARRAY_CANONICAL_NAME = Array.class.getCanonicalName();
-
 	CtTypeReference<?> componentType;
 
 	public CtArrayTypeReferenceImpl() {
@@ -44,6 +38,10 @@ public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implemen
 
 	@Override
 	public CtTypeReference<?> getComponentType() {
+		if (componentType == null) {
+			// a sensible default component type to facilitate object creation and testing
+			componentType = getFactory().Type().get(Object.class).getReference();
+		}
 		return componentType;
 	}
 
@@ -67,12 +65,12 @@ public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implemen
 
 	@Override
 	public String getSimpleName() {
-		return ARRAY_SIMPLE_NAME;
+		return getComponentType().getSimpleName() + "[]";
 	}
 
 	@Override
 	public String getQualifiedName() {
-		return ARRAY_CANONICAL_NAME;
+		return getComponentType().getQualifiedName() + "[]";
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -16,7 +16,6 @@
  */
 package spoon.support.reflect.reference;
 
-import spoon.SpoonException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.reference.CtReference;
@@ -46,9 +45,6 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 
 	@Override
 	public <T extends CtReference> T setSimpleName(String simplename) {
-		if (simplename.contains("?")) {
-			throw new SpoonException("A reference can't have a \"?\" in its name.");
-		}
 		Factory factory = getFactory();
 		if (factory instanceof FactoryImpl) {
 			simplename = ((FactoryImpl) factory).dedup(simplename);

--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -23,7 +23,7 @@ public class ArraysTest {
 	public void testArrayReferences() throws Exception {
 		CtType<?> type = build("spoon.test.arrays", "ArrayClass");
 		assertEquals("ArrayClass", type.getSimpleName());
-		assertEquals("int[][][]", type.getField("i").getType().toString());
+		assertEquals("int[][][]", type.getField("i").getType().getSimpleName());
 		assertEquals(3, ((CtArrayTypeReference<?>) type.getField("i").getType()).getDimensionCount());
 		final CtArrayTypeReference<?> arrayTypeReference = (CtArrayTypeReference<?>) type.getField("i").getDefaultExpression().getType();
 		assertEquals(1, arrayTypeReference.getArrayType().getAnnotations().size());
@@ -31,8 +31,8 @@ public class ArraysTest {
 
 		CtField<?> x = type.getField("x");
 		assertTrue(x.getType() instanceof CtArrayTypeReference);
-		assertEquals("Array", x.getType().getSimpleName());
-		assertEquals("java.lang.reflect.Array", x.getType().getQualifiedName());
+		assertEquals("int[]", x.getType().getSimpleName());
+		assertEquals("int[]", x.getType().getQualifiedName());
 		assertEquals("int", ((CtArrayTypeReference<?>) x.getType()).getComponentType().getSimpleName());
 		assertTrue(((CtArrayTypeReference<?>) x.getType()).getComponentType().getActualClass().equals(int.class));
 	}

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -89,7 +89,7 @@ public class ConstructorCallTest {
 		assertTrue(implicitArray.isImplicit());
 		final CtArrayTypeReference implicitArrayTyped = (CtArrayTypeReference) implicitArray;
 		assertEquals("", implicitArrayTyped.toString());
-		assertEquals("Array", implicitArrayTyped.getSimpleName());
+		assertEquals("AtomicLong[]", implicitArrayTyped.getSimpleName());
 		assertTrue(implicitArrayTyped.getComponentType().isImplicit());
 		assertEquals("", implicitArrayTyped.getComponentType().toString());
 		assertEquals("AtomicLong", implicitArrayTyped.getComponentType().getSimpleName());

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -300,7 +300,7 @@ public class LambdaTest {
 		assertEquals("a", ctParameter.getSimpleName());
 		assertTrue(ctParameter.getType().isImplicit());
 		assertEquals("", ctParameter.getType().toString());
-		assertEquals("Array", ctParameter.getType().getSimpleName());
+		assertEquals("Object[]", ctParameter.getType().getSimpleName());
 
 		final CtArrayTypeReference typeParameter = (CtArrayTypeReference) ctParameter.getType();
 		assertTrue(typeParameter.getComponentType().isImplicit());

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -503,13 +503,6 @@ public class TypeReferenceTest {
 		assertNull(reference.getBoundingType());
 	}
 
-	@Test(expected = SpoonException.class)
-	public void testReferenceName() throws Exception {
-		final Factory factory = createFactory();
-		final CtTypeReference<Object> typeReference = factory.Core().createTypeReference();
-		typeReference.setSimpleName("?");
-	}
-
 	@Test
 	public void testIgnoreEnclosingClassInActualTypes() throws Exception {
 		final CtType<Panini> aPanini = buildClass(Panini.class);

--- a/src/test/java/spoon/test/varargs/VarArgsTest.java
+++ b/src/test/java/spoon/test/varargs/VarArgsTest.java
@@ -25,7 +25,8 @@ public class VarArgsTest {
 		CtParameter<?> param1 = m.getParameters().get(1);
 		assertEquals(true, param1.isVarArgs());
 		assertEquals("java.lang.String[]", param1.getType().toString());
-		assertEquals("Array", param1.getType().getSimpleName());
+		assertEquals("String[]", param1.getType().getSimpleName());
+		assertEquals("java.lang.String[]", param1.getType().getQualifiedName());
 		assertEquals("java.lang.String", ((CtArrayTypeReference<?>)param1.getType()).getComponentType().toString());
 		// we can even rewrite the vararg
 		assertEquals("void foo(int arg0, java.lang.String... args) {"


### PR DESCRIPTION
java.lang.reflect.Array only contains static utility methods and is not all all a superclass of arrays.

`(new int[0]).getClass().getCanonicalName()` gives `int[]` which should be the result of Spoon.

the removal of the defensive exception is required, because of the presence of another cryptic yet not critical bug (a `TypeReference` which should be a a `TypeParameterReference` while cloning). 

this fix is also a prerequisite to another fix on equality to come later.