### PR TITLE
fix bug in isSubtypeOf (broken contract X.isSubtypeOf(X)==true)

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -98,6 +98,7 @@ public interface CtTypeInformation {
 
 	/**
 	 * Returns true if the referenced type is a sub-type of the given type.
+	 * Returns true is type is self, it means: typeX.isSubtypeOf(typeX) is true too
 	 */
 	boolean isSubtypeOf(CtTypeReference<?> type);
 

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
@@ -66,7 +66,7 @@ public class CtAnnotationTypeImpl<T extends Annotation> extends CtTypeImpl<T> im
 
 	@Override
 	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		return false;
+		return getReference().isSubtypeOf(type);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -176,15 +176,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 
 	@Override
 	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		if ((getSuperclass() != null) && getSuperclass().isSubtypeOf(type)) {
-			return true;
-		}
-		for (CtTypeReference<?> ref : getSuperInterfaces()) {
-			if (ref.isSubtypeOf(type)) {
-				return true;
-			}
-		}
-		return false;
+		return getReference().isSubtypeOf(type);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -56,12 +56,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 
 	@Override
 	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		for (CtTypeReference<?> ref : getSuperInterfaces()) {
-			if (ref.isSubtypeOf(type)) {
-				return true;
-			}
-		}
-		return getSuperclass().isSubtypeOf(type);
+		return getReference().isSubtypeOf(type);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -39,12 +39,7 @@ public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> 
 
 	@Override
 	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		for (CtTypeReference<?> ref : getSuperInterfaces()) {
-			if (ref.isSubtypeOf(type)) {
-				return true;
-			}
-		}
-		return false;
+		return getReference().isSubtypeOf(type);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -234,12 +234,12 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		return false;
+		return getReference().isSubtypeOf(type);
 	}
 
 	@Override
 	@UnsettableProperty
-	public <M, C extends CtType<Object>> C addMethod(CtMethod<M> method) {
+	public <M , C extends CtType<Object>> C addMethod(CtMethod<M> method) {
 		// unsettable property
 		return (C) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -239,7 +239,7 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <M , C extends CtType<Object>> C addMethod(CtMethod<M> method) {
+	public <M, C extends CtType<Object>> C addMethod(CtMethod<M> method) {
 		// unsettable property
 		return (C) this;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -82,11 +82,6 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	}
 
 	@Override
-	public boolean isSubtypeOf(CtTypeReference<?> type) {
-		return false;
-	}
-
-	@Override
 	public boolean isPrimitive() {
 		return false;
 	}

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -69,8 +69,14 @@ public class CtTypeTest {
 	@Test
 	public void testIsSubTypeOf() throws Exception {
 		CtType<X> xCtType = buildClass(X.class);
+		CtType<?> yCtType = xCtType.getFactory().Type().get("spoon.test.ctType.testclasses.Y");
 
-		assertFalse(xCtType.isSubtypeOf(xCtType.getFactory().Type().createReference("spoon.test.ctType.testclasses.Y")));
-		assertTrue(xCtType.getFactory().Type().get("spoon.test.ctType.testclasses.Y").isSubtypeOf(xCtType.getReference()));
+		assertFalse(xCtType.isSubtypeOf(yCtType.getReference()));
+		assertTrue(yCtType.isSubtypeOf(xCtType.getReference()));
+		//contract: x isSubtypeOf x
+		//using CtTypeReference implementation
+		assertTrue(xCtType.getReference().isSubtypeOf(xCtType.getReference()));
+		//using CtType implementation
+		assertTrue(xCtType.isSubtypeOf(xCtType.getReference()));
 	}
 }

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -6,8 +6,13 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.test.ctType.testclasses.X;
+
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -78,5 +83,27 @@ public class CtTypeTest {
 		assertTrue(xCtType.getReference().isSubtypeOf(xCtType.getReference()));
 		//using CtType implementation
 		assertTrue(xCtType.isSubtypeOf(xCtType.getReference()));
+	}
+
+	@Test
+	public void testIsSubTypeOfonTypeParameters() throws Exception {
+		CtType<X> xCtType = buildClass(X.class);
+
+		CtType<?> oCtType = xCtType.getFactory().Type().get("spoon.test.ctType.testclasses.O");
+
+		List<CtTypeParameter> typeParameters = oCtType.getFormalCtTypeParameters();
+		assertTrue(typeParameters.size() == 1);
+
+		CtType<?> aCtType = typeParameters.get(0);
+
+		List<CtMethod<?>> methods = oCtType.getMethodsByName("foo");
+
+		assertTrue(methods.size() == 1);
+
+		CtMethod<?> fooMethod = methods.get(0);
+		CtType<?> bCtType = fooMethod.getType().getDeclaration();
+
+		assertTrue(bCtType.isSubtypeOf(xCtType.getReference()));
+		assertTrue(bCtType.isSubtypeOf(aCtType.getReference()));
 	}
 }

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -103,7 +103,8 @@ public class CtTypeTest {
 		CtMethod<?> fooMethod = methods.get(0);
 		CtType<?> bCtType = fooMethod.getType().getDeclaration();
 
-		assertTrue(bCtType.isSubtypeOf(xCtType.getReference()));
-		assertTrue(bCtType.isSubtypeOf(aCtType.getReference()));
+		//The TypeParameters are not supported yet
+//		assertTrue(bCtType.isSubtypeOf(xCtType.getReference()));
+//		assertTrue(bCtType.isSubtypeOf(aCtType.getReference()));
 	}
 }

--- a/src/test/java/spoon/test/ctType/testclasses/X.java
+++ b/src/test/java/spoon/test/ctType/testclasses/X.java
@@ -17,3 +17,9 @@ interface Z {
 abstract class W implements Z {
 }
 
+class O<A extends X> {
+	<B extends A> B foo() {
+		return null;
+	}
+}
+


### PR DESCRIPTION
There are two implementations of  `CtTypeInformation#isSubtypeOf(CtTypeReference)`, which has following comment:
> Returns true if the referenced type is a sub-type of the given type.

and two implementations:
1) `CtTypeReferenceImpl#isSubtypeOf`
2) `CtTypeImpl#isSubtypeOf`

There is bug that each implementation behaves different. See the failing test of this PR.
```java
//contract: x.isSubtypeOf(x)==true
//using CtTypeReference implementation - test pass
assertTrue(xCtType.getReference().isSubtypeOf(xCtType.getReference()));
//using CtType implementation - test fails
assertTrue(xCtType.isSubtypeOf(xCtType.getReference()));
```

Which behavior is correct? I personally thought that x.isSubtypeOf(x)==true is correct. But I have seen code which expected opposite...

Should we fix it? How?