### PR TITLE
feature CtQuery#select(Filter)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
@@ -53,6 +53,16 @@ public interface CtQuery extends CtQueryable {
 	@Override
 	<R extends CtElement> CtQuery filterChildren(Filter<R> filter);
 
+	/**
+	 * The matched element for which (filter.matches(element)==true) is sent to the next query step.
+	 *
+	 * The elements which throw {@link ClassCastException} during {@link Filter#matches(CtElement)}
+	 * are considered as **not matching**, ie. are excluded.
+	 *
+	 * @param filter used to detect if input element can pass to next query step
+	 * @return this to support fluent API
+	 */
+	<R extends CtElement> CtQuery select(Filter<R> filter);
 
 	/**
 	 * Query elements based on a function, the behavior depends on the return type of the function.

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -126,6 +126,18 @@ public class CtQueryImpl implements CtQuery {
 		return this;
 	}
 
+	@Override
+	public <R extends CtElement> CtQueryImpl select(final Filter<R> filter) {
+		map(new CtFunction<R, Boolean>() {
+			@Override
+			public Boolean apply(R input) {
+				return filter.matches(input);
+			}
+		});
+		stepFailurePolicy(QueryFailurePolicy.IGNORE);
+		return this;
+	}
+
 	/**
 	 * Evaluates this query, ignoring bound input - if any
 	 *

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -535,6 +535,20 @@ public class FilterTest {
 	}
 	
 	@Test
+	public void testFilterQueryStep() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });
+		launcher.addInputResource("./src/test/java/spoon/test/filters/testclasses");
+		launcher.run();
+		
+		//Contract: the filter(Filter) can be used to detect if input of query step should pass to next query step.
+		List<CtElement> realList = launcher.getFactory().Package().getRootPackage().filterChildren(e->{return true;}).select(new TypeFilter<>(CtClass.class)).list();
+		List<CtElement> expectedList = launcher.getFactory().Package().getRootPackage().filterChildren(new TypeFilter<>(CtClass.class)).list();
+		assertArrayEquals(expectedList.toArray(), realList.toArray());
+		assertTrue(expectedList.size()>0);
+	}
+
+	@Test
 	public void testFunctionQueryStep() throws Exception {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });


### PR DESCRIPTION
Actually Filter can be used as mapping function this way:
```java
Filter filter = new SomeFilter();
element.map(new CtFunction<R, Boolean>() {
	@Override
	public Boolean apply(R input) {
		return filter.matches(input);
	}
}).failurePolicy(QueryFailurePolicy.IGNORE);
```
There are these problems:
* I needed 2 minutes to write it and 1h to found that failurePolicy must be added too - and as a author I know the queries the best - so current way how legacy filters can be used is ugly and error prone.
* the failurePolicy is set to whole query, but it should be set only to the query step which uses the filter. Internally there is already a `CtQueryImpl#stepFailurePolicy`, which should be therefore called instead, but then the code would be even more ugly.

So this PR allows to write:
```java
element.filter(new SomeFilter());
```