### PR TITLE
Set the type of a parameter declared in a lambda to Object instead of ommitting them when unknown.

### DIFF
--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -100,10 +100,11 @@ public class ExecutableFactory extends SubFactory {
 		CtTypeReference<?> refs[] = new CtTypeReference[e.getParameters().size()];
 		int i = 0;
 		for (CtParameter<?> param : e.getParameters()) {
-			if (param.getType() != null) {
-				// With a lambda and in noclasspath (when the type of parameters isn't specified), we don't have a type.
-				refs[i++] = param.getType().clone();
-			}
+			refs[i++] = param.getType() != null
+					? param.getType().clone()
+					// With a lambda and in noclasspath (when the type of
+					// parameters isn't specified), we assume Object.
+					: factory.Type().OBJECT.clone();
 		}
 		String executableName = e.getSimpleName();
 		if (e instanceof CtMethod) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -198,12 +198,11 @@ class JDTTreeBuilderHelper {
 				@SuppressWarnings("unchecked")
 				final List<CtParameter<?>> parametersOfExecutable = executable.getParameters();
 				for (CtParameter<?> parameter : parametersOfExecutable) {
-					if (parameter.getType() != null) {
-						parameterTypesOfExecutable.add(parameter.getType().clone());
-					} else {
-						// it's the best match :(
-						parameterTypesOfExecutable.add(typeFactory.OBJECT);
-					}
+					parameterTypesOfExecutable.add(parameter.getType() != null
+							? parameter.getType().clone()
+							// it's the best match :(
+							: typeFactory.OBJECT.clone()
+					);
 				}
 
 				// find executable's corresponding jdt element

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -940,9 +940,11 @@ public class ReferenceBuilder {
 				List<CtTypeReference<?>> parametersType = new ArrayList<>();
 				List<CtParameter<?>> parameters = ctLambda.getParameters();
 				for (CtParameter<?> parameter : parameters) {
-					if (parameter.getType() != null) {
-						parametersType.add(parameter.getType().clone());
-					}
+					parametersType.add(parameter.getType() != null
+							? parameter.getType().clone()
+							// it's the best match :(
+							: jdtTreeBuilder.getFactory().Type().OBJECT.clone()
+					);
 				}
 				return jdtTreeBuilder.getFactory().Executable().createReference(declaringType, ctLambda.getType(), ctLambda.getSimpleName(), parametersType);
 			}

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -6,6 +6,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.reference.CtParameterReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
@@ -58,6 +59,62 @@ public class ParameterTest {
 		for (CtParameterReference element : elements) {
 			assertEquals(ctParameter, element.getDeclaration());
 			assertEquals(ctParameter.getReference(), element);
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testMultiParameterLambdaTypeReference() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/noclasspath/lambdas/MultiParameterLambda.java");
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.buildModel();
+
+		List<CtParameter> parameters;
+
+		// test string parameters
+		parameters = launcher.getModel()
+						.getElements(new NameFilter<CtMethod>("stringLambda"))
+						.get(0)
+						.getElements(new TypeFilter<>(CtParameter.class));
+		assertEquals(2, parameters.size());
+		for (final CtParameter param : parameters) {
+			for (final CtTypeReference refType :
+					(List<CtTypeReference>) param.getReference()
+							.getDeclaringExecutable()
+							.getParameters()) {
+				assertEquals(launcher.getFactory().Type().STRING, refType);
+			}
+		}
+
+		// test integer parameters
+		parameters = launcher.getModel()
+				.getElements(new NameFilter<CtMethod>("integerLambda"))
+				.get(0)
+				.getElements(new TypeFilter<>(CtParameter.class));
+		assertEquals(2, parameters.size());
+		for (final CtParameter param : parameters) {
+			for (final CtTypeReference refType :
+					(List<CtTypeReference>) param.getReference()
+					.getDeclaringExecutable()
+					.getParameters()) {
+				assertEquals(launcher.getFactory().Type().INTEGER, refType);
+			}
+		}
+
+		// test unknown parameters
+		parameters = launcher.getModel()
+				.getElements(new NameFilter<CtMethod>("unknownLambda"))
+				.get(0)
+				.getElements(new TypeFilter<>(CtParameter.class));
+		assertEquals(2, parameters.size());
+		for (final CtParameter param : parameters) {
+			for (final CtTypeReference refType :
+					(List<CtTypeReference>) param.getReference()
+							.getDeclaringExecutable()
+							.getParameters()) {
+				assertEquals(launcher.getFactory().Type().OBJECT, refType);
+			}
 		}
 	}
 }

--- a/src/test/resources/noclasspath/lambdas/MultiParameterLambda.java
+++ b/src/test/resources/noclasspath/lambdas/MultiParameterLambda.java
@@ -1,0 +1,31 @@
+import java.util.Map;
+import java.util.HashMap;
+
+import test.Unknown;
+
+public class MultiParameterLambda {
+
+	public void stringLambda() {
+		final Map<String, String> map = new HashMap<>();
+		map.put("a", "A");
+		map.put("b", "B");
+		map.put("c", "C");
+		map.forEach((key, value) -> System.out.println(key + ", " + value));
+	}
+
+	public void integerLambda() {
+		final Map<Integer, Integer> map = new HashMap<>();
+		map.put(1, 100);
+		map.put(2, 200);
+		map.put(3, 300);
+		map.forEach((key, value) -> System.out.println(key + ", " + value));
+	}
+
+	public void unknownLambda() {
+		final Map<Unknown, Unknown> map = new HashMap<>();
+		map.put(new Unknown(), new Unknown());
+		map.put(new Unknown(), new Unknown());
+		map.put(new Unknown(), new Unknown());
+		map.forEach((key, value) -> System.out.println(key + ", " + value));
+	}
+}


### PR DESCRIPTION
This PR also contains a fix for a minor bug introduced in #1098.