### PR TITLE
improve performance of DirectReferenceFilter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/DirectReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/DirectReferenceFilter.java
@@ -38,6 +38,9 @@ public class DirectReferenceFilter<T extends CtReference> extends AbstractFilter
 	}
 
 	public boolean matches(T reference) {
+		if (super.matches(reference) == false) {
+			return false;
+		}
 		return this.reference.equals(reference);
 	}
 }


### PR DESCRIPTION
The DirectReferenceFilter should first call `super.matches(...)`, which fast checks whether visited element is of required type. Then it can check equality of that element.
Otherwise the equality is tested for each child element and it is useless.