### PR TITLE
Fix NPE when empty working dir

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -392,7 +392,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 					.classpathOptions(new ClasspathOptions().encoding(this.encoding).classpath(classpath)) //
 					.complianceOptions(new ComplianceOptions().compliance(javaCompliance)) //
 					.advancedOptions(new AdvancedOptions().preserveUnusedVars().continueExecution().enableJavadoc()) //
-					.sources(new SourceOptions().sources()) // no sources, handled by the JDTBatchCompiler
+					.sources(new SourceOptions().sources(sourcesFolder.getFiles())) // no sources, handled by the JDTBatchCompiler
 					.build();
 		} else {
 			args = jdtBuilder.build();

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -392,7 +392,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 					.classpathOptions(new ClasspathOptions().encoding(this.encoding).classpath(classpath)) //
 					.complianceOptions(new ComplianceOptions().compliance(javaCompliance)) //
 					.advancedOptions(new AdvancedOptions().preserveUnusedVars().continueExecution().enableJavadoc()) //
-					.sources(new SourceOptions().sources(sourcesFolder.getFiles())) // no sources, handled by the JDTBatchCompiler
+					.sources(new SourceOptions().sources(sourcesFolder.getAllJavaFiles())) // no sources, handled by the JDTBatchCompiler
 					.build();
 		} else {
 			args = jdtBuilder.build();

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -8,6 +8,8 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.support.JavaOutputProcessor;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,6 +68,22 @@ public class LauncherTest {
 		assertTrue(inputSources.get(0).getPath().replace('\\', '/').contains("src/main/java"));
 		assertEquals("UTF-16", builder.getEncoding());
 
+	}
+
+	/**
+	 * This test should be launched after setting an empty working directory
+	 * @throws Exception
+	 */
+	@Test
+	public void testLauncherInEmptyWorkingDir() throws Exception {
+		Path path = Files.createTempDirectory("spoon-empty");
+
+		String workingDir = System.getProperty("user.dir");
+		System.setProperty("user.dir", path.toFile().getAbsolutePath());
+
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("/Users/urli/Github/spoon/src/test/java/spoon/LauncherTest.java");
+		launcher.buildModel();
 	}
 
 }

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -71,16 +71,25 @@ public class LauncherTest {
 
 	}
 
-	/**
-	 * This test should be launched after setting an empty working directory
-	 * @throws Exception
-	 */
 	@Test
-	@Ignore
 	public void testLauncherInEmptyWorkingDir() throws Exception {
+
+		// Contract: Spoon can be launched in an empty folder as a working directory
+		// See: https://github.com/INRIA/spoon/pull/1208
+		// This test does not fail (it's not enough to change user.dir we should launch process inside that dir) but it explains the problem
 		final Launcher launcher = new Launcher();
-		launcher.addInputResource("/set/absolute/path/spoon/src/test/java/spoon/LauncherTest.java");
-		launcher.buildModel();
+		Path path = Files.createTempDirectory("emptydir");
+
+		String oldUserDir = System.getProperty("user.dir");
+		System.setProperty("user.dir", path.toFile().getAbsolutePath());
+
+		// path should exist, otherwise it would crash on a filenotfoundexception before showing the bug
+		launcher.addInputResource(oldUserDir+"/src/test/java/spoon/LauncherTest.java");
+		try {
+			launcher.buildModel();
+		} finally {
+			System.setProperty("user.dir", oldUserDir);
+		}
 	}
 
 }

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -76,11 +76,6 @@ public class LauncherTest {
 	 */
 	@Test
 	public void testLauncherInEmptyWorkingDir() throws Exception {
-		Path path = Files.createTempDirectory("spoon-empty");
-
-		String workingDir = System.getProperty("user.dir");
-		System.setProperty("user.dir", path.toFile().getAbsolutePath());
-
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("/Users/urli/Github/spoon/src/test/java/spoon/LauncherTest.java");
 		launcher.buildModel();

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -1,6 +1,7 @@
 package spoon;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import spoon.compiler.Environment;
@@ -75,9 +76,10 @@ public class LauncherTest {
 	 * @throws Exception
 	 */
 	@Test
+	@Ignore
 	public void testLauncherInEmptyWorkingDir() throws Exception {
 		final Launcher launcher = new Launcher();
-		launcher.addInputResource("/Users/urli/Github/spoon/src/test/java/spoon/LauncherTest.java");
+		launcher.addInputResource("/set/absolute/path/spoon/src/test/java/spoon/LauncherTest.java");
 		launcher.buildModel();
 	}
 


### PR DESCRIPTION
Fix a funny bug which happens when launching Spoon in an empty working directory: we have a NPE because JDT cannot find a .java file... We fix it by passing as argument to JDT the list of java files we want to Spoon. It should then fix #1116 