### PR TITLE
fix CCE on Query#forEach call of CtConsumer#apply

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -279,7 +279,12 @@ public class CtQueryImpl implements CtQuery {
 		}
 
 		private boolean isFailOnCCE() {
-			return getStep().isFailOnCCE();
+			AbstractStep step = getStep();
+			if (step == null) {
+				//it is final consumer. Never throw CCE on final forEach consumer
+				return false;
+			}
+			return step.isFailOnCCE();
 		}
 
 		private AbstractStep getStep() {

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -813,4 +813,25 @@ public class FilterTest {
 		assertEquals(1, list.size());
 		assertEquals("x", list.get(0));
 	}
+
+	@Test
+	public void testClassCastExceptionOnForEach() throws Exception {
+		// contract: bound query, without any mapping
+
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });
+		launcher.addInputResource("./src/test/java/spoon/test/filters/testclasses");
+		launcher.run();
+		
+		class Context {
+			int count = 0;
+		}
+		
+		Context context = new Context();
+		//contract: if the query produces elements which cannot be cast to forEach consumer, then they are ignored
+		launcher.getFactory().Package().getRootPackage().filterChildren(f->{return true;}).forEach((CtType t)->{
+			context.count++;
+		});
+		assertTrue(context.count>0);
+	}
 }


### PR DESCRIPTION
test and fix contract: If the query produces elements, which cannot be cast to forEach consumer, then they are ignored.

Current behavior: the new test `testClassCastExceptionOnForEach` fails with NullPointerException