### PR TITLE
travis: Remove the -Xdoclint parameter in pom.xml fix #1106

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -567,7 +567,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <additionalparam>-Xdoclint:-missing</additionalparam>
           <quiet>true</quiet>
         </configuration>
       </plugin>


### PR DESCRIPTION
Remove the -Xdoclint parameter in pom.xml to show errors related to javadoc using java 8 rules. Travis should fail when those errors occured. Fix #1106 