### PR TITLE
review: feature: ParentFunction

### DIFF
--- a/src/main/java/spoon/reflect/CtModelImpl.java
+++ b/src/main/java/spoon/reflect/CtModelImpl.java
@@ -51,7 +51,12 @@ public class CtModelImpl implements CtModel {
 				public CtElement getParent() throws ParentNotInitializedException {
 					return null;
 				}
-							});
+
+				@Override
+				public Factory getFactory() {
+					return CtRootPackage.this.getFactory();
+				}
+			});
 		}
 
 		@Override

--- a/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+
+/**
+ * This Function expects a {@link CtElement} as input
+ * and returns all parents of this element.
+ *
+ * By default input is not returned,
+ * but this behavior can be changed by call of {@link #includingSelf(boolean)} with value true
+ */
+public class ParentFunction implements CtConsumableFunction<CtElement> {
+
+	private boolean includingSelf = false;
+
+	public ParentFunction() {
+	}
+
+	/**
+	 * @param includingSelf if true then input element is sent to output too. By default it is false.
+	 */
+	public ParentFunction includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
+	}
+
+	@Override
+	public void apply(CtElement input, CtConsumer<Object> outputConsumer) {
+		if (includingSelf) {
+			outputConsumer.accept(input);
+		}
+		CtElement parent = input;
+		while (parent != null) {
+			parent = parent.getParent();
+			outputConsumer.accept(parent);
+		}
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
@@ -17,6 +17,7 @@
 package spoon.reflect.visitor.filter;
 
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 
@@ -44,11 +45,15 @@ public class ParentFunction implements CtConsumableFunction<CtElement> {
 
 	@Override
 	public void apply(CtElement input, CtConsumer<Object> outputConsumer) {
+		if (input == null) {
+			return;
+		}
 		if (includingSelf) {
 			outputConsumer.accept(input);
 		}
+		CtPackage rootPackage = input.getFactory().getModel().getRootPackage();
 		CtElement parent = input;
-		while (parent != null) {
+		while (parent != null && parent != rootPackage) {
 			parent = parent.getParent();
 			outputConsumer.accept(parent);
 		}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -937,16 +937,21 @@ public class FilterTest {
 		
 		Context context = new Context();
 		
-		context.expectedParent = varStrings.getParent();
+		context.expectedParent = varStrings;
 		
 		varStrings.map(new ParentFunction()).forEach((parent)->{
+			context.expectedParent = context.expectedParent.getParent();
 			assertSame(context.expectedParent, parent);
-			if(context.expectedParent.getParent()!=null) {
-				context.expectedParent = context.expectedParent.getParent();
-			}
 		});
 		
-		//Check that it visited all parents till root package
-		assertSame(launcher.getFactory().Package().getRootPackage(), context.expectedParent);
+		//context.expectedParent is last visited element
+		
+		//Check that last visited element was root package
+		assertSame(launcher.getFactory().getModel().getRootPackage(), context.expectedParent);
+		
+		//contract: if includingSelf(false), then parent of input element is first element
+		assertSame(varStrings.getParent(), varStrings.map(new ParentFunction().includingSelf(false)).first());
+		//contract: if includingSelf(true), then input element is first element
+		assertSame(varStrings, varStrings.map(new ParentFunction().includingSelf(true)).first());
 	}
 }


### PR DESCRIPTION
Implements new mapping functions, which visits all the parents of current element. 
It is needed by to LocalVariableScopeFunction to detect scope of local variable, by searching for a parent which matches some rules... will be used in next PR, which fixes LocalVariableScopeFunction for variables used in CtLoop expressions and CtTryWithResource.

Note: I have one question to the scanning of all parents. It is "Which parent is the top parent?"
If I visit parents until the getParent()==null, then I get to helper annonymous class based on CtElementImpl, which is declared in CtModelImpl$CtRootPackage$1. I guess it is not correct ... Your opinion please?
The test actually fails because the scanning does not end on RootPackage, but one level below...