### PR TITLE
review1: feature: CtTypeParameter#isSubtypeOf

### DIFF
--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -97,6 +97,12 @@ public class ExecutableFactory extends SubFactory {
 	 * Creates an executable reference from an existing executable.
 	 */
 	public <T> CtExecutableReference<T> createReference(CtExecutable<T> e) {
+		CtExecutableReference<T> er = createReferenceInternal(e);
+		er.setParent(e);
+		return er;
+	}
+
+	private <T> CtExecutableReference<T> createReferenceInternal(CtExecutable<T> e) {
 		CtTypeReference<?> refs[] = new CtTypeReference[e.getParameters().size()];
 		int i = 0;
 		for (CtParameter<?> param : e.getParameters()) {

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -82,6 +82,7 @@ import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
@@ -105,6 +106,7 @@ import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.chain.CtQuery;
+import spoon.support.visitor.GenericTypeAdapter;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -743,6 +745,11 @@ public interface Factory {
 	 *  @see TypeFactory#createIntersectionTypeReferenceWithBounds(List)
 	 */
 	<T> CtIntersectionTypeReference<T> createIntersectionTypeReferenceWithBounds(List<CtTypeReference<?>> bounds);
+
+	/**
+	 * @see TypeFactory#createTypeAdapter(CtFormalTypeDeclarer)
+	 */
+	GenericTypeAdapter createTypeAdapter(CtFormalTypeDeclarer formalTypeDeclarer);
 
 	/**
 	 *  @see TypeFactory#createReferences(List)

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -83,6 +83,7 @@ import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
@@ -108,6 +109,7 @@ import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.chain.CtQuery;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
+import spoon.support.visitor.GenericTypeAdapter;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -1015,6 +1017,11 @@ public class FactoryImpl implements Factory, Serializable {
 	@Override
 	public <T> CtIntersectionTypeReference<T> createIntersectionTypeReferenceWithBounds(List<CtTypeReference<?>> bounds) {
 		return Type().createIntersectionTypeReferenceWithBounds(bounds);
+	}
+
+	@Override
+	public GenericTypeAdapter createTypeAdapter(CtFormalTypeDeclarer formalTypeDeclarer) {
+		return Type().createTypeAdapter(formalTypeDeclarer);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -656,7 +656,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				final CtTypeReference<?> parameterType = parameterTypes[i];
 				if (parameterType instanceof CtArrayTypeReference) {
 					if (ctParameterType instanceof CtArrayTypeReference) {
-						if (!isSameParameter(((CtArrayTypeReference) ctParameterType).getComponentType(), ((CtArrayTypeReference) parameterType).getComponentType())) {
+						if (!isSameParameter(candidate, ((CtArrayTypeReference) ctParameterType).getComponentType(), ((CtArrayTypeReference) parameterType).getComponentType())) {
 							cont = false;
 						} else {
 							if (!(((CtArrayTypeReference) ctParameterType).getDimensionCount() == ((CtArrayTypeReference) parameterType).getDimensionCount())) {
@@ -666,7 +666,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 					} else {
 						cont = false;
 					}
-				} else if (!isSameParameter(ctParameterType, parameterType)) {
+				} else if (!isSameParameter(candidate, ctParameterType, parameterType)) {
 					cont = false;
 				}
 			}
@@ -677,7 +677,19 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		return null;
 	}
 
-	private boolean isSameParameter(CtTypeReference<?> ctParameterType, CtTypeReference<?> expectedType) {
+	private boolean isSameParameter(CtMethod<?> method, CtTypeReference<?> ctParameterType, CtTypeReference<?> expectedType) {
+		if (expectedType instanceof CtTypeParameterReference) {
+			/*
+			 * the expectedType is a generic parameter whose declaration should be searched in scope of method
+			 * (not in scope of it's parent, where it can found another/wrong type parameter declaration of same name.
+			 */
+			CtTypeParameterReference tpr = (CtTypeParameterReference) expectedType;
+			expectedType = tpr.clone();
+			expectedType.setParent(method);
+			if (expectedType.getDeclaration() == null) {
+				return false;
+			}
+		}
 		if (expectedType instanceof CtTypeParameterReference && ctParameterType instanceof CtTypeParameterReference) {
 			// Check if Object or extended.
 			if (!ctParameterType.equals(expectedType)) {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.reference;
 
+import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtType;
@@ -91,7 +92,7 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	public Class<Object> getActualClass() {
 		if (isUpper()) {
 			if (getBoundingType() == null) {
-				return Object.class;
+				return (Class<Object>) getTypeErasure().getActualClass();
 			}
 			return (Class<Object>) getBoundingType().getActualClass();
 		}
@@ -201,7 +202,16 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 
 	@Override
 	public CtTypeReference<?> getTypeErasure() {
-		return getDeclaration().getTypeErasure();
+		CtTypeParameter typeParam = getDeclaration();
+		if (typeParam == null) {
+			throw new SpoonException("Cannot resolve type erasure of the type parameter reference, which is not able to found it's declaration.");
+		}
+		return typeParam.getTypeErasure();
+	}
+
+	@Override
+	public boolean isSubtypeOf(CtTypeReference<?> type) {
+		return getDeclaration().isSubtypeOf(type);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -1,0 +1,495 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import spoon.SpoonException;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtWildcardReference;
+import spoon.reflect.visitor.chain.CtConsumer;
+import spoon.reflect.visitor.chain.ScanningMode;
+import spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction;
+
+/**
+ * Helper class created from type X or reference to X.
+ * It provides access to actual type arguments
+ * of any super type of type X adapted to type X.<br>
+ * Example:<br>
+ * <pre>
+ * //reference to `ArrayList` with actual type argument `Integer`
+ * CtTypeReference arrayListRef = ... //ArrayList&lt;Integer&gt;
+ * //type java.util.List with type parameter `E`
+ * CtType list = ... //List&lt;E&gt;
+ * //adapting of type parameter `E` to scope of arrayListRef
+ * CtTypeReference typeParamE_adaptedTo_arrayListRef = new ClassTypingContext(arrayListRef).adaptType(list.getFormalCtTypeParameters().get(0))
+ * //the value of `E` in scope of arrayListRef is `Integer`
+ * assertEquals(Integer.class.getName(), typeParamE_adaptedTo_arrayListRef.getQualifiedName());
+ * </pre>
+ */
+public class ClassTypingContext implements GenericTypeAdapter {
+	/*
+	 * super type hierarchy of the enclosing class
+	 */
+	private ClassTypingContext enclosingClassTypingContext;
+
+	/*
+	 * maps qualified name of the type to the actual type arguments of this type in `scope`
+	 */
+	private Map<String, List<CtTypeReference<?>>> typeToArguments = new HashMap<>();
+	/**
+	 * remember which super class was last visited.
+	 * The next super class scanning will start here
+	 */
+	private CtTypeInformation lastResolvedSuperclass;
+	/**
+	 * the set of qualified names of all visited classes and interfaces, which assures that interfaces are visited only once
+	 */
+	private Set<String> visitedSet;
+
+	/**
+	 * @param typeReference {@link CtTypeReference} whose actual type arguments are used for resolving of input type parameters
+	 */
+	public ClassTypingContext(CtTypeReference<?> typeReference) {
+		lastResolvedSuperclass = typeReference;
+		CtTypeReference<?> enclosing = getEnclosingType(typeReference);
+		if (enclosing != null) {
+			enclosingClassTypingContext = createEnclosingHierarchy(enclosing);
+		}
+		typeToArguments.put(typeReference.getQualifiedName(), typeReference.getActualTypeArguments());
+	}
+
+	/**
+	 * @param type {@link CtType} whose formal type parameters are transformed to {@link CtTypeReference}s,
+	 * which plays role of actual type arguments, used for resolving of input type parameters
+	 */
+	public ClassTypingContext(CtType<?> type) {
+		lastResolvedSuperclass = type;
+		CtType<?> enclosing = getEnclosingType(type);
+		if (enclosing != null) {
+			enclosingClassTypingContext = createEnclosingHierarchy(enclosing);
+		}
+		typeToArguments.put(type.getQualifiedName(), getTypeReferences(type.getFormalCtTypeParameters()));
+	}
+
+	@Override
+	public CtTypeReference<?> adaptType(CtTypeInformation type) {
+		if (type instanceof CtTypeReference<?>) {
+			if (type instanceof CtTypeParameterReference) {
+				return adaptTypeParameter(((CtTypeParameterReference) type).getDeclaration());
+			}
+			return (CtTypeReference<?>) type;
+		}
+		if (type instanceof CtTypeParameter) {
+			return adaptTypeParameter((CtTypeParameter) type);
+		}
+		return ((CtType<?>) type).getReference();
+	}
+
+	/**
+	 * detects if `superTypeRef` is a super type of the type or type reference,
+	 * which was send to constructor of this instance.
+	 * It takes into account the actual type arguments of this type and `superTypeRef`
+	 *
+	 * So for example:<br>
+	 * <pre>
+	 * CtTypeReference listInteger = ...//List&lt;Integer&gt;
+	 * CtTypeReference listString = ...//List&lt;Integer&gt;
+	 * assertFalse(new ClassTypingContext(listInteger).isSubtypeOf(listString))
+	 * CtTypeReference listExtendsNumber = ...//List&lt;? extends Number&gt;
+	 * assertTrue(new ClassTypingContext(listInteger).isSubtypeOf(listExtendsNumber))
+	 * </pre>
+	 * @param superTypeRef the reference
+	 * @return true if this type (including actual type arguments) is a sub type of superTypeRef
+	 */
+	public boolean isSubtypeOf(CtTypeReference<?> superTypeRef) {
+		List<CtTypeReference<?>> adaptedArgs = resolveActualTypeArgumentsOf(superTypeRef);
+		if (adaptedArgs == null) {
+			//the superTypeRef was not found in super type hierarchy
+			return false;
+		}
+		if (isSubTypeByActualTypeArguments(superTypeRef, adaptedArgs) == false) {
+			return false;
+		}
+		CtTypeReference<?> enclosingTypeRef = getEnclosingType(superTypeRef);
+		if (enclosingTypeRef != null) {
+			if (enclosingClassTypingContext == null) {
+				return false;
+			}
+			return enclosingClassTypingContext.isSubtypeOf(enclosingTypeRef);
+		}
+		return true;
+	}
+
+	/**
+	 * resolve actual type argument values of the provided type reference
+	 * @param typeRef the reference to the type
+	 * 	whose actual type argument values has to be resolved in scope of `scope` type
+	 * @return actual type arguments of `typeRef` in scope of `scope` element or null if typeRef is not a super type of `scope`
+	 */
+	public List<CtTypeReference<?>> resolveActualTypeArgumentsOf(CtTypeReference<?> typeRef) {
+		final String typeQualifiedName = typeRef.getQualifiedName();
+		List<CtTypeReference<?>> args = typeToArguments.get(typeQualifiedName);
+		if (args != null) {
+			//the actual type arguments of `type` are already resolved
+			return args;
+		}
+		//resolve hierarchy of enclosing class first.
+		CtTypeReference<?> enclosingTypeRef = getEnclosingType(typeRef);
+		if (enclosingTypeRef != null) {
+			if (enclosingClassTypingContext == null) {
+				return null;
+			}
+			//`type` is inner class. Resolve it's enclosing class arguments first
+			if (enclosingClassTypingContext.resolveActualTypeArgumentsOf(enclosingTypeRef) == null) {
+				return null;
+			}
+		}
+		/*
+		 * the `type` is either top level, static or resolved inner class.
+		 * So it has no parent actual type arguments or they are resolved now
+		 */
+		/*
+		 * detect where to start/continue with resolving of super classes and super interfaces
+		 * to found actual type arguments of input `type`
+		 */
+		if (lastResolvedSuperclass == null) {
+			/*
+			 * whole super inheritance hierarchy was already resolved for this level.
+			 * It means that `type` is not a super type of `scope` on the level `level`
+			 */
+			return null;
+		}
+		final HierarchyListener listener = new HierarchyListener(getVisitedSet());
+		/*
+		 * visit super inheritance class hierarchy of lastResolve type of level of `type` to found it's actual type arguments.
+		 */
+		((CtElement) lastResolvedSuperclass).map(new SuperInheritanceHierarchyFunction()
+				.includingSelf(false)
+				.returnTypeReferences(true)
+				.setListener(listener))
+		.forEach(new CtConsumer<CtTypeReference<?>>() {
+			@Override
+			public void accept(CtTypeReference<?> typeRef) {
+				/*
+				 * typeRef is a reference from sub type to super type.
+				 * It contains actual type arguments in scope of sub type,
+				 * which are going to be substituted as arguments to formal type parameters of super type
+				 */
+				String superTypeQualifiedName = typeRef.getQualifiedName();
+				List<CtTypeReference<?>> superTypeActualTypeArgumentsResolvedFromSubType = resolveTypeParameters(typeRef.getActualTypeArguments());
+				//Remember actual type arguments of `type`
+				typeToArguments.put(superTypeQualifiedName, superTypeActualTypeArgumentsResolvedFromSubType);
+				if (typeQualifiedName.equals(superTypeQualifiedName)) {
+					/*
+					 * we have found actual type arguments of input `type`
+					 * We can finish. But only after all interfaces of last visited class are processed too
+					 */
+					listener.foundArguments = superTypeActualTypeArgumentsResolvedFromSubType;
+				}
+			}
+		});
+		return listener.foundArguments;
+	}
+
+	@Override
+	public ClassTypingContext getEnclosingGenericTypeAdapter() {
+		return enclosingClassTypingContext;
+	}
+
+	/**
+	 * might be used to create custom chain of super type hierarchies
+	 */
+	protected ClassTypingContext createEnclosingHierarchy(CtType<?> enclosingType) {
+		return new ClassTypingContext(enclosingType);
+	}
+	/**
+	 * might be used to create custom chain of super type hierarchies
+	 */
+	protected ClassTypingContext createEnclosingHierarchy(CtTypeReference<?> enclosingTypeRef) {
+		return new ClassTypingContext(enclosingTypeRef);
+	}
+
+	static List<CtTypeReference<?>> getTypeReferences(List<? extends CtType<?>> types) {
+		List<CtTypeReference<?>> refs = new ArrayList<>(types.size());
+		for (CtType<?> type : types) {
+			refs.add(type.getReference());
+		}
+		return refs;
+	}
+
+	/**
+	 * @param type the potential inner class, whose enclosing type should be returned
+	 * @return enclosing type of a `type` is an inner type or null if `type` is explicitly or implicitly static or top level type
+	 */
+	private CtType<?> getEnclosingType(CtType<?> type) {
+		if (type.hasModifier(ModifierKind.STATIC)) {
+			return null;
+		}
+		CtType<?> declType = type.getDeclaringType();
+		if (declType == null) {
+			return null;
+		}
+		if (declType.isInterface()) {
+			//nested types of interfaces are static
+			return null;
+		}
+		return declType;
+	}
+
+	/**
+	 * @param typeRef the potential inner class, whose enclosing type should be returned
+	 * @return enclosing type of a `type` is an inner type or null if `type` is explicitly or implicitly static or top level type
+	 */
+	private CtTypeReference<?> getEnclosingType(CtTypeReference<?> typeRef) {
+		CtType<?> type = typeRef.getTypeDeclaration();
+		if (type.hasModifier(ModifierKind.STATIC)) {
+			return null;
+		}
+		CtType<?> declType = type.getDeclaringType();
+		if (declType == null) {
+			return null;
+		}
+		if (declType.isInterface()) {
+			//nested types of interfaces are static
+			return null;
+		}
+		return typeRef.getDeclaringType();
+	}
+
+	/**
+	 * adapts `typeParam` to the {@link CtTypeReference}
+	 * of scope of this {@link ClassTypingContext}
+	 * In can be {@link CtTypeParameterReference} again - depending actual type arguments of this {@link ClassTypingContext}.
+	 *
+	 * @param typeParam to be resolved {@link CtTypeParameter}
+	 * @return {@link CtTypeReference} or {@link CtTypeParameterReference} adapted to scope of this {@link ClassTypingContext}
+	 *  or null if `typeParam` cannot be adapted to target `scope`
+	 */
+	private CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
+		CtFormalTypeDeclarer declarer = typeParam.getTypeParameterDeclarer();
+		if ((declarer instanceof CtType<?>) == false) {
+			return null;
+		}
+		//get the actual type argument values for the declarer of `typeParam`
+		List<CtTypeReference<?>> actualTypeArguments = resolveActualTypeArgumentsOf(((CtType<?>) declarer).getReference());
+		if (actualTypeArguments == null) {
+			if (enclosingClassTypingContext != null) {
+				//try to adapt parameter using enclosing class typing context
+				return enclosingClassTypingContext.adaptType(typeParam);
+			}
+			return null;
+		}
+		return getValue(actualTypeArguments, typeParam, declarer);
+	}
+
+	/**
+	 * Create visitedSet lazily
+	 */
+	private Set<String> getVisitedSet() {
+		if (visitedSet == null) {
+			visitedSet = new HashSet<>();
+		}
+		return visitedSet;
+	}
+
+	/**
+	 * the listener which assures that
+	 * - each interface of super inheritance hierarchy is visited only once
+	 * - the scanning of super inheritance hierarchy early stops when we have found
+	 */
+	private class HierarchyListener extends SuperInheritanceHierarchyFunction.DistinctTypeListener {
+		List<CtTypeReference<?>> foundArguments;
+		HierarchyListener(Set<String> visitedSet) {
+			super(visitedSet);
+		}
+		@Override
+		public ScanningMode enter(CtElement element) {
+			ScanningMode mode = super.enter(element);
+			if (mode == ScanningMode.SKIP_ALL) {
+				//this interface was already visited. Do not visit it again
+				return mode;
+			}
+			CtType<?> type = ((CtTypeReference<?>) element).getTypeDeclaration();
+			if (type instanceof CtClass) {
+				if (foundArguments != null) {
+					//we have found result then we can finish before entering super class. All interfaces of found type should be still visited
+					//skip before super class (and it's interfaces) of found type is visited
+					return ScanningMode.SKIP_ALL;
+				}
+				/*
+				 * we are visiting class (not interface)
+				 * Remember that, so we can continue at this place if needed.
+				 * If we enter class, then this listener assures that that class and all it's not yet visited interfaces are visited
+				 */
+				lastResolvedSuperclass = type;
+			}
+			//this type was not visited yet. Visit it normally
+			return ScanningMode.NORMAL;
+		}
+	}
+
+	/**
+	 * resolve typeRefs declared in scope of declarer using actual type arguments registered in typeScopeToActualTypeArguments
+	 * @param typeRefs to be resolved type references
+	 * @return resolved type references - one for each `typeRefs`
+	 * @throws SpoonException if they cannot be resolved. It should not normally happen. If it happens then spoon AST model is probably not consistent.
+	 */
+	private List<CtTypeReference<?>> resolveTypeParameters(List<CtTypeReference<?>> typeRefs) {
+		List<CtTypeReference<?>> result = new ArrayList<>(typeRefs.size());
+		for (CtTypeReference<?> typeRef : typeRefs) {
+			if (typeRef instanceof CtTypeParameterReference) {
+				CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
+				CtTypeParameter typeParam = typeParamRef.getDeclaration();
+				CtFormalTypeDeclarer declarer = typeParam.getTypeParameterDeclarer();
+				if ((declarer instanceof CtType<?>) == false) {
+					throw new SpoonException("Cannot adapt type parameters of non type scope");
+				}
+				CtType<?> typeDeclarer = (CtType<?>) declarer;
+				List<CtTypeReference<?>> actualTypeArguments = typeToArguments.get(typeDeclarer.getQualifiedName());
+				if (actualTypeArguments == null) {
+					/*
+					 * the actualTypeArguments of this declarer cannot be resolved.
+					 * There is probably a model inconsistency
+					 */
+					throw new SpoonException("Cannot resolve " + (result.size() + 1) + ") type parameter <" + typeParamRef.getSimpleName() + ">  of declarer " + declarer);
+				}
+				if (actualTypeArguments.size() != typeDeclarer.getFormalCtTypeParameters().size()) {
+					if (actualTypeArguments.isEmpty() == false) {
+						throw new SpoonException("Unexpected actual type arguments " + actualTypeArguments + " on " + typeDeclarer);
+					}
+					/*
+					 * the scope type was delivered as type reference without appropriate type arguments.
+					 * Use references to formal type parameters
+					 */
+					actualTypeArguments = getTypeReferences(typeDeclarer.getFormalCtTypeParameters());
+					typeToArguments.put(typeDeclarer.getQualifiedName(), actualTypeArguments);
+				}
+				typeRef = getValue(actualTypeArguments, typeParam, declarer);
+			}
+			result.add(typeRef);
+		}
+		return result;
+	}
+
+	private static CtTypeReference<?> getValue(List<CtTypeReference<?>> arguments, CtTypeParameter typeParam, CtFormalTypeDeclarer declarer) {
+		if (declarer.getFormalCtTypeParameters().size() != arguments.size()) {
+			throw new SpoonException("Unexpected count of actual type arguments");
+		}
+		int typeParamIdx = declarer.getFormalCtTypeParameters().indexOf(typeParam);
+		return arguments.get(typeParamIdx);
+	}
+
+	/**
+	 * Substitutes the typeParameter by its value
+	 * @param typeParameter - to be substituted parameter
+	 * @param declarer - the declarer of typeParameter
+	 * @param values - the list of parameter values
+	 * @return the value from values on the same position as typeParameter in declarer.getFormalCtTypeParameters()
+	 */
+	static <T, U extends List<T>> T substituteBy(CtTypeParameter typeParameter, CtFormalTypeDeclarer declarer, U values) {
+		List<CtTypeParameter> typeParams = declarer.getFormalCtTypeParameters();
+		int position = typeParams.indexOf(typeParameter);
+		if (position == -1) {
+			throw new SpoonException("Type parameter <" + typeParameter.getSimpleName() + " not found in scope " + declarer.getShortRepresentation());
+		}
+		if (values.size() != typeParams.size()) {
+			throw new SpoonException("Unexpected count of parameters");
+		}
+		return values.get(position);
+	}
+
+	/**
+	 * @return true if actualType arguments of `scope` are fitting as a subtype of superTypeArgs
+	 */
+	private boolean isSubTypeByActualTypeArguments(CtTypeReference<?> superTypeRef, List<CtTypeReference<?>> expectedSuperTypeArguments) {
+		List<CtTypeReference<?>> superTypeArgs = superTypeRef.getActualTypeArguments();
+		if (superTypeArgs.isEmpty()) {
+			//the raw type or not a generic type. Arguments are ignored in sub type detection
+			return true;
+		}
+		List<CtTypeReference<?>> subTypeArgs = expectedSuperTypeArguments;
+		if (subTypeArgs.isEmpty()) {
+			//the raw type or not a generic type
+			return true;
+		}
+		if (subTypeArgs.size() != superTypeArgs.size()) {
+			//the number of arguments is not same - it should not happen ...
+			return false;
+		}
+		for (int i = 0; i < subTypeArgs.size(); i++) {
+			CtTypeReference<?> superArg = superTypeArgs.get(i);
+			CtTypeReference<?> subArg = subTypeArgs.get(i);
+			if (isSubTypeArg(subArg, superArg) == false) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * @return true if actualType argument `subArg` is fitting as a subtype of actual type argument `superArg`
+	 */
+	private boolean isSubTypeArg(CtTypeReference<?> subArg, CtTypeReference<?> superArg) {
+		if (superArg instanceof CtWildcardReference) {
+			CtWildcardReference wr = (CtWildcardReference) superArg;
+			CtTypeReference<?> superBound = wr.getBoundingType();
+			if (superBound == null) {
+				//everything extends from object, nothing is super of Object
+				return wr.isUpper();
+			}
+			if (subArg instanceof CtWildcardReference) {
+				CtWildcardReference subWr = (CtWildcardReference) subArg;
+				CtTypeReference<?> subBound = subWr.getBoundingType();
+				if (subBound == null) {
+					//nothing is super of object
+					return false;
+				}
+				if (wr.isUpper() != subWr.isUpper()) {
+					//one is "super" second is "extends"
+					return false;
+				}
+				if (wr.isUpper()) {
+					//both are extends
+					return subBound.isSubtypeOf(superBound);
+				}
+				//both are super
+				return superBound.isSubtypeOf(subBound);
+			}
+			if (wr.isUpper()) {
+				return subArg.isSubtypeOf(superBound);
+			} else {
+				return superBound.isSubtypeOf(subArg);
+			}
+		}
+		//superArg is not a wildcard. Only same type is matching
+		return subArg.equals(superArg);
+	}
+}

--- a/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
+++ b/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * Provides adapting of generic types from one scope to another scope.
+ */
+public interface GenericTypeAdapter {
+	/**
+	 * adapts `type` to the {@link CtTypeReference}
+	 * of the scope of this {@link ClassTypingContext}
+	 *
+	 * This mapping function is able to resolve {@link CtTypeParameter} of:<br>
+	 * A) input type or any super class or any enclosing class of input type or it's super class<br>
+	 * B) super interfaces of input type or super interfaces of it's super classes.<br>
+	 *
+	 * @param type to be adapted type
+	 * @return {@link CtTypeReference} adapted to scope of this {@link ClassTypingContext}
+	 * or null if type cannot be adapted to this `scope`.
+	 */
+	CtTypeReference<?> adaptType(CtTypeInformation type);
+
+	/**
+	 * @return the {@link GenericTypeAdapter}, which adapts generic types of enclosing type
+	 */
+	GenericTypeAdapter getEnclosingGenericTypeAdapter();
+}

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -1,0 +1,312 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import static spoon.support.visitor.ClassTypingContext.getTypeReferences;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * For the `scopeMethod` and super type hierarchy of it's declaring type,
+ * it is able to adapt type parameters
+ * and compare method signatures.
+ */
+public class MethodTypingContext implements GenericTypeAdapter {
+
+	private CtExecutable<?> scopeMethod;
+	private List<CtTypeReference<?>> actualTypeArguments;
+	private ClassTypingContext classTypingContext;
+
+	public MethodTypingContext() {
+	}
+
+	public MethodTypingContext setMethod(CtMethod<?> scopeMethod) {
+		this.scopeMethod = scopeMethod;
+		actualTypeArguments = getTypeReferences(scopeMethod.getFormalCtTypeParameters());
+		return this;
+	}
+
+	public MethodTypingContext setConstructor(CtConstructor<?> scopeConstructor) {
+		this.scopeMethod = scopeConstructor;
+		actualTypeArguments = getTypeReferences(scopeConstructor.getFormalCtTypeParameters());
+		return this;
+	}
+
+	@Override
+	public ClassTypingContext getEnclosingGenericTypeAdapter() {
+		if (classTypingContext == null && scopeMethod != null) {
+			classTypingContext = new ClassTypingContext(((CtTypeMember) scopeMethod).getDeclaringType());
+		}
+		return classTypingContext;
+	}
+
+	public MethodTypingContext setClassTypingContext(ClassTypingContext classTypingContext) {
+		this.classTypingContext = classTypingContext;
+		return this;
+	}
+
+	public MethodTypingContext setInvocation(CtInvocation<?> invocation) {
+		if (classTypingContext == null) {
+			CtExpression<?> target = invocation.getTarget();
+			if (target != null) {
+				CtTypeReference<?> targetTypeRef = target.getType();
+				if (targetTypeRef != null) {
+					classTypingContext = new ClassTypingContext(targetTypeRef);
+				}
+			}
+		}
+		setExecutableReference(invocation.getExecutable());
+		return this;
+	}
+
+	public MethodTypingContext setExecutableReference(CtExecutableReference<?> execRef) {
+		this.actualTypeArguments = execRef.getActualTypeArguments();
+		this.scopeMethod = (CtMethod<?>) execRef.getDeclaration();
+		if (classTypingContext == null) {
+			CtTypeReference<?> declaringTypeRef = execRef.getDeclaringType();
+			if (declaringTypeRef != null) {
+				classTypingContext = new ClassTypingContext(declaringTypeRef);
+			}
+		}
+		return this;
+	}
+
+	@Override
+	public CtTypeReference<?> adaptType(CtTypeInformation type) {
+		if (type instanceof CtTypeReference<?>) {
+			if (type instanceof CtTypeParameterReference) {
+				return adaptTypeParameter(((CtTypeParameterReference) type).getDeclaration());
+			}
+			return (CtTypeReference<?>) type;
+		}
+		if (type instanceof CtTypeParameter) {
+			return adaptTypeParameter((CtTypeParameter) type);
+		}
+		return ((CtType<?>) type).getReference();
+	}
+
+	/**
+	 * @param thatMethod - to be checked method
+	 * @return true if scope method overrides `thatMethod`
+	 */
+	public boolean isOverriding(CtMethod<?> thatMethod) {
+		CtType<?> thatDeclType = thatMethod.getDeclaringType();
+		if (getEnclosingGenericTypeAdapter().isSubtypeOf(thatDeclType.getReference()) == false) {
+			return false;
+		}
+		return isSubSignature(thatMethod);
+	}
+
+	/**
+	 * scope method is subsignature of thatMethod if either
+	 * A) scope method is same signature like thatMethod
+	 * B) scope method is same signature like type erasure of thatMethod
+	 * See https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2
+	 *
+	 * @param thatMethod - the checked method
+	 * @return true if scope method is subsignature of thatMethod
+	 */
+	public boolean isSubSignature(CtMethod<?> thatMethod) {
+		return checkSignature(thatMethod, true);
+	}
+
+	/**
+	 * The same signature is the necessary condition for method A overrides method B.
+	 * @param thatMethod - the checked method
+	 * @return true if this method and `thatMethod` has same signature
+	 */
+	public boolean isSameSignature(CtMethod<?> thatMethod) {
+		return checkSignature(thatMethod, false);
+	}
+
+	private boolean checkSignature(CtMethod<?> thatMethod, boolean canTypeErasure) {
+		//https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.2
+		if (mightBeSameSignature(thatMethod) == false) {
+			return false;
+		}
+		List<CtTypeParameter> formalCtTypeParameters = ((CtFormalTypeDeclarer) scopeMethod).getFormalCtTypeParameters();
+		List<CtTypeParameter> thatTypeParameters = thatMethod.getFormalCtTypeParameters();
+		boolean useTypeErasure = false;
+		if (formalCtTypeParameters.size() == thatTypeParameters.size()) {
+			//the methods has same count of formal parameters
+			//check that formal type parameters are same
+			for (int i = 0; i < formalCtTypeParameters.size(); i++) {
+				if (isSameMethodFormalTypeParameter(formalCtTypeParameters.get(i), thatTypeParameters.get(i)) == false) {
+					return false;
+				}
+			}
+		} else {
+			//the methods has different count of formal type parameters.
+			if (canTypeErasure == false) {
+				//type erasure is not allowed. So not generic methods cannot match with generic methods
+				return false;
+			}
+			//non generic method can override a generic one if type erasure is allowed
+			if (formalCtTypeParameters.isEmpty() == false) {
+				//scope methods has some parameters. It is generic too, it is not a subsignature of that method
+				return false;
+			}
+			//scope method has zero formal type parameters. It is not generic.
+			useTypeErasure = true;
+		}
+		List<CtTypeReference<?>> thisParameterTypes = getParameterTypes(scopeMethod.getParameters());
+		List<CtTypeReference<?>> thatParameterTypes = getParameterTypes(thatMethod.getParameters());
+		//check that parameters are same after adapted to same scope
+		for (int i = 0; i < thisParameterTypes.size(); i++) {
+			CtTypeReference<?> thisType = thisParameterTypes.get(i);
+			CtTypeReference<?> thatType = thatParameterTypes.get(i);
+			if (useTypeErasure) {
+				if (thatType instanceof CtTypeParameterReference) {
+					thatType = ((CtTypeParameterReference) thatType).getTypeErasure();
+				}
+			} else {
+				thatType = adaptType(thatType);
+			}
+			if (thatType == null) {
+				//the type cannot be adapted.
+				return false;
+			}
+			if (thisType.equals(thatType) == false) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Check if thatMethod might have same signature like scope method.
+	 * Check only attributes, which does not need adapting or type erasure
+	 * @param thatMethod the to be checked method
+	 * @return true if `thatMethod` might have same signature like scope method
+	 */
+	private boolean mightBeSameSignature(CtMethod<?> thatMethod) {
+		if (scopeMethod == thatMethod) {
+			return true;
+		}
+		if ((thatMethod instanceof CtMethod) == false) {
+			return false;
+		}
+		if (thatMethod.getSimpleName().equals(scopeMethod.getSimpleName()) == false) {
+			return false;
+		}
+		if (scopeMethod.getParameters().size() != thatMethod.getParameters().size()) {
+			//the methods has different count of parameters they cannot have same signature
+			return false;
+		}
+		if (((CtFormalTypeDeclarer) scopeMethod).getFormalCtTypeParameters().size() != thatMethod.getFormalCtTypeParameters().size()) {
+			//the methods has different count of formal type parameters they cannot have same signature
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * adapts `typeParam` to the {@link CtTypeReference}
+	 * of scope of this {@link MethodTypingContext}
+	 * In can be {@link CtTypeParameterReference} again - depending actual type arguments of this {@link MethodTypingContext}.
+	 *
+	 * Note: this method is not checking whether declarer method is overridden by scope method,
+	 * so it it may adapt parameters of potentially override equivalent methods.
+	 * Use {@link #checkSignature(CtMethod, boolean)} to check if method overrides another method
+	 *
+	 * @param superParam to be resolved {@link CtTypeParameter}
+	 * @return {@link CtTypeReference} or {@link CtTypeParameterReference} adapted to scope of this {@link MethodTypingContext}
+	 *  or null if `typeParam` cannot be adapted to target `scope`
+	 */
+	private CtTypeReference<?> adaptTypeParameter(CtTypeParameter superParam) {
+		CtFormalTypeDeclarer superDeclarer = superParam.getTypeParameterDeclarer();
+		if (superDeclarer instanceof CtType<?>) {
+			return getEnclosingGenericTypeAdapter().adaptType(superParam);
+		}
+		if (superDeclarer instanceof CtMethod) {
+			CtMethod<?> superMethod = (CtMethod<?>) superDeclarer;
+			/*
+			 * The type parameters of generic executables are same (can be adapted to each other)
+			 * 1) the methods are same or if methods overrides each other
+			 * 2) they are declared on same position
+			 * 3) they have same bound after adapting
+			 * See https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.4.4
+			 */
+			if (mightBeSameSignature(superMethod) == false) {
+				//the methods are different. Cannot adapt parameter
+				return null;
+			}
+			/*
+			 * we do not know 100% if thatMethod overrides scope method,
+			 * but we cannot detect it here, because that check would need adapting of type parameters,
+			 * which would cause StackOverflowError
+			 */
+			int superParamPosition = superMethod.getFormalCtTypeParameters().indexOf(superParam);
+			CtTypeParameter scopeParam = ((CtFormalTypeDeclarer) scopeMethod).getFormalCtTypeParameters().get(superParamPosition);
+			if (isSameMethodFormalTypeParameter(scopeParam, superParam) == false) {
+				//the argument cannot be adapted if bounds are not same
+				return null;
+			}
+			return actualTypeArguments.get(superParamPosition);
+		}
+		return null;
+	}
+
+	/**
+	 * Formal type parameters of method are same if
+	 * 1) both methods have same number of formal type parameters
+	 * 2) bounds of Formal type parameters are after adapting same types
+	 *
+	 * This method checks only point (2). Point (1) has to be already checked by caller
+	 * @return if bounds are same after adapting
+	 */
+	private boolean isSameMethodFormalTypeParameter(CtTypeParameter scopeParam, CtTypeParameter superParam) {
+		CtTypeReference<?> scopeBound = getBound(scopeParam);
+		CtTypeReference<?> superBoundAdapted = adaptType(getBound(superParam));
+		if (superBoundAdapted == null) {
+			return false;
+		}
+		return scopeBound.getQualifiedName().equals(superBoundAdapted.getQualifiedName());
+	}
+
+	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
+		CtTypeReference<?> bound = typeParam.getSuperclass();
+		if (bound == null) {
+			bound = typeParam.getFactory().Type().OBJECT;
+		}
+		return bound;
+	}
+
+	private static List<CtTypeReference<?>> getParameterTypes(List<CtParameter<?>> params) {
+		List<CtTypeReference<?>> types = new ArrayList<>(params.size());
+		for (CtParameter<?> param : params) {
+			types.add(param.getType());
+		}
+		return types;
+	}
+}

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -2,17 +2,29 @@ package spoon.test.ctType;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtComment;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.NameFilter;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.ctType.testclasses.X;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -84,27 +96,98 @@ public class CtTypeTest {
 		//using CtType implementation
 		assertTrue(xCtType.isSubtypeOf(xCtType.getReference()));
 	}
-
+	
 	@Test
 	public void testIsSubTypeOfonTypeParameters() throws Exception {
 		CtType<X> xCtType = buildClass(X.class);
+		Factory factory = xCtType.getFactory();
 
-		CtType<?> oCtType = xCtType.getFactory().Type().get("spoon.test.ctType.testclasses.O");
+		CtType<?> oCtType = factory.Type().get("spoon.test.ctType.testclasses.O");
+		CtType<?> pCtType = factory.Type().get("spoon.test.ctType.testclasses.P");
+		CtTypeReference<?> objectCtTypeRef = factory.Type().OBJECT;
 
-		List<CtTypeParameter> typeParameters = oCtType.getFormalCtTypeParameters();
-		assertTrue(typeParameters.size() == 1);
+		List<CtTypeParameter> oTypeParameters = oCtType.getFormalCtTypeParameters();
+		assertTrue(oTypeParameters.size() == 1);
+		List<CtTypeParameter> pTypeParameters = pCtType.getFormalCtTypeParameters();
+		assertTrue(pTypeParameters.size() == 2);
 
-		CtType<?> aCtType = typeParameters.get(0);
+		CtType<?> O_A_CtType = oTypeParameters.get(0);
+		CtType<?> P_D_CtType = pTypeParameters.get(0);
+		CtType<?> P_F_CtType = pTypeParameters.get(1);
 
-		List<CtMethod<?>> methods = oCtType.getMethodsByName("foo");
+		CtMethod<?> O_FooMethod = oCtType.filterChildren(new NameFilter<>("foo")).first();
+		CtMethod<?> P_FooMethod = pCtType.filterChildren(new NameFilter<>("foo")).first();
 
-		assertTrue(methods.size() == 1);
+		CtType<?> O_B_CtType = O_FooMethod.getType().getDeclaration();
+		CtType<?> P_E_CtType = P_FooMethod.getType().getDeclaration();
 
-		CtMethod<?> fooMethod = methods.get(0);
-		CtType<?> bCtType = fooMethod.getType().getDeclaration();
+		assertTrue(O_B_CtType.isSubtypeOf(xCtType.getReference()));
+		assertTrue(O_B_CtType.isSubtypeOf(O_A_CtType.getReference()));
+		
+		assertTrue(P_E_CtType.isSubtypeOf(xCtType.getReference()));
+		assertTrue(P_E_CtType.isSubtypeOf(P_D_CtType.getReference()));
+		assertTrue(P_E_CtType.isSubtypeOf(O_A_CtType.getReference()));
+		
+		assertTrue(P_D_CtType.isSubtypeOf(O_A_CtType.getReference()));
+		assertTrue(P_E_CtType.isSubtypeOf(O_B_CtType.getReference()));
 
-		//The TypeParameters are not supported yet
-//		assertTrue(bCtType.isSubtypeOf(xCtType.getReference()));
-//		assertTrue(bCtType.isSubtypeOf(aCtType.getReference()));
+		assertTrue(P_E_CtType.isSubtypeOf(objectCtTypeRef));
+		assertTrue(P_F_CtType.isSubtypeOf(objectCtTypeRef));
+	}
+	
+	@Test
+	public void testIsSubTypeOfonTypeReferences() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[]{"-c"});
+		launcher.addInputResource("./src/test/java/spoon/test/ctType/testclasses/SubtypeModel.java");
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+		
+		CtType<?> oCtType = factory.Class().get("spoon.test.ctType.testclasses.SubtypeModel");
+		CtMethod<?> O_FooMethod = oCtType.filterChildren(new NameFilter<>("foo")).first();
+
+		Map<String, CtTypeReference<?>> nameToTypeRef = new HashMap<>();
+		O_FooMethod.filterChildren(new TypeFilter<>(CtLocalVariable.class)).forEach((CtLocalVariable var)->{
+			nameToTypeRef.put(var.getSimpleName(), var.getType());
+		});
+		
+		int[] count = new int[1];
+
+		O_FooMethod.filterChildren(new TypeFilter<>(CtAssignment.class)).forEach((CtAssignment ass)->{
+			for (CtComment comment : ass.getComments()) {
+				checkIsNotSubtype(comment, nameToTypeRef);
+				count[0]++;
+			};
+			count[0]++;
+			checkIsSubtype(((CtVariableAccess) ass.getAssigned()).getVariable().getType(), ((CtVariableAccess) ass.getAssignment()).getVariable().getType(), nameToTypeRef);
+		});
+		
+		assertTrue(count[0]>(9*8));
+	}
+
+	private void checkIsSubtype(CtTypeReference superType, CtTypeReference subType, Map<String, CtTypeReference<?>> nameToTypeRef) {
+		String msg = getTypeName(subType)+" isSubTypeOf "+getTypeName(superType);
+		assertTrue(msg, subType.isSubtypeOf(superType));
+	}
+
+	private static final Pattern assignment = Pattern.compile("\\s*(\\w+)\\s*=\\s*(\\w+);");
+	private void checkIsNotSubtype(CtComment comment, Map<String, CtTypeReference<?>> nameToTypeRef) {
+		Matcher m = assignment.matcher(comment.getContent());
+		assertTrue(m.matches());
+		CtTypeReference<?> superType = nameToTypeRef.get(m.group(1));
+		CtTypeReference<?> subType = nameToTypeRef.get(m.group(2));
+		String msg = getTypeName(subType)+" is NOT SubTypeOf "+getTypeName(superType);
+		assertFalse(msg, subType.isSubtypeOf(superType));
+	}
+	
+	private String getTypeName(CtTypeReference<?> ref) {
+		String name;
+		CtReference r= ref.getParent(CtReference.class);
+		if(r!=null) {
+			name = r.getSimpleName();
+		} else {
+			name = ref.getParent(CtNamedElement.class).getSimpleName();
+		}
+		return ref.toString()+" "+name;
 	}
 }

--- a/src/test/java/spoon/test/ctType/testclasses/SubtypeModel.java
+++ b/src/test/java/spoon/test/ctType/testclasses/SubtypeModel.java
@@ -1,0 +1,123 @@
+package spoon.test.ctType.testclasses;
+
+//We have to declare own implementations of these well known classes, to have them on class path :-)
+interface List<E> {};
+class ArrayList<E> implements List<E> {}
+
+class ListOfX extends ArrayList<X> {}
+class ListOfA1<A> extends ArrayList<A> {}
+class ListOfA3<A,B,C> extends ArrayList<B> {}
+
+public class SubtypeModel<A extends X> {
+
+	void foo() {
+		/*
+		 * Following code (including comments!) is part of model, which is used to test by CtTypeTest#testIsSubTypeOfonTypeReferences
+		 */
+		List listRaw = new ArrayList();
+		List<Object> listObject = new ArrayList<>();
+		List<?> listAll = new ArrayList<>();
+		List<X> listX = new ArrayList<>();
+		ListOfX listOfX = new ListOfX();
+		ListOfA1<X> listOfA1_X = new ListOfA1<>();
+		ListOfA3<O<A>,X,O<Y>> listOfA3_X = new ListOfA3<>();
+		List<Y> listY = new ArrayList<>();
+		List<? extends X> listExtendsX = new ArrayList<>();
+		List<? extends Y> listExtendsY = new ArrayList<>();
+		List<? super X> listSuperX = new ArrayList<>();
+		List<? super Y> listSuperY = new ArrayList<>();
+		
+		X x = null;
+		Y y = null;
+		
+		listExtendsX = listOfA3_X;
+
+		x = y;
+//		y = x;
+		
+		listRaw = listObject; 
+		listRaw = listAll; 
+		listRaw = listX; 
+		listRaw = listY; 
+		listRaw = listExtendsX; 
+		listRaw = listExtendsY;
+		listRaw = listSuperX;
+		listRaw = listSuperY;
+		
+		listObject = listRaw;
+//		listObject = listAll; 
+//		listObject = listX; 
+//		listObject = listY; 
+//		listObject = listExtendsX; 
+//		listObject = listExtendsY;
+//		listObject = listSuperX;
+//		listObject = listSuperY;
+		
+		listAll = listRaw;
+		listAll = listObject; 
+		listAll = listX; 
+		listAll = listY; 
+		listAll = listExtendsX; 
+		listAll = listExtendsY;
+		listAll = listSuperX;
+		listAll = listSuperY;
+
+		listX = listRaw;
+//		listX = listObject; 
+//		listX = listAll; 
+//		listX = listY; 
+//		listX = listExtendsX; 
+//		listX = listExtendsY;
+//		listX = listSuperX;
+//		listX = listSuperY;
+
+		listY = listRaw;
+//		listY = listObject; 
+//		listY = listAll; 
+//		listY = listX; 
+//		listY = listExtendsX; 
+//		listY = listExtendsY;
+//		listY = listSuperX;
+//		listY = listSuperY;
+
+		listExtendsX = listRaw;
+//		listExtendsX = listObject; 
+//		listExtendsX = listAll; 
+		listExtendsX = listX; 
+		listExtendsX = listOfX;
+		listExtendsX = listOfA1_X;
+		listExtendsX = listOfA3_X;
+		listExtendsX = listY; 
+		listExtendsX = listExtendsY;
+//		listExtendsX = listSuperX;
+//		listExtendsX = listSuperY;
+
+		listExtendsY = listRaw;
+//		listExtendsY = listObject; 
+//		listExtendsY = listAll; 
+//		listExtendsY = listX; 
+//		listExtendsY = listOfX; 
+		listExtendsY = listY; 
+//		listExtendsY = listExtendsX; 
+//		listExtendsY = listSuperX;
+//		listExtendsY = listSuperY;
+
+		listSuperX = listRaw;
+		listSuperX = listObject; 
+//		listSuperX = listAll; 
+		listSuperX = listX; 
+//		listSuperX = listY; 
+//		listSuperX = listExtendsX; 
+//		listSuperX = listExtendsY;
+//		listSuperX = listSuperY;
+
+		listSuperY = listRaw;
+		listSuperY = listObject; 
+//		listSuperY = listAll; 
+		listSuperY = listX; 
+		listSuperY = listY; 
+//		listSuperY = listExtendsX; 
+//		listSuperY = listExtendsY;
+		listSuperY = listSuperX;
+	}
+}

--- a/src/test/java/spoon/test/ctType/testclasses/X.java
+++ b/src/test/java/spoon/test/ctType/testclasses/X.java
@@ -23,3 +23,13 @@ class O<A extends X> {
 	}
 }
 
+class P<D extends X, F> extends O<D> {
+	@Override
+	<E extends D> E foo() {
+		return null;
+	}
+}
+
+class K<A extends List<? extends X>> {
+	<B extends A> void m(List<? extends B> l) {}
+}

--- a/src/test/java/spoon/test/generics/testclasses/CelebrationLunch.java
+++ b/src/test/java/spoon/test/generics/testclasses/CelebrationLunch.java
@@ -1,0 +1,40 @@
+package spoon.test.generics.testclasses;
+
+public class CelebrationLunch<K,L,M> extends Lunch<M,K> {
+	public class WeddingLunch<X> extends CelebrationLunch<Tacos, Paella, X> {
+		class Section<Y> {
+			<S> void reserve(S section) {}
+		}
+		@Override
+		<C> void eatMe(X paramA, Tacos paramB, C paramC){}
+	}
+	public class WeddingLunch2<X> {
+		class Section<Y> {
+			<S> void reserve(S section) {}
+		}
+	}
+	@Override
+	<C> void eatMe(M paramA, K paramB, C paramC){}
+	
+	<R> void prepare(R cook) {
+	}
+	
+	void celebrate() {
+		CelebrationLunch<Integer,Long,Double> cl = new CelebrationLunch<>();
+		CelebrationLunch<Integer,Long,Double>.WeddingLunch<Mole> disgust = cl.new WeddingLunch<>();
+		disgust.<Tacos>prepare(new Tacos());
+		CelebrationLunch<Integer,Long,Double>.WeddingLunch<Mole>.Section<Paella> section = disgust.new Section<>();
+		section.<Tacos>reserve(null);
+	}
+}
+
+class SubCelebrationLunch<K2,L2,M2> extends CelebrationLunch<K2,L2,M2> {
+	public class SubWeddingLunch<X2> extends WeddingLunch2<X2> {}
+}
+
+class SubSubCelebrationLunch<K2,L2,M2> extends SubCelebrationLunch<K2,L2,M2> {
+	public class SubSubWeddingLunch<X2> extends SubWeddingLunch<X2> {
+		class SubSection<Y2> extends Section<Y2> {
+		}
+	}
+}

--- a/src/test/java/spoon/test/generics/testclasses/Lunch.java
+++ b/src/test/java/spoon/test/generics/testclasses/Lunch.java
@@ -1,0 +1,5 @@
+package spoon.test.generics.testclasses;
+
+public class Lunch<A,B> {
+	<C> void eatMe(A paramA, B paramB, C paramC){}
+}


### PR DESCRIPTION
Implements #1160.

The implementation of isSubtypeOf on type parameters is quite complex task, which needs all the basic steps below, which fits to commits of this PR.

There are:
BS1) new interface GenericTypeAdapter
BS2) CtSuperTypeHierarchy - adapts generic types to Type scope
BS3) CtMethodSuperTypeHierarchy - adapts generic types to Method/Constructor scope
BS4) CtFormalTypeDeclarer#getGenericTypeAdapter(), which creates instance of CtSuperTypeHierarchy  or CtMethodSuperTypeHierarchy for the scope of this declarer
BS5) CtTypeParameterImpl#isSubtypeOf - finally the implementation of isSubtypeOf  - the target of this PR
BS6) simpler and more correct implementation of `CtTypeParameterImpl#isSubtypeOf(CtTypeReference)`, based on new algorithms
+ first and incomplete tests ... the testing of this java generics stuff is quite tricky ... too many combinations.