### PR TITLE
Fix a bug with annotation values order

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -70,7 +70,8 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	/**
 	 * Returns this annotation's elements and their values. This is returned in
 	 * the form of a map that associates element names with their corresponding
-	 * values.
+	 * values. If you iterate over the map with entrySet(), the iteration order
+	 * complies with the order of annotation values in the source code.
 	 *
 	 * @return this annotation's element names and their values, or an empty map
 	 * if there are none

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -43,6 +43,7 @@ import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.reflect.code.CtExpressionImpl;
 
 import java.lang.annotation.Annotation;
@@ -53,10 +54,14 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotation}.
@@ -68,7 +73,21 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	CtTypeReference<A> annotationType;
 
-	private Map<String, CtExpression> elementValues = new TreeMap<>();
+	private Map<String, CtExpression> elementValues = new TreeMap(){
+		@Override
+		public Set<Entry<String,CtExpression>> entrySet() {
+			Set<Entry<String,CtExpression>> result = new TreeSet<Entry<String, CtExpression>>(new Comparator<Entry<String,CtExpression>>() {
+				final CtLineElementComparator comp = new CtLineElementComparator();
+				@Override
+				public int compare(Entry<String,CtExpression> o1, Entry<String,CtExpression> o2) {
+					return comp.compare(o1.getValue(), o2.getValue());
+				}
+			}
+			);
+			result.addAll(super.entrySet());
+			return result;
+		}
+	};
 
 	public CtAnnotationImpl() {
 		super();

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -55,7 +55,6 @@ import java.lang.reflect.Proxy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -73,13 +72,13 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	CtTypeReference<A> annotationType;
 
-	private Map<String, CtExpression> elementValues = new TreeMap(){
+	private Map<String, CtExpression> elementValues = new TreeMap() {
 		@Override
-		public Set<Entry<String,CtExpression>> entrySet() {
-			Set<Entry<String,CtExpression>> result = new TreeSet<Entry<String, CtExpression>>(new Comparator<Entry<String,CtExpression>>() {
+		public Set<Entry<String, CtExpression>> entrySet() {
+			Set<Entry<String, CtExpression>> result = new TreeSet<Entry<String, CtExpression>>(new Comparator<Entry<String, CtExpression>>() {
 				final CtLineElementComparator comp = new CtLineElementComparator();
 				@Override
-				public int compare(Entry<String,CtExpression> o1, Entry<String,CtExpression> o2) {
+				public int compare(Entry<String, CtExpression> o1, Entry<String, CtExpression> o2) {
 					return comp.compare(o1.getValue(), o2.getValue());
 				}
 			}

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -132,18 +132,10 @@ public class AnnotationValuesTest {
 
 	private static final String nl = System.lineSeparator();
 
-	private static final String strCtClassOracle = "@HasDefaultsAnnotation(" + nl  +
-			"      o = Breakfast.PANCAKES," + nl  +
-			"      p = 1701," + nl  +
-			"      f = 11.1," + nl  +
-			"      m = {9, 8, 1}," + nl  +
-			"      l = Override.class," + nl  +
-			"      j = @AnnotationA," + nl  +
-			"      q = @AnnotationC(\"bar\")," + nl  +
-			"      r = {Float.class, Double.class})" + nl  +
-			"  public class IsAnnotated {" + nl  +
-			"    // empty" + nl  +
-			"  }";
+	private static final String strCtClassOracle = "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES, p = 1701, f = 11.1, m = { 9 , 8 , 1 }, l = java.lang.Override.class, j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA" + nl +
+			", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(value = \"bar\")" + nl +
+			", r = { java.lang.Float.class , java.lang.Double.class })" + nl +
+			"public class IsAnnotated {}";
 
 	static class Request {
 		private static Request myself = new Request();

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -5,6 +5,7 @@ import spoon.Launcher;
 import spoon.SpoonAPI;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
@@ -12,6 +13,7 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
+import java.util.List;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
@@ -52,12 +54,14 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
 
-		assertEquals(0, spoon.getFactory().Package().getRootPackage().getElements(new AbstractFilter<CtConstructorCall>() {
+		List<CtConstructorCall> treeSetWithoutComparators = spoon.getFactory().Package().getRootPackage().filterChildren(new TypeFilter<>(TreeSet.class)).filterChildren(new AbstractFilter<CtConstructorCall>() {
 			@Override
 			public boolean matches(CtConstructorCall element) {
-				return element.getType().getActualClass().equals(TreeSet.class);
-			};
-		}).size());
+				return element.getActualTypeArguments().size() == 0;
+			}
+		}).list();
+
+		assertEquals(0, treeSetWithoutComparators.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -54,10 +54,10 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
 
-		List<CtConstructorCall> treeSetWithoutComparators = spoon.getFactory().Package().getRootPackage().filterChildren(new TypeFilter<>(TreeSet.class)).filterChildren(new AbstractFilter<CtConstructorCall>() {
+		List<CtConstructorCall> treeSetWithoutComparators = spoon.getFactory().Package().getRootPackage().filterChildren(new AbstractFilter<CtConstructorCall>() {
 			@Override
 			public boolean matches(CtConstructorCall element) {
-				return element.getActualTypeArguments().size() == 0;
+				return element.getType().getActualClass().equals(TreeSet.class) && element.getArguments().size() == 0;
 			}
 		}).list();
 

--- a/src/test/java/spoon/test/template/SubTemplate.java
+++ b/src/test/java/spoon/test/template/SubTemplate.java
@@ -1,13 +1,23 @@
 package spoon.test.template;
 
 
+import spoon.reflect.declaration.CtParameter;
 import spoon.template.Parameter;
+
+import java.util.List;
 
 public class SubTemplate extends SuperTemplate {
 
 	public void toBeOverriden() {
 		super.toBeOverriden();
 	}
+
+	public void methodWithTemplatedParameters(Object params) {
+		super.toBeOverriden();
+	}
+
+	@Parameter
+	public List<CtParameter> params;
 
 	@Parameter
 	public void ignoredMethod(){}


### PR DESCRIPTION
Change the contract of getValues in CtAnnotation in order to keep the order of annotation parameters.