### PR TITLE
review ParameterReferenceFunction, ParameterScopeFunction

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/ParameterReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParameterReferenceFunction.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.reference.CtParameterReference;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+
+/**
+ * This Query expects a {@link CtParameter} as input
+ * and returns all {@link CtParameterReference}s, which refers this input.
+ * <br>
+ * Usage:<br>
+ * <pre> {@code
+ * CtParameter param = ...;
+ * param
+ *   .map(new ParameterReferenceFunction())
+ *   .forEach((CtParameterReference ref)->...process references...);
+ * }
+ * </pre>
+ */
+public class ParameterReferenceFunction implements CtConsumableFunction<CtParameter<?>> {
+
+	public ParameterReferenceFunction() {
+	}
+
+	@Override
+	public void apply(CtParameter<?> parameter, CtConsumer<Object> outputConsumer) {
+		parameter
+			.map(new ParameterScopeFunction())
+			.select(new DirectReferenceFilter<CtParameterReference<?>>(parameter.getReference()))
+			.forEach(outputConsumer);
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/filter/ParameterScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParameterScopeFunction.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+
+/**
+ * This Query expects a {@link CtParameter} as input
+ * and returns all CtElements,
+ * which are in visibility scope of that parameter.
+ * In other words, it returns all elements,
+ * which might be reference to that parameter.
+ * <br>
+ * It can be used to search for variable declarations or
+ * variable references which might be in name conflict with input parameter.
+ * <br>
+ * Usage:<br>
+ * <pre> {@code
+ * CtParameter param = ...;
+ * param.map(new ParameterScopeFunction()).forEach(...process result...);
+ * }
+ * </pre>
+ */
+public class ParameterScopeFunction implements CtConsumableFunction<CtParameter<?>> {
+
+	public ParameterScopeFunction() {
+	}
+
+	@Override
+	public void apply(CtParameter<?> parameter, CtConsumer<Object> outputConsumer) {
+		CtExecutable<?> exec = parameter.getParent(CtExecutable.class);
+		if (exec == null) {
+			//cannot search for parameter references of parameter which has no executable
+			return;
+		}
+		exec.filterChildren(null).forEach(outputConsumer);
+	}
+}

--- a/src/test/java/spoon/test/query_function/QueryTest.java
+++ b/src/test/java/spoon/test/query_function/QueryTest.java
@@ -95,6 +95,22 @@ public class QueryTest {
 		assertEquals(countOfModelClasses, context.classCount);
 	}
 
+	@Test
+	public void testParameterReferenceFunction() throws Exception {
+		//visits all the CtParameter elements whose name is "field" and search for all their references
+		//The test detects whether found references are correct by these two checks:
+		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
+		//2) the model is searched for all variable references which has same identification number and counts them
+		//Then it checks that counted number of references and found number of references is same 
+		factory.Package().getRootPackage().filterChildren((CtParameter<?> param)->{
+			if(param.getSimpleName().equals("field")) {
+				int value = getLiteralValue(param);
+				checkVariableAccess(param, value, new ParameterReferenceFunction());
+			}
+			return false;
+		}).list();
+	}
+	
 	private void checkVariableAccess(CtVariable<?> var, int value, CtConsumableFunction<?> query) {
 		class Context {
 			int classCount = 0;

--- a/src/test/java/spoon/test/query_function/QueryTest.java
+++ b/src/test/java/spoon/test/query_function/QueryTest.java
@@ -1,0 +1,206 @@
+package spoon.test.query_function;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.reflect.code.CtAbstractInvocation;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.position.NoSourcePosition;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtCatchVariableReference;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtVariableReference;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.filter.ParameterReferenceFunction;
+import spoon.test.query_function.testclasses.packageA.ClassA;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class QueryTest {
+	
+	static int countOfModelClasses = 5;
+
+	Factory factory;
+	CtClass<?> classA;
+	CtClass<?> classA_privateChild;
+	CtClass<?> classA_protectedChild;
+	CtClass<?> classA_publicChild;
+	CtClass<?> classA_packProtChild;
+
+	@Before
+	public void setup() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });
+		launcher.getEnvironment().setCommentEnabled(true);
+		launcher.addInputResource("./src/test/java/spoon/test/query_function/testclasses");
+		launcher.run();
+		factory = launcher.getFactory();
+		classA = factory.Class().get(ClassA.class);
+		classA_privateChild = factory.Class().get(ClassA.class.getName()+"$PrivateChildA");
+		classA_protectedChild = factory.Class().get(ClassA.class.getName()+"$ProtectedChildA");
+		classA_publicChild = factory.Class().get(ClassA.class.getName()+"$PublicChildA");
+		classA_packProtChild = factory.Class().get(ClassA.class.getName()+"$PackageProtectedChildA");
+	}
+	
+	@Test
+	public void testCheckModelConsistency() {
+		//this constructor creates all nested classes, creates all fields and calls all methods and checks that each field occurrence has assigned correct literal
+		new ClassA();
+		
+		//1) search for all variable declarations with name "field" 
+		//2) check that each of them is using different identification value
+		class Context {
+			int classCount = 0;
+			Map<Integer, CtElement> unique = new HashMap<>();
+		}
+		Context context = new Context();
+		
+		factory.Package().getRootPackage().filterChildren((CtElement e)->{
+			if (e instanceof CtType) {
+				context.classCount++;
+			}
+			if (e instanceof CtVariable) {
+				CtVariable<?> var = (CtVariable<?>) e;
+				if("field".equals(var.getSimpleName())==false) {
+					return false;
+				}
+				//check only these variables whose name is "field"
+				Integer val = getLiteralValue(var);
+				CtElement ambiquous = context.unique.put(val, var);
+				if(ambiquous!=null) {
+					fail("Two variables ["+ambiquous.toString()+","+var.toString()+"] has same value");
+				}
+			}
+			return false;
+		}).list();
+		assertEquals(countOfModelClasses, context.classCount);
+	}
+
+	private void checkVariableAccess(CtVariable<?> var, int value, CtConsumableFunction<?> query) {
+		class Context {
+			int classCount = 0;
+			int realCount = 0;
+			int expectedCount = 0;
+			Set<String> unique = new HashSet<>();
+		}
+		Context context = new Context();
+		//use FieldReferenceQuery to found all occurences of the field
+		var.map(query).forEach((CtVariableReference<?> fr)->{
+			//check that all the found field references has same right hand expression
+			assertEquals(value, getVariableReferenceValue(fr));
+			context.realCount++;
+		});
+		//use filterChildren to scan all field references and count the number of field references which has same value => expectedCount
+		factory.Package().getRootPackage().filterChildren((CtElement e)->{
+			if (e instanceof CtType) {
+				context.classCount++;
+			}
+			if (e instanceof CtVariableReference) {
+				CtVariableReference<?> fr = (CtVariableReference<?>) e;
+				if("field".equals(fr.getSimpleName())==false) {
+					return false;
+				}
+				int refValue = getVariableReferenceValue(fr);
+				if(refValue<0) {
+					fail();
+				}
+				if(refValue==value) {
+					context.expectedCount++;
+				}
+			}
+			return false;
+		}).list();
+		//check that we are counting the correct set of classes. Update this number when you change the model
+		//check that both scans found same number of references
+		assertEquals("field="+value, context.expectedCount, context.realCount);
+		System.out.println("field="+value+" found "+context.realCount+" referenes");
+	}
+	
+	private int getVariableReferenceValue(CtVariableReference<?> fr) {
+		CtBinaryOperator binOp = fr.getParent(CtBinaryOperator.class);
+		if(binOp==null) {
+			if (fr instanceof CtCatchVariableReference) {
+				return getCommentValue(fr);
+			}
+			return -1;
+		}
+		return getLiteralValue(binOp.getRightHandOperand());
+	}
+
+	private Integer getLiteralValue(CtVariable<?> var) {
+		CtExpression<?> exp = var.getDefaultExpression();
+		if(exp!=null) {
+			return getLiteralValue(exp);
+		}
+		if (var instanceof CtParameter) {
+			CtParameter param = (CtParameter) var;
+			CtExecutable<?> l_exec = param.getParent(CtExecutable.class);
+			int l_argIdx = l_exec.getParameters().indexOf(param);
+			assertTrue(l_argIdx>=0);
+			CtExecutableReference<?> l_execRef = l_exec.getReference();
+			List<CtAbstractInvocation<?>> list = l_exec.getFactory().Package().getRootPackage().filterChildren((CtAbstractInvocation inv)->{
+				return inv.getExecutable().equals(l_execRef);
+			}).list();
+			assertEquals(1, list.size());
+			CtAbstractInvocation inv = list.get(0);
+			return getLiteralValue((CtExpression<?>)inv.getArguments().get(l_argIdx));
+		}
+		if(var instanceof CtCatchVariable) {
+			return getCommentValue(var);
+		}
+		throw new AssertionError("Unexpected variable "+var.toString());
+	}
+	
+	private int getCommentValue(CtElement e) {
+		while(true) {
+			if(e==null) {
+				return -1;
+			}
+			if(e.getComments().isEmpty()==false) {
+				break;
+			}
+			e = e.getParent();
+		}
+		if(e.getComments().size()==1) {
+			String l_c = e.getComments().get(0).getContent();
+			return Integer.parseInt(l_c);
+		}
+		return -1;
+	}
+	
+	private Integer getLiteralValue(CtExpression<?> exp) {
+		return ((CtLiteral<Integer>) exp).getValue();
+	}
+	
+	private SourcePosition getPosition(CtElement e) {
+		SourcePosition sp = e.getPosition();
+		while(sp instanceof NoSourcePosition) {
+			e = e.getParent();
+			if(e==null) {
+				break;
+			}
+			sp = e.getPosition();
+		}
+		return sp;
+	}
+
+}

--- a/src/test/java/spoon/test/query_function/testclasses/packageA/ClassA.java
+++ b/src/test/java/spoon/test/query_function/testclasses/packageA/ClassA.java
@@ -1,0 +1,169 @@
+package spoon.test.query_function.testclasses.packageA;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * There are several fields/variables with name "field" in this class. Each of them has assigned different ID
+ */
+public class ClassA {
+	
+	int field = 0;
+	
+	PrivateChildA c1 = new PrivateChildA(5);
+	ProtectedChildA c2 = new ProtectedChildA(6);
+	PublicChildA c3 = new PublicChildA(7);
+	PackageProtectedChildA c4 = new PackageProtectedChildA(8);
+	
+
+	public ClassA() {
+		int field = 1;
+		assertTrue(field == 1);
+		assertTrue(this.field == 0);
+		
+		assertTrue(this.c1.field == 3);
+		assertTrue(this.c2.field == 9);
+		assertTrue(this.c3.field == 10);
+		assertTrue(this.c4.field == 11);
+		
+		this.c1.m(4);
+		this.c2.m(12);
+		this.c3.m(13);
+		this.c4.m(14);
+		
+		m();
+	}
+	
+	void m() {
+		assertTrue(field == 0);
+		assertTrue(this.field == 0);
+		assertTrue(ClassA.this.field == 0);
+		assertTrue(ClassA.this.c1.field == 3);
+		assertTrue(ClassA.this.c2.field == 9);
+		assertTrue(ClassA.this.c3.field == 10);
+		assertTrue(ClassA.this.c4.field == 11);
+		{
+			int field = 15;
+			assertTrue(field == 15);
+		}
+		try
+		{
+			int field = 16;
+			assertTrue(field == 16);
+			throw new IllegalArgumentException();
+		}
+		catch(IllegalArgumentException e) {
+			int field = 17;
+			assertTrue(field == 17);
+		}
+		catch(Exception /*21*/field) {
+			//21
+			field.getMessage();
+		}
+		while(true) {
+			int field = 18;
+			assertTrue(field == 18);
+			break;
+		}
+		switch(7) {
+		case 7:
+			int field=19;
+			assertTrue(field == 19);
+			break;
+		}
+		{
+			int field=22;
+			assertTrue(field == 22);
+			{
+				assertTrue(field == 22);
+				assertTrue(this.field == 0);
+				assertTrue(ClassA.this.field == 0);
+				assertTrue(ClassA.this.c1.field == 3);
+				assertTrue(ClassA.this.c2.field == 9);
+				assertTrue(ClassA.this.c3.field == 10);
+				assertTrue(ClassA.this.c4.field == 11);
+			}
+			
+		}
+		int field=20;
+		assertTrue(field == 20);
+		{
+			assertTrue(field == 20);
+			assertTrue(this.field == 0);
+			assertTrue(ClassA.this.field == 0);
+			assertTrue(ClassA.this.c1.field == 3);
+			assertTrue(ClassA.this.c2.field == 9);
+			assertTrue(ClassA.this.c3.field == 10);
+			assertTrue(ClassA.this.c4.field == 11);
+		}
+	}
+	
+	
+	private class PrivateChildA {
+		int field = 3;
+		
+		PrivateChildA(int field) {
+			assertTrue(field == 5);
+			assertTrue(this.field == 3);
+			assertTrue(field == 5);
+		}
+		
+		void m(int field) {
+			assertTrue(field == 4);
+			assertTrue(ClassA.this.field == 0);
+			assertTrue(this.field == 3);
+			assertTrue(ClassA.this.c1.field == 3);
+			assertTrue(ClassA.this.c2.field == 9);
+			assertTrue(ClassA.this.c3.field == 10);
+			assertTrue(ClassA.this.c4.field == 11);
+		}
+	}
+	
+	protected class ProtectedChildA {
+		int field = 9;
+		ProtectedChildA(int field) {
+			assertTrue(field == 6);
+		}
+		void m(int field) {
+			assertTrue(field == 12);
+			assertTrue(this.field == 9);
+			assertTrue(ClassA.this.field == 0);
+			assertTrue(ClassA.this.c1.field == 3);
+			assertTrue(ClassA.this.c2.field == 9);
+			assertTrue(ClassA.this.c3.field == 10);
+			assertTrue(ClassA.this.c4.field == 11);
+		}
+	}
+	
+	public class PublicChildA {
+		int field = 10;
+		PublicChildA(int field) {
+			assertTrue(field == 7);
+		}
+		void m(int field) {
+			assertTrue(field == 13);
+			assertTrue(this.field == 10);
+			assertTrue(ClassA.this.field == 0);
+			assertTrue(ClassA.this.c1.field == 3);
+			assertTrue(ClassA.this.c2.field == 9);
+			assertTrue(ClassA.this.c3.field == 10);
+			assertTrue(ClassA.this.c4.field == 11);
+		}
+		
+	}
+
+	class PackageProtectedChildA {
+		int field = 11;
+		PackageProtectedChildA(int field) {
+			assertTrue(field == 8);
+		}
+		void m(int field) {
+			assertTrue(field == 14);
+			assertTrue(this.field == 11);
+			assertTrue(ClassA.this.field == 0);
+			assertTrue(ClassA.this.c1.field == 3);
+			assertTrue(ClassA.this.c2.field == 9);
+			assertTrue(ClassA.this.c3.field == 10);
+			assertTrue(ClassA.this.c4.field == 11);
+		}
+	}
+}


### PR DESCRIPTION
First query of the set of PRs, which will be produced from #1114. It is the simplest one - good one to discuss basic topics.

Please decide:
Q1) Is the package `spoon.reflect.visitor.query` OK?

Q2) I am not sure with the `filter` field, which does filtering of elements in scope of parameter visibility. It would be simpler to have query, which simply returns all elements in scope of parameter. And if somebody wants to filter them then s/he can apply `CtQuery#map` in next query step. But it is true that actually I need filtering in all use cases of `ParameterScopeQuery`, so may be it is correct.

Any other feedback/idea?