### PR TITLE
review: fix: Dynamic lookup issues by removing dynamic lookup

### DIFF
--- a/src/main/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/main/java/spoon/generating/CloneVisitorGenerator.java
@@ -525,6 +525,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 	private CtClass<Object> createCloneBuilder() {
 		final CtPackage aPackage = getFactory().Package().getOrCreate(TARGET_CLONE_PACKAGE);
 		final CtClass<Object> target = getFactory().Class().get(GENERATING_BUILDER_CLONE);
+		target.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 		target.addModifier(ModifierKind.PUBLIC);
 		aPackage.addType(target);
 		final List<CtTypeReference> references = target.getElements(new TypeFilter<CtTypeReference>(CtTypeReference.class) {
@@ -537,7 +538,6 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 			reference.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 			reference.setPackage(aPackage.getReference());
 		}
-		target.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 		return target;
 	}
 }

--- a/src/main/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/main/java/spoon/generating/CloneVisitorGenerator.java
@@ -525,7 +525,6 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 	private CtClass<Object> createCloneBuilder() {
 		final CtPackage aPackage = getFactory().Package().getOrCreate(TARGET_CLONE_PACKAGE);
 		final CtClass<Object> target = getFactory().Class().get(GENERATING_BUILDER_CLONE);
-		target.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 		target.addModifier(ModifierKind.PUBLIC);
 		aPackage.addType(target);
 		final List<CtTypeReference> references = target.getElements(new TypeFilter<CtTypeReference>(CtTypeReference.class) {
@@ -538,6 +537,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 			reference.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 			reference.setPackage(aPackage.getReference());
 		}
+		target.setSimpleName(TARGET_BUILDER_CLONE_TYPE);
 		return target;
 	}
 }

--- a/src/main/java/spoon/refactoring/Refactoring.java
+++ b/src/main/java/spoon/refactoring/Refactoring.java
@@ -28,6 +28,33 @@ import java.util.List;
  */
 public final class Refactoring {
 	/**
+	 * Changes names of the inherited reference of type qualified by oldName
+	 *
+	 * @param type
+	 * 		Type in the AST.
+	 * @param oldName
+	 * 		The old qualified name of type
+	 * @param name
+	 * 		New name of the element.
+	 */
+	public static void changeInheritedTypeName(final CtType<?> type, String oldName, String name) {
+
+		final String typeQFN = oldName;
+
+		final List<CtTypeReference<?>> references = Query.getElements(type.getFactory(), new TypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
+			@Override
+			public boolean matches(CtTypeReference<?> reference) {
+				String refFQN = reference.getQualifiedName();
+				return typeQFN.equals(refFQN);
+			}
+		});
+
+		for (CtTypeReference<?> reference : references) {
+			reference.setSimpleName(name);
+		}
+	}
+
+	/**
 	 * Changes name of a type element.
 	 *
 	 * @param type
@@ -36,16 +63,7 @@ public final class Refactoring {
 	 * 		New name of the element.
 	 */
 	public static void changeTypeName(final CtType<?> type, String name) {
-		final List<CtTypeReference<?>> references = Query.getElements(type.getFactory(), new TypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
-			@Override
-			public boolean matches(CtTypeReference<?> reference) {
-				return type.getQualifiedName().equals(reference.getQualifiedName());
-			}
-		});
-
+		Refactoring.changeInheritedTypeName(type, type.getQualifiedName(), name);
 		type.setSimpleName(name);
-		for (CtTypeReference<?> reference : references) {
-			reference.setSimpleName(name);
-		}
 	}
 }

--- a/src/main/java/spoon/refactoring/Refactoring.java
+++ b/src/main/java/spoon/refactoring/Refactoring.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 public final class Refactoring {
 	/**
-	 * Changes names of the inherited reference of type qualified by oldName
+	 * Changes name of a type element.
 	 *
 	 * @param type
 	 * 		Type in the AST.

--- a/src/main/java/spoon/refactoring/Refactoring.java
+++ b/src/main/java/spoon/refactoring/Refactoring.java
@@ -32,14 +32,12 @@ public final class Refactoring {
 	 *
 	 * @param type
 	 * 		Type in the AST.
-	 * @param oldName
-	 * 		The old qualified name of type
 	 * @param name
 	 * 		New name of the element.
 	 */
-	public static void changeInheritedTypeName(final CtType<?> type, String oldName, String name) {
+	public static void changeTypeName(final CtType<?> type, String name) {
 
-		final String typeQFN = oldName;
+		final String typeQFN = type.getQualifiedName();
 
 		final List<CtTypeReference<?>> references = Query.getElements(type.getFactory(), new TypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
 			@Override
@@ -49,21 +47,9 @@ public final class Refactoring {
 			}
 		});
 
+		type.setSimpleName(name);
 		for (CtTypeReference<?> reference : references) {
 			reference.setSimpleName(name);
 		}
-	}
-
-	/**
-	 * Changes name of a type element.
-	 *
-	 * @param type
-	 * 		Type in the AST.
-	 * @param name
-	 * 		New name of the element.
-	 */
-	public static void changeTypeName(final CtType<?> type, String name) {
-		Refactoring.changeInheritedTypeName(type, type.getQualifiedName(), name);
-		type.setSimpleName(name);
 	}
 }

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -91,9 +91,8 @@ public class SnippetCompilationHelper {
 
 		if (ret instanceof CtClass) {
 			CtClass klass = (CtClass) ret;
-			klass.setSimpleName(klass.getSimpleName().replaceAll("^[0-9]*", ""));
-			klass.setParent(ret.getFactory().Package().getRootPackage());
 			ret.getFactory().Package().getRootPackage().addType(klass);
+			klass.setSimpleName(klass.getSimpleName().replaceAll("^[0-9]*", ""));
 		}
 		return ret;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -16,7 +16,6 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.refactoring.Refactoring;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -16,10 +16,17 @@
  */
 package spoon.support.reflect.declaration;
 
+import spoon.refactoring.Refactoring;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import java.util.List;
 
 public abstract class CtNamedElementImpl extends CtElementImpl implements CtNamedElement {
 
@@ -42,6 +49,22 @@ public abstract class CtNamedElementImpl extends CtElementImpl implements CtName
 		Factory factory = getFactory();
 		if (factory instanceof FactoryImpl) {
 			simpleName = ((FactoryImpl) factory).dedup(simpleName);
+		}
+
+		if (this instanceof CtType && !simpleName.equals("")) {
+			final CtType type = (CtType) this;
+			final List<CtTypeReference<?>> references = Query.getElements(type, new TypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
+				@Override
+				public boolean matches(CtTypeReference<?> reference) {
+					return type.getQualifiedName().equals(reference.getQualifiedName());
+				}
+			});
+
+			this.simpleName = simpleName;
+			for (CtTypeReference<?> reference : references) {
+				reference.setSimpleName(simpleName);
+			}
+			return (T) this;
 		}
 		this.simpleName = simpleName;
 		return (T) this;

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -17,15 +17,9 @@
 package spoon.support.reflect.declaration;
 
 import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.reference.CtReference;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.Query;
-import spoon.reflect.visitor.filter.TypeFilter;
-
-import java.util.List;
 
 public abstract class CtNamedElementImpl extends CtElementImpl implements CtNamedElement {
 
@@ -50,21 +44,6 @@ public abstract class CtNamedElementImpl extends CtElementImpl implements CtName
 			simpleName = ((FactoryImpl) factory).dedup(simpleName);
 		}
 
-		if (this instanceof CtType && !simpleName.equals("")) {
-			final CtType type = (CtType) this;
-			final List<CtTypeReference<?>> references = Query.getElements(type, new TypeFilter<CtTypeReference<?>>(CtTypeReference.class) {
-				@Override
-				public boolean matches(CtTypeReference<?> reference) {
-					return type.getQualifiedName().equals(reference.getQualifiedName());
-				}
-			});
-
-			this.simpleName = simpleName;
-			for (CtTypeReference<?> reference : references) {
-				reference.setSimpleName(simpleName);
-			}
-			return (T) this;
-		}
 		this.simpleName = simpleName;
 		return (T) this;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -27,6 +27,7 @@ import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.SpoonClassNotFoundException;
 import spoon.support.util.RtHelper;
 
 import java.lang.reflect.AnnotatedElement;
@@ -130,33 +131,7 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtField<T> getDeclaration() {
-		final CtField<T> ctField = lookupDynamically();
-		if (ctField != null) {
-			return ctField;
-		}
 		return fromDeclaringType();
-	}
-
-	private CtField<T> lookupDynamically() {
-		CtElement element = this;
-		CtField optional = null;
-		String name = getSimpleName();
-		try {
-			do {
-				CtType type = element.getParent(CtType.class);
-				if (type == null) {
-					return null;
-				}
-				final CtField potential = type.getField(name);
-				if (potential != null) {
-					optional = potential;
-				}
-				element = type;
-			} while (optional == null);
-		} catch (ParentNotInitializedException e) {
-			return null;
-		}
-		return optional;
 	}
 
 	private CtField<T> fromDeclaringType() {

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -17,17 +17,14 @@
 package spoon.support.reflect.reference;
 
 import spoon.Launcher;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
-import spoon.support.SpoonClassNotFoundException;
 import spoon.support.util.RtHelper;
 
 import java.lang.reflect.AnnotatedElement;

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -30,12 +30,17 @@ import java.util.List;
 
 import org.junit.Test;
 
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.eval.VisitorPartialEvaluator;
+import spoon.test.field.testclasses.A;
 import spoon.test.field.testclasses.AddFieldAtTop;
 
 public class FieldTest {
@@ -101,5 +106,27 @@ public class FieldTest {
 		first.setType(factory.Type().INTEGER_PRIMITIVE);
 		first.setSimpleName(name);
 		return first;
+	}
+
+	@Test
+	public void testGetDefaultExpression() throws Exception {
+		final CtClass<A> aClass = (CtClass<A>) buildClass(A.class);
+
+		CtClass<A.ClassB> bClass = aClass.getFactory().Class().get(A.ClassB.class);
+		List<CtMethod<?>> methods = bClass.getMethodsByName("getKey");
+
+		assertEquals(1, methods.size());
+
+		CtReturn<?> returnExpression = methods.get(0).getBody().getStatement(0);
+
+		CtFieldRead field = (CtFieldRead) returnExpression.getReturnedExpression();
+
+		assertEquals("spoon.test.field.testclasses.A.BaseClass.PREFIX", field.toString());
+
+		VisitorPartialEvaluator visitorPartial = new VisitorPartialEvaluator();
+
+		Object retour = visitorPartial.evaluate(methods.get(0));
+
+		assertTrue(retour != null);
 	}
 }

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -30,7 +30,9 @@ import java.util.List;
 
 import org.junit.Test;
 
+import spoon.Launcher;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
@@ -42,6 +44,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
 import spoon.test.field.testclasses.A;
 import spoon.test.field.testclasses.AddFieldAtTop;
+import spoon.test.field.testclasses.BaseClass;
 
 public class FieldTest {
 	@Test
@@ -110,7 +113,12 @@ public class FieldTest {
 
 	@Test
 	public void testGetDefaultExpression() throws Exception {
-		final CtClass<A> aClass = (CtClass<A>) buildClass(A.class);
+		Launcher spoon = new Launcher();
+		spoon.addInputResource("./src/test/java/spoon/test/field/testclasses/A.java");
+		spoon.addInputResource("./src/test/java/spoon/test/field/testclasses/BaseClass.java");
+		spoon.buildModel();
+
+		final CtClass<A> aClass = spoon.getFactory().Class().get(A.class);
 
 		CtClass<A.ClassB> bClass = aClass.getFactory().Class().get(A.ClassB.class);
 		List<CtMethod<?>> methods = bClass.getMethodsByName("getKey");
@@ -119,9 +127,16 @@ public class FieldTest {
 
 		CtReturn<?> returnExpression = methods.get(0).getBody().getStatement(0);
 
-		CtFieldRead field = (CtFieldRead) returnExpression.getReturnedExpression();
+		CtFieldRead fieldRead = (CtFieldRead) returnExpression.getReturnedExpression();
 
-		assertEquals("spoon.test.field.testclasses.A.BaseClass.PREFIX", field.toString());
+		assertEquals("spoon.test.field.testclasses.BaseClass.PREFIX", fieldRead.toString());
+
+		CtField<?> field = fieldRead.getVariable().getDeclaration();
+
+		CtClass<BaseClass> baseClass = aClass.getFactory().Class().get(BaseClass.class);
+		CtField<?> expectedField = baseClass.getField("PREFIX");
+
+		assertEquals(expectedField, field);
 
 		VisitorPartialEvaluator visitorPartial = new VisitorPartialEvaluator();
 

--- a/src/test/java/spoon/test/field/testclasses/A.java
+++ b/src/test/java/spoon/test/field/testclasses/A.java
@@ -1,0 +1,17 @@
+package spoon.test.field.testclasses;
+
+/**
+ * Created by urli on 10/03/2017.
+ */
+public class A {
+    public class BaseClass {
+        public final static String PREFIX = "BasePrefix";
+    }
+
+    public class ClassB {
+        public final static String PREFIX = BaseClass.PREFIX + ".b";
+        public String getKey() {
+            return BaseClass.PREFIX;
+        }
+    }
+}

--- a/src/test/java/spoon/test/field/testclasses/A.java
+++ b/src/test/java/spoon/test/field/testclasses/A.java
@@ -4,9 +4,7 @@ package spoon.test.field.testclasses;
  * Created by urli on 10/03/2017.
  */
 public class A {
-    public class BaseClass {
-        public final static String PREFIX = "BasePrefix";
-    }
+
 
     public class ClassB {
         public final static String PREFIX = BaseClass.PREFIX + ".b";

--- a/src/test/java/spoon/test/field/testclasses/BaseClass.java
+++ b/src/test/java/spoon/test/field/testclasses/BaseClass.java
@@ -1,0 +1,5 @@
+package spoon.test.field.testclasses;
+
+public class BaseClass {
+        public final static String PREFIX = "BasePrefix";
+    }

--- a/src/test/java/spoon/test/reference/CloneReferenceTest.java
+++ b/src/test/java/spoon/test/reference/CloneReferenceTest.java
@@ -5,6 +5,7 @@ import spoon.Launcher;
 import spoon.refactoring.Refactoring;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtScanner;
@@ -19,9 +20,10 @@ public class CloneReferenceTest {
 
     @Test
     public void testGetDeclarationAfterClone() throws Exception {
+        // contract: all variable references of the clone (but fields) should point to the variable of the clone
         Launcher spoon = new Launcher();
 
-        List<String> names = Arrays.asList("f1", "f2", "a", "b", "x", "field", "param", "e");
+        List<String> names = Arrays.asList("f1", "f2", "a", "b", "x", "param", "e");
         spoon.addInputResource("./src/test/resources/noclasspath/A2.java");
         spoon.getEnvironment().setComplianceLevel(8);
         spoon.getEnvironment().setNoClasspath(true);
@@ -37,9 +39,6 @@ public class CloneReferenceTest {
         }
 
         CtClass b = a.clone();
-        b.setSimpleName("newName"); // this won't work: you should use a real refactoring of names
-        b.getPackage().addType(b);
-        Refactoring.changeInheritedTypeName(b, a.getQualifiedName(), "newName");
 
         // test after clone
         for (String name : names) {
@@ -48,6 +47,36 @@ public class CloneReferenceTest {
             CtVariable var2 = refVar1.getDeclaration();
             assertTrue("Var1 and var2 are not the same element", var1 == var2);
         }
+    }
+
+    @Test
+    public void testGetDeclarationOfFieldAfterClone() throws Exception {
+        // contract: all field references of the clone point to the old class
+        // behaviour changed on https://github.com/INRIA/spoon/pull/1215
+        Launcher spoon = new Launcher();
+
+        String name = "field";
+        spoon.addInputResource("./src/test/resources/noclasspath/A2.java");
+        spoon.getEnvironment().setComplianceLevel(8);
+        spoon.getEnvironment().setNoClasspath(true);
+        spoon.buildModel();
+
+
+        final CtClass<Object> a = spoon.getFactory().Class().get("A2");
+        // test before clone
+        CtField oldVar1 = (CtField)findVariable(a, name);
+        CtField oldVar2 = (CtField)findReference(a, name).getDeclaration();
+        assertTrue(oldVar1 == oldVar2);
+
+        CtClass b = a.clone();
+
+        // test after clone
+        CtField var1 = (CtField)findVariable(b, name);
+        CtVariableReference refVar1 = findReference(b, name);
+        CtField var2 = (CtField)refVar1.getDeclaration();
+        assertTrue(var1 != var2);
+        assertTrue(var2 == oldVar1);
+        assertTrue(var1.getParent(CtClass.class) == b);
     }
 
     class Finder<T> extends CtScanner {

--- a/src/test/java/spoon/test/reference/CloneReferenceTest.java
+++ b/src/test/java/spoon/test/reference/CloneReferenceTest.java
@@ -36,12 +36,14 @@ public class CloneReferenceTest {
         }
 
         CtClass b = a.clone();
+        b.setSimpleName("newName");
+        b.getPackage().addType(b);
 
         // test after clone
         for (String name : names) {
             CtVariable var1 = findVariable(b, name);
             CtVariable var2 = findReference(b, name).getDeclaration();
-            assertTrue(var1 == var2);
+            assertTrue("Var1 and var2 are not the same element", var1 == var2);
         }
     }
 

--- a/src/test/java/spoon/test/reference/CloneReferenceTest.java
+++ b/src/test/java/spoon/test/reference/CloneReferenceTest.java
@@ -2,6 +2,7 @@ package spoon.test.reference;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.refactoring.Refactoring;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtVariable;
@@ -36,13 +37,15 @@ public class CloneReferenceTest {
         }
 
         CtClass b = a.clone();
-        b.setSimpleName("newName");
+        b.setSimpleName("newName"); // this won't work: you should use a real refactoring of names
         b.getPackage().addType(b);
+        Refactoring.changeInheritedTypeName(b, a.getQualifiedName(), "newName");
 
         // test after clone
         for (String name : names) {
             CtVariable var1 = findVariable(b, name);
-            CtVariable var2 = findReference(b, name).getDeclaration();
+            CtVariableReference refVar1 = findReference(b, name);
+            CtVariable var2 = refVar1.getDeclaration();
             assertTrue("Var1 and var2 are not the same element", var1 == var2);
         }
     }


### PR DESCRIPTION
The issue #1213 shows that in some cases dynamic lookup just fail to find the right class. Then we propose to remove the dynamic lookup, and to improve the setName instead. 
According to @tdurieux dynamic lookup was introduced to support the clone operations: we propose instead to always use renaming operation after using clone, and then to improve renaming to also rename children of a type. 

A mandatory change is then needed: to use the `setName` operation *after* putting a type in the package. 