### PR TITLE
review: improve PotentialVariableDeclarationFunction, simplify its usage

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -685,13 +685,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 						 */
 						final CtField<?> field = f.getVariable().getFieldDeclaration();
 						final String fieldName = field.getSimpleName();
-						CtVariable<?> var = f.getVariable().map(new PotentialVariableDeclarationFunction()).select(new Filter<CtVariable<?>>() {
-							@Override
-							public boolean matches(CtVariable<?> element) {
-								//finish if we have found a declaration of variable with the same name.
-								return fieldName.equals(element.getSimpleName());
-							}
-						}).first();
+						CtVariable<?> var = f.getVariable().map(new PotentialVariableDeclarationFunction(fieldName)).first();
 						if (var != field) {
 							//another variable declaration was found which is hiding the field declaration for this field access. Make the field access expicit
 							target.setImplicit(false);

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -40,16 +40,16 @@ import spoon.reflect.visitor.chain.CtQueryAware;
  * This mapping function searches for all {@link CtVariable} instances,
  * which might be a declaration of an input {@link CtElement}.
  * <br>
- * It returns {@link CtLocalVariable} instances too
- * It returns {@link CtCatchVariable} instances from catch blocks.
- * It returns {@link CtParameter} instances from methods, lambdas and catch blocks.
- * It returns {@link CtField} instances from wrapping classes and their super classes too.
- * <br>
- * The elements are visited in defined order. First are elements from nearest parent blocks,
- * then fields of wrapping classes, then fields of super classes, etc.
- * <br>
  * It can be used to search for variable declarations of
  * variable references and for detection of variable name conflicts
+ * <br>
+ * It returns {@link CtLocalVariable} instances,
+ * or it returns {@link CtCatchVariable} instances of catch blocks,
+ * or i returns {@link CtParameter} instances of methods, lambdas and catch blocks.
+ * or it returns {@link CtField} instances from wrapping classes and their super classes too.
+ * <br>
+ * The elements are visited in the following order: first elements are thought in the nearest parent blocks,
+ * then in the fields of wrapping classes, then in the fields of super classes, etc.
  * <br>
  * Example: Search for all potential {@link CtVariable} declarations<br>
  * <pre> {@code
@@ -57,7 +57,7 @@ import spoon.reflect.visitor.chain.CtQueryAware;
  * varRef.map(new PotentialVariableDeclarationFunction()).forEach(...process result...);
  * }
  * </pre>
- * Example: Search for {@link CtVariable} declaration of variable named `varName` in scope scop
+ * Example: Search for {@link CtVariable} declaration of variable named `varName` in scope "scope"
  * <pre> {@code
  * CtElement scope = ...;
  * String varName = "anVariableName";

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.visitor.CtVisitor;
-import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 
 /**
@@ -70,12 +69,7 @@ public class CtLocalVariableReferenceImpl<T>
 			// successively iterate through all parents of this reference and
 			// return first result (which must be the closest declaration
 			// respecting visible scope)
-			CtVariable<?> var = map(new PotentialVariableDeclarationFunction()).select(new Filter<CtVariable<?>>() {
-				@Override
-				public boolean matches(CtVariable<?> var) {
-					return simpleName.equals(var.getSimpleName());
-				}
-			}).first();
+			CtVariable<?> var = map(new PotentialVariableDeclarationFunction(simpleName)).first();
 			if (var instanceof CtLocalVariable) {
 				return (CtLocalVariable<T>) var;
 			}


### PR DESCRIPTION
This PR is refactoring of `PotentialVariableDeclarationFunction`. There are following changes
1) There is new constructor which accepts variable name. Such mapping function then returns only `CtVariable` instances with that name. It simplifies usage of `PotentialVariableDeclarationFunction`, because on all 3 places where I am using that function it is needed to filter by variable name too. See simplified code of `DefaultJavaPrettyPrinter` and `CtLocalVariableReferenceImpl`, which are part of this PR
2) It now returns only instances of `CtVariable`. Before it returned all `CtElements`, which were on the way from mapping function input to the found variable declaration. It is change in behavior! I hope it is OK, because the PotentialVariableDeclarationFunction is not in spoon for long time, so it does not have many clients. I am open to rollback this change (2), if you think it is wrong step. But I think it is more consistent now.
3) There is new method `boolean PotentialVariableDeclarationFunction#isTypeOnTheWay()`, which can be called by another mapping function or after query is finished and returns true if there is a local class between input element and returned variable declaration. That information can be used to decide whether variable represented by input element can shadow found variable declaration or whether it is in conflict. 

These improvements are needed by #1005.