### PR TITLE
Improve pretty-printer and import mechanism with static imports

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1727,7 +1727,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		for (CtType<?> t : types) {
 			imports.addAll(computeImports(t));
 		}
-
 		elementPrinterHelper.writeHeader(types, imports);
 		for (CtType<?> t : types) {
 			scan(t);

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1723,25 +1723,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		} else {
 			this.importsContext = new MinimalImportScanner();
 		}
-		Set<CtReference> importsBeforeFiltering = new HashSet<>();
-		for (CtType<?> t : types) {
-			importsBeforeFiltering.addAll(computeImports(t));
-		}
-
 		Set<CtReference> imports = new HashSet<>();
-		for (CtReference ref : importsBeforeFiltering) {
-			if (ref instanceof CtTypeReference) {
-				CtTypeReference typeRef = (CtTypeReference) ref;
-				printer.write("import " + typeRef.getQualifiedName() + ";").writeln().writeTabs();
-			} else if (ref instanceof CtExecutableReference) {
-				CtExecutableReference execRef = (CtExecutableReference) ref;
-				if (execRef.getDeclaringType() != null) {
-					printer.write("import static " + this.removeInnerTypeSeparator(execRef.getDeclaringType().getQualifiedName()) + "." + execRef.getSimpleName() + ";").writeln().writeTabs();
-				}
-			} else if (ref instanceof CtFieldReference) {
-				CtFieldReference fieldRef = (CtFieldReference) ref;
-				printer.write("import static " + this.removeInnerTypeSeparator(fieldRef.getDeclaringType().getQualifiedName()) + "." + fieldRef.getSimpleName() + ";").writeln().writeTabs();
-			}
+		for (CtType<?> t : types) {
+			imports.addAll(computeImports(t));
 		}
 
 		elementPrinterHelper.writeHeader(types, imports);

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -377,7 +377,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	 */
 	private boolean declaringTypeIsLocalOrImported(CtTypeReference declaringType) {
 		if (declaringType != null) {
-			if (isImportedInClassImports(declaringType)) {
+			if (isImportedInClassImports(declaringType) || classNamePresentInJavaLang(declaringType)) {
 				return true;
 			}
 

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -381,6 +381,10 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 				return true;
 			}
 
+			if (addClassImport(declaringType)) {
+				return true;
+			}
+
 			while (declaringType != null) {
 				if (declaringType.equals(targetType)) {
 					return true;

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
@@ -26,9 +27,13 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -44,7 +49,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 /**
@@ -63,6 +72,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	//top declaring type of that import
 	protected CtTypeReference<?> targetType;
 	private Map<String, Boolean> namesPresentInJavaLang = new HashMap<>();
+	private Set<String> fieldAndMethodsNames = new HashSet<String>();
 
 	@Override
 	public <T> void visitCtFieldRead(CtFieldRead<T> fieldRead) {
@@ -381,7 +391,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 				return true;
 			}
 
-			if (addClassImport(declaringType)) {
+			if (!isTypeInCollision(declaringType, false) && addClassImport(declaringType)) {
 				return true;
 			}
 
@@ -482,5 +492,147 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 			namesPresentInJavaLang.put(ref.getSimpleName(), presentInJavaLang);
 		}
 		return presentInJavaLang;
+	}
+
+	protected Set<String> lookForLocalVariables(CtElement parent) {
+		Set<String> result = new HashSet<>();
+
+		// try to get the block container
+		// if the first container is the class, then we are not in a block and we can quit now.
+		while (parent != null && !(parent instanceof CtBlock)) {
+			if (parent instanceof CtClass) {
+				return result;
+			}
+			parent = parent.getParent();
+		}
+
+		if (parent != null) {
+			CtBlock block = (CtBlock) parent;
+			boolean innerClass = false;
+
+			// now we have the first container block, we want to check if we're not in an inner class
+			while (parent != null && !(parent instanceof CtClass)) {
+				parent = parent.getParent();
+			}
+
+			if (parent != null) {
+				// uhoh it's not a package as a parent, we must in an inner block:
+				// let's find the last block BEFORE the class call: some collision could occur because of variables defined in that block
+				if (!(parent.getParent() instanceof CtPackage)) {
+					while (parent != null && !(parent instanceof CtBlock)) {
+						parent = parent.getParent();
+					}
+
+					if (parent != null) {
+						block = (CtBlock) parent;
+					}
+				}
+			}
+
+			AccessibleVariablesFinder avf = new AccessibleVariablesFinder(block);
+			List<CtVariable> variables = avf.find();
+
+			for (CtVariable variable : variables) {
+				result.add(variable.getSimpleName());
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Test if the reference can be imported, i.e. test if the importation could lead to a collision.
+	 * In FQN mode, it only tests the first package name: if a collision occurs with this first one, it should be imported.
+	 * @param ref
+	 * @return true if the ref should be imported.
+	 */
+	protected boolean isTypeInCollision(CtReference ref, boolean fqnMode) {
+		if (targetType.getSimpleName().equals(ref.getSimpleName()) && !targetType.equals(ref)) {
+			return true;
+		}
+
+		try {
+			CtElement parent;
+			if (ref instanceof CtTypeReference) {
+				parent = ref.getParent();
+			} else {
+				parent = ref;
+			}
+
+			Set<String> localVariablesOfBlock = new HashSet<>();
+
+			if (parent instanceof CtField) {
+				this.fieldAndMethodsNames.add(((CtField) parent).getSimpleName());
+			} else if (parent instanceof CtMethod) {
+				this.fieldAndMethodsNames.add(((CtMethod) parent).getSimpleName());
+			} else {
+				localVariablesOfBlock = this.lookForLocalVariables(parent);
+			}
+
+			while (!(parent instanceof CtPackage)) {
+				if ((parent instanceof CtFieldReference) || (parent instanceof CtExecutableReference)) {
+					CtReference parentType = (CtReference) parent;
+					LinkedList<String> qualifiedNameTokens = new LinkedList<>();
+
+					// we don't want to test the current ref name, as we risk to create field import and make autoreference
+					if (parentType != parent) {
+						qualifiedNameTokens.add(parentType.getSimpleName());
+					}
+
+					CtTypeReference typeReference;
+					if (parent instanceof CtFieldReference) {
+						typeReference = ((CtFieldReference) parent).getDeclaringType();
+					} else {
+						typeReference = ((CtExecutableReference) parent).getDeclaringType();
+					}
+
+					if (typeReference != null) {
+						qualifiedNameTokens.add(typeReference.getSimpleName());
+
+						if (typeReference.getPackage() != null) {
+							CtPackage ctPackage = typeReference.getPackage().getDeclaration();
+
+							while (ctPackage != null) {
+								qualifiedNameTokens.add(ctPackage.getSimpleName());
+
+								CtElement packParent = ctPackage.getParent();
+								if (packParent.getParent() != null && !((CtPackage) packParent).getSimpleName().equals(CtPackage.TOP_LEVEL_PACKAGE_NAME)) {
+									ctPackage = (CtPackage) packParent;
+								} else {
+									ctPackage = null;
+								}
+							}
+						}
+					}
+					if (!qualifiedNameTokens.isEmpty()) {
+						// qualified name token are ordered in the reverse order
+						// if the first package name is a variable name somewhere, it could lead to a collision
+						if (fieldAndMethodsNames.contains(qualifiedNameTokens.getLast()) || localVariablesOfBlock.contains(qualifiedNameTokens.getLast())) {
+							qualifiedNameTokens.removeLast();
+
+							if (fqnMode) {
+								return true;
+							} else {
+								// but if the other package names are not a variable name, it's ok to import
+								for (int i = qualifiedNameTokens.size() - 1; i > 0; i--) {
+									String testedToken = qualifiedNameTokens.get(i);
+									if (!fieldAndMethodsNames.contains(testedToken) && !localVariablesOfBlock.contains(testedToken)) {
+										return false;
+									}
+								}
+								return true;
+							}
+						}
+					}
+
+
+				}
+				parent = parent.getParent();
+			}
+		} catch (ParentNotInitializedException e) {
+			return false;
+		}
+
+		return false;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
@@ -28,7 +28,7 @@ import spoon.reflect.reference.CtTypeReference;
 public class MinimalImportScanner extends ImportScannerImpl implements ImportScanner {
 
 	/**
-	 * This method is very similar with @link{ImportScannerImpl#canTypeBeImported} but we import them only if there is a collision
+	 * This method use @link{ImportScannerImpl#isTypeInCollision} to import a ref only if there is a collision
 	 * @param ref
 	 * @return true if the ref should be imported.
 	 */

--- a/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
@@ -16,23 +16,10 @@
  */
 package spoon.reflect.visitor;
 
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtVariable;
-import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
-
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
 
 /**
  * A scanner dedicated to import only the necessary packages, @see spoon.test.variable.AccessFullyQualifiedTest
@@ -40,70 +27,8 @@ import java.util.Set;
  */
 public class MinimalImportScanner extends ImportScannerImpl implements ImportScanner {
 
-	private Set<String> fieldAndMethodsNames = new HashSet<String>();
-
-	private CtClass getParentClass(CtReference ref) {
-		CtElement parent = ref.getParent();
-
-		while (parent != null && !(parent instanceof CtClass)) {
-			parent = parent.getParent();
-		}
-
-		if (parent == null) {
-			return null;
-		} else {
-			return (CtClass) parent;
-		}
-	}
-
-	private Set<String> lookForLocalVariables(CtElement parent) {
-		Set<String> result = new HashSet<>();
-
-		// try to get the block container
-		// if the first container is the class, then we are not in a block and we can quit now.
-		while (parent != null && !(parent instanceof CtBlock)) {
-			if (parent instanceof CtClass) {
-				return result;
-			}
-			parent = parent.getParent();
-		}
-
-		if (parent != null) {
-			CtBlock block = (CtBlock) parent;
-			boolean innerClass = false;
-
-			// now we have the first container block, we want to check if we're not in an inner class
-			while (parent != null && !(parent instanceof CtClass)) {
-				parent = parent.getParent();
-			}
-
-			if (parent != null) {
-				// uhoh it's not a package as a parent, we must in an inner block:
-				// let's find the last block BEFORE the class call: some collision could occur because of variables defined in that block
-				if (!(parent.getParent() instanceof CtPackage)) {
-					while (parent != null && !(parent instanceof CtBlock)) {
-						parent = parent.getParent();
-					}
-
-					if (parent != null) {
-						block = (CtBlock) parent;
-					}
-				}
-			}
-
-			AccessibleVariablesFinder avf = new AccessibleVariablesFinder(block);
-			List<CtVariable> variables = avf.find();
-
-			for (CtVariable variable : variables) {
-				result.add(variable.getSimpleName());
-			}
-		}
-
-		return result;
-	}
-
 	/**
-	 * Test if the reference should be imported by looking if there is a name conflict
+	 * This method is very similar with @link{ImportScannerImpl#canTypeBeImported} but we import them only if there is a collision
 	 * @param ref
 	 * @return true if the ref should be imported.
 	 */
@@ -113,74 +38,7 @@ public class MinimalImportScanner extends ImportScannerImpl implements ImportSca
 			return true;
 		}
 
-		try {
-			CtElement parent;
-			if (ref instanceof CtTypeReference) {
-				parent = ref.getParent();
-			} else {
-				parent = ref;
-			}
-
-			Set<String> localVariablesOfBlock = new HashSet<>();
-
-			if (parent instanceof CtField) {
-				this.fieldAndMethodsNames.add(((CtField) parent).getSimpleName());
-			} else if (parent instanceof CtMethod) {
-				this.fieldAndMethodsNames.add(((CtMethod) parent).getSimpleName());
-			} else {
-				localVariablesOfBlock = this.lookForLocalVariables(parent);
-			}
-
-			while (!(parent instanceof CtPackage)) {
-				if ((parent instanceof CtFieldReference) || (parent instanceof CtExecutableReference)) {
-					CtReference parentType = (CtReference) parent;
-					LinkedList<String> qualifiedNameTokens = new LinkedList<>();
-
-					// we don't want to test the current ref name, as we risk to create field import and make autoreference
-					if (parentType != parent) {
-						qualifiedNameTokens.add(parentType.getSimpleName());
-					}
-
-					CtTypeReference typeReference;
-					if (parent instanceof CtFieldReference) {
-						typeReference = ((CtFieldReference) parent).getDeclaringType();
-					} else {
-						typeReference = ((CtExecutableReference) parent).getDeclaringType();
-					}
-
-					if (typeReference != null) {
-						qualifiedNameTokens.add(typeReference.getSimpleName());
-
-						if (typeReference.getPackage() != null) {
-							CtPackage ctPackage = typeReference.getPackage().getDeclaration();
-
-							while (ctPackage != null) {
-								qualifiedNameTokens.add(ctPackage.getSimpleName());
-
-								CtElement packParent = ctPackage.getParent();
-								if (packParent.getParent() != null && !((CtPackage) packParent).getSimpleName().equals(CtPackage.TOP_LEVEL_PACKAGE_NAME)) {
-									ctPackage = (CtPackage) packParent;
-								} else {
-									ctPackage = null;
-								}
-							}
-						}
-					}
-					if (!qualifiedNameTokens.isEmpty()) {
-						if (fieldAndMethodsNames.contains(qualifiedNameTokens.getLast()) || localVariablesOfBlock.contains(qualifiedNameTokens.getLast())) {
-							return true;
-						}
-					}
-
-
-				}
-				parent = parent.getParent();
-			}
-		} catch (ParentNotInitializedException e) {
-			return false;
-		}
-
-		return false;
+		return isTypeInCollision(ref, true);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -265,19 +265,27 @@ public class ElementPrinterHelper {
 			}
 			printer.writeln().writeln().writeTabs();
 			for (CtReference ref : imports) {
+				String importStr = "import";
+				String importTypeStr = "";
+
 				if (ref instanceof CtTypeReference) {
 					CtTypeReference typeRef = (CtTypeReference) ref;
-					printer.write("import " + typeRef.getQualifiedName() + ";").writeln().writeTabs();
+					importTypeStr = typeRef.getQualifiedName();
 				} else if (ref instanceof CtExecutableReference) {
+					importStr += " static";
 					CtExecutableReference execRef = (CtExecutableReference) ref;
 					if (execRef.getDeclaringType() != null) {
-						printer.write("import static " + this.removeInnerTypeSeparator(execRef.getDeclaringType().getQualifiedName()) + "." + execRef.getSimpleName() + ";").writeln().writeTabs();
+						importTypeStr = this.removeInnerTypeSeparator(execRef.getDeclaringType().getQualifiedName())+ "." + execRef.getSimpleName();
 					}
 				} else if (ref instanceof CtFieldReference) {
+					importStr += " static";
 					CtFieldReference fieldRef = (CtFieldReference) ref;
-					printer.write("import static " + this.removeInnerTypeSeparator(fieldRef.getDeclaringType().getQualifiedName()) + "." + fieldRef.getSimpleName() + ";").writeln().writeTabs();
+					importTypeStr = this.removeInnerTypeSeparator(fieldRef.getDeclaringType().getQualifiedName()) + "." + fieldRef.getSimpleName();
 				}
 
+				if (!importTypeStr.equals("")) {
+					printer.write(importStr+" "+importTypeStr+";").writeln().writeTabs();
+				}
 			}
 			printer.writeln().writeTabs();
 		}

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -275,7 +275,7 @@ public class ElementPrinterHelper {
 					importStr += " static";
 					CtExecutableReference execRef = (CtExecutableReference) ref;
 					if (execRef.getDeclaringType() != null) {
-						importTypeStr = this.removeInnerTypeSeparator(execRef.getDeclaringType().getQualifiedName())+ "." + execRef.getSimpleName();
+						importTypeStr = this.removeInnerTypeSeparator(execRef.getDeclaringType().getQualifiedName()) + "." + execRef.getSimpleName();
 					}
 				} else if (ref instanceof CtFieldReference) {
 					importStr += " static";
@@ -284,7 +284,7 @@ public class ElementPrinterHelper {
 				}
 
 				if (!importTypeStr.equals("")) {
-					printer.write(importStr+" "+importTypeStr+";").writeln().writeTabs();
+					printer.write(importStr + " " + importTypeStr + ";").writeln().writeTabs();
 				}
 			}
 			printer.writeln().writeTabs();

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -90,8 +90,10 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should not contain import static: "+result, !result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"));
-		assertTrue("The result should contain import type: "+result, result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"));
+		assertTrue("The result should not contain import static: ", !result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"));
+		assertTrue("The result should contain import type: ", result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"));
+		assertTrue("The result should contain import for TestCase: ", result.contains("import junit.framework.TestCase;"));
+		assertTrue("The result should contain assertTrue(...): ", result.contains("TestCase.assertTrue(\"blabla\".equals(\"toto\"));"));
 		assertTrue("The result should use System.out.println(Constants.READY): "+result, result.contains("System.out.println(Constants.READY);"));
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -77,6 +77,25 @@ public class PrinterTest {
 	}
 
 	@Test
+	public void testAutoimportModeDontImportUselessStatic() {
+		Launcher spoon = new Launcher();
+		PrettyPrinter printer = spoon.createPrettyPrinter();
+		spoon.getEnvironment().setAutoImports(true);
+		spoon.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java");
+		spoon.buildModel();
+
+		CtType element = spoon.getFactory().Class().getAll().get(0);
+		List<CtType<?>> toPrint = new ArrayList<>();
+		toPrint.add(element);
+		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
+		String result = printer.getResult();
+
+		assertTrue("The result should not contain import static: "+result, !result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"));
+		assertTrue("The result should contain import type: "+result, result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"));
+		assertTrue("The result should use System.out.println(Constants.READY): "+result, result.contains("System.out.println(Constants.READY);"));
+	}
+
+	@Test
 	public void testRuleCanBeBuild() {
 		Launcher spoon = new Launcher();
 		PrettyPrinter printer = spoon.createPrettyPrinter();

--- a/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
@@ -1,0 +1,12 @@
+package spoon.test.prettyprinter.testclasses;
+
+import spoon.test.prettyprinter.testclasses.sub.Constants;
+
+/**
+ * Created by urli on 30/01/2017.
+ */
+public class ImportStatic {
+    public static void main(String[] args) throws Exception {
+        System.out.println(Constants.READY);
+    }
+}

--- a/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
@@ -2,11 +2,14 @@ package spoon.test.prettyprinter.testclasses;
 
 import spoon.test.prettyprinter.testclasses.sub.Constants;
 
+import static junit.framework.TestCase.assertTrue;
+
 /**
  * Created by urli on 30/01/2017.
  */
 public class ImportStatic {
     public static void main(String[] args) throws Exception {
+        assertTrue("blabla".equals("toto"));
         System.out.println(Constants.READY);
     }
 }

--- a/src/test/java/spoon/test/prettyprinter/testclasses/sub/Constants.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/sub/Constants.java
@@ -1,0 +1,10 @@
+package spoon.test.prettyprinter.testclasses.sub;
+
+/**
+ * Created by urli on 30/01/2017.
+ */
+public class Constants {
+    public static int READY = 0x1;
+    public static int RUNNING = 0x2;
+}
+


### PR DESCRIPTION
Avoid to import static elements such as `java.lang.System.out` when using `System.out.println`. 
Fix #1152. 