### PR TITLE
fix CtTypeReferenceImpl#canAccess of protected and interface members

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -264,6 +264,22 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		}
 	}
 
+	/**
+	 * Detects if this type is an code responsible for implementing of that type.<br>
+	 * In means it detects whether this type can access protected members of that type
+	 * @return true if this type or any declaring type recursively is subtype of type or directly is the type.
+	 */
+	private boolean isImplementationOf(CtTypeReference<?> type) {
+		CtTypeReference<?> impl = this;
+		while (impl != null) {
+			if (impl.isSubtypeOf(type)) {
+				return true;
+			}
+			impl = impl.getDeclaringType();
+		}
+		return false;
+	}
+
 	@Override
 	public <C extends CtActualTypeContainer> C setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
 		if (actualTypeArguments == null || actualTypeArguments.isEmpty()) {
@@ -621,26 +637,45 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 				return true;
 			}
 			if (modifiers.contains(ModifierKind.PROTECTED)) {
-				if (isSubtypeOf(type)) {
-					//is visible in subtypes
+				//the accessed type is protected in scope of declaring type.
+				CtTypeReference<?> declaringType = type.getDeclaringType();
+				if (declaringType == null) {
+					//top level type cannot be protected. So this is a model inconsistency.
+					throw new SpoonException("The protected class " + type.getQualifiedName() + " has no declaring class.");
+				}
+				if (isImplementationOf(declaringType)) {
+					//type is visible in code which implements declaringType
 					return true;
 				} //else it is visible in same package, like package protected
+				return isInSamePackage(type);
 			}
 			if (modifiers.contains(ModifierKind.PRIVATE)) {
 				//it is visible in scope of the same class only
 				return type.getTopLevelType().getQualifiedName().equals(this.getTopLevelType().getQualifiedName());
 			}
-			//package protected
-			if (type.getTopLevelType().getPackage().getSimpleName().equals(this.getTopLevelType().getPackage().getSimpleName())) {
-				//visible only in scope of the same package
+			/*
+			 * no modifier, we have to check if it is nested type and if yes, if parent is interface or class.
+			 * In case of no parent then implicit access is package protected
+			 * In case of parent is interface, then implicit access is PUBLIC
+			 * In case of parent is class, then implicit access is package protected
+			 */
+			CtTypeReference<?> declaringTypeRef = type.getDeclaringType();
+			if (declaringTypeRef != null && declaringTypeRef.isInterface()) {
+				//the declaring type is interface, then implicit access is PUBLIC
 				return true;
 			}
-			return false;
+			//package protected
+			//visible only in scope of the same package
+			return isInSamePackage(type);
 		} catch (SpoonClassNotFoundException e) {
 			handleParentNotFound(e);
 			//if the modifiers cannot be resolved then we expect that it is visible
 			return true;
 		}
+	}
+
+	private boolean isInSamePackage(CtTypeReference<?> type) {
+		return type.getTopLevelType().getPackage().getSimpleName().equals(this.getTopLevelType().getPackage().getSimpleName());
 	}
 
 	@Override
@@ -659,7 +694,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	public CtTypeReference<?> getAccessType() {
 		CtTypeReference<?> declType = this.getDeclaringType();
 		if (declType == null) {
-			throw new SpoonException("The nestedType is expected, but it is: " + getQualifiedName());
+			throw new SpoonException("The declaring type is expected, but " + getQualifiedName() + " is top level type");
 		}
 		CtType<?> contextType = getParent(CtType.class);
 		if (contextType == null) {

--- a/src/test/java/spoon/test/imports/testclasses/ClientClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/ClientClass.java
@@ -3,6 +3,18 @@ package spoon.test.imports.testclasses;
 import spoon.test.imports.testclasses.internal.ChildClass;
 
 public class ClientClass extends ChildClass {
-	private class InnerClass extends spoon.test.imports.testclasses.internal.ChildClass.InnerClassProtected {
-	}
-}
+	private class InnerClass extends spoon.test.imports.testclasses.internal.ChildClass.InnerClassProtected {}
+	private class InnerClass2 implements spoon.test.imports.testclasses.internal.PublicInterface2 {}
+	private class InnerClass3a implements spoon.test.imports.testclasses.internal.PublicInterface2.NestedInterface {}
+	private class InnerClass3b extends spoon.test.imports.testclasses.internal.PublicInterface2.NestedClass {}
+	//SuperClass is package protected so it is not visible. 
+//	private class InnerClassX implements spoon.test.imports.testclasses.internal.SuperClass.PublicInterface {}
+	//ChildClass.PackageProtectedInterface is package protected so it is not visible.
+//	private class InnerClassX implements spoon.test.imports.testclasses.internal.ChildClass.PackageProtectedInterface {}
+	private class InnerClass4 implements spoon.test.imports.testclasses.internal.ChildClass.ProtectedInterface {}
+	private class InnerClass5 implements spoon.test.imports.testclasses.internal.ChildClass.ProtectedInterface.NestedOfProtectedInterface {}
+	private class InnerClass6 implements spoon.test.imports.testclasses.internal.ChildClass.ProtectedInterface.NestedPublicInterface {}
+	private class InnerClass7 implements spoon.test.imports.testclasses.internal.ChildClass.PublicInterface {}
+	private class InnerClass8 implements spoon.test.imports.testclasses.internal.ChildClass.PublicInterface.NestedOfPublicInterface {}
+	private class InnerClass9 implements spoon.test.imports.testclasses.internal.ChildClass.PublicInterface.NestedPublicInterface {}
+} 

--- a/src/test/java/spoon/test/imports/testclasses/internal/PublicInterface2.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal/PublicInterface2.java
@@ -1,0 +1,9 @@
+package spoon.test.imports.testclasses.internal;
+
+public interface PublicInterface2 {
+	//this is public too https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.6.1
+	interface NestedInterface {
+	}
+	class NestedClass {
+	}
+}

--- a/src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java
+++ b/src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java
@@ -3,4 +3,22 @@ package spoon.test.imports.testclasses.internal;
 class SuperClass {
 	protected class InnerClassProtected {
 	}
+	interface PackageProtectedInterface {
+		interface NestedOfPackageProtectedInterface {
+		}
+		public interface NestedPublicInterface {
+		}
+	}
+	protected interface ProtectedInterface {
+		interface NestedOfProtectedInterface {
+		}
+		public interface NestedPublicInterface {
+		}
+	}
+	public interface PublicInterface {
+		interface NestedOfPublicInterface {
+		}
+		public interface NestedPublicInterface {
+		}
+	}
 }


### PR DESCRIPTION
fix of #1188 