### PR TITLE
Type of filter by reflection

### DIFF
--- a/src/main/java/spoon/reflect/visitor/QueryVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/QueryVisitor.java
@@ -35,14 +35,15 @@ public class QueryVisitor<T extends CtElement> extends CtScanner {
 	/**
 	 * Constructs a query visitor with a given filter.
 	 */
+	@SuppressWarnings("unchecked")
 	public QueryVisitor(Filter<T> filter) {
 		super();
 		this.filter = filter;
 		if (filter instanceof AbstractFilter) {
-			filteredType =  ((AbstractFilter) filter).getType();
+			filteredType =  ((AbstractFilter<T>) filter).getType();
 		} else {
 			Class<?>[] params = RtHelper.getMethodParameterTypes(filter.getClass(), "matches", 1);
-			filteredType = (Class<T>)params[0];
+			filteredType = (Class<T>) params[0];
 		}
 	}
 

--- a/src/main/java/spoon/reflect/visitor/QueryVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/QueryVisitor.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.support.util.RtHelper;
 
 /**
  * A simple visitor that takes a filter and returns all the elements that match
@@ -37,7 +38,12 @@ public class QueryVisitor<T extends CtElement> extends CtScanner {
 	public QueryVisitor(Filter<T> filter) {
 		super();
 		this.filter = filter;
-		filteredType = filter instanceof AbstractFilter ? ((AbstractFilter) filter).getType() : null;
+		if (filter instanceof AbstractFilter) {
+			filteredType =  ((AbstractFilter) filter).getType();
+		} else {
+			Class<?>[] params = RtHelper.getMethodParameterTypes(filter.getClass(), "matches", 1);
+			filteredType = (Class<T>)params[0];
+		}
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -16,8 +16,10 @@
  */
 package spoon.reflect.visitor.filter;
 
+import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.Filter;
+import spoon.support.util.RtHelper;
 
 /**
  * Defines an abstract filter based on matching on the element types.
@@ -31,18 +33,21 @@ public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 	/**
 	 * Creates a filter with the type of the potentially matching elements.
 	 */
-	// TODO: INFER TYPE BY INTROSPECTION
 	@SuppressWarnings("unchecked")
 	public AbstractFilter(Class<? super T> type) {
 		this.type = (Class<T>) type;
 	}
 
 	/**
-	 * Creates a filter with the no typing constraint.
+	 * Creates a filter with the type computed by reflection from the matches method parameter
 	 */
 	@SuppressWarnings("unchecked")
 	public AbstractFilter() {
-		this.type = (Class<T>) CtElement.class;
+		Class<?>[] params = RtHelper.getMethodParameterTypes(getClass(), "matches", 1);
+		if (params == null) {
+			throw new SpoonException("The method matches with one parameter was not found on the class " + getClass().getName());
+		}
+		this.type = (Class<T>) params[0];
 	}
 
 	public Class<T> getType() {

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
@@ -41,4 +41,10 @@ public abstract class AbstractReferenceFilter<T extends CtReference> extends Abs
 		super(type);
 	}
 
+	/**
+	 * Creates a filter with the type computed by reflection from the matches method parameter
+	 */
+	public AbstractReferenceFilter() {
+		super();
+	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -57,7 +57,7 @@ public class CtLocalVariableReferenceImpl<T>
 		if (factory == null) {
 			return null;
 		}
-		final SimpleNameFilter filter = new SimpleNameFilter(factory);
+		final SimpleNameFilter filter = new SimpleNameFilter();
 
 		// successively iterate through all parents of this reference and
 		// return first result (which must be the closest declaration
@@ -99,10 +99,8 @@ public class CtLocalVariableReferenceImpl<T>
 	private final class SimpleNameFilter
 			extends AbstractFilter<CtLocalVariable<T>> {
 
-		@SuppressWarnings("unchecked")
-		SimpleNameFilter(final Factory pFactory) {
-			super((Class<CtLocalVariable<T>>)
-					pFactory.Core().createLocalVariable().getClass());
+		SimpleNameFilter() {
+			super();
 		}
 
 		@Override

--- a/src/main/java/spoon/support/util/RtHelper.java
+++ b/src/main/java/spoon/support/util/RtHelper.java
@@ -185,4 +185,25 @@ public abstract class RtHelper {
 		}
 		return l;
 	}
+
+	/**
+	 * Looks for first public method of clazz (or any super class or super interface),
+	 * whose name is equal to methodName and number of parameters is numParams
+	 * @param clazz
+	 * @param methodName
+	 * @param numParams
+	 * @return the types of the parameters of such method or null if not found
+	 */
+	public static Class<?>[] getMethodParameterTypes(Class<?> clazz, String methodName, int numParams) {
+		Method[] methods = clazz.getMethods();
+		for (Method method : methods) {
+			if (method.getName().equals(methodName)) {
+				Class<?>[] params = method.getParameterTypes();
+				if (params.length == numParams) {
+					return params;
+				}
+			}
+		}
+		return null;
+	}
 }


### PR DESCRIPTION
The type of the Filter does not have to be specified in constructor, but is computed by reflection from the matches parameter type.

This PR is based on #1013, so I have to rebase it after you merge #1013. Just have a look if code like this OK, or we can make it even simpler?
```java
List<CtNewClass<?>> elements = foo.getElements(new AbstractFilter<CtNewClass<?>>() {
	@Override
	public boolean matches(CtNewClass<?> element) {
		return true;
	}
});
```