### PR TITLE
Depends on #1238. feature: TypeFactory#createReference(type,includingFormalTypeParams)

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -356,8 +356,7 @@ public class TypeFactory extends SubFactory {
 			ref.addAnnotation(ctAnnotation.clone());
 		}
 		ref.setSimpleName(type.getSimpleName());
-		//TypeParameter reference without parent is unusable. It lost information about it's declarer
-		ref.setParent(type);
+
 		return ref;
 	}
 

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -356,7 +356,7 @@ public class TypeFactory extends SubFactory {
 			ref.addAnnotation(ctAnnotation.clone());
 		}
 		ref.setSimpleName(type.getSimpleName());
-
+		ref.setParent(type);
 		return ref;
 	}
 

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -316,15 +316,29 @@ public class TypeFactory extends SubFactory {
 	 * Create a reference to a simple type
 	 */
 	public <T> CtTypeReference<T> createReference(CtType<T> type) {
+		return createReference(type, false);
+	}
+
+	/**
+	 * @param includingFormalTypeParameter if true then references to formal type parameters
+	 * 	are added as actual type arguments of returned {@link CtTypeReference}
+	 */
+	public <T> CtTypeReference<T> createReference(CtType<T> type, boolean includingFormalTypeParameter) {
 		CtTypeReference<T> ref = factory.Core().createTypeReference();
 
 		if (type.getDeclaringType() != null) {
-			ref.setDeclaringType(createReference(type.getDeclaringType()));
+			ref.setDeclaringType(createReference(type.getDeclaringType(), includingFormalTypeParameter));
 		} else if (type.getPackage() != null) {
 			ref.setPackage(factory.Package().createReference(type.getPackage()));
 		}
 
 		ref.setSimpleName(type.getSimpleName());
+
+		if (includingFormalTypeParameter) {
+			for (CtTypeParameter formalTypeParam : type.getFormalCtTypeParameters()) {
+				ref.addActualTypeArgument(formalTypeParam.getReference());
+			}
+		}
 		return ref;
 	}
 

--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -72,7 +72,11 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 	 */
 	<T extends CtTypeParameterReference> T setBoundingType(CtTypeReference<?> superType);
 
-	// overriding the return type
+	/**
+	 * Returns the {@link CtTypeParameter}, a {@link CtTypeParameter}, that declares the type parameter
+	 * referenced or <code>null</code> if the reference is not in a context where such type parameter is declared.
+	 * See also {@link #getTypeParameterDeclaration()} which has a different semantic.
+	 */
 	@Override
 	@DerivedProperty
 	CtTypeParameter getDeclaration();

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -20,6 +20,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeParameter;
 import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
 
@@ -181,4 +182,25 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 */
 	@DerivedProperty
 	CtTypeReference<?> getAccessType();
+
+	/**
+	 * If this type reference is used as a type argument (see {@link #getActualTypeArguments()}), returns the type parameter declaration in the target type, returns null otherwise.
+	 *
+	 * In the following example, getTypeParameterDeclaration of "String" returns the type parameter definition "X".
+	 * <pre>
+	 * class Dog&lt;X&gt;{}
+	 * Dog&lt;String&gt;var = ...;
+	 * </pre>
+	 **
+	 * In this other example, getTypeParameterDeclaration of T in Dog&lt;T&gt; returns the type parameter definition "X" (while {@link #getDeclaration()} returns the "T" of Cat).
+	 * <pre>
+	 * class Dog&lt;X&gt;{}
+	 * class Cat&lt;T&gt; {
+	 * Dog&lt;T&gt; dog;
+	 * }
+	 * </pre>
+	 */
+	@DerivedProperty
+	CtTypeParameter getTypeParameterDeclaration();
+
 }

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -16,15 +16,11 @@
  */
 package spoon.support.reflect.reference;
 
-import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtActualTypeContainer;
-import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -184,22 +180,6 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 			CtTypeParameter result = findTypeParamDeclaration((CtFormalTypeDeclarer) e, this.getSimpleName());
 			if (result != null) {
 				return result;
-			}
-		}
-
-		CtElement parent = this.getParent();
-
-		// case 2: this is an actual type argument of a type reference eg List<E>
-		if (parent instanceof CtTypeReference) {
-			CtType t = ((CtTypeReference) parent).getTypeDeclaration();
-			return findTypeParamDeclaration(t, this.getSimpleName());
-		}
-
-		// case 3: this is an actual type argument of a method/constructor reference
-		if (parent instanceof CtExecutableReference) {
-			CtExecutable<?> exec = ((CtExecutableReference<?>) parent).getExecutableDeclaration();
-			if (exec instanceof CtMethod || exec instanceof CtConstructor) {
-				return findTypeParamDeclaration((CtFormalTypeDeclarer) exec, this.getSimpleName());
 			}
 		}
 		return null;

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -19,9 +19,15 @@ package spoon.support.reflect.reference;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtArrayTypeReference;
@@ -800,5 +806,31 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	@Override
 	public CtTypeReference<T> clone() {
 		return (CtTypeReference<T>) super.clone();
+	}
+
+	@Override
+	public CtTypeParameter getTypeParameterDeclaration() {
+
+		CtElement parent = this.getParent();
+
+		// case 1: this is an actual type argument of a type reference eg List<E>
+		if (parent instanceof CtTypeReference) {
+			CtType t = ((CtTypeReference) parent).getTypeDeclaration();
+			return findTypeParamDeclarationByPosition(t, ((CtTypeReference) parent).getActualTypeArguments().indexOf(this));
+		}
+
+		// case 2: this is an actual type argument of a method/constructor reference
+		if (parent instanceof CtExecutableReference) {
+			CtExecutable<?> exec = ((CtExecutableReference<?>) parent).getExecutableDeclaration();
+			if (exec instanceof CtMethod || exec instanceof CtConstructor) {
+				return findTypeParamDeclarationByPosition((CtFormalTypeDeclarer) exec, ((CtTypeReference) parent).getActualTypeArguments().indexOf(this));
+			}
+		}
+
+		return null;
+	}
+
+	private CtTypeParameter findTypeParamDeclarationByPosition(CtFormalTypeDeclarer type, int position) {
+		return type.getFormalCtTypeParameters().get(position);
 	}
 }

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -558,4 +558,17 @@ public class GenericsTest {
 		assertFalse(aTacos.isGenerics());
 		assertFalse(ctTypeReference.isGenerics());
 	}
+	@Test
+	public void testGenericTypeReference() throws Exception {
+		CtType<Tacos> aTacos = buildNoClasspath(Tacos.class).Type().get(Tacos.class);
+		//this returns a type reference with unitialized actual type arguments.
+//		CtTypeReference<?> genericTypeRef = aTacos.getReference();
+		CtTypeReference<?> genericTypeRef = aTacos.getFactory().Type().createReference(aTacos, true);
+		
+		assertTrue(genericTypeRef.getActualTypeArguments().size()>0);
+		assertEquals(aTacos.getFormalCtTypeParameters().size(), genericTypeRef.getActualTypeArguments().size());
+		for(int i=0; i<aTacos.getFormalCtTypeParameters().size(); i++) {
+			assertSame("TypeParameter reference idx="+i+" is different", aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getDeclaration());
+		}
+	}
 }

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -172,6 +172,7 @@ public class GenericsTest {
 		assertEquals("T", classThatDefinesANewTypeArgument.getFormalCtTypeParameters().get(0).getSimpleName());
 		assertSame(classThatDefinesANewTypeArgument, typeParam.getTypeParameterDeclarer());
 		CtTypeParameterReference typeParamReference = typeParam.getReference();
+		assertSame(typeParam, typeParamReference.getDeclaration());
 
 		// creating an appropriate context
 		CtMethod m = classThatDefinesANewTypeArgument.getFactory().createMethod();
@@ -182,6 +183,7 @@ public class GenericsTest {
 
 		// the final assertions
 		assertSame(typeParam, typeParamReference.getDeclaration());
+
 		assertSame(classThatDefinesANewTypeArgument, typeParamReference.getDeclaration().getParent());
 
 		// now testing that the getDeclaration of a type parameter is actually a dynamic lookup
@@ -589,12 +591,7 @@ public class GenericsTest {
 
 		CtTypeParameter typeParam = aTacos.getFormalCtTypeParameters().get(0);
 		CtTypeParameterReference typeParamRef = typeParam.getReference();
-
-
-		// a tyoe parameter ref with no context cannot be resolved
-		assertSame(null, typeParamRef.getDeclaration());
-		// by default a typeParamRef is not in a tree
-		assertEquals(false, typeParamRef.isParentInitialized());
+		assertSame(typeParam, typeParamRef.getDeclaration());
 
 		assertEquals("spoon.test.generics.ClassThatDefinesANewTypeArgument", typeRef.toString());
 
@@ -611,7 +608,11 @@ public class GenericsTest {
 		//typeParamRef has got new parent 
 		assertSame(typeRef, typeParamRef.getParent());
 
-		assertSame(typeParam, typeParamRef.getDeclaration());
+		// null because without context
+		assertEquals(null, typeParamRef.getDeclaration());
+		assertEquals(typeParam, typeParamRef.getTypeParameterDeclaration());
+		typeParamRef.setSimpleName("Y");
+		assertEquals(typeParam, typeParamRef.getTypeParameterDeclaration());
 	}
 	@Test
 	public void testGenericTypeReference() throws Exception {
@@ -626,7 +627,13 @@ public class GenericsTest {
 		assertTrue(genericTypeRef.getActualTypeArguments().size()>0);
 		assertEquals(aTacos.getFormalCtTypeParameters().size(), genericTypeRef.getActualTypeArguments().size());
 		for(int i=0; i<aTacos.getFormalCtTypeParameters().size(); i++) {
-			assertSame("TypeParameter reference idx="+i+" is different", aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getDeclaration());
+			assertSame("TypeParameter reference idx="+i+" is different", aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
+
+			// contract: getTypeParameterDeclaration goes back to the declaration, eevn without context
+			assertSame(aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
+
 		}
+
+
 	}
 }

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -559,6 +559,31 @@ public class GenericsTest {
 		assertFalse(ctTypeReference.isGenerics());
 	}
 	@Test
+	public void testTypeParameterReferenceAsActualTypeArgument() throws Exception {
+		CtType<Tacos> aTacos = buildNoClasspath(Tacos.class).Type().get(Tacos.class);
+		
+		CtTypeReference<?> typeRef = aTacos.getReference();
+		CtTypeParameter typeParam = aTacos.getFormalCtTypeParameters().get(0);
+		CtTypeParameterReference typeParamRef = typeParam.getReference();
+		
+		//typeParamRef is able to resolve it's typeParam - OK
+		assertSame(typeParam, typeParamRef.getDeclaration());
+		//the reference to parent is used by legacy 
+		//CtTypeParameterReferenceImpl#getRecursiveDeclaration 
+		//to detect declaration - it is probably wrong approach
+		assertSame(typeParam, typeParamRef.getParent());
+		
+		//this assignment changes parent of typeParamRef to typeRef
+		typeRef.addActualTypeArgument(typeParamRef);
+		//stored typeParamRef is same like the added one, no clone - OK
+		assertSame(typeParamRef, typeRef.getActualTypeArguments().get(0));
+		//typeParamRef has got new parent 
+		assertSame(typeRef, typeParamRef.getParent());
+		//and therefore it lost the link to declaring CtFormalTypeDeclarer, 
+		//so this assertion FAILS
+		assertSame(typeParam, typeParamRef.getDeclaration());
+	}
+	@Test
 	public void testGenericTypeReference() throws Exception {
 		CtType<Tacos> aTacos = buildNoClasspath(Tacos.class).Type().get(Tacos.class);
 		//this returns a type reference with unitialized actual type arguments.


### PR DESCRIPTION
A baby step. The TypeFactory method which creates a CtTypeReference, which has initialized actual type arguments following formal type parameters of the input CtType.

I need it to simplify architecture of CtTypeParameter resolving algorithm. This algorithm can be theoretically applied to
A) CtTypeReference - which has actual type arguments
B) CtType - which has formal type parameters

The new method of this PR let's me simplify it to A) only, because B) can be easily covered to A) by:
```java
CtTypeReference typeRef = fatory.Type().createReference(type, true);
```