### PR TITLE
Fix for a bug concerning multiples comments before a catch block

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -457,6 +457,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public void visitCtCatch(CtCatch catchBlock) {
+		elementPrinterHelper.writeComment(catchBlock, CommentOffset.BEFORE);
 		printer.write(" catch (");
 		CtCatchVariable<? extends Throwable> parameter = catchBlock.getParameter();
 		if (parameter.getMultiTypes().size() > 0) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -24,6 +24,7 @@ import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtIf;
@@ -187,6 +188,7 @@ class JDTCommentBuilder {
 		// visitor that inserts the comment in the element
 		CtInheritanceScanner insertionVisitor = new CtInheritanceScanner() {
 			private boolean isScanned = false;
+
 			@Override
 			public void scan(CtElement e) {
 				if (e == null) {
@@ -372,6 +374,14 @@ class JDTCommentBuilder {
 			@Override
 			public <T> void visitCtParameter(CtParameter<T> e) {
 				e.addComment(comment);
+			}
+
+			@Override
+			public void visitCtCatch(CtCatch e) {
+				if (comment.getPosition().getLine() <= e.getPosition().getLine()) {
+					e.addComment(comment);
+					return;
+				}
 			}
 		};
 		insertionVisitor.scan(commentParent);

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -29,6 +29,7 @@ import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.visitor.AstParentConsistencyChecker;
@@ -110,7 +111,7 @@ public class CommentTest {
 
 		List<CtComment> comments = type.getElements(new TypeFilter<CtComment>(CtComment.class));
 		// verify that the number of comment present in the AST is correct
-		assertEquals(57, comments.size());
+		assertEquals(59, comments.size());
 
 		// verify that all comments present in the AST is printed
 		for (CtComment comment : comments) {
@@ -228,7 +229,9 @@ public class CommentTest {
 				+ "try {" + newLine
 				+ "    // comment in try" + newLine
 				+ "    i++;" + newLine
-				+ "} catch (java.lang.Exception e) {" + newLine
+				+ "}// between" + newLine
+				+ "// try/catch" + newLine
+				+ " catch (java.lang.Exception e) {" + newLine
 				+ "    // comment in catch" + newLine
 				+ "}", ctTry.toString());
 
@@ -625,12 +628,12 @@ public class CommentTest {
 	@Test
 	public void testCommentsInComment1And2() {
 		Factory f = getSpoonFactory();
-		f.getModel().getRootPackage().accept(new AstParentConsistencyChecker());
 		CtClass<?> type = (CtClass<?>) f.Type().get(Comment1.class);
-		List<CtComment> comments = type.getComments();
-		assertEquals(2, comments.size());
+		List<CtComment> comments = type.getElements(new TypeFilter<CtComment>(CtComment.class));
+		assertEquals(4, comments.size());
 
 		type = (CtClass<?>) f.Type().get(Comment2.class);
-		assertEquals(1, type.getComments().size());
+		comments = type.getElements(new TypeFilter<CtComment>(CtComment.class));
+		assertEquals(1, comments.size());
 	}
 }

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -31,6 +31,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
+import spoon.reflect.visitor.AstParentConsistencyChecker;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DefaultCoreFactory;
@@ -38,6 +39,8 @@ import spoon.support.JavaOutputProcessor;
 import spoon.support.StandardEnvironment;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.test.comment.testclasses.BlockComment;
+import spoon.test.comment.testclasses.Comment1;
+import spoon.test.comment.testclasses.Comment2;
 import spoon.test.comment.testclasses.InlineComment;
 
 import java.io.FileOutputStream;
@@ -617,5 +620,17 @@ public class CommentTest {
 		} finally {
 			write(codeElementsDocumentationPage.toString(), new FileOutputStream("doc/code_elements.md"));
 		}
+	}
+
+	@Test
+	public void testCommentsInComment1And2() {
+		Factory f = getSpoonFactory();
+		f.getModel().getRootPackage().accept(new AstParentConsistencyChecker());
+		CtClass<?> type = (CtClass<?>) f.Type().get(Comment1.class);
+		List<CtComment> comments = type.getComments();
+		assertEquals(2, comments.size());
+
+		type = (CtClass<?>) f.Type().get(Comment2.class);
+		assertEquals(1, type.getComments().size());
 	}
 }

--- a/src/test/java/spoon/test/comment/testclasses/Comment1.java
+++ b/src/test/java/spoon/test/comment/testclasses/Comment1.java
@@ -1,5 +1,7 @@
 package spoon.test.comment.testclasses;
 
+// comment 1
+// comment 2
 public class Comment1 {
 
     public void code_1()

--- a/src/test/java/spoon/test/comment/testclasses/Comment1.java
+++ b/src/test/java/spoon/test/comment/testclasses/Comment1.java
@@ -1,0 +1,14 @@
+package spoon.test.comment.testclasses;
+
+public class Comment1 {
+
+    public void code_1()
+    {
+        try {		}
+        // A
+        // B
+        catch (Exception ex)
+        {		}
+    }
+
+}

--- a/src/test/java/spoon/test/comment/testclasses/Comment2.java
+++ b/src/test/java/spoon/test/comment/testclasses/Comment2.java
@@ -1,0 +1,8 @@
+package spoon.test.comment.testclasses;
+
+public class Comment2 {
+
+    // C
+    @interface Code_2{}
+
+}

--- a/src/test/java/spoon/test/comment/testclasses/InlineComment.java
+++ b/src/test/java/spoon/test/comment/testclasses/InlineComment.java
@@ -67,7 +67,10 @@ public class InlineComment {
 		try {
 			// comment in try
 			i++;
-		} catch (Exception e) {
+		}
+		// between
+		// try/catch
+		catch (Exception e) {
 			// comment in catch
 		}
 		// comment synchronized


### PR DESCRIPTION
Multiple comments placed before a catch block were ignored, see #1073. This PR contains test to spot the bug and a fix.