### PR TITLE
review FieldReferenceFunction, FieldScopeFunction, SubtypeFilter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
@@ -43,7 +43,7 @@ public class FieldReferenceFunction implements CtConsumableFunction<CtField<?>> 
 	public void apply(CtField<?> field, CtConsumer<Object> outputConsumer) {
 		field
 			.map(new FieldScopeFunction())
-			.filter(new DirectReferenceFilter<CtFieldReference<?>>(field.getReference()))
+			.select(new DirectReferenceFilter<CtFieldReference<?>>(field.getReference()))
 			.forEach(outputConsumer);
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+
+/**
+ * This Query expects a {@link CtField} as input
+ * and returns all {@link CtFieldReference}s, which refers this input.
+ * <br>
+ * Usage:<br>
+ * <pre> {@code
+ * CtField param = ...;
+ * param
+ *   .map(new FieldReferenceFunction())
+ *   .forEach((CtFieldReference ref)->...process references...);
+ * }
+ * </pre>
+ */
+public class FieldReferenceFunction implements CtConsumableFunction<CtField<?>> {
+
+	public FieldReferenceFunction() {
+	}
+
+	@Override
+	public void apply(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		field
+			.map(new FieldScopeFunction())
+			.filter(new DirectReferenceFilter<CtFieldReference<?>>(field.getReference()))
+			.forEach(outputConsumer);
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
@@ -56,13 +56,13 @@ public class FieldScopeFunction implements CtConsumableFunction<CtField<?>> {
 		}
 	}
 	protected void searchForPrivateField(CtField<?> field, CtConsumer<Object> outputConsumer) {
-		//private field can be referred from the scope of current top level type only
+		//private field can be referred from the scope of current top level type only and children
 		field.getTopLevelType()
 			.filterChildren(null)
 			.forEach(outputConsumer);
 	}
 	protected void searchForProtectedField(CtField<?> field, CtConsumer<Object> outputConsumer) {
-		//protected field can be referred from the scope of current top level type only
+		//protected field can be referred from the scope of current top level type only and children
 		field.getFactory().getModel().getRootPackage()
 			//search for all types which inherits from declaring type of this field
 			.filterChildren(new SubtypeFilter(field.getDeclaringType().getReference()))

--- a/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+
+/**
+ * This Query expects a {@link CtField} as input
+ * and returns all CtElements,
+ * which are in visibility scope of that field.
+ * In other words, it returns all elements,
+ * which might be reference to that field.
+ * <br>
+ * It can be used to search for variable declarations or
+ * variable references which might be in name conflict with input field.
+ * <br>
+ * Usage:<br>
+ * <pre> {@code
+ * CtField param = ...;
+ * param.map(new FieldScopeFunction()).forEach(...process result...);
+ * }
+ * </pre>
+ */
+public class FieldScopeFunction implements CtConsumableFunction<CtField<?>> {
+
+	public FieldScopeFunction() {
+	}
+
+	@Override
+	public void apply(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		if (field.hasModifier(ModifierKind.PRIVATE)) {
+			searchForPrivateField(field, outputConsumer);
+		} else if (field.hasModifier(ModifierKind.PUBLIC)) {
+			searchForPublicField(field, outputConsumer);
+		} else if (field.hasModifier(ModifierKind.PROTECTED)) {
+			searchForProtectedField(field, outputConsumer);
+		} else {
+			searchForPackageProtectedField(field, outputConsumer);
+		}
+	}
+	protected void searchForPrivateField(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		//private field can be referred from the scope of current top level type only
+		field.getTopLevelType()
+			.filterChildren(null)
+			.forEach(outputConsumer);
+	}
+	protected void searchForProtectedField(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		//protected field can be referred from the scope of current top level type only
+		field.getFactory().getModel().getRootPackage()
+			//search for all types which inherits from declaring type of this field
+			.filterChildren(new SubtypeFilter(field.getDeclaringType().getReference()))
+			//visit all elements in scope of these inherited types
+			.filterChildren(null)
+			.forEach(outputConsumer);
+	}
+	protected void searchForPublicField(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		//public field is visible everywhere
+		field.getFactory().getModel().getRootPackage()
+			//visit all children of root package
+			.filterChildren(null)
+			.forEach(outputConsumer);
+	}
+	protected void searchForPackageProtectedField(CtField<?> field, CtConsumer<Object> outputConsumer) {
+		//package protected fields are visible in scope of the package of the top level type of the `field`
+		field.getTopLevelType().getPackage()
+			//visit all children of package, where top level type of the field is declared
+			.filterChildren(null)
+			.forEach(outputConsumer);
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/filter/SubtypeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubtypeFilter.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Filter;
+
+/**
+ * Matches all CtType elements, which are sub type of {@link #superType}
+ * Matches the input `superType` too.
+ * Call {@link #includingSelf(boolean)} with value false, if instance of {@link #superType} should no match this {@link Filter}
+ */
+public class SubtypeFilter extends AbstractFilter<CtType<?>> {
+
+	private CtTypeReference<?> superType;
+	private String superTypeQualifiedName;
+
+	public SubtypeFilter(CtTypeReference<?> superType) {
+		this.superType = superType;
+	}
+
+	/**
+	 * @param includingSelf if false then element which is equal to to #superType is not matching
+	 */
+	public SubtypeFilter includingSelf(boolean includingSelf) {
+		if (includingSelf) {
+			superTypeQualifiedName = null;
+		} else {
+			superTypeQualifiedName = superType.getQualifiedName();
+		}
+		return this;
+	}
+
+	@Override
+	public boolean matches(CtType<?> mayBeSubType) {
+		if (superTypeQualifiedName != null && superTypeQualifiedName.equals(mayBeSubType.getQualifiedName())) {
+			//we should not accept superType
+			return false;
+		}
+		return mayBeSubType.isSubtypeOf(superType);
+	}
+}

--- a/src/test/java/spoon/test/query_function/QueryTest.java
+++ b/src/test/java/spoon/test/query_function/QueryTest.java
@@ -28,7 +28,9 @@ import spoon.reflect.visitor.filter.CatchVariableReferenceFunction;
 import spoon.reflect.visitor.filter.FieldReferenceFunction;
 import spoon.reflect.visitor.filter.LocalVariableReferenceFunction;
 import spoon.reflect.visitor.filter.ParameterReferenceFunction;
+import spoon.test.query_function.testclasses.ClassC;
 import spoon.test.query_function.testclasses.packageA.ClassA;
+import spoon.test.query_function.testclasses.packageA.ClassB;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,7 +44,7 @@ import static org.junit.Assert.fail;
 
 public class QueryTest {
 	
-	static int countOfModelClasses = 5;
+	static int countOfModelClasses = 12;
 
 	Factory factory;
 	CtClass<?> classA;
@@ -70,6 +72,9 @@ public class QueryTest {
 	public void testCheckModelConsistency() {
 		//this constructor creates all nested classes, creates all fields and calls all methods and checks that each field occurrence has assigned correct literal
 		new ClassA();
+		new ClassB();
+		new spoon.test.query_function.testclasses.packageB.ClassA();
+		new ClassC();
 		
 		//1) search for all variable declarations with name "field" 
 		//2) check that each of them is using different identification value
@@ -97,7 +102,7 @@ public class QueryTest {
 			}
 			return false;
 		}).list();
-		assertEquals(countOfModelClasses, context.classCount);
+		assertEquals("Update count of model classes:", countOfModelClasses, context.classCount);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/query_function/QueryTest.java
+++ b/src/test/java/spoon/test/query_function/QueryTest.java
@@ -15,6 +15,7 @@ import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtVariable;
@@ -24,6 +25,7 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.filter.CatchVariableReferenceFunction;
+import spoon.reflect.visitor.filter.FieldReferenceFunction;
 import spoon.reflect.visitor.filter.LocalVariableReferenceFunction;
 import spoon.reflect.visitor.filter.ParameterReferenceFunction;
 import spoon.test.query_function.testclasses.packageA.ClassA;
@@ -145,6 +147,22 @@ public class QueryTest {
 			return false;
 		}).list();
 	}	
+
+	@Test
+	public void testFieldReferenceFunction() throws Exception {
+		//visits all the CtField elements whose name is "field" and search for all their references
+		//The test detects whether found references are correct by these two checks:
+		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
+		//2) the model is searched for all variable references which has same identification number and counts them
+		//Then it checks that counted number of references and found number of references is same 
+		factory.Package().getRootPackage().filterChildren((CtField<?> var)->{
+			if(var.getSimpleName().equals("field")) {
+				int value = getLiteralValue(var);
+				checkVariableAccess(var, value, new FieldReferenceFunction());
+			}
+			return false;
+		}).list();
+	}
 
 	private void checkVariableAccess(CtVariable<?> var, int value, CtConsumableFunction<?> query) {
 		class Context {

--- a/src/test/java/spoon/test/query_function/testclasses/ClassC.java
+++ b/src/test/java/spoon/test/query_function/testclasses/ClassC.java
@@ -1,0 +1,22 @@
+package spoon.test.query_function.testclasses;
+
+import static org.junit.Assert.assertTrue;
+
+public class ClassC {
+
+	//package protected field
+	int field = 300;
+	int packageProtectedField = 301;
+	private int privateField = 302;
+	protected int protectedField = 303;
+	public int publicField = 304;
+	
+	public ClassC() {
+		assertTrue(field == 300);
+		assertTrue(packageProtectedField == 301);
+		assertTrue(privateField == 302);
+		assertTrue(protectedField == 303);
+		assertTrue(publicField == 304);
+	}
+
+}

--- a/src/test/java/spoon/test/query_function/testclasses/packageA/ClassA.java
+++ b/src/test/java/spoon/test/query_function/testclasses/packageA/ClassA.java
@@ -2,12 +2,20 @@ package spoon.test.query_function.testclasses.packageA;
 
 import static org.junit.Assert.assertTrue;
 
+import spoon.test.query_function.testclasses.ClassC;
+
 /**
  * There are several fields/variables with name "field" in this class. Each of them has assigned different ID
  */
 public class ClassA {
 	
 	int field = 0;
+	
+	int packageProtectedField = 501;
+	private int privateField = 502;
+	protected int protectedField = 503;
+	public int publicField = 504;
+	
 	
 	PrivateChildA c1 = new PrivateChildA(5);
 	ProtectedChildA c2 = new ProtectedChildA(6);
@@ -18,6 +26,11 @@ public class ClassA {
 	public ClassA() {
 		int field = 1;
 		assertTrue(field == 1);
+		assertTrue(packageProtectedField == 501);
+		assertTrue(privateField == 502);
+		assertTrue(protectedField == 503);
+		assertTrue(publicField == 504);
+
 		assertTrue(this.field == 0);
 		
 		assertTrue(this.c1.field == 3);
@@ -31,6 +44,27 @@ public class ClassA {
 		this.c4.m(14);
 		
 		m();
+		
+		ClassB classB = new ClassB();
+		assertTrue(classB.field == 200);
+		assertTrue(classB.packageProtectedField == 201);
+		assertTrue(classB.protectedField == 203);
+		assertTrue(classB.publicField == 204);
+
+		ClassC classC = new ClassC();
+//		assertTrue(classC.field == 300);
+//		assertTrue(classC.packageProtectedField == 301);
+//		assertTrue(classC.protectedField == 303);
+		assertTrue(classC.publicField == 304);
+		
+		assertTrue(packageProtectedField == 501);
+		assertTrue(ClassA.this.packageProtectedField == 501);
+		assertTrue(privateField == 502);
+		assertTrue(ClassA.this.privateField == 502);
+		assertTrue(protectedField == 503);
+		assertTrue(ClassA.this.protectedField == 503);
+		assertTrue(publicField == 504);
+		assertTrue(ClassA.this.publicField == 504);
 	}
 	
 	void m() {
@@ -98,7 +132,7 @@ public class ClassA {
 	}
 	
 	
-	private class PrivateChildA {
+	private class PrivateChildA extends ClassB {
 		int field = 3;
 		
 		PrivateChildA(int field) {
@@ -115,10 +149,29 @@ public class ClassA {
 			assertTrue(ClassA.this.c2.field == 9);
 			assertTrue(ClassA.this.c3.field == 10);
 			assertTrue(ClassA.this.c4.field == 11);
+			
+			assertTrue(super.field == 200);
+			assertTrue(packageProtectedField == 201);
+			assertTrue(super.packageProtectedField == 201);
+//			assertTrue(privateField == 202);
+			assertTrue(protectedField == 203);
+			assertTrue(super.protectedField == 203);
+			assertTrue(publicField == 204);
+			assertTrue(super.publicField == 204);
+			
+//			assertTrue(packageProtectedField == 501);
+			assertTrue(ClassA.this.packageProtectedField == 501);
+			assertTrue(privateField == 502);
+			assertTrue(ClassA.this.privateField == 502);
+//			assertTrue(protectedField == 503);
+			assertTrue(ClassA.this.protectedField == 503);
+//			assertTrue(publicField == 504);
+			assertTrue(ClassA.this.publicField == 504);
+
 		}
 	}
 	
-	protected class ProtectedChildA {
+	protected class ProtectedChildA extends ClassC {
 		int field = 9;
 		ProtectedChildA(int field) {
 			assertTrue(field == 6);
@@ -131,22 +184,57 @@ public class ClassA {
 			assertTrue(ClassA.this.c2.field == 9);
 			assertTrue(ClassA.this.c3.field == 10);
 			assertTrue(ClassA.this.c4.field == 11);
+
+//			assertTrue(super.field == 300);
+//			assertTrue(packageProtectedField == 301);
+//			assertTrue(super.packageProtectedField == 301);
+//			assertTrue(privateField == 302);
+			assertTrue(protectedField == 303);
+			assertTrue(super.protectedField == 303);
+			assertTrue(publicField == 304);
+			assertTrue(super.publicField == 304);
+			
+			assertTrue(packageProtectedField == 501);
+			assertTrue(ClassA.this.packageProtectedField == 501);
+			assertTrue(privateField == 502);
+			assertTrue(ClassA.this.privateField == 502);
+			assertTrue(ClassA.this.protectedField == 503);
+			assertTrue(ClassA.this.publicField == 504);
 		}
 	}
 	
 	public class PublicChildA {
 		int field = 10;
+		
+		int packageProtectedField = 401;
+		private int privateField = 402;
+		protected int protectedField = 403;
+		public int publicField = 404;
+		
 		PublicChildA(int field) {
 			assertTrue(field == 7);
 		}
 		void m(int field) {
 			assertTrue(field == 13);
+			assertTrue(packageProtectedField == 401);
+			assertTrue(privateField == 402);
+			assertTrue(protectedField == 403);
+			assertTrue(publicField == 404);
 			assertTrue(this.field == 10);
 			assertTrue(ClassA.this.field == 0);
 			assertTrue(ClassA.this.c1.field == 3);
 			assertTrue(ClassA.this.c2.field == 9);
 			assertTrue(ClassA.this.c3.field == 10);
 			assertTrue(ClassA.this.c4.field == 11);
+			
+//			assertTrue(packageProtectedField == 501);
+			assertTrue(ClassA.this.packageProtectedField == 501);
+//			assertTrue(privateField == 502);
+			assertTrue(ClassA.this.privateField == 502);
+//			assertTrue(protectedField == 503);
+			assertTrue(ClassA.this.protectedField == 503);
+//			assertTrue(publicField == 504);
+			assertTrue(ClassA.this.publicField == 504);
 		}
 		
 	}

--- a/src/test/java/spoon/test/query_function/testclasses/packageA/ClassB.java
+++ b/src/test/java/spoon/test/query_function/testclasses/packageA/ClassB.java
@@ -1,0 +1,22 @@
+package spoon.test.query_function.testclasses.packageA;
+
+import static org.junit.Assert.assertTrue;
+
+public class ClassB {
+
+	//package protected field
+	int field = 200;
+	int packageProtectedField = 201;
+	private int privateField = 202;
+	protected int protectedField = 203;
+	public int publicField = 204;
+	
+	public ClassB() {
+		assertTrue(field == 200);
+		assertTrue(packageProtectedField == 201);
+		assertTrue(privateField == 202);
+		assertTrue(protectedField == 203);
+		assertTrue(publicField == 204);
+	}
+
+}

--- a/src/test/java/spoon/test/query_function/testclasses/packageB/ClassA.java
+++ b/src/test/java/spoon/test/query_function/testclasses/packageB/ClassA.java
@@ -1,0 +1,191 @@
+package spoon.test.query_function.testclasses.packageB;
+
+import static org.junit.Assert.assertTrue;
+
+import spoon.test.query_function.testclasses.packageA.ClassB;
+
+/**
+ * There are several fields/variables with name "field" in this class. Each of them has assigned different ID
+ * This ...packageB.ClassA is a copy of structure from packageA.ClassA, including same name - to create ambiguity as much as possible to test variable searching algorithms 
+ * - with new IDs
+ * - with fields packageA.ClassA 
+ */
+public class ClassA {
+	
+	int field = 100;
+	
+	PrivateChildA c1 = new PrivateChildA(105);
+	ProtectedChildA c2 = new ProtectedChildA(106);
+	PublicChildA c3 = new PublicChildA(107);
+	PackageProtectedChildA c4 = new PackageProtectedChildA(108);
+	
+
+	public ClassA() {
+		int field = 101;
+		assertTrue(field == 101);
+		assertTrue(this.field == 100);
+		
+		assertTrue(this.c1.field == 103);
+		assertTrue(this.c2.field == 109);
+		assertTrue(this.c3.field == 110);
+		assertTrue(this.c4.field == 111);
+		
+		this.c1.m(104);
+		this.c2.m(112);
+		this.c3.m(113);
+		this.c4.m(114);
+		
+		m();
+		
+		ClassB classB = new ClassB();
+		//these fields are not accessible
+//		assertTrue(classB.field == 200);
+//		assertTrue(classB.packageProtectedField == 201);
+//		assertTrue(classB.protectedField == 203);
+		assertTrue(classB.publicField == 204);
+	}
+	
+	void m() {
+		assertTrue(field == 100);
+		assertTrue(this.field == 100);
+		assertTrue(ClassA.this.field == 100);
+		assertTrue(ClassA.this.c1.field == 103);
+		assertTrue(ClassA.this.c2.field == 109);
+		assertTrue(ClassA.this.c3.field == 110);
+		assertTrue(ClassA.this.c4.field == 111);
+		{
+			int field = 115;
+			assertTrue(field == 115);
+		}
+		try
+		{
+			int field = 116;
+			assertTrue(field == 116);
+			throw new IllegalArgumentException();
+		}
+		catch(IllegalArgumentException e) {
+			int field = 117;
+			assertTrue(field == 117);
+		}
+		catch(Exception /*121*/field) {
+			//121
+			field.getMessage();
+		}
+		while(true) {
+			int field = 118;
+			assertTrue(field == 118);
+			break;
+		}
+		switch(7) {
+		case 7:
+			int field=119;
+			assertTrue(field == 119);
+			break;
+		}
+		{
+			int field=122;
+			assertTrue(field == 122);
+			{
+				assertTrue(field == 122);
+				assertTrue(this.field == 100);
+				assertTrue(ClassA.this.field == 100);
+				assertTrue(ClassA.this.c1.field == 103);
+				assertTrue(ClassA.this.c2.field == 109);
+				assertTrue(ClassA.this.c3.field == 110);
+				assertTrue(ClassA.this.c4.field == 111);
+			}
+			
+		}
+		int field=120;
+		assertTrue(field == 120);
+		{
+			assertTrue(field == 120);
+			assertTrue(this.field == 100);
+			assertTrue(ClassA.this.field == 100);
+			assertTrue(ClassA.this.c1.field == 103);
+			assertTrue(ClassA.this.c2.field == 109);
+			assertTrue(ClassA.this.c3.field == 110);
+			assertTrue(ClassA.this.c4.field == 111);
+		}
+	}
+	
+	
+	private class PrivateChildA extends ClassB {
+		int field = 103;
+		
+		PrivateChildA(int field) {
+			assertTrue(field == 105);
+			assertTrue(this.field == 103);
+			assertTrue(field == 105);
+		}
+		
+		void m(int field) {
+			assertTrue(field == 104);
+			assertTrue(ClassA.this.field == 100);
+			assertTrue(this.field == 103);
+			assertTrue(ClassA.this.c1.field == 103);
+			assertTrue(ClassA.this.c2.field == 109);
+			assertTrue(ClassA.this.c3.field == 110);
+			assertTrue(ClassA.this.c4.field == 111);
+			
+//			assertTrue(super.field == 200);
+//			assertTrue(packageProtectedField == 201);
+//			assertTrue(super.packageProtectedField == 201);
+//			assertTrue(privateField == 202);
+			assertTrue(protectedField == 203);
+			assertTrue(super.protectedField == 203);
+			assertTrue(publicField == 204);
+			assertTrue(super.publicField == 204);
+			
+		}
+	}
+	
+	protected class ProtectedChildA {
+		int field = 109;
+		ProtectedChildA(int field) {
+			assertTrue(field == 106);
+		}
+		void m(int field) {
+			assertTrue(field == 112);
+			assertTrue(this.field == 109);
+			assertTrue(ClassA.this.field == 100);
+			assertTrue(ClassA.this.c1.field == 103);
+			assertTrue(ClassA.this.c2.field == 109);
+			assertTrue(ClassA.this.c3.field == 110);
+			assertTrue(ClassA.this.c4.field == 111);
+		}
+	}
+	
+	public class PublicChildA {
+		int field = 110;
+		PublicChildA(int field) {
+			assertTrue(field == 107);
+		}
+		void m(int field) {
+			assertTrue(field == 113);
+			assertTrue(this.field == 110);
+			assertTrue(ClassA.this.field == 100);
+			assertTrue(ClassA.this.c1.field == 103);
+			assertTrue(ClassA.this.c2.field == 109);
+			assertTrue(ClassA.this.c3.field == 110);
+			assertTrue(ClassA.this.c4.field == 111);
+		}
+		
+	}
+
+	class PackageProtectedChildA {
+		int field = 111;
+		PackageProtectedChildA(int field) {
+			assertTrue(field == 108);
+		}
+		void m(int field) {
+			assertTrue(field == 114);
+			assertTrue(this.field == 111);
+			assertTrue(ClassA.this.field == 100);
+			assertTrue(ClassA.this.c1.field == 103);
+			assertTrue(ClassA.this.c2.field == 109);
+			assertTrue(ClassA.this.c3.field == 110);
+			assertTrue(ClassA.this.c4.field == 111);
+		}
+	}
+}


### PR DESCRIPTION
This PR contains FieldReferenceFunction, FieldScopeFunction, SubtypeFilter.
The main purpose is FieldReferenceFunction, which returns all the references to the field. Other two are helper classes which might be useful for others so they are public.

It depends on these PRs
* CtQuery#filter(Filter) #1142
* CtQuery#filterChildren(null) #1140

The tests will be added later, because they share a lot with tests of #1136