### PR TITLE
review: introduction of CtScannerFunction

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
@@ -166,4 +166,16 @@ public interface CtQuery extends CtQueryable {
 	 */
 	@Override
 	<I> CtQuery map(CtConsumableFunction<I> queryStep);
+
+	/**
+	 * terminates current query evaluation.
+	 * This method returns normally. It does not throw exception.
+	 * But it causes that query evaluation engine terminates
+	 * and returns all the till now collected results.
+	 */
+	void terminate();
+	/**
+	 * @return true if evaluation has to be/was terminated
+	 */
+	boolean isTerminated();
 }

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.chain;
+
+/**
+ * The mapping function can implement this interface,
+ * when it needs the context of the {@link CtQuery} instance,
+ * where this mapping function is going to be evaluated
+ */
+public interface CtQueryAware {
+	/**
+	 * This method is called once when mapping function is added to the {@link CtQuery}
+	 * @param query the instance of bound {@link CtQuery}
+	 */
+	void setQuery(CtQuery query);
+}

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
@@ -21,7 +21,8 @@ package spoon.reflect.visitor.chain;
  * that need to access the state of the top-level {@link CtQuery} instance
  * containing the function to be evaluated.
  *
- * Not meant to be implemented directly, only in conjunction with {@link CtFunction} or {@link spoon.reflect.visitor.Filter}.
+ * Not meant to be implemented directly, only in conjunction with
+ * {@link CtConsumableFunction}, {@link CtFunction} or {@link spoon.reflect.visitor.Filter}.
  */
 public interface CtQueryAware {
 	/**

--- a/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
@@ -18,7 +18,6 @@ package spoon.reflect.visitor.filter;
 
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
-import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.CtQuery;

--- a/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.EarlyTerminatingScanner;
+import spoon.reflect.visitor.Filter;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+import spoon.reflect.visitor.chain.CtQuery;
+import spoon.reflect.visitor.chain.CtQueryAware;
+import spoon.reflect.visitor.chain.CtScannerListener;
+import spoon.reflect.visitor.chain.ScanningMode;
+
+/**
+ * A mapping function, which scans all children of input element.<br>
+ * There is possible to register {@link CtScannerListener} to listen for enter/exit of each scanned AST node
+ * and optionally to skip processing of children.<br>
+ * There is possible to register {@link Filter} to filter AST nodes which are sent to the next step<br>
+ * Note: The listener is called for each scanned AST node, but the filter is called only for nodes where {@link CtScannerListener#enter(CtElement)} returns true
+ */
+public class CtScannerFunction implements CtConsumableFunction<CtElement>, CtQueryAware {
+
+	private final Scanner scanner;
+	private boolean includingSelf = true;
+
+	public CtScannerFunction() {
+		scanner = new Scanner();
+	}
+
+	/**
+	 * @param includingSelf if true then input element is sent to output too. By default it is false.
+	 */
+	public CtScannerFunction includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
+	}
+
+	/**
+	 * @param listener the implementation of {@link CtScannerListener}, which will listen for enter/exit of nodes during scanning of AST
+	 * @return this to support fluent API
+	 */
+	public CtScannerFunction setListener(CtScannerListener listener) {
+		scanner.setListener(listener);
+		return this;
+	}
+
+	@Override
+	public void apply(CtElement input, CtConsumer<Object> outputConsumer) {
+		scanner.next = outputConsumer;
+		if (this.includingSelf) {
+			scanner.scan(input);
+		} else {
+			input.accept(scanner);
+		}
+	}
+
+	/*
+	 * it is called automatically by CtQuery implementation,
+	 * when this mapping function is added.
+	 */
+	@Override
+	public void setQuery(CtQuery query) {
+		scanner.query = query;
+	}
+
+	private static class Scanner extends EarlyTerminatingScanner<Void> {
+		protected CtConsumer<Object> next;
+		private CtQuery query;
+
+		@Override
+		protected void doScan(CtElement element, ScanningMode mode) {
+			//send input to output
+			if (mode.visitElement) {
+				next.accept(element);
+			}
+			if (mode.visitChildren) {
+				element.accept(this);
+			}
+		}
+		/*
+		 * override {@link EarlyTerminatingScanner#isTerminated()} and let it stop when query is terminated
+		 */
+		@Override
+		protected boolean isTerminated() {
+			return query.isTerminated();
+		}
+	}
+}


### PR DESCRIPTION
As I mentioned in #1005 it is sometime needed to 
* R1 to know when query step of type filterChildren enter/exit an element on one selected query step.
* R2 to be able to skip processing of children of current element 
* R3 to be able to skip processing of siblings and children of current elements
* R4 to be able to make mapping functions aware of query processing state (actually mainly whether query is terminated)


There is already a Query Execution Context (QEC) impelemented by class `CtQueryImpl$CurrentStep`. 

There are needed these two things to implement this PR:
1.  to get access to the QEC, or to provide own extension of that context
2.  to define API of that QEC, which can be used to
    * drive execution of query 
    * or to get query processing state.
      * the list of all Functions of the query
      * the index of actually processed Function
      * the depth of current node in the tree of nodes visited by this query


## Access to QEC
The client might get access to QEC, by these ways:
**Access1) CtQuery#createQueryContext()**
By creation of QEC before query is executed. Then that instance can be used in functions of query to drive query
```java
//1) create instance of QEC
 CtQueryContext cc = anElement.map(...).createQueryContext();
//2) use QEC to process query and to drive query, etc.
cc.forEach(...)
```

**Access2) CtQuery#setQueryContext()**
By creating an own instance of QEC and setting it to query
```java
//1) create instance of QEC
 CtQueryContext cc = new QEC();
//assign that instance to query
anElement.map(...).setQueryContext(cc).forEach(...)
```

**Access3) (CtQueryContext)outputConsumer**
By conversion of outputConsumer of `CtConsumableFunction(Object,CtConsumer)` to QEC.
```java
anElement.map((input, output)->{
CtQueryContext cc = (CtQueryContext)output;
//use cc to drive query
}).forEach((output)->{
CtQueryContext cc = (CtQueryContext)output;
//use the same cc instance like above to drive query
});
```
**Access4) CtQuery extends CtQueryContext**
CtQuery extends CtQueryContext, so all the methods are available through query instance.

## API of QEC
There might be these methods on QEC:
* setOutputConsumer(CtConsumer) - sets the CtConsumer which will get results of this query execution
* accept(Object input) - executes the query with input.
* setTerminated(boolean) - terminates whole query
* boolean isTerminated() - returns true if query is terminated
* void onEnter(CtQueryListener<T>) - register listener which is called before element is sent to mapping function
* void onEnter(Filter, CtQueryListener<T>) - some like onEnter, but calls listener only for elements which match the filter.
* void onExit(CtQueryListener<T>) - register listener which is called after element is sent to mapping function
* void onExit(Filter, CtQueryListener<T>) - same like onExit, but but calls listener only for elements which match the filter.
* void onExitOf(Object, CtQueryListener<T>) - same like onExit, but calls listener only when element is same like provided object.
* void skipElement(CtElement); - skips element and all children. The mapping function is not called for such element and it's children
* void setSkipMode(SkipMode); - skips elements depending mode until next call of setSkipMode or end of query.

```java
interface CtQueryListener<T> {
   void onElement(T element, CtQueryContext QEC);
}
```

Example
```java
//create query listener which skips all children of method
CtQueryListener ql = new CtQueryListener() {
  boolean skipping = false;
   //return false to skip current element
   boolean onElement(CtElement e, CtQueryContext context) {
       if(skipping) return false;
       if(e instanceof CtMethod) {
          //if client wants to be called on exit of this element, then he can register listener for that
          context.onExitOf(e, (e, context)->{
             skipping = false;
          });
          return false;
       }
       return true;
   }
}
anElement.map(...)..onEnter(ql).forEach(...);
```
...to be continued... 
Feedbacks and suggestions are welcome