### PR TITLE
WiP: chore(maven): Change pom.xml to add revapi 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ jdk:
 # from https://docs.travis-ci.com/user/customizing-the-build
 # A build on Travis CI is made up of two steps: install: (install any dependencies required), script: (run the build script)
 
-env:
-  global:
-    - secure: "P76wAc2GqqrNu8062IvCOLO3i+bt2UPoARKRGhFf0J7SBs8Lzg/W2VAFW/oe2m8gjjr5a7X95hUmHsmnvpJ87sIn6j4xcDNohVouE32J1K4D+tChdwWLN2AS2D5gphkclW4JKMmQjuk6Sat/iEXW1PWgbe9xKJzW9vZKazxC9M8="
-
 install:
   - # download deps with maven
   - mvn dependency:resolve
@@ -40,6 +36,5 @@ script: |
   mvn coveralls:report -Pcoveralls --fail-never &&
 
   # documentation
-  python chore/check-links-in-doc.py &&
-  python chore/revapy.py spoon-bot INRIA/spoon
+  python chore/check-links-in-doc.py
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jdk:
 # A build on Travis CI is made up of two steps: install: (install any dependencies required), script: (run the build script)
 
 env:
-  secure: "efbXGdgEbwLrkAU17JnAC2DkZiOr+8kSjkzpTPeAewXK1uJsthj95fwGVZ3+OrRBMcf52vTZheeLj2Qe5cocbEbxWFLtrxIp3L9hNp5BYXd4cn33d3Tx10ll7Ba0EswP/sbVkXsfihwKhLc3PCBph5+Z+YUh/LAA2zPjAN4H2RQ="
+  - secure: "P76wAc2GqqrNu8062IvCOLO3i+bt2UPoARKRGhFf0J7SBs8Lzg/W2VAFW/oe2m8gjjr5a7X95hUmHsmnvpJ87sIn6j4xcDNohVouE32J1K4D+tChdwWLN2AS2D5gphkclW4JKMmQjuk6Sat/iEXW1PWgbe9xKJzW9vZKazxC9M8="
 
 install:
   - # download deps with maven

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,6 @@ script: |
   mvn coveralls:report -Pcoveralls --fail-never &&
 
   # documentation
-  python chore/check-links-in-doc.py
-  'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then python chore/revapy.py spoon-bot INRIA/spoon; fi'
+  python chore/check-links-in-doc.py &&
+  python chore/revapy.py spoon-bot INRIA/spoon
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ jdk:
 # from https://docs.travis-ci.com/user/customizing-the-build
 # A build on Travis CI is made up of two steps: install: (install any dependencies required), script: (run the build script)
 
+env:
+  secure: "efbXGdgEbwLrkAU17JnAC2DkZiOr+8kSjkzpTPeAewXK1uJsthj95fwGVZ3+OrRBMcf52vTZheeLj2Qe5cocbEbxWFLtrxIp3L9hNp5BYXd4cn33d3Tx10ll7Ba0EswP/sbVkXsfihwKhLc3PCBph5+Z+YUh/LAA2zPjAN4H2RQ="
+
 install:
   - # download deps with maven
   - mvn dependency:resolve
-  - pip install --user CommonMark requests
+  - pip install --user CommonMark requests pygithub
   - sudo apt-get install xmlstarlet
   
 script: |
@@ -37,4 +40,5 @@ script: |
 
   # documentation
   python chore/check-links-in-doc.py
+  'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then python chore/revapy.py spoon-bot INRIA/spoon; fi'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ jdk:
 # A build on Travis CI is made up of two steps: install: (install any dependencies required), script: (run the build script)
 
 env:
-  - secure: "P76wAc2GqqrNu8062IvCOLO3i+bt2UPoARKRGhFf0J7SBs8Lzg/W2VAFW/oe2m8gjjr5a7X95hUmHsmnvpJ87sIn6j4xcDNohVouE32J1K4D+tChdwWLN2AS2D5gphkclW4JKMmQjuk6Sat/iEXW1PWgbe9xKJzW9vZKazxC9M8="
+  global:
+    - secure: "P76wAc2GqqrNu8062IvCOLO3i+bt2UPoARKRGhFf0J7SBs8Lzg/W2VAFW/oe2m8gjjr5a7X95hUmHsmnvpJ87sIn6j4xcDNohVouE32J1K4D+tChdwWLN2AS2D5gphkclW4JKMmQjuk6Sat/iEXW1PWgbe9xKJzW9vZKazxC9M8="
 
 install:
   - # download deps with maven

--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -4,11 +4,17 @@ Old API: **<#list analysis.oldApi.archives as archive>${archive.name}<#sep>, </#
 
 New API: **<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#list>**
 
-Old | New | Code | Description | Breaking
-:---: | :---: | :---: | :---: | :---:
 <#list reports as report>
 <#list report.differences as diff>
-${report.oldElement!"none"} | ${report.newElement!"none"} | ${diff.code} | ${diff.description!"none"} | <#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list> |
+| Name | Element |
+| :---: | :---: |
+| Old | ${report.oldElement!"none"} |
+| New | ${report.newElement!"none"} |
+| Code | ${diff.code} |
+| Description | ${diff.description!"none"} |
+| Breaking | <#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list> |
 </#list>
+<#sep>
+
+</#sep>
 </#list>
-</table>

--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -4,15 +4,19 @@ Old API: **<#list analysis.oldApi.archives as archive>${archive.name}<#sep>, </#
 
 New API: **<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#list>**
 
+Detected changes: ${reports?size}.
+
 <#list reports as report>
 <#list report.differences as diff>
+## Change ${report?index+1}
+
 | Name | Element |
 | :---: | :---: |
 | Old | ${report.oldElement!"none"} |
 | New | ${report.newElement!"none"} |
 | Code | ${diff.code} |
 | Description | ${diff.description!"none"} |
-| Breaking | <#list diff.classification?keys as compat>${compat}?lower_case: ${diff.classification?api.get(compat)}?lower_case<#sep>, </#list> |
+| Breaking | <#list diff.classification?keys as compat>${compat?lower_case}: ${diff.classification?api.get(compat)?lower_case}<#sep>, </#list> |
 </#list>
 <#sep>
 

--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -4,23 +4,11 @@ Old API: **<#list analysis.oldApi.archives as archive>${archive.name}<#sep>, </#
 
 New API: **<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#list>**
 
-<table>
-<tr>
-    <th>Old</th>
-    <th>New</th>
-    <th>Code</th>
-    <th>Description</th>
-    <th>Breaking</th>
-</tr>
+Old | New | Code | Description | Breaking
+:---: | :---: | :---: | :---: | :---:
 <#list reports as report>
 <#list report.differences as diff>
-<tr>
-    <td style="text-align:center">${report.oldElement!"none"}</td>
-    <td style="text-align:center">${report.newElement!"none"}</td>
-    <td style="text-align:center">${diff.code}</td>
-    <td style="text-align:center">${diff.description!"none"}</td>
-    <td style="text-align:center"><#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list></td>
-</tr>
+${report.oldElement!"none"} | ${report.newElement!"none"} | ${diff.code} | ${diff.description!"none"} | <#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list> |
 </#list>
 </#list>
 </table>

--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -1,0 +1,26 @@
+# Revapi Analysis results
+
+Old API: **<#list analysis.oldApi.archives as archive>${archive.name}<#sep>, </#list>**
+
+New API: **<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#list>**
+
+<table>
+<tr>
+    <th>Old</th>
+    <th>New</th>
+    <th>Code</th>
+    <th>Description</th>
+    <th>Breaking</th>
+</tr>
+<#list reports as report>
+<#list report.differences as diff>
+<tr>
+    <td style="text-align:center">${report.oldElement!"none"}</td>
+    <td style="text-align:center">${report.newElement!"none"}</td>
+    <td style="text-align:center">${diff.code}</td>
+    <td style="text-align:center">${diff.description!"none"}</td>
+    <td style="text-align:center"><#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list></td>
+</tr>
+</#list>
+</#list>
+</table>

--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -12,7 +12,7 @@ New API: **<#list analysis.newApi.archives as archive>${archive.name}<#sep>, </#
 | New | ${report.newElement!"none"} |
 | Code | ${diff.code} |
 | Description | ${diff.description!"none"} |
-| Breaking | <#list diff.classification?keys as compat>${compat}: ${diff.classification?api.get(compat)}<#sep>, </#list> |
+| Breaking | <#list diff.classification?keys as compat>${compat}?lower_case: ${diff.classification?api.get(compat)}?lower_case<#sep>, </#list> |
 </#list>
 <#sep>
 

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -8,10 +8,23 @@ revapi_file = "./target/revapi.report"
 
 args = sys.argv
 
-if (args.__len__() < 3) or os.environ.get('GITHUB_TOKEN') == None or os.environ.get('TRAVIS_PULL_REQUEST') == None:
+def usage():
     print "Usage: "+str(args[0])+ " <login> <repository>"
     print "The following environement variable must be set as well: GITHUB_TOKEN and TRAVIS_PULL_REQUEST"
     exit(1)
+
+if (args.__len__() < 3):
+    print "Error in the args number"
+    usage()
+
+if os.environ.get('GITHUB_TOKEN') == None:
+    print "You forgot to specify GITHUB_TOKEN"
+    usage()
+
+if os.environ.get('TRAVIS_PULL_REQUEST') == None:
+    print "You forgot to specify TRAVIS_PULL_REQUEST"
+    usage()
+
 
 if (str(os.environ.get('TRAVIS_PULL_REQUEST')) == "false"):
     print "Revapi report ignored as this is not launched by PR."

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -8,7 +8,7 @@ revapi_file = "./target/revapi.report"
 
 args = sys.argv
 
-if (args.__len__() < 3) || os.environ.get('GITHUB_TOKEN') == None || os.environ.get('TRAVIS_PULL_REQUEST') == None:
+if (args.__len__() < 3) or os.environ.get('GITHUB_TOKEN') == None or os.environ.get('TRAVIS_PULL_REQUEST') == None:
     print "Usage: "+str(args[0])+ " <login> <repository>"
     print "The following environement variable must be set as well: GITHUB_TOKEN and TRAVIS_PULL_REQUEST"
     exit(1)

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -13,6 +13,10 @@ if (args.__len__() < 3) or os.environ.get('GITHUB_TOKEN') == None or os.environ.
     print "The following environement variable must be set as well: GITHUB_TOKEN and TRAVIS_PULL_REQUEST"
     exit(1)
 
+if (str(os.environ.get('TRAVIS_PULL_REQUEST')) == "false"):
+    print "Revapi report ignored as this is not launched by PR."
+    exit(0)
+
 login = args[1]
 token = os.environ['GITHUB_TOKEN']
 repo_name = args[2]

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -11,7 +11,7 @@ revapi_file = "./target/revapi.report"
 args = sys.argv
 
 def usage():
-    print "Usage: "+str(args[0])+ " <github_login> <github_token> <PRPayload>"
+    print "Usage: "+str(args[0])+ " <github_login> <github_token> <PR_payload_path>"
     exit(1)
 
 if (args.__len__() < 4):
@@ -22,7 +22,11 @@ if (not(os.path.isfile(revapi_file))):
     print "Revapi report file cannot be found at the following location: "+revapi_file
     exit(1)
 
-file_content = "";
+if (not(os.path.isfile(args[3]))):
+    print "JSON payload file cannot be found at the following location: "+args[3]
+    exit(1)
+
+file_content = ""
 with open(revapi_file) as f:
     for line in f:
         file_content += line+"\n"
@@ -41,7 +45,16 @@ except GithubException as e:
     print e
     exit(1)
 
-payloadJSON = json.loads(args[3])
+payload_string = ""
+with open(args[3]) as f:
+    for line in f:
+        payload_string += line
+
+if (payload_string == ""):
+    print "Payload is empty"
+    exit(1)
+
+payloadJSON = json.loads(payload_string)
 repo_name = payloadJSON['repository']['full_name']
 pr_id = payloadJSON['pull_request']['number']
 

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# Retrieve revapi Report and publish it as PR comment
+
+import os, sys
+from github import *
+
+revapi_file = "./target/revapi.report"
+
+args = sys.argv
+
+if (args.__len__() < 3) || os.environ.get('GITHUB_TOKEN') == None || os.environ.get('TRAVIS_PULL_REQUEST') == None:
+    print "Usage: "+str(args[0])+ " <login> <repository>"
+    print "The following environement variable must be set as well: GITHUB_TOKEN and TRAVIS_PULL_REQUEST"
+    exit(1)
+
+login = args[1]
+token = os.environ['GITHUB_TOKEN']
+repo_name = args[2]
+pr_id = int(os.environ['TRAVIS_PULL_REQUEST'])
+
+if (not(os.path.isfile(revapi_file))):
+    print "Revapi report file cannot be found at the following location: "+revapi_file
+    exit(1)
+
+file_content = "";
+with open(revapi_file) as f:
+    for line in f:
+        file_content += line+"\n"
+
+if (file_content == ""):
+    print "Revapi report is empty"
+    exit(1)
+
+try:
+    gh = Github(login,token)
+    repo = gh.get_repo(repo_name,True)
+
+    pr = repo.get_pull(pr_id)
+    pr.create_issue_comment(file_content)
+except GithubException as e:
+    print "Error while creating the PR comment."
+    print e
+    exit(1)

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -29,7 +29,7 @@ if (not(os.path.isfile(args[3]))):
 file_content = ""
 with open(revapi_file) as f:
     for line in f:
-        file_content += line+"\n"
+        file_content += line
 
 if (file_content == ""):
     print "Revapi report is empty"

--- a/chore/revapy.py
+++ b/chore/revapy.py
@@ -6,7 +6,7 @@
 import os, sys, json
 from github import *
 
-revapi_file = "./target/revapi.report"
+revapi_file = "./target/revapi_report.md"
 
 args = sys.argv
 

--- a/pom.xml
+++ b/pom.xml
@@ -492,12 +492,12 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
         <!-- Lock down plugin version for build reproducibility -->
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <dependencies>
           <dependency>
             <groupId>org.revapi</groupId>
             <artifactId>revapi-java</artifactId>
-            <version>0.13.0</version>
+            <version>0.13.1</version>
           </dependency>
         </dependencies>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       <name>Maven Repository for JDT Compiler release</name>
       <url>http://spoon.gforge.inria.fr/repositories/releases</url>
     </repository>
+    <repository>
+      <id>gforge.inria.fr-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>http://spoon.gforge.inria.fr/repositories/snapshots</url>
+    </repository>
   </repositories>
 
   <distributionManagement>
@@ -506,21 +511,9 @@
         <configuration>
           <alwaysCheckForReleaseVersion>false</alwaysCheckForReleaseVersion>
           <oldVersion>LATEST</oldVersion>
-          <analysisConfiguration>
-            {
-              "revapi": {
-                "java": {
-                    "filter": {
-                      "packages": {
-                        "regex": true,
-                        "include": ["spoon\\..*"],
-                        "exclude": ["spoon\\..*\\.test(\\..*)?"]
-                      }
-                    }
-                }
-              }
-            }
-          </analysisConfiguration>
+          <analysisConfigurationFiles>
+            <file>${project.basedir}/revapi.json</file>
+          </analysisConfigurationFiles>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -499,15 +499,12 @@
             <artifactId>revapi-java</artifactId>
             <version>0.13.1</version>
           </dependency>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-reporter-text</artifactId>
+            <version>0.7.0</version>
+          </dependency>
         </dependencies>
-        <executions>
-          <execution>
-            <id>revapi-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
         <configuration>
           <alwaysCheckForReleaseVersion>false</alwaysCheckForReleaseVersion>
           <oldVersion>LATEST</oldVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -482,7 +482,49 @@
 	</executions>
       </plugin>
 
+      <!-- Used for checking backward compatibility (binary and source) -->
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <!-- Lock down plugin version for build reproducibility -->
+        <version>0.8.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.revapi</groupId>
+            <artifactId>revapi-java</artifactId>
+            <version>0.13.0</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>revapi-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <alwaysCheckForReleaseVersion>false</alwaysCheckForReleaseVersion>
+          <oldVersion>LATEST</oldVersion>
+          <analysisConfiguration>
+            {
+              "revapi": {
+                "java": {
+                    "filter": {
+                      "packages": {
+                        "regex": true,
+                        "include": ["spoon\\..*"],
+                        "exclude": ["spoon\\..*\\.test(\\..*)?"]
+                      }
+                    }
+                }
+              }
+            }
+          </analysisConfiguration>
+        </configuration>
+      </plugin>
     </plugins>
+
 
     <pluginManagement>
       <plugins>

--- a/revapi.json
+++ b/revapi.json
@@ -23,24 +23,9 @@
       }
     },
 
-    // use the semantic version module to check changes respectively to the versions of the API
-    // doc here: http://revapi.org/modules/revapi-basic-features/extensions/semver-ignore.html
-    "semver" : {
-      "ignore" : {
-        "enabled" : true,
-
-        // specify to ignore kind of errors based on version number
-        "versionIncreaseAllows" : {
-          "major" : "breaking",
-          "minor" : "nonBreaking",
-          "patch" : "equivalent"
-        },
-      }
-    },
-
     "reporter" : {
       "text" : {
-        "minSeverity": "POTENTIALLY_BREAKING",
+        "minSeverity": "BREAKING",
         "output" : "target/revapi.report"
       }
     }

--- a/revapi.json
+++ b/revapi.json
@@ -1,26 +1,41 @@
 {
   "revapi": {
+    // use java module
+    // Doc there: http://revapi.org/modules/revapi-java/extensions/java.html
     "java": {
+
+      // filter rules to compare API
       "filter": {
+
+        // specify which package to filter
         "packages": {
           "regex": true,
           "include": ["spoon\\..*"],
           "exclude": ["spoon\\..*\\.test(\\..*)?"]
         }
-      },
-      "missing-classes": {
-        "behavior": "report"
+
+        /*
+        // Exclude all impl classes
+        "classes": {
+          "regex": true,
+          "exclude": [".*Impl.*"]
+        }
+        */
       }
     },
+
+    // use the semantic version module to check changes respectively to the versions of the API
+    // doc here: http://revapi.org/modules/revapi-basic-features/extensions/semver-ignore.html
     "semver" : {
       "ignore" : {
         "enabled" : true,
+
+        // specify to ignore kind of errors based on version number
         "versionIncreaseAllows" : {
           "major" : "breaking",
           "minor" : "nonBreaking",
           "patch" : "equivalent"
         },
-        "passThroughDifferences": ["java.class.nonPublicPartOfAPI"]
       }
     }
   }

--- a/revapi.json
+++ b/revapi.json
@@ -20,13 +20,16 @@
           "exclude": [".*Impl.*"]
         }
 
-      }
+      },
+      "reportUsesFor": ["java.missing.newClass", "java.missing.oldClass"]
     },
 
     "reporter" : {
       "text" : {
         "minSeverity": "BREAKING",
-        "output" : "target/revapi.report"
+        "output" : "target/revapi_report.md",
+        "template": "chore/revapi_tpl.ftl",
+        "append": false
       }
     }
   }

--- a/revapi.json
+++ b/revapi.json
@@ -12,15 +12,14 @@
           "regex": true,
           "include": ["spoon\\..*"],
           "exclude": ["spoon\\..*\\.test(\\..*)?"]
-        }
+        },
 
-        /*
         // Exclude all impl classes
         "classes": {
           "regex": true,
           "exclude": [".*Impl.*"]
         }
-        */
+
       }
     },
 
@@ -36,6 +35,13 @@
           "minor" : "nonBreaking",
           "patch" : "equivalent"
         },
+      }
+    },
+
+    "reporter" : {
+      "text" : {
+        "minSeverity": "POTENTIALLY_BREAKING",
+        "output" : "target/revapi.report"
       }
     }
   }

--- a/revapi.json
+++ b/revapi.json
@@ -1,0 +1,27 @@
+{
+  "revapi": {
+    "java": {
+      "filter": {
+        "packages": {
+          "regex": true,
+          "include": ["spoon\\..*"],
+          "exclude": ["spoon\\..*\\.test(\\..*)?"]
+        }
+      },
+      "missing-classes": {
+        "behavior": "report"
+      }
+    },
+    "semver" : {
+      "ignore" : {
+        "enabled" : true,
+        "versionIncreaseAllows" : {
+          "major" : "breaking",
+          "minor" : "nonBreaking",
+          "patch" : "equivalent"
+        },
+        "passThroughDifferences": ["java.class.nonPublicPartOfAPI"]
+      }
+    }
+  }
+}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -67,7 +67,7 @@ import java.util.Set;
 import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.getModifiers;
 import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.isLhsAssignment;
 
-class JDTTreeBuilderHelper {
+public class JDTTreeBuilderHelper {
 	private final JDTTreeBuilder jdtTreeBuilder;
 
 	JDTTreeBuilderHelper(JDTTreeBuilder jdtTreeBuilder) {


### PR DESCRIPTION
Use revapi to compare Spoon API against the last published snapshot. Fix #1023.
Thanks a lot @metlos for the support and quick changes on revapi.
Launched today and obtain the following result:
```
[INFO] Comparing [fr.inria.gforge.spoon:spoon-core:jar:5.6.0-20170112.234557-2] against [fr.inria.gforge.spoon:spoon-core:jar:5.6.0-SNAPSHOT] (including their transitive dependencies).
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18.682 s
[INFO] Finished at: 2017-01-13T09:22:53+01:00
[INFO] Final Memory: 117M/857M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.revapi:revapi-maven-plugin:0.8.1:check (revapi-check) on project spoon-core: The following API problems caused the build to fail:
[ERROR] java.method.addedToInterface: method spoon.reflect.factory.QueryFactory spoon.reflect.factory.Factory::Query(): Method was added to an interface. (breaks semantic versioning)
[ERROR] java.method.addedToInterface: method spoon.reflect.visitor.chain.CtQuery spoon.reflect.factory.Factory::createQuery(): Method was added to an interface. (breaks semantic versioning)
[ERROR] java.method.addedToInterface: method spoon.reflect.visitor.chain.CtQuery spoon.reflect.factory.Factory::createQuery(java.lang.Object): Method was added to an interface. (breaks semantic versioning)
[ERROR] java.field.serialVersionUIDUnchanged: field spoon.reflect.factory.FactoryImpl.serialVersionUID: The class changed in an incompatible way with regards to serialization but the serialVersionUID field stayed unchanged. This might be ok and/or desired but is suspicious. (breaks semantic versioning)
[ERROR] java.method.added: method spoon.reflect.factory.QueryFactory spoon.reflect.factory.FactoryImpl::Query(): Method was added. (breaks semantic versioning)
[ERROR] java.method.added: method spoon.reflect.visitor.chain.CtQuery spoon.reflect.factory.FactoryImpl::createQuery(): Method was added. (breaks semantic versioning)
[ERROR] java.method.added: method spoon.reflect.visitor.chain.CtQuery spoon.reflect.factory.FactoryImpl::createQuery(java.lang.Object): Method was added. (breaks semantic versioning)
[ERROR] java.class.added: class spoon.reflect.factory.QueryFactory: Class was added. (breaks semantic versioning)
[ERROR] java.class.nonPublicPartOfAPI: class spoon.support.compiler.jdt.JDTTreeBuilderHelper: Class 'spoon.support.compiler.jdt.JDTTreeBuilderHelper' is indirectly included in the API (by the means of method return type for example) but the class is not accessible (neither public nor protected).
[ERROR] Use chain of the type in the old API: spoon.support.compiler.jdt.JDTTreeBuilderHelper is returned from method spoon.support.compiler.jdt.JDTTreeBuilderHelper spoon.support.compiler.jdt.JDTTreeBuilder::getHelper() (method spoon.support.compiler.jdt.JDTTreeBuilderHelper spoon.support.compiler.jdt.JDTTreeBuilder::getHelper() is part of the API)
[ERROR] Use chain of the type in the new API: spoon.support.compiler.jdt.JDTTreeBuilderHelper is returned from method spoon.support.compiler.jdt.JDTTreeBuilderHelper spoon.support.compiler.jdt.JDTTreeBuilder::getHelper() (method spoon.support.compiler.jdt.JDTTreeBuilderHelper spoon.support.compiler.jdt.JDTTreeBuilder::getHelper() is part of the API)
```
It currently breaks a `mvn install` and so, it should break a Travis build if a change in the API is not documented.
We can still ignore some changes in the API editing revapi.json file. Maybe it should be good to document our process concerning changes in the API and the usage of revapi (add justification to breaks inside the revapi.json).