### PR TITLE
review 1: feature: CtTypeParameter#getTypeDeclarer()

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -34,6 +34,12 @@ public interface CtTypeParameter extends CtType<Object> {
 	@DerivedProperty
 	CtTypeParameterReference getReference();
 
+	/**
+	 * @return the {@link CtFormalTypeDeclarer}, which declares this {@link CtTypeParameter}
+	 */
+	@DerivedProperty
+	CtFormalTypeDeclarer getTypeDeclarer();
+
 	// override the return type
 	@Override
 	CtTypeParameter clone();

--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -38,7 +38,7 @@ public interface CtTypeParameter extends CtType<Object> {
 	 * @return the {@link CtFormalTypeDeclarer}, which declares this {@link CtTypeParameter}
 	 */
 	@DerivedProperty
-	CtFormalTypeDeclarer getTypeDeclarer();
+	CtFormalTypeDeclarer getTypeParameterDeclarer();
 
 	// override the return type
 	@Override

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -342,6 +342,8 @@ public class TypeFactory extends SubFactory {
 			ref.addAnnotation(ctAnnotation.clone());
 		}
 		ref.setSimpleName(type.getSimpleName());
+		//TypeParameter reference without parent is unusable. It lost information about it's declarer
+		ref.setParent(type);
 		return ref;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -17,12 +17,14 @@
 package spoon.support.reflect.declaration;
 
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -76,6 +78,15 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	@Override
 	public CtTypeParameter clone() {
 		return (CtTypeParameter) super.clone();
+	}
+
+	@Override
+	public CtFormalTypeDeclarer getTypeDeclarer() {
+		try {
+			return getParent(CtFormalTypeDeclarer.class);
+		} catch (ParentNotInitializedException e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -81,7 +81,7 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	}
 
 	@Override
-	public CtFormalTypeDeclarer getTypeDeclarer() {
+	public CtFormalTypeDeclarer getTypeParameterDeclarer() {
 		try {
 			return getParent(CtFormalTypeDeclarer.class);
 		} catch (ParentNotInitializedException e) {

--- a/src/test/java/spoon/test/generics/ClassThatBindsAGenericType.java
+++ b/src/test/java/spoon/test/generics/ClassThatBindsAGenericType.java
@@ -4,13 +4,10 @@ import java.io.File;
 import java.util.ArrayList;
 
 @SuppressWarnings("serial")
-public class ClassThatBindsAGenericType extends ArrayList<File> {
+class ClassThatBindsAGenericType extends ArrayList<File> {
 
 	public static void main(String[] args) throws Exception {
 	}
 	
 }
 
-class ClassThatDefinesANewTypeArgument<T> {
-	void foo(T t){}
-}

--- a/src/test/java/spoon/test/generics/ClassThatDefinesANewTypeArgument.java
+++ b/src/test/java/spoon/test/generics/ClassThatDefinesANewTypeArgument.java
@@ -1,0 +1,5 @@
+package spoon.test.generics;
+
+public class ClassThatDefinesANewTypeArgument<T> {
+	void foo(T t){}
+}

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -143,8 +143,9 @@ public class GenericsTest {
 
 	@Test
 	public void testTypeParameterReference() throws Exception {
-		CtClass<?> classThatBindsAGenericType = build("spoon.test.generics", "ClassThatBindsAGenericType");
-		CtClass<?> classThatDefinesANewTypeArgument = classThatBindsAGenericType.getPackage().getElements(new NameFilter<CtClass<?>>("ClassThatDefinesANewTypeArgument")).get(0);
+		Factory factory = build(ClassThatBindsAGenericType.class, ClassThatDefinesANewTypeArgument.class);
+		CtClass<?> classThatBindsAGenericType = factory.Class().get(ClassThatBindsAGenericType.class);
+		CtClass<?> classThatDefinesANewTypeArgument = factory.Class().get(ClassThatDefinesANewTypeArgument.class);
 
 		CtTypeReference<?> tr1 = classThatBindsAGenericType.getSuperclass();
 		CtTypeReference<?> trExtends = tr1.getActualTypeArguments().get(0);
@@ -165,21 +166,11 @@ public class GenericsTest {
 
 	@Test
 	public void testTypeParameterDeclarer() throws Exception {
-		CtClass<?> classThatBindsAGenericType = build("spoon.test.generics", "ClassThatBindsAGenericType");
-		CtClass<?> classThatDefinesANewTypeArgument = classThatBindsAGenericType.getPackage().getElements(new NameFilter<CtClass<?>>("ClassThatDefinesANewTypeArgument")).get(0);
-
+		// contract: one can navigate to the declarer of a type parameter
+		CtClass<?> classThatDefinesANewTypeArgument = build("spoon.test.generics", "ClassThatDefinesANewTypeArgument");
 		CtTypeParameter typeParam = classThatDefinesANewTypeArgument.getFormalCtTypeParameters().get(0);
-		assertSame(typeParam.getParent(CtFormalTypeDeclarer.class), typeParam.getTypeParameterDeclarer()); 
-	}
-
-	@Test
-	public void testTypeParameterReferenceDeclaration() throws Exception {
-		CtClass<?> classThatBindsAGenericType = build("spoon.test.generics", "ClassThatBindsAGenericType");
-		CtClass<?> classThatDefinesANewTypeArgument = classThatBindsAGenericType.getPackage().getElements(new NameFilter<CtClass<?>>("ClassThatDefinesANewTypeArgument")).get(0);
-
-		CtTypeParameter typeParam = classThatDefinesANewTypeArgument.getFormalCtTypeParameters().get(0);
-		//contract: the the reference to type parameter must be able to return the same type parameter
-		assertSame(typeParam, typeParam.getReference().getDeclaration()); 
+		assertSame(classThatDefinesANewTypeArgument, typeParam.getTypeParameterDeclarer());
+		assertSame(typeParam, typeParam.getReference().getDeclaration());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertSame;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.buildNoClasspath;
@@ -29,6 +30,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
@@ -159,6 +161,25 @@ public class GenericsTest {
 		assertEquals(java.io.File.class, trExtends.getActualClass());
 		assertEquals("T", tr2.getSimpleName());
 		assertEquals("T", tr3.getSimpleName());
+	}
+
+	@Test
+	public void testTypeParameterDeclarer() throws Exception {
+		CtClass<?> classThatBindsAGenericType = build("spoon.test.generics", "ClassThatBindsAGenericType");
+		CtClass<?> classThatDefinesANewTypeArgument = classThatBindsAGenericType.getPackage().getElements(new NameFilter<CtClass<?>>("ClassThatDefinesANewTypeArgument")).get(0);
+
+		CtTypeParameter typeParam = classThatDefinesANewTypeArgument.getFormalCtTypeParameters().get(0);
+		assertSame(typeParam.getParent(CtFormalTypeDeclarer.class), typeParam.getTypeParameterDeclarer()); 
+	}
+
+	@Test
+	public void testTypeParameterReferenceDeclaration() throws Exception {
+		CtClass<?> classThatBindsAGenericType = build("spoon.test.generics", "ClassThatBindsAGenericType");
+		CtClass<?> classThatDefinesANewTypeArgument = classThatBindsAGenericType.getPackage().getElements(new NameFilter<CtClass<?>>("ClassThatDefinesANewTypeArgument")).get(0);
+
+		CtTypeParameter typeParam = classThatDefinesANewTypeArgument.getFormalCtTypeParameters().get(0);
+		//contract: the the reference to type parameter must be able to return the same type parameter
+		assertSame(typeParam, typeParam.getReference().getDeclaration()); 
 	}
 
 	@Test


### PR DESCRIPTION
During work with `CtTypeParameter` I always needed to know where this parameter is declared. I suggest to introduce this new API method into `CtTypeParameter`.
```java
	/**
	 * @return the {@link CtFormalTypeDeclarer}, which declares this {@link CtTypeParameter}
	 */
	@DerivedProperty
	CtFormalTypeDeclarer getTypeDeclarer();
```

This PR fixes bug in `TypeFactory#createReference(CtTypeParameter)`, which created reference without parent, so there was lost information about type parameter declarer. CtTypeParameterReference without declarer is useless.