### PR TITLE
feature: CtLambda#getMethod() and fix of #1159

### DIFF
--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -66,7 +66,7 @@ public interface CtLambda<T> extends CtExpression<T>, CtExecutable<T> {
 	 * Must be defined as a non-default method in an interface, e.g. Consumer.accept().
 	 */
 	@DerivedProperty
-	<R> CtMethod<R> getMethod();
+	<R> CtMethod<R> getOverriddenMethod();
 
 	/**
 	 * Sets the expression in the body of the lambda. Nothing will change

--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -17,7 +17,9 @@
 package spoon.reflect.code;
 
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
 import java.util.Set;
@@ -58,6 +60,12 @@ public interface CtLambda<T> extends CtExpression<T>, CtExecutable<T> {
 	 * of statements.
 	 */
 	CtExpression<T> getExpression();
+
+	/**
+	 * @return a method which is implemented by this lambda expression
+	 */
+	@DerivedProperty
+	<R> CtMethod<R> getMethod();
 
 	/**
 	 * Sets the expression in the body of the lambda. Nothing will change

--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -62,7 +62,8 @@ public interface CtLambda<T> extends CtExpression<T>, CtExecutable<T> {
 	CtExpression<T> getExpression();
 
 	/**
-	 * @return a method which is implemented by this lambda expression
+	 * @return the method that this lambda expression implements.
+	 * Must be defined as a non-default method in an interface, e.g. Consumer.accept().
 	 */
 	@DerivedProperty
 	<R> CtMethod<R> getMethod();

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -111,7 +111,7 @@ public class ExecutableFactory extends SubFactory {
 			boolean isStatic = ((CtMethod) e).hasModifier(ModifierKind.STATIC);
 			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(), isStatic, ((CtMethod<T>) e).getType().clone(), executableName, refs);
 		} else if (e instanceof CtLambda) {
-			CtMethod<T> lambdaMethod = ((CtLambda) e).getMethod();
+			CtMethod<T> lambdaMethod = ((CtLambda) e).getOverriddenMethod();
 			return createReference(e.getParent(CtType.class).getReference(), lambdaMethod == null ? null : lambdaMethod.getType(), executableName, refs);
 		} else if (e instanceof CtAnonymousExecutable) {
 			return createReference(((CtAnonymousExecutable) e).getDeclaringType().getReference(), e.getType().clone(), executableName);

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -111,7 +111,8 @@ public class ExecutableFactory extends SubFactory {
 			boolean isStatic = ((CtMethod) e).hasModifier(ModifierKind.STATIC);
 			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(), isStatic, ((CtMethod<T>) e).getType().clone(), executableName, refs);
 		} else if (e instanceof CtLambda) {
-			return createReference(e.getParent(CtType.class).getReference(), e.getType(), executableName, refs);
+			CtMethod<T> lambdaMethod = ((CtLambda) e).getMethod();
+			return createReference(e.getParent(CtType.class).getReference(), lambdaMethod == null ? null : lambdaMethod.getType(), executableName, refs);
 		} else if (e instanceof CtAnonymousExecutable) {
 			return createReference(((CtAnonymousExecutable) e).getDeclaringType().getReference(), e.getType().clone(), executableName);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -91,7 +91,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <R> CtMethod<R> getMethod() {
+	public <R> CtMethod<R> getOverriddenMethod() {
 		//The type of this lambda expression. For example: `Consumer<Integer>`
 		CtTypeReference<T> lambdaTypeRef = getType();
 		if (lambdaTypeRef == null) {

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -356,7 +356,7 @@ public class LambdaTest {
 	@Test
 	public void testLambdaMethod() throws Exception {
 		CtLambda<?> lambda = getLambdaInFooByNumber(8);
-		CtMethod<?> method = lambda.getMethod();
+		CtMethod<?> method = lambda.getOverriddenMethod();
 		CtTypeReference<?> iface = lambda.getType();
 		assertEquals(Consumer.class.getName(), iface.getQualifiedName());
 		assertEquals(iface.getTypeDeclaration().getMethodsByName("accept").get(0), method);

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -360,6 +360,13 @@ public class LambdaTest {
 		CtTypeReference<?> iface = lambda.getType();
 		assertEquals(Consumer.class.getName(), iface.getQualifiedName());
 		assertEquals(iface.getTypeDeclaration().getMethodsByName("accept").get(0), method);
+/* This assertion fails now		
+		CtExecutableReference<?> lambdaRef = lambda.getReference();
+		CtExecutableReference<?> methodRef = lambdaRef.getOverridingExecutable();
+// because methodRef is null
+		CtExecutable<?> method2 = methodRef.getDeclaration();
+		assertEquals("The lambda.getMethod() != lambda.getReference().getOverridingExecutable().getDeclaration()", method, method2);
+*/
 	}
 
 	private void assertTypedBy(Class<?> expectedType, CtTypeReference<?> type) {

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -29,6 +29,7 @@ import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -340,6 +341,25 @@ public class LambdaTest {
 
 		assertNotNull(collect);
 		assertEquals(1, collect.size());
+	}
+	
+	@Test
+	public void testEqualsLambdaParameterRef() throws Exception {
+		CtLambda<?> lambda = getLambdaInFooByNumber(8);
+		CtParameter<?> param = (CtParameter<?>)lambda.getParameters().get(0);
+		CtParameterReference paramRef1 = param.getReference();
+		CtParameterReference paramRef2 = lambda.filterChildren(new TypeFilter<>(CtParameterReference.class)).first();
+		assertTrue(paramRef1.getDeclaringExecutable().getType().equals(paramRef2.getDeclaringExecutable().getType())); 
+		assertTrue(paramRef1.equals(paramRef2));
+	}
+
+	@Test
+	public void testLambdaMethod() throws Exception {
+		CtLambda<?> lambda = getLambdaInFooByNumber(8);
+		CtMethod<?> method = lambda.getMethod();
+		CtTypeReference<?> iface = lambda.getType();
+		assertEquals(Consumer.class.getName(), iface.getQualifiedName());
+		assertEquals(iface.getTypeDeclaration().getMethodsByName("accept").get(0), method);
 	}
 
 	private void assertTypedBy(Class<?> expectedType, CtTypeReference<?> type) {

--- a/src/test/java/spoon/test/lambda/testclasses/Foo.java
+++ b/src/test/java/spoon/test/lambda/testclasses/Foo.java
@@ -2,6 +2,7 @@ package spoon.test.lambda.testclasses;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 public class Foo {
@@ -46,6 +47,12 @@ public class Foo {
 		if (((Predicate<Person>) p -> p.age > 18).test(new Person(10))) {
 			System.err.println("Enjoy, you have more than 18.");
 		}
+	}
+
+	public void m9() {
+		Consumer<Integer> c = (field)->{
+			field=1;
+		};
 	}
 
 	public static void printPersonsWithPredicate(List<Person> roster, Predicate<Person> tester) {


### PR DESCRIPTION
This PR fixes issue #1159. The issue #1159 is caused by wrong return type of CtExecutableReference created for lambda. Therefore this code failed too:
```java
assertTrue(lambdaRef.getDeclaringExecutable().getType()
     .equals(paramRef.getDeclaringExecutable().getType()));
``` 

Now there is a question whether solution of this PR is correct.

In current spoon model the interface `CtLambda` represents both:
* `CtExpression`, which returns an instance, which implements a type defined by result of `CtLambda.getType()`
* `CtExecutable`, which represents an executable element. It means it has parameters, body, thrownTypes ... and **return type** 

The problem was that **return type** of executable element was not accessible. Therefore during creation of CtExecutableReference of lambda expression, there was used wrong return type of that executable (see change in `ExecutableFactory`).

Now the  issue #1159 is fixed - the parameter references are equal.
... but I have found another issue #1163, which causes that `CtLambdaImpl#getExecutableType` actually does not work correctly.