### PR TITLE
review 1: fix CtExecutableReference#isOverriding on anonymous class

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -236,11 +236,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		if (!isSame) {
 			return false;
 		}
-		if (getDeclaringType().isAnonymous()) {
-			if (!getDeclaringType().getDeclaringType().isSubtypeOf(executable.getDeclaringType())) {
-				return false;
-			}
-		} else if (!getDeclaringType().isSubtypeOf(executable.getDeclaringType())) {
+		if (!getDeclaringType().isSubtypeOf(executable.getDeclaringType())) {
 			return false;
 		}
 		return true;

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -287,7 +287,8 @@ public class FilterTest {
 
 
 		final List<CtMethod<?>> overridingMethods = Arrays.asList(ts.toArray(new CtMethod[0]));
-		assertEquals(2, overridingMethods.size());
+		assertEquals(3, overridingMethods.size());
+		assertEquals("spoon.test.filters.testclasses.AbstractTostada$1", overridingMethods.get(2).getParent(CtClass.class).getQualifiedName());
 		assertEquals(SubTostada.class, overridingMethods.get(1).getParent(CtClass.class).getActualClass());
 		assertEquals("spoon.test.filters.testclasses.Tostada$1", overridingMethods.get(0).getParent(CtClass.class).getQualifiedName());
 
@@ -328,13 +329,15 @@ public class FilterTest {
 
 		final CtClass<AbstractTostada> anAbstractTostada = launcher.getFactory().Class().get(AbstractTostada.class);
 
-		final List<CtMethod<?>> overridingMethods = Query.getElements(launcher.getFactory(), new OverridingMethodFilter(anAbstractTostada.getMethodsByName("make").get(0)));
+		List<CtMethod<?>> overridingMethods = Query.getElements(launcher.getFactory(), new OverridingMethodFilter(anAbstractTostada.getMethodsByName("make").get(0)));
 		assertEquals(2, overridingMethods.size());
 		assertEquals("spoon.test.filters.testclasses.AbstractTostada$1", overridingMethods.get(0).getParent(CtClass.class).getQualifiedName());
 		assertEquals(Tostada.class, overridingMethods.get(1).getParent(CtClass.class).getActualClass());
 
 		final CtClass<Tostada> aTostada = launcher.getFactory().Class().get(Tostada.class);
-		assertEquals(0, Query.getElements(launcher.getFactory(), new OverridingMethodFilter(aTostada.getMethodsByName("make").get(0))).size());
+		overridingMethods = Query.getElements(launcher.getFactory(), new OverridingMethodFilter(aTostada.getMethodsByName("make").get(0)));
+		assertEquals(1, overridingMethods.size());
+		assertEquals("spoon.test.filters.testclasses.AbstractTostada$1", overridingMethods.get(0).getParent(CtClass.class).getQualifiedName());
 	}
 
 	@Test


### PR DESCRIPTION
I think that `CtExecutableReferenceImpl#isOverriding` handles wrong anonymous types.

I think that anonymous classs
```java
public abstract class AbstractTostada implements ITostada {
	@Override
	public ITostada make() {
//following anonymous class extends Tostada (not ITostada!), therefore it overrides Tostada#make and prepare
//---->
		return new Tostada() {
			@Override
			public void prepare() {
				super.prepare();
			}

			@Override
			public ITostada make() {
				return super.make();
			}
		};
	}

	public abstract void prepare();
}
```
The origin code 
```java
	if (getDeclaringType().isAnonymous()) {
		if (!getDeclaringType().getDeclaringType().isSubtypeOf(executable.getDeclaringType())) {
			return false;
		}
	} 
```
is not understandable for me. So I think it is buggy. May be there was some special case which has to be handled for anonymous classes, which @GerardPaligot wanted to handle, but the code is actually wrong. Any idea what was the origin purpose of that code?