### PR TITLE
add CtTypeMember.getTopLevelType()

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeMember.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeMember.java
@@ -30,6 +30,11 @@ public interface CtTypeMember extends CtModifiable {
 	 * @return declaring class
 	 */
 	@DerivedProperty
-	CtType<?> getDeclaringType();
+	<T> CtType<T> getDeclaringType();
 
+	/**
+	 * Returns top level declaring type of this. If this is already a TopLevelType, then it returns this
+	 */
+	@DerivedProperty
+	<T> CtType<T> getTopLevelType();
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypeMember.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeMember.java
@@ -30,10 +30,11 @@ public interface CtTypeMember extends CtModifiable {
 	 * @return declaring class
 	 */
 	@DerivedProperty
-	<T> CtType<T> getDeclaringType();
+	CtType<?> getDeclaringType();
 
 	/**
-	 * Returns top level declaring type of this. If this is already a TopLevelType, then it returns this
+	 * Returns the top level type declaring this type if an inner type or type member.
+	 * If this is already a top-level type, then returns itself.
 	 */
 	@DerivedProperty
 	<T> CtType<T> getTopLevelType();

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -17,7 +17,6 @@
 package spoon.support.reflect.declaration;
 
 import spoon.reflect.declaration.CtAnonymousExecutable;
-import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
@@ -59,11 +58,6 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	@Override
 	public Set<ModifierKind> getModifiers() {
 		return modifiers;
-	}
-
-	@Override
-	public CtClass<?> getDeclaringType() {
-		return (CtClass<?>) parent;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -21,6 +21,7 @@ import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtShadowable;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
@@ -63,12 +64,18 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
+	@SuppressWarnings("unchecked")
+	public CtType<T> getDeclaringType() {
+		return (CtType<T>) parent;
+	}
+
+	@Override
 	@DerivedProperty
 	public CtTypeReference<T> getType() {
 		if (getDeclaringType() == null) {
 			return null;
 		}
-		return this.<T>getDeclaringType().getReference();
+		return getDeclaringType().getReference();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtShadowable;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
@@ -64,18 +63,12 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public CtType<T> getDeclaringType() {
-		return (CtType<T>) parent;
-	}
-
-	@Override
 	@DerivedProperty
 	public CtTypeReference<T> getType() {
 		if (getDeclaringType() == null) {
 			return null;
 		}
-		return getDeclaringType().getReference();
+		return this.<T>getDeclaringType().getReference();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -52,10 +52,9 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		super();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Override
-	public <T> CtType<T> getDeclaringType() {
-		return (CtType<T>) parent;
+	public CtType<?> getDeclaringType() {
+		return (CtType<?>) parent;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -27,6 +27,8 @@ import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.util.QualifiedNameBasedSortedSet;
@@ -37,7 +39,7 @@ import spoon.support.visitor.SignaturePrinter;
  *
  * @author Renaud Pawlak
  */
-public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements CtExecutable<R> {
+public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements CtExecutable<R>, CtTypeMember {
 	private static final long serialVersionUID = 1L;
 
 	CtBlock<?> body;
@@ -48,6 +50,17 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	public CtExecutableImpl() {
 		super();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> CtType<T> getDeclaringType() {
+		return (CtType<T>) parent;
+	}
+
+	@Override
+	public <T> CtType<T> getTopLevelType() {
+		return getDeclaringType().getTopLevelType();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -28,7 +28,6 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.util.QualifiedNameBasedSortedSet;
@@ -39,7 +38,7 @@ import spoon.support.visitor.SignaturePrinter;
  *
  * @author Renaud Pawlak
  */
-public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements CtExecutable<R>, CtTypeMember {
+public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements CtExecutable<R> {
 	private static final long serialVersionUID = 1L;
 
 	CtBlock<?> body;
@@ -52,12 +51,10 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		super();
 	}
 
-	@Override
 	public CtType<?> getDeclaringType() {
 		return (CtType<?>) parent;
 	}
 
-	@Override
 	public <T> CtType<T> getTopLevelType() {
 		return getDeclaringType().getTopLevelType();
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -62,6 +62,11 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
+	public <T> CtType<T> getTopLevelType() {
+		return getDeclaringType().getTopLevelType();
+	}
+
+	@Override
 	public CtExpression<T> getDefaultExpression() {
 		return defaultExpression;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtShadowable;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
@@ -75,11 +74,6 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		}
 		this.returnType = type;
 		return (C) this;
-	}
-
-	@Override
-	public CtType<?> getDeclaringType() {
-		return (CtType<?>) parent;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -298,15 +298,15 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public <T> CtType<T> getTopLevelType() {
-		@SuppressWarnings("unchecked")
-		CtType<T> top = (CtType<T>) this;
+		CtType<?> top = this;
 
 		while (true) {
-			CtType<T> nextTop = top.getDeclaringType();
+			CtType<?> nextTop = top.getDeclaringType();
 			if (nextTop == null) {
-				return top;
+				return (CtType<T>) top;
 			}
 			top = nextTop;
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -299,6 +299,20 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
+	public <T> CtType<T> getTopLevelType() {
+		@SuppressWarnings("unchecked")
+		CtType<T> top = (CtType<T>) this;
+
+		while (true) {
+			CtType<T> nextTop = top.getDeclaringType();
+			if (nextTop == null) {
+				return top;
+			}
+			top = nextTop;
+		}
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public <N extends CtType<?>> N getNestedType(final String name) {
 		class NestedTypeScanner extends EarlyTerminatingScanner<CtType<?>> {

--- a/src/test/java/spoon/test/parent/TopLevelTypeTest.java
+++ b/src/test/java/spoon/test/parent/TopLevelTypeTest.java
@@ -1,0 +1,46 @@
+package spoon.test.parent;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+
+public class TopLevelTypeTest
+{
+	Factory factory;
+
+	@Before
+	public void setup() throws Exception {
+		Launcher spoon = new Launcher();
+		spoon.setArgs(new String[] {"--output-type", "nooutput" });
+		factory = spoon.createFactory();
+		spoon.createCompiler(
+				factory,
+				SpoonResourceHelper
+						.resources("./src/test/java/spoon/test/parent/Foo.java"))
+				.build();
+	}
+
+
+	@Test
+	public void testTopLevelType() throws Exception {
+		CtClass<?> foo = factory.Class().get(Foo.class);
+		assertEquals(foo, foo.getTopLevelType());
+		CtMethod<?> internalClassMethod = foo.getMethod("internalClass");
+		assertEquals(foo, internalClassMethod.getDeclaringType());
+		assertEquals(foo, internalClassMethod.getTopLevelType());
+		CtClass<?> internalClass = (CtClass<?>)internalClassMethod.getBody().getStatement(0);
+		assertEquals(foo, internalClassMethod.getDeclaringType());
+		assertEquals(foo, internalClassMethod.getTopLevelType());
+		CtMethod<?> mm = internalClass.getMethod("m");
+		assertEquals(internalClass, mm.getDeclaringType());
+		assertEquals(foo, mm.getTopLevelType());
+	}
+
+}


### PR DESCRIPTION
I have added new method 
```java
interface CtTypeMember
	/**
	 * Returns top level declaring type of this. 
         * If this is already a TopLevelType, then it returns this
	 */
	<T> CtType<T> getTopLevelType();
```
I need it for next PR, which brings some new Refactoring methods for changing of the name of the CtVariable based elements.

Please give me feedback, if such method is acceptable. If yes, then I will add test case too.

Note: I also moved some getDeclaringType to more common place in the hierarchy of CtExecutableImpl, so I did not had to copy the implementation of getTopLevelType 3 times.