### PR TITLE
functional ElementConsumer in queries

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -22,6 +22,7 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitable;
+import spoon.reflect.visitor.ElementConsumer;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Root;
 import spoon.support.DerivedProperty;
@@ -168,6 +169,11 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable {
 	 * If the receiver (this) matches the filter, it is also returned
 	 */
 	<E extends CtElement> List<E> getElements(Filter<E> filter);
+	/**
+	 * calls the {@link ElementConsumer#accept(CtElement)} for all the children elements recursively matching the filter.
+	 * If the receiver (this) matches the filter, it is also sent to accept
+	 */
+	<E extends CtElement> void forEachElement(Filter<E> filter, ElementConsumer<E> consumer);
 
 	/**
 	 * @param filter

--- a/src/main/java/spoon/reflect/visitor/ElementConsumer.java
+++ b/src/main/java/spoon/reflect/visitor/ElementConsumer.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2006-2016 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import spoon.reflect.declaration.CtElement;
+
+public interface ElementConsumer<T extends CtElement> {
+	void accept(T t);
+}

--- a/src/main/java/spoon/reflect/visitor/Query.java
+++ b/src/main/java/spoon/reflect/visitor/Query.java
@@ -67,6 +67,11 @@ public abstract class Query {
 		return visitor.getResult();
 	}
 
+	public static <E extends CtElement> void forEachElement(CtElement rootElement, Filter<E> filter, ElementConsumer<E> consumer) {
+		new QueryVisitor<>(filter, consumer).scan(rootElement);
+	}
+
+
 	/**
 	 * Returns all the program element references that match the filter.
 	 *
@@ -103,5 +108,6 @@ public abstract class Query {
 			Factory factory, Filter<R> filter) {
 		return getElements(factory, filter);
 	}
+
 
 }

--- a/src/main/java/spoon/reflect/visitor/QueryVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/QueryVisitor.java
@@ -19,6 +19,7 @@ package spoon.reflect.visitor;
 import java.util.ArrayList;
 import java.util.List;
 
+import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.util.RtHelper;
@@ -53,7 +54,7 @@ public class QueryVisitor<T extends CtElement> extends CtScanner {
 		}
 		this.consumer = consumer;
 	}
-	
+
 	private static class ArrayConsumer<T extends CtElement> implements ElementConsumer<T> {
 		final List<T> result = new ArrayList<>();
 		@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -28,6 +28,7 @@ import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
+import spoon.reflect.visitor.ElementConsumer;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.ModelConsistencyChecker;
 import spoon.reflect.visitor.Query;
@@ -252,6 +253,11 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	public <E extends CtElement> List<E> getElements(Filter<E> filter) {
 		return Query.getElements(this, filter);
+	}
+
+	@Override
+	public <E extends CtElement> void forEachElement(Filter<E> filter, ElementConsumer<E> p_consumer) {
+		Query.forEachElement(this, filter, p_consumer);
 	}
 
 	public <T extends CtReference> List<T> getReferences(Filter<T> filter) {


### PR DESCRIPTION
Support for queries like this:
```java
anElement.forEachElement(anFilter, (e)->...do something with filtered element e...)
```
I believe that such filtering approach is more memory efficient and less code has to be written, because **most of the code** which uses
```java 
List result = anElement.getElements(filter)
```
is followed by a `for(...){...}` cycle. 

But again it can be used in nice way only if java 8 is used by client code