### PR TITLE
fix(equal): actual type refs must be part of equality

### DIFF
--- a/src/main/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/main/java/spoon/generating/CloneVisitorGenerator.java
@@ -80,7 +80,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 		final CtTypeAccess<Object> cloneBuilderType = factory.Code().createTypeAccess(cloneBuilder);
 		final CtVariableAccess<Object> builderFieldAccess = factory.Code().createVariableRead(factory.Field().createReference(target.getReference(), cloneBuilder, "builder"), false);
 		final CtFieldReference<Object> other = factory.Field().createReference((CtField) target.getField("other"));
-		final CtVariableAccess<Object> otherRead = factory.Code().createVariableRead(other, false);
+		final CtVariableAccess<Object> otherRead = factory.Code().createVariableRead(other, true);
 
 		new CtScanner() {
 			private final List<String> internals = Collections.singletonList("CtCircularTypeReference");
@@ -199,7 +199,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 					"spoon.support.reflect.declaration.CtCodeSnippetImpl", "spoon.support.reflect.declaration.CtFormalTypeDeclarerImpl", //
 					"spoon.support.reflect.declaration.CtGenericElementImpl", "spoon.support.reflect.reference.CtGenericElementReferenceImpl", //
 					"spoon.support.reflect.declaration.CtModifiableImpl", "spoon.support.reflect.declaration.CtMultiTypedElementImpl", //
-					"spoon.support.reflect.declaration.CtTypeMemberImpl");
+					"spoon.support.reflect.declaration.CtTypeMemberImpl", "spoon.support.reflect.declaration.CtElementImpl");
 			private final List<String> excludesFields = Arrays.asList("factory", "elementValues", "target", "metadata");
 			private final CtTypeReference<List> LIST_REFERENCE = factory.Type().createReference(List.class);
 			private final CtTypeReference<Collection> COLLECTION_REFERENCE = factory.Type().createReference(Collection.class);
@@ -216,13 +216,13 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 				if ("scanCtVisitable".equals(element.getSimpleName())) {
 					return;
 				}
-				final String qualifiedName = "spoon.support" + element.getParameters().get(0).getType().getQualifiedName().substring(5) + "Impl";
-				if (excludesAST.contains(qualifiedName)) {
+				final String qualifiedNameOfImplClass = "spoon.support" + element.getParameters().get(0).getType().getQualifiedName().substring(5) + "Impl";
+				if (excludesAST.contains(qualifiedNameOfImplClass)) {
 					return;
 				}
-				final CtType<?> declaration = factory.Class().get(qualifiedName);
+				final CtType<?> declaration = factory.Class().get(qualifiedNameOfImplClass);
 				if (declaration == null) {
-					throw new SpoonException(qualifiedName + " doesn't have declaration in the source path for " + element.getSignature());
+					throw new SpoonException(qualifiedNameOfImplClass + " doesn't have declaration in the source path for " + element.getSignature());
 				}
 
 				CtMethod<T> clone = element.clone();
@@ -486,7 +486,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 					if (type.isSubtypeOf(factory.Type().createReference(CtElement.class))) {
 						return true;
 					}
-					if (type.equals(LIST_REFERENCE) || type.equals(COLLECTION_REFERENCE) || type.equals(SET_REFERENCE)) {
+					if (type.getQualifiedName().equals(LIST_REFERENCE.getQualifiedName()) || type.getQualifiedName().equals(COLLECTION_REFERENCE.getQualifiedName()) || type.getQualifiedName().equals(SET_REFERENCE.getQualifiedName())) {
 						if (type.getActualTypeArguments().get(0).isSubtypeOf(CTELEMENT_REFERENCE)) {
 							return true;
 						}

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -82,7 +82,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 			CtConstructor<T> c = (CtConstructor<T>) typeMember;
 			boolean cont = c.getParameters().size() == parameterTypes.length;
 			for (int i = 0; cont && (i < c.getParameters().size()) && (i < parameterTypes.length); i++) {
-				if (!parameterTypes[i].equals(c.getParameters().get(i).getType())) {
+				if (!parameterTypes[i].getQualifiedName().equals(c.getParameters().get(i).getType().getQualifiedName())) {
 					cont = false;
 				}
 			}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -710,7 +710,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			} else {
 				return getFactory().Type().objectType().equals(expectedType);
 			}
-		} else if (!expectedType.equals(ctParameterType)) {
+		} else if (!expectedType.getQualifiedName().equals(ctParameterType.getQualifiedName())) {
 			return false;
 		}
 		return true;

--- a/src/main/java/spoon/support/visitor/clone/CloneBuilder.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneBuilder.java
@@ -25,6 +25,213 @@ package spoon.support.visitor.clone;
  * This class is generated automatically by the processor {@link spoon.generating.CloneVisitorGenerator}.
  */
 public class CloneBuilder extends spoon.reflect.visitor.CtInheritanceScanner {
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtCodeSnippetExpression(spoon.reflect.code.CtCodeSnippetExpression<T> e) {
+		((spoon.reflect.code.CtCodeSnippetExpression<T>) (other)).setValue(e.getValue());
+		super.visitCtCodeSnippetExpression(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtCodeSnippetStatement(spoon.reflect.code.CtCodeSnippetStatement e) {
+		((spoon.reflect.code.CtCodeSnippetStatement) (other)).setValue(e.getValue());
+		super.visitCtCodeSnippetStatement(e);
+	}
+
+	/**
+	 * Scans an abstract named element.
+	 */
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void scanCtNamedElement(spoon.reflect.declaration.CtNamedElement e) {
+		((spoon.reflect.declaration.CtNamedElement) (other)).setSimpleName(e.getSimpleName());
+		super.scanCtNamedElement(e);
+	}
+
+	/**
+	 * Scans an abstract reference.
+	 */
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void scanCtReference(spoon.reflect.reference.CtReference reference) {
+		((spoon.reflect.reference.CtReference) (other)).setSimpleName(reference.getSimpleName());
+		super.scanCtReference(reference);
+	}
+
+	/**
+	 * Scans an abstract statement.
+	 */
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void scanCtStatement(spoon.reflect.code.CtStatement s) {
+		((spoon.reflect.code.CtStatement) (other)).setLabel(s.getLabel());
+		super.scanCtStatement(s);
+	}
+
+	/**
+	 * Scans an abstract type.
+	 */
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void scanCtType(spoon.reflect.declaration.CtType<T> type) {
+		((spoon.reflect.declaration.CtType<T>) (other)).setModifiers(type.getModifiers());
+		((spoon.reflect.declaration.CtType<T>) (other)).setShadow(type.isShadow());
+		super.scanCtType(type);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T, A extends T> void visitCtOperatorAssignment(spoon.reflect.code.CtOperatorAssignment<T, A> e) {
+		((spoon.reflect.code.CtOperatorAssignment<T, A>) (other)).setKind(e.getKind());
+		super.visitCtOperatorAssignment(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <A extends java.lang.annotation.Annotation> void visitCtAnnotation(spoon.reflect.declaration.CtAnnotation<A> e) {
+		((spoon.reflect.declaration.CtAnnotation<A>) (other)).setShadow(e.isShadow());
+		super.visitCtAnnotation(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtAnonymousExecutable(spoon.reflect.declaration.CtAnonymousExecutable e) {
+		((spoon.reflect.declaration.CtAnonymousExecutable) (other)).setModifiers(e.getModifiers());
+		super.visitCtAnonymousExecutable(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtBinaryOperator(spoon.reflect.code.CtBinaryOperator<T> e) {
+		((spoon.reflect.code.CtBinaryOperator<T>) (other)).setKind(e.getKind());
+		super.visitCtBinaryOperator(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtBreak(spoon.reflect.code.CtBreak e) {
+		((spoon.reflect.code.CtBreak) (other)).setTargetLabel(e.getTargetLabel());
+		super.visitCtBreak(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtConstructor(spoon.reflect.declaration.CtConstructor<T> e) {
+		((spoon.reflect.declaration.CtConstructor<T>) (other)).setModifiers(e.getModifiers());
+		((spoon.reflect.declaration.CtConstructor<T>) (other)).setShadow(e.isShadow());
+		super.visitCtConstructor(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtContinue(spoon.reflect.code.CtContinue e) {
+		((spoon.reflect.code.CtContinue) (other)).setTargetLabel(e.getTargetLabel());
+		super.visitCtContinue(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtExecutableReference(spoon.reflect.reference.CtExecutableReference<T> e) {
+		((spoon.reflect.reference.CtExecutableReference<T>) (other)).setStatic(e.isStatic());
+		super.visitCtExecutableReference(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtField(spoon.reflect.declaration.CtField<T> e) {
+		((spoon.reflect.declaration.CtField<T>) (other)).setModifiers(e.getModifiers());
+		((spoon.reflect.declaration.CtField<T>) (other)).setShadow(e.isShadow());
+		super.visitCtField(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtFieldReference(spoon.reflect.reference.CtFieldReference<T> e) {
+		((spoon.reflect.reference.CtFieldReference<T>) (other)).setFinal(e.isFinal());
+		((spoon.reflect.reference.CtFieldReference<T>) (other)).setStatic(e.isStatic());
+		super.visitCtFieldReference(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtInvocation(spoon.reflect.code.CtInvocation<T> e) {
+		((spoon.reflect.code.CtInvocation<T>) (other)).setLabel(e.getLabel());
+		super.visitCtInvocation(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtLiteral(spoon.reflect.code.CtLiteral<T> e) {
+		((spoon.reflect.code.CtLiteral<T>) (other)).setValue(e.getValue());
+		super.visitCtLiteral(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtLocalVariable(spoon.reflect.code.CtLocalVariable<T> e) {
+		((spoon.reflect.code.CtLocalVariable<T>) (other)).setSimpleName(e.getSimpleName());
+		((spoon.reflect.code.CtLocalVariable<T>) (other)).setModifiers(e.getModifiers());
+		super.visitCtLocalVariable(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtCatchVariable(spoon.reflect.code.CtCatchVariable<T> e) {
+		((spoon.reflect.code.CtCatchVariable<T>) (other)).setSimpleName(e.getSimpleName());
+		((spoon.reflect.code.CtCatchVariable<T>) (other)).setModifiers(e.getModifiers());
+		super.visitCtCatchVariable(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtMethod(spoon.reflect.declaration.CtMethod<T> e) {
+		((spoon.reflect.declaration.CtMethod<T>) (other)).setDefaultMethod(e.isDefaultMethod());
+		((spoon.reflect.declaration.CtMethod<T>) (other)).setModifiers(e.getModifiers());
+		((spoon.reflect.declaration.CtMethod<T>) (other)).setShadow(e.isShadow());
+		super.visitCtMethod(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	@java.lang.Override
+	public <T> void visitCtConstructorCall(spoon.reflect.code.CtConstructorCall<T> e) {
+		((spoon.reflect.code.CtConstructorCall<T>) (other)).setLabel(e.getLabel());
+		super.visitCtConstructorCall(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	@java.lang.Override
+	public <T> void visitCtLambda(spoon.reflect.code.CtLambda<T> e) {
+		((spoon.reflect.code.CtLambda<T>) (other)).setSimpleName(e.getSimpleName());
+		super.visitCtLambda(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T, A extends T> void visitCtOperatorAssignement(spoon.reflect.code.CtOperatorAssignment<T, A> assignment) {
+		((spoon.reflect.code.CtOperatorAssignment<T, A>) (other)).setKind(assignment.getKind());
+		super.visitCtOperatorAssignement(assignment);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtPackage(spoon.reflect.declaration.CtPackage e) {
+		((spoon.reflect.declaration.CtPackage) (other)).setShadow(e.isShadow());
+		super.visitCtPackage(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtParameter(spoon.reflect.declaration.CtParameter<T> e) {
+		((spoon.reflect.declaration.CtParameter<T>) (other)).setVarArgs(e.isVarArgs());
+		((spoon.reflect.declaration.CtParameter<T>) (other)).setModifiers(e.getModifiers());
+		((spoon.reflect.declaration.CtParameter<T>) (other)).setShadow(e.isShadow());
+		super.visitCtParameter(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public void visitCtTypeParameterReference(spoon.reflect.reference.CtTypeParameterReference e) {
+		((spoon.reflect.reference.CtTypeParameterReference) (other)).setUpper(e.isUpper());
+		super.visitCtTypeParameterReference(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtTypeReference(spoon.reflect.reference.CtTypeReference<T> e) {
+		((spoon.reflect.reference.CtTypeReference<T>) (other)).setShadow(e.isShadow());
+		super.visitCtTypeReference(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	public <T> void visitCtUnaryOperator(spoon.reflect.code.CtUnaryOperator<T> e) {
+		((spoon.reflect.code.CtUnaryOperator<T>) (other)).setKind(e.getKind());
+		((spoon.reflect.code.CtUnaryOperator<T>) (other)).setLabel(e.getLabel());
+		super.visitCtUnaryOperator(e);
+	}
+
+	// auto-generated, see spoon.generating.CloneVisitorGenerator
+	@java.lang.Override
+	public void visitCtComment(spoon.reflect.code.CtComment e) {
+		((spoon.reflect.code.CtComment) (other)).setContent(e.getContent());
+		((spoon.reflect.code.CtComment) (other)).setCommentType(e.getCommentType());
+		super.visitCtComment(e);
+	}
+
 	public static <T extends spoon.reflect.declaration.CtElement> T build(spoon.reflect.declaration.CtElement element, spoon.reflect.declaration.CtElement other) {
 		return spoon.support.visitor.clone.CloneBuilder.build(new spoon.support.visitor.clone.CloneBuilder(), element, other);
 	}
@@ -39,223 +246,6 @@ public class CloneBuilder extends spoon.reflect.visitor.CtInheritanceScanner {
 
 	public void setOther(spoon.reflect.declaration.CtElement other) {
 		spoon.support.visitor.clone.CloneBuilder.this.other = other;
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtCodeSnippetExpression(spoon.reflect.code.CtCodeSnippetExpression<T> e) {
-		((spoon.reflect.code.CtCodeSnippetExpression<T>) (this.other)).setValue(e.getValue());
-		super.visitCtCodeSnippetExpression(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtCodeSnippetStatement(spoon.reflect.code.CtCodeSnippetStatement e) {
-		((spoon.reflect.code.CtCodeSnippetStatement) (this.other)).setValue(e.getValue());
-		super.visitCtCodeSnippetStatement(e);
-	}
-
-	/**
-	 * Scans an abstract element.
-	 */
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void scanCtElement(spoon.reflect.declaration.CtElement e) {
-		((spoon.reflect.declaration.CtElement) (this.other)).setPosition(e.getPosition());
-		((spoon.reflect.declaration.CtElement) (this.other)).setImplicit(e.isImplicit());
-		super.scanCtElement(e);
-	}
-
-	/**
-	 * Scans an abstract named element.
-	 */
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void scanCtNamedElement(spoon.reflect.declaration.CtNamedElement e) {
-		((spoon.reflect.declaration.CtNamedElement) (this.other)).setSimpleName(e.getSimpleName());
-		super.scanCtNamedElement(e);
-	}
-
-	/**
-	 * Scans an abstract reference.
-	 */
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void scanCtReference(spoon.reflect.reference.CtReference reference) {
-		((spoon.reflect.reference.CtReference) (this.other)).setSimpleName(reference.getSimpleName());
-		super.scanCtReference(reference);
-	}
-
-	/**
-	 * Scans an abstract statement.
-	 */
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void scanCtStatement(spoon.reflect.code.CtStatement s) {
-		((spoon.reflect.code.CtStatement) (this.other)).setLabel(s.getLabel());
-		super.scanCtStatement(s);
-	}
-
-	/**
-	 * Scans an abstract type.
-	 */
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void scanCtType(spoon.reflect.declaration.CtType<T> type) {
-		((spoon.reflect.declaration.CtType<T>) (this.other)).setModifiers(type.getModifiers());
-		((spoon.reflect.declaration.CtType<T>) (this.other)).setShadow(type.isShadow());
-		super.scanCtType(type);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T, A extends T> void visitCtOperatorAssignment(spoon.reflect.code.CtOperatorAssignment<T, A> e) {
-		((spoon.reflect.code.CtOperatorAssignment<T, A>) (this.other)).setKind(e.getKind());
-		super.visitCtOperatorAssignment(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <A extends java.lang.annotation.Annotation> void visitCtAnnotation(spoon.reflect.declaration.CtAnnotation<A> e) {
-		((spoon.reflect.declaration.CtAnnotation<A>) (this.other)).setShadow(e.isShadow());
-		super.visitCtAnnotation(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtAnonymousExecutable(spoon.reflect.declaration.CtAnonymousExecutable e) {
-		((spoon.reflect.declaration.CtAnonymousExecutable) (this.other)).setModifiers(e.getModifiers());
-		super.visitCtAnonymousExecutable(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtBinaryOperator(spoon.reflect.code.CtBinaryOperator<T> e) {
-		((spoon.reflect.code.CtBinaryOperator<T>) (this.other)).setKind(e.getKind());
-		super.visitCtBinaryOperator(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtBreak(spoon.reflect.code.CtBreak e) {
-		((spoon.reflect.code.CtBreak) (this.other)).setTargetLabel(e.getTargetLabel());
-		super.visitCtBreak(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtConstructor(spoon.reflect.declaration.CtConstructor<T> e) {
-		((spoon.reflect.declaration.CtConstructor<T>) (this.other)).setModifiers(e.getModifiers());
-		((spoon.reflect.declaration.CtConstructor<T>) (this.other)).setShadow(e.isShadow());
-		super.visitCtConstructor(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtContinue(spoon.reflect.code.CtContinue e) {
-		((spoon.reflect.code.CtContinue) (this.other)).setTargetLabel(e.getTargetLabel());
-		super.visitCtContinue(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtExecutableReference(spoon.reflect.reference.CtExecutableReference<T> e) {
-		((spoon.reflect.reference.CtExecutableReference<T>) (this.other)).setStatic(e.isStatic());
-		super.visitCtExecutableReference(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtField(spoon.reflect.declaration.CtField<T> e) {
-		((spoon.reflect.declaration.CtField<T>) (this.other)).setModifiers(e.getModifiers());
-		((spoon.reflect.declaration.CtField<T>) (this.other)).setShadow(e.isShadow());
-		super.visitCtField(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtFieldReference(spoon.reflect.reference.CtFieldReference<T> e) {
-		((spoon.reflect.reference.CtFieldReference<T>) (this.other)).setFinal(e.isFinal());
-		((spoon.reflect.reference.CtFieldReference<T>) (this.other)).setStatic(e.isStatic());
-		super.visitCtFieldReference(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtInvocation(spoon.reflect.code.CtInvocation<T> e) {
-		((spoon.reflect.code.CtInvocation<T>) (this.other)).setLabel(e.getLabel());
-		super.visitCtInvocation(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtLiteral(spoon.reflect.code.CtLiteral<T> e) {
-		((spoon.reflect.code.CtLiteral<T>) (this.other)).setValue(e.getValue());
-		super.visitCtLiteral(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtLocalVariable(spoon.reflect.code.CtLocalVariable<T> e) {
-		((spoon.reflect.code.CtLocalVariable<T>) (this.other)).setSimpleName(e.getSimpleName());
-		((spoon.reflect.code.CtLocalVariable<T>) (this.other)).setModifiers(e.getModifiers());
-		super.visitCtLocalVariable(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtCatchVariable(spoon.reflect.code.CtCatchVariable<T> e) {
-		((spoon.reflect.code.CtCatchVariable<T>) (this.other)).setSimpleName(e.getSimpleName());
-		((spoon.reflect.code.CtCatchVariable<T>) (this.other)).setModifiers(e.getModifiers());
-		super.visitCtCatchVariable(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtMethod(spoon.reflect.declaration.CtMethod<T> e) {
-		((spoon.reflect.declaration.CtMethod<T>) (this.other)).setDefaultMethod(e.isDefaultMethod());
-		((spoon.reflect.declaration.CtMethod<T>) (this.other)).setModifiers(e.getModifiers());
-		((spoon.reflect.declaration.CtMethod<T>) (this.other)).setShadow(e.isShadow());
-		super.visitCtMethod(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	@java.lang.Override
-	public <T> void visitCtConstructorCall(spoon.reflect.code.CtConstructorCall<T> e) {
-		((spoon.reflect.code.CtConstructorCall<T>) (this.other)).setLabel(e.getLabel());
-		super.visitCtConstructorCall(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	@java.lang.Override
-	public <T> void visitCtLambda(spoon.reflect.code.CtLambda<T> e) {
-		((spoon.reflect.code.CtLambda<T>) (this.other)).setSimpleName(e.getSimpleName());
-		super.visitCtLambda(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T, A extends T> void visitCtOperatorAssignement(spoon.reflect.code.CtOperatorAssignment<T, A> assignment) {
-		((spoon.reflect.code.CtOperatorAssignment<T, A>) (this.other)).setKind(assignment.getKind());
-		super.visitCtOperatorAssignement(assignment);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtPackage(spoon.reflect.declaration.CtPackage e) {
-		((spoon.reflect.declaration.CtPackage) (this.other)).setShadow(e.isShadow());
-		super.visitCtPackage(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtParameter(spoon.reflect.declaration.CtParameter<T> e) {
-		((spoon.reflect.declaration.CtParameter<T>) (this.other)).setVarArgs(e.isVarArgs());
-		((spoon.reflect.declaration.CtParameter<T>) (this.other)).setModifiers(e.getModifiers());
-		((spoon.reflect.declaration.CtParameter<T>) (this.other)).setShadow(e.isShadow());
-		super.visitCtParameter(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public void visitCtTypeParameterReference(spoon.reflect.reference.CtTypeParameterReference e) {
-		((spoon.reflect.reference.CtTypeParameterReference) (this.other)).setUpper(e.isUpper());
-		super.visitCtTypeParameterReference(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtTypeReference(spoon.reflect.reference.CtTypeReference<T> e) {
-		((spoon.reflect.reference.CtTypeReference<T>) (this.other)).setShadow(e.isShadow());
-		super.visitCtTypeReference(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	public <T> void visitCtUnaryOperator(spoon.reflect.code.CtUnaryOperator<T> e) {
-		((spoon.reflect.code.CtUnaryOperator<T>) (this.other)).setKind(e.getKind());
-		((spoon.reflect.code.CtUnaryOperator<T>) (this.other)).setLabel(e.getLabel());
-		super.visitCtUnaryOperator(e);
-	}
-
-	// auto-generated, see spoon.generating.CloneVisitorGenerator
-	@java.lang.Override
-	public void visitCtComment(spoon.reflect.code.CtComment e) {
-		((spoon.reflect.code.CtComment) (this.other)).setContent(e.getContent());
-		((spoon.reflect.code.CtComment) (this.other)).setCommentType(e.getCommentType());
-		super.visitCtComment(e);
 	}
 }
 

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -25,14 +25,6 @@ package spoon.support.visitor.clone;
  * This class is generated automatically by the processor {@link spoon.generating.CloneVisitorGenerator}.
  */
 public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
-	private final spoon.support.visitor.clone.CloneBuilder builder = new spoon.support.visitor.clone.CloneBuilder();
-
-	private spoon.reflect.declaration.CtElement other;
-
-	public <T extends spoon.reflect.declaration.CtElement> T getClone() {
-		return ((T) (other));
-	}
-
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <A extends java.lang.annotation.Annotation> void visitCtAnnotation(final spoon.reflect.declaration.CtAnnotation<A> annotation) {
 		spoon.reflect.declaration.CtAnnotation<A> aCtAnnotation = spoon.support.visitor.clone.CloneBuilder.build(this.builder, annotation, annotation.getFactory().Core().createAnnotation());
@@ -793,6 +785,14 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 		aCtComment.setComments(spoon.support.visitor.equals.CloneHelper.clone(comment.getComments()));
 		aCtComment.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(comment.getAnnotations()));
 		this.other = aCtComment;
+	}
+
+	private final spoon.support.visitor.clone.CloneBuilder builder = new spoon.support.visitor.clone.CloneBuilder();
+
+	private spoon.reflect.declaration.CtElement other;
+
+	public <T extends spoon.reflect.declaration.CtElement> T getClone() {
+		return ((T) (other));
 	}
 }
 

--- a/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
@@ -42,50 +42,5 @@ public class EqualsVisitor extends CtBiScannerDefault {
 			fail();
 		}
 	}
-
-	@Override
-	public <T> void visitCtTypeReference(final spoon.reflect.reference.CtTypeReference<T> reference) {
-		spoon.reflect.reference.CtTypeReference other = ((spoon.reflect.reference.CtTypeReference) (stack.peek()));
-		enter(reference);
-		biScan(reference.getPackage(), other.getPackage());
-		biScan(reference.getDeclaringType(), other.getDeclaringType());
-
-		//biScan(reference.getActualTypeArguments(), other.getActualTypeArguments()); // required to be commented
-
-		biScan(reference.getAnnotations(), other.getAnnotations());
-		biScan(reference.getComments(), other.getComments());
-		exit(reference);
-	}
-
-	@Override
-	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
-		spoon.reflect.reference.CtArrayTypeReference other = ((spoon.reflect.reference.CtArrayTypeReference) (stack.peek()));
-		enter(reference);
-		biScan(reference.getComments(), other.getComments());
-		biScan(reference.getPackage(), other.getPackage());
-		biScan(reference.getDeclaringType(), other.getDeclaringType());
-		biScan(reference.getComponentType(), other.getComponentType());
-
-		//biScan(reference.getActualTypeArguments(), other.getActualTypeArguments()); // required to be commented
-
-		biScan(reference.getAnnotations(), other.getAnnotations());
-		exit(reference);
-	}
-
-	@Override
-	public <T> void visitCtExecutableReference(final spoon.reflect.reference.CtExecutableReference<T> reference) {
-		spoon.reflect.reference.CtExecutableReference other = ((spoon.reflect.reference.CtExecutableReference) (stack.peek()));
-		enter(reference);
-		biScan(reference.getDeclaringType(), other.getDeclaringType());
-		biScan(reference.getParameters(), other.getParameters());
-
-		//biScan(reference.getActualTypeArguments(), other.getActualTypeArguments());  // required to be commented
-
-		biScan(reference.getAnnotations(), other.getAnnotations());
-		biScan(reference.getComments(), other.getComments());
-		exit(reference);
-	}
-
-
 }
 

--- a/src/test/java/spoon/processing/CtGenerationTest.java
+++ b/src/test/java/spoon/processing/CtGenerationTest.java
@@ -113,14 +113,23 @@ public class CtGenerationTest {
 		launcher.run();
 
 		// cp ./target/generated/spoon/support/visitor/clone/CloneBuilder.java  ./src/main/java/spoon/support/visitor/clone/CloneBuilder.java
-		// cp ./target/generated/spoon/support/visitor/clone/CloneVisitor.java  ./src/main/java/spoon/support/visitor/clone/CloneVisitor.java
-		CtElement expected = build(new File(launcher.getModelBuilder().getSourceOutputDirectory()+"/spoon/support/visitor/clone/")).Package().get("spoon.support.visitor.clone");
-		CtElement actual = build(new File("./src/main/java/spoon/support/visitor/clone/")).Package().get("spoon.support.visitor.clone");
+		CtClass<Object> actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory()+"/spoon/support/visitor/clone/CloneBuilder.java")).Class().get("spoon.support.visitor.clone.CloneBuilder");
+		CtClass<Object> expected = build(new File("./src/main/java/spoon/support/visitor/clone/CloneBuilder.java")).Class().get("spoon.support.visitor.clone.CloneBuilder");
 		try {
 			assertThat(actual)
 					.isEqualTo(expected);
 		} catch (AssertionError e) {
-			throw new ComparisonFailure("Generated clone classes different", expected.toString(), actual.toString());
+			throw new ComparisonFailure("CloneBuilder different", expected.toString(), actual.toString());
+		}
+
+		// cp ./target/generated/spoon/support/visitor/clone/CloneVisitor.java  ./src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+		actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory()+"/spoon/support/visitor/clone/CloneVisitor.java")).Class().get("spoon.support.visitor.clone.CloneVisitor");
+		expected = build(new File("./src/main/java/spoon/support/visitor/clone/CloneVisitor.java")).Class().get("spoon.support.visitor.clone.CloneVisitor");
+		try {
+			assertThat(actual)
+					.isEqualTo(expected);
+		} catch (AssertionError e) {
+			throw new ComparisonFailure("CloneVisitor different", expected.toString(), actual.toString());
 		}
 	}
 

--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -87,4 +87,13 @@ public class EqualTest {
 		assertEquals(1, var2.getCatchers().get(0).getParameter().getMultiTypes().size());
 		assertNotEquals(var2, var);
 	}
+
+	@Test
+	public void testEqualsActualTypeRef() throws Exception {
+		// contract: actual type refs are part of the identity
+		Factory factory = new Launcher().createFactory();
+		CtLocalVariable var = factory.Code().createCodeSnippetStatement("java.util.List<String> l ").compile();
+		CtLocalVariable var2 = factory.Code().createCodeSnippetStatement("java.util.List<Object> l ").compile();
+		assertNotEquals(var2, var);
+	}
 }

--- a/src/test/java/spoon/test/intercession/IntercessionContractTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionContractTest.java
@@ -26,23 +26,21 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.junit.Assert.fail;
+import static spoon.test.parent.ParentContractTest.createCompatibleObject;
 
+// contract: one can call all setters with null as parameter (no problem with parent)
 @RunWith(Parameterized.class)
 public class IntercessionContractTest {
 
-	@Parameterized.Parameters(name = "{0}")
+	@Parameterized.Parameters(name = "{1}")
 	public static Collection<Object[]> data() throws Exception {
 		final Launcher launcher = new Launcher();
 		final Factory factory = launcher.getFactory();
 		launcher.getEnvironment().setNoClasspath(true);
-		// interfaces.
+		// all metamodel interfaces.
 		launcher.addInputResource("./src/main/java/spoon/reflect/code");
 		launcher.addInputResource("./src/main/java/spoon/reflect/declaration");
 		launcher.addInputResource("./src/main/java/spoon/reflect/reference");
-		// implementations.
-		launcher.addInputResource("./src/main/java/spoon/support/reflect/code");
-		launcher.addInputResource("./src/main/java/spoon/support/reflect/declaration");
-		launcher.addInputResource("./src/main/java/spoon/support/reflect/reference");
 		launcher.buildModel();
 
 		final List<Object[]> values = new ArrayList<>();
@@ -51,73 +49,19 @@ public class IntercessionContractTest {
 			protected boolean isToBeProcessed(CtMethod<?> candidate) {
 				return (candidate.getSimpleName().startsWith("set") //
 						|| candidate.getSimpleName().startsWith("add")) //
-						&& candidate.hasModifier(ModifierKind.PUBLIC) //
-						&& takeSetterForCtElement(candidate) //
-						&& avoidInterfaces(candidate) //
-						&& avoidThrowUnsupportedOperationException(candidate);
+						&& takeSetterForCtElement(candidate); //
 			}
 
 			@Override
 			protected void process(CtMethod<?> element) {
-				values.add(new Object[] { getDeclaringClassConcrete(element), element.getReference().getActualMethod() });
-			}
-
-			private Class<?> getDeclaringClassConcrete(CtMethod<?> element) {
-				final CtType<?> declaringType = element.getDeclaringType();
-				if (!declaringType.hasModifier(ModifierKind.ABSTRACT)) {
-					return declaringType.getActualClass();
-				}
-				final List<CtTypeReference<?>> superClasses = getSuperClassesOf(declaringType);
-				superClasses.add(declaringType.getReference());
-				final List<CtClass<?>> elements = Query.getElements(factory, new TypeFilter<CtClass<?>>(CtClass.class) {
-					@Override
-					public boolean matches(CtClass<?> element) {
-						return super.matches(element)
-								// Want a concrete class.
-								&& !element.hasModifier(ModifierKind.ABSTRACT)
-								// Class can't be one of the superclass (or itself) of the declaring class.
-								&& !superClasses.contains(element.getReference())
-								// Current class have in its super class hierarchy the given declaring class.
-								&& getSuperClassesOf(element).contains(declaringType.getReference());
-					}
-				});
-				if (elements.size() <= 0) {
-					fail("Can't have an abstract class without any concrete sub class. Error detected with " + declaringType.getQualifiedName());
-				}
-				return takeFirstOneCorrect(element, elements);
-			}
-
-			private Class<?> takeFirstOneCorrect(CtMethod<?> element, List<CtClass<?>> potentials) {
-				for (CtClass<?> potential : potentials) {
-					final CtMethod<?> method = potential.getMethod(
-							element.getType(), element.getSimpleName(),
-							element.getParameters().stream().map(CtTypedElement::getType).toArray(CtTypeReference[]::new));
-					if (method == null) {
-						continue;
-					}
-					if (avoidThrowUnsupportedOperationException(method)) {
-						return potential.getActualClass();
-					}
-				}
-				// Method don't declared in sub classes.
-				return potentials.get(0).getActualClass();
-			}
-
-			private List<CtTypeReference<?>> getSuperClassesOf(CtType<?> declaringType) {
-				final List<CtTypeReference<?>> superClasses = new ArrayList<>();
-				CtTypeReference<?> declaringTypeReference = declaringType.getReference();
-				while (declaringTypeReference.getSuperclass() != null) {
-					superClasses.add(declaringTypeReference.getSuperclass());
-					declaringTypeReference = declaringTypeReference.getSuperclass();
-				}
-				return superClasses;
+				values.add(new Object[] { createCompatibleObject(element.getDeclaringType().getReference()), element.getReference().getActualMethod() });
 			}
 		}.scan(launcher.getModel().getRootPackage());
 		return values;
 	}
 
 	@Parameterized.Parameter(0)
-	public Class<?> declaringClass;
+	public Object instance;
 
 	@Parameterized.Parameter(1)
 	public Method toTest;
@@ -125,22 +69,12 @@ public class IntercessionContractTest {
 	@Test
 	public void testContract() throws Throwable {
 		Factory factory = new FactoryImpl(new DefaultCoreFactory(),new StandardEnvironment());
-		try {
-			Object element = declaringClass.newInstance();
-			if (element instanceof FactoryAccessor) {
-				((FactoryAccessor) element).setFactory(factory);
-			}
-			// we invoke the setter
-			toTest.invoke(element, new Object[] { null });
-		} catch (NullPointerException e) {
-			fail("Shouldn't throw NPE.");
-		} catch (InvocationTargetException e) {
-			if (!(e.getTargetException() instanceof UnsupportedOperationException)) {
-				throw new RuntimeException("Unexpected exception happened with " + toTest.getName() + " in " + declaringClass.getName(), e.getTargetException());
-			}
-		} catch (Exception e) {
-			throw new RuntimeException("Unexpected exception happened with " + toTest.getName() + " in " + declaringClass.getName(), e);
+		Object element = instance;
+		if (element instanceof FactoryAccessor) {
+			((FactoryAccessor) element).setFactory(factory);
 		}
+		// we invoke the setter
+		toTest.invoke(element, new Object[] { null });
 	}
 
 }

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -150,7 +150,7 @@ public class MainTest {
 				assertNotNull(typeDeclaration);
 				assertEquals(reference.getSimpleName(), typeDeclaration.getSimpleName());
 				assertEquals(reference.getQualifiedName(), typeDeclaration.getQualifiedName());
-				assertEquals(reference, typeDeclaration.getReference());
+
 				if (reference.getDeclaration() == null) {
 					assertTrue(typeDeclaration.isShadow());
 				}
@@ -165,24 +165,18 @@ public class MainTest {
 					return;
 				}
 				final CtExecutable<T> executableDeclaration = reference.getExecutableDeclaration();
-				assertNotNull(executableDeclaration);
+				assertNotNull("cannot find decl for " + reference.toString(),executableDeclaration);
 				assertEquals(reference.getSimpleName(), executableDeclaration.getSimpleName());
 
 				// when a generic type is used in a parameter and return type, the shadow type doesn't have these information.
-				boolean hasGeneric = false;
 				for (int i = 0; i < reference.getParameters().size(); i++) {
 					if (reference.getParameters().get(i) instanceof CtTypeParameterReference) {
-						hasGeneric = true;
 						continue;
 					}
 					if (reference.getParameters().get(i) instanceof CtArrayTypeReference && ((CtArrayTypeReference) reference.getParameters().get(i)).getComponentType() instanceof CtTypeParameterReference) {
-						hasGeneric = true;
 						continue;
 					}
-					assertEquals(reference.getParameters().get(i), executableDeclaration.getParameters().get(i).getType());
-				}
-				if (!hasGeneric) {
-					assertEquals(reference, executableDeclaration.getReference());
+					assertEquals(reference.getParameters().get(i).getQualifiedName(), executableDeclaration.getParameters().get(i).getType().getQualifiedName());
 				}
 
 				if (reference.getDeclaration() == null && CtShadowable.class.isAssignableFrom(executableDeclaration.getClass())) {
@@ -206,8 +200,7 @@ public class MainTest {
 				final CtField<T> fieldDeclaration = reference.getFieldDeclaration();
 				assertNotNull(fieldDeclaration);
 				assertEquals(reference.getSimpleName(), fieldDeclaration.getSimpleName());
-				assertEquals(reference.getType(), fieldDeclaration.getType());
-				assertEquals(reference, fieldDeclaration.getReference());
+				assertEquals(reference.getType().getQualifiedName(), fieldDeclaration.getType().getQualifiedName());
 
 				if (reference.getDeclaration() == null) {
 					assertTrue(fieldDeclaration.isShadow());

--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -266,7 +266,7 @@ public class ReplaceTest {
 
 		final CtTypeReference<Object> expected = factory.Type().createReference("spoon.test.replace.testclasses.Tacos");
 		assertEquals(expected, aMethod.getType());
-		assertEquals(expected, aMethod.getElements(new TypeFilter<>(CtConstructorCall.class)).get(0).getType());
+		assertEquals(expected.getTypeDeclaration(), aMethod.getElements(new TypeFilter<>(CtConstructorCall.class)).get(0).getType().getTypeDeclaration());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -291,8 +291,8 @@ public class TargetedExpressionTest {
 		assertEqualsInvocation(new ExpectedTargetedExpression().declaringType(expectedFuuType).target(CtFieldReadImpl.class).result("fuu.method()"), elements.get(5));
 		assertEqualsInvocation(new ExpectedTargetedExpression().declaringType(expectedSuperClassType).target(expectedSuperThisAccess).result("superMethod()"), elements.get(6));
 
-		assertEquals(fooTypeAccess, ((CtThisAccess) elements.get(2).getTarget()).getTarget());
-		assertEquals(fooTypeAccess, ((CtThisAccess) elements.get(3).getTarget()).getTarget());
+		assertEquals(fooTypeAccess.getType().getQualifiedName(), ((CtThisAccess) elements.get(2).getTarget()).getTarget().getType().getQualifiedName());
+		assertEquals(fooTypeAccess.getType().getQualifiedName(), ((CtThisAccess) elements.get(3).getTarget()).getTarget().getType().getQualifiedName());
 		assertEquals(superClassTypeAccess, ((CtThisAccess) elements.get(6).getTarget()).getTarget());
 	}
 
@@ -455,14 +455,12 @@ public class TargetedExpressionTest {
 			assertNull(fieldAccess.getVariable().getDeclaringType());
 		} else {
 			assertEquals(expected.isLocal, fieldAccess.getVariable().getDeclaringType().isLocalType());
-			assertEquals(expected.declaringType, fieldAccess.getVariable().getDeclaringType());
+			assertEquals(expected.declaringType.getQualifiedName(), fieldAccess.getVariable().getDeclaringType().getQualifiedName());
 		}
 		if (expected.targetClass != null) {
 			assertEquals(expected.targetClass, fieldAccess.getTarget().getClass());
 		} else if (expected.targetString != null) {
 			assertEquals(expected.targetString, fieldAccess.getTarget().toString());
-		} else {
-			assertEquals(expected.target, fieldAccess.getTarget());
 		}
 		assertEquals(expected.result, fieldAccess.toString());
 		if (expected.type != null) {
@@ -470,16 +468,18 @@ public class TargetedExpressionTest {
 		}
 	}
 
+
 	private void assertEqualsInvocation(ExpectedTargetedExpression expected, CtInvocation<?> invocation) {
-		assertEquals("declaring type not identical", expected.declaringType, invocation.getExecutable().getDeclaringType());
+		// two required parts: toString and declaringType (type containing the method to be called)
+		assertEquals(expected.result, invocation.toString());
+		assertEquals(expected.declaringType, invocation.getExecutable().getDeclaringType());
+
+		// + two optional parts
 		if (expected.targetClass != null) {
 			assertEquals(expected.targetClass, invocation.getTarget().getClass());
 		} else if (expected.targetString != null) {
 			assertEquals(expected.targetString, invocation.getTarget().toString());
-		} else {
-			assertEquals("target is not equal ", expected.target, invocation.getTarget());
 		}
-		assertEquals(expected.result, invocation.toString());
 	}
 
 	private class ExpectedTargetedExpression {


### PR DESCRIPTION
this fixes a very old and deep bug, which was enforced in certain existing assertions.

but now we have the expected:

```
CtLocalVariable var = factory.Code().createCodeSnippetStatement("java.util.List<String> l ").compile();
CtLocalVariable var2 = factory.Code().createCodeSnippetStatement("java.util.List<Object> l ").compile();
assertNotEquals(var2, var); // the generics are taken into account
```
(this holds for any actual type parameter).

