### PR TITLE
Template matcher improvements

### DIFF
--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -201,12 +201,13 @@ public abstract class Parameters {
 	 */
 	public static boolean isParameterSource(CtFieldReference<?> ref) {
 		CtField<?> field = ref.getDeclaration();
-		if (field != null) {
-			// we must have the source of this fieldref
-			if (ref.getDeclaration().getAnnotation(Parameter.class) != null) {
-				//it is the template field which represents template parameter, because of "Parameter" annotation
-				return true;
-			}
+		if (field == null) {
+			// we must have the source of this fieldref, otherwise we cannot use it as template parameter
+			return false;
+		}
+		if (field.getAnnotation(Parameter.class) != null) {
+			//it is the template field which represents template parameter, because of "Parameter" annotation
+			return true;
 		}
 		if (ref.getType() instanceof CtTypeParameterReference) {
 			//the template fields, which are using generic type like <T>, are not template parameters

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -200,18 +200,27 @@ public abstract class Parameters {
 	 * Tells if a given field is a template parameter.
 	 */
 	public static boolean isParameterSource(CtFieldReference<?> ref) {
-		try {
-			return (ref.getDeclaration() != null // we must have the source of
-					// this fieldref
-					&& ref.getDeclaration().getAnnotation(Parameter.class) != null) || (!((ref.getType() instanceof CtTypeParameterReference) || ref.getSimpleName().equals("this"))
-					&& getTemplateParameterType(ref.getFactory()).isSubtypeOf(ref.getType()));
-		} catch (RuntimeException e) {
-			// if (e.getCause() instanceof ClassNotFoundException) {
-			// return false;
-			// } else {
-			throw e;
-			// }
+		CtField<?> field = ref.getDeclaration();
+		if (field != null) {
+			// we must have the source of this fieldref
+			if (ref.getDeclaration().getAnnotation(Parameter.class) != null) {
+				//it is the template field which represents template parameter, because of "Parameter" annotation
+				return true;
+			}
 		}
+		if (ref.getType() instanceof CtTypeParameterReference) {
+			//the template fields, which are using generic type like <T>, are not template parameters
+			return false;
+		}
+		if (ref.getSimpleName().equals("this")) {
+			//the reference to this is not template parameter
+			return false;
+		}
+		if (getTemplateParameterType(ref.getFactory()).isSubtypeOf(ref.getType())) {
+			//the type of template field is or extends from class TemplateParameter.
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -16,7 +16,7 @@
  */
 package spoon.support.template;
 
-import spoon.Launcher;
+import spoon.SpoonException;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLiteral;
@@ -191,7 +191,7 @@ public abstract class Parameters {
 				}
 			}
 		} catch (Exception e) {
-			Launcher.LOGGER.error(e.getMessage(), e);
+			throw new SpoonException("Getting of template parameters failed", e);
 		}
 		return params;
 	}

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -35,7 +35,6 @@ import spoon.template.TemplateParameter;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,8 +181,8 @@ public abstract class Parameters {
 	 * Gets the names of all the template parameters of a given template type
 	 * (including the ones defined by the super types).
 	 */
-	public static Collection<String> getNames(CtClass<? extends Template<?>> templateType) {
-		Collection<String> params = new ArrayList<>();
+	public static List<String> getNames(CtClass<? extends Template<?>> templateType) {
+		List<String> params = new ArrayList<>();
 		try {
 			for (CtFieldReference<?> f : templateType.getReference().getAllFields()) {
 				if (isParameterSource(f)) {

--- a/src/main/java/spoon/template/TemplateMatcher.java
+++ b/src/main/java/spoon/template/TemplateMatcher.java
@@ -68,10 +68,7 @@ public class TemplateMatcher {
 	}
 
 	private List<String> getTemplateNameParameters(CtClass<? extends Template<?>> templateType) {
-		final List<String> ts = new ArrayList<>();
-		final Collection<String> c = Parameters.getNames(templateType);
-		ts.addAll(c);
-		return ts;
+		return Parameters.getNames(templateType);
 	}
 
 	private List<CtTypeReference<?>> getTemplateTypeParameters(final CtClass<? extends Template<?>> templateType) {


### PR DESCRIPTION
I am learning how TemplateMatcher works. I suggest some little code improvements.

There is a bug fix too, int this PR, in `isParameterSource` method, which returned before true, in some cases, even when `ref.getDeclaration()` was null. It might be OK in this method, but it would fail immediately on NullPointerException in `Parameters.getParameterName()` on `f.getDeclaration().getAnnotation(...)' so I think the change in the `isParameterSource` expression is correct.

I replaced `Launcher.LOGGER.error(...)` by throwing of exception. I guess that spoon should visibly fail if client wants to use a template, but something bad happens. The writing to log is not enough in such case. But here I am not sure, so if you do not agree, then I gladly rollback this change.