### PR TITLE
review1: feature: CtTypeParameter#getTypeErasure()

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -160,4 +160,11 @@ public interface CtTypeInformation {
 	@DerivedProperty
 	Collection<CtExecutableReference<?>> getAllExecutables();
 
+	/**
+	 * @return type (not generic one), which is used by java compiler to ensure that no new classes are created for parameterized types;
+	 * consequently, generics incur no runtime overhead.
+	 * See https://docs.oracle.com/javase/tutorial/java/generics/erasure.html
+	 */
+	@DerivedProperty
+	CtTypeReference<?> getTypeErasure();
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -161,8 +161,7 @@ public interface CtTypeInformation {
 	Collection<CtExecutableReference<?>> getAllExecutables();
 
 	/**
-	 * @return type (not generic one), which is used by java compiler to ensure that no new classes are created for parameterized types;
-	 * consequently, generics incur no runtime overhead.
+	 * @return the type erasure, which is computed by the java compiler to ensure that no new classes are created for parametrized types so that generics incur no runtime overhead.
 	 * See https://docs.oracle.com/javase/tutorial/java/generics/erasure.html
 	 */
 	@DerivedProperty

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -880,6 +880,11 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		return Collections.unmodifiableSet(l);
 	}
 
+	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		return getReference();
+	}
+
 	boolean isShadow;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -249,6 +249,20 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	}
 
 	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		CtTypeReference<?> boundType = getBound(this);
+		return boundType.getTypeErasure();
+	}
+
+	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
+		CtTypeReference<?> bound = typeParam.getSuperclass();
+		if (bound == null) {
+			bound = typeParam.getFactory().Type().OBJECT;
+		}
+		return bound;
+	}
+
+	@Override
 	@UnsettableProperty
 	public <M, C extends CtType<Object>> C addMethod(CtMethod<M> method) {
 		// unsettable property

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -74,6 +74,14 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	}
 
 	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		if (bounds == null || bounds.isEmpty()) {
+			return getFactory().Type().OBJECT;
+		}
+		return bounds.get(0).getTypeErasure();
+	}
+
+	@Override
 	public CtIntersectionTypeReference<T> clone() {
 		return (CtIntersectionTypeReference<T>) super.clone();
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -200,6 +200,11 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	}
 
 	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		return getDeclaration().getTypeErasure();
+	}
+
+	@Override
 	public CtTypeParameterReference clone() {
 		return (CtTypeParameterReference) super.clone();
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -833,4 +833,14 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	private CtTypeParameter findTypeParamDeclarationByPosition(CtFormalTypeDeclarer type, int position) {
 		return type.getFormalCtTypeParameters().get(position);
 	}
+
+	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		if (getActualTypeArguments().isEmpty()) {
+			return this;
+		}
+		CtTypeReference<?> erasedRef = clone();
+		erasedRef.getActualTypeArguments().clear();
+		return erasedRef;
+	}
 }

--- a/src/test/java/spoon/test/ctType/CtTypeParameterTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeParameterTest.java
@@ -1,0 +1,127 @@
+package spoon.test.ctType;
+
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Test;
+
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.NameFilter;
+import spoon.test.ctType.testclasses.ErasureModelA;
+import spoon.testing.utils.ModelUtils;
+
+import static org.junit.Assert.*;
+
+public class CtTypeParameterTest {
+
+	@Test
+	public void testTypeErasure() throws Exception {
+		//contract: the erasure type computed by CtParameterType(Reference)#getTypeErasure is same like the type of method parameter made by java compiler 
+		CtClass<?> ctModel = (CtClass<?>) ModelUtils.buildClass(ErasureModelA.class);
+		//visit all methods of type ctModel
+		//visit all inner types and their methods recursively `getTypeErasure` returns expected value
+		//for each formal type parameter or method parameter check if 
+		checkType(ctModel);
+	}
+	
+	private void checkType(CtType<?> type) throws NoSuchFieldException, SecurityException {
+		List<CtTypeParameter> l_typeParams = type.getFormalCtTypeParameters();
+		for (CtTypeParameter ctTypeParameter : l_typeParams) {
+			checkTypeParamErasureOfType(ctTypeParameter, type.getActualClass());
+		}
+		
+		for (CtTypeMember typeMemeber : type.getTypeMembers()) {
+			if (typeMemeber instanceof CtFormalTypeDeclarer) {
+				CtFormalTypeDeclarer ftDecl = (CtFormalTypeDeclarer) typeMemeber;
+				l_typeParams = ftDecl.getFormalCtTypeParameters();
+				if (typeMemeber instanceof CtExecutable<?>) {
+					CtExecutable<?> exec = (CtExecutable<?>) typeMemeber;
+					for (CtTypeParameter ctTypeParameter : l_typeParams) {
+						checkTypeParamErasureOfExecutable(ctTypeParameter, exec);
+					}
+					for (CtParameter<?> param : exec.getParameters()) {
+						checkParameterErasureOfExecutable(param, exec);
+					}
+				} else if (typeMemeber instanceof CtType<?>) {
+					CtType<?> nestedType = (CtType<?>) typeMemeber;
+					checkType(nestedType);
+				}
+			}
+		}
+	}
+	
+	private void checkTypeParamErasureOfType(CtTypeParameter typeParam, Class<?> clazz) throws NoSuchFieldException, SecurityException {
+		Field field = clazz.getDeclaredField("param"+typeParam.getSimpleName());
+		assertEquals("TypeErasure of type param "+getTypeParamIdentification(typeParam), field.getType().getName(), typeParam.getTypeErasure().getQualifiedName());
+	}
+
+	private void checkTypeParamErasureOfExecutable(CtTypeParameter typeParam, CtExecutable<?> exec) throws NoSuchFieldException, SecurityException {
+		CtParameter<?> param = exec.filterChildren(new NameFilter<>("param"+typeParam.getSimpleName())).first();
+		assertNotNull("Missing param"+typeParam.getSimpleName() + " in "+ exec.getSignature(), param);
+		int paramIdx = exec.getParameters().indexOf(param);
+		Class declClass = exec.getParent(CtType.class).getActualClass();
+		Executable declExec;
+		if (exec instanceof CtConstructor) {
+			declExec = declClass.getDeclaredConstructors()[0];
+		} else {
+			declExec = getMethodByName(declClass, exec.getSimpleName());
+		}
+		Class<?> paramType = declExec.getParameterTypes()[paramIdx];
+		assertEquals("TypeErasure of executable param "+getTypeParamIdentification(typeParam), paramType.getName(), typeParam.getTypeErasure().toString());
+	}
+	
+	private void checkParameterErasureOfExecutable(CtParameter<?> param, CtExecutable<?> exec) {
+		CtTypeReference<?> paramTypeRef = param.getType();
+		paramTypeRef = paramTypeRef.getTypeErasure();
+		int paramIdx = exec.getParameters().indexOf(param);
+		Class declClass = exec.getParent(CtType.class).getActualClass();
+		Executable declExec;
+		if (exec instanceof CtConstructor) {
+			declExec = declClass.getDeclaredConstructors()[0];
+		} else {
+			declExec = getMethodByName(declClass, exec.getSimpleName());
+		}
+		Class<?> paramType = declExec.getParameterTypes()[paramIdx];
+		assertEquals(0, paramTypeRef.getActualTypeArguments().size());
+		assertEquals("TypeErasure of executable "+exec.getSignature()+" parameter "+param.getSimpleName(), paramType.getName(), paramTypeRef.getQualifiedName());
+	}
+	
+	
+	private Executable getMethodByName(Class declClass, String simpleName) {
+		for (Method method : declClass.getDeclaredMethods()) {
+			if(method.getName().equals(simpleName)) {
+				return method;
+			}
+		}
+		fail("Method "+simpleName+" not found in "+declClass.getName());
+		return null;
+	}
+
+	private String getTypeParamIdentification(CtTypeParameter typeParam) {
+		String result = "<"+typeParam.getSimpleName()+">";
+		CtFormalTypeDeclarer l_decl = typeParam.getParent(CtFormalTypeDeclarer.class);
+		if (l_decl instanceof CtType) {
+			return ((CtType) l_decl).getQualifiedName()+result;
+		}
+		if (l_decl instanceof CtExecutable) {
+			CtExecutable exec = (CtExecutable) l_decl;
+			if (exec instanceof CtMethod) {
+				result=exec.getSignature()+result;
+			}
+			return exec.getParent(CtType.class).getQualifiedName()+"#"+result;
+		}
+		throw new AssertionError();
+	}
+}

--- a/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
+++ b/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
@@ -24,7 +24,11 @@ public class ErasureModelA<A, B extends Exception, C extends B, D extends List<B
 
 	public <I> void wildCardMethod(I paramI, ErasureModelA<? extends I, B, C, D> extendsI) {
 	}
-	
+
+	// simple case
+	public void list(List<Object> x, List<List<Object>> y, List<String> z) {
+	}
+
 	static class ModelB<A2,B2 extends Exception, C2 extends B2, D2 extends List<B2>> extends ErasureModelA<A2,B2,C2,D2> {
 		A2 paramA2;
 		B2 paramB2;

--- a/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
+++ b/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
@@ -1,0 +1,52 @@
+package spoon.test.ctType.testclasses;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class ErasureModelA<A, B extends Exception, C extends B, D extends List<B>> {
+	
+	A paramA;
+	B paramB;
+	C paramC;
+	D paramD;
+
+	public <I, J extends C> ErasureModelA(I paramI, J paramJ, D paramD) {
+	}
+
+	public <I, J extends C> void method(I paramI, J paramJ, D paramD) {
+	}
+	
+	public <I, J extends C> void method2(I paramI, J paramJ, D paramD) {
+	}
+	
+	public <I, J extends C, K extends ErasureModelA<A,B,C,D>&Serializable> void method3(I paramI, J paramJ, D paramD, K paramK) {
+	}
+
+	public <I> void wildCardMethod(I paramI, ErasureModelA<? extends I, B, C, D> extendsI) {
+	}
+	
+	static class ModelB<A2,B2 extends Exception, C2 extends B2, D2 extends List<B2>> extends ErasureModelA<A2,B2,C2,D2> {
+		A2 paramA2;
+		B2 paramB2;
+		C2 paramC2;
+		D2 paramD2;
+
+		public <I, J extends C2> ModelB(I paramI, J paramJ, D2 paramD2) {
+			super(paramI, paramJ, paramD2);
+		}
+			
+		@Override
+		public <I, J extends C2> void method(I paramI, J paramJ, D2 paramD2) {
+		}
+	}
+
+	static class ModelC extends ErasureModelA<Integer, RuntimeException, IllegalArgumentException, List<RuntimeException>> {
+
+		public ModelC(Float paramI, IllegalArgumentException paramJ, ModelC paramK) {
+			super(paramI, paramJ, null);
+		}
+		
+		public void method(Float paramI, IllegalArgumentException paramJ, ModelC paramK) {
+		}
+	}
+}


### PR DESCRIPTION
Adds new method:
* CtTypeParamer#getTypeErasure() - returns type erasure of generic parameter

This method and #1225  are needed to correctly detect whether method overrides another method following [specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2)