### PR TITLE
refactor: enforce the architectural rule 'never mix stateful objects and stateless helper classes containing static methods'

### DIFF
--- a/src/main/java/spoon/processing/AbstractManualProcessor.java
+++ b/src/main/java/spoon/processing/AbstractManualProcessor.java
@@ -19,6 +19,7 @@ package spoon.processing;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
+import spoon.testing.utils.ProcessorUtils;
 
 import java.util.Set;
 
@@ -98,7 +99,7 @@ public abstract class AbstractManualProcessor implements Processor<CtElement> {
 	}
 
 	public final void initProperties(ProcessorProperties properties) {
-		AbstractProcessor.initProperties(this, properties);
+		ProcessorUtils.initProperties(this, properties);
 	}
 
 	@Override

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -21,11 +21,10 @@ import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
-import spoon.support.util.RtHelper;
+import spoon.testing.utils.ProcessorUtils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
@@ -90,7 +89,8 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 	 * Helper method to load the properties of the given processor (uses
 	 * {@link Environment#getProcessorProperties(String)}).
 	 */
-	public static ProcessorProperties loadProperties(Processor<?> p) {
+	public ProcessorProperties loadProperties() {
+		Processor<?> p = this;
 		ProcessorProperties props = null;
 		try {
 			props = p.getFactory().getEnvironment().getProcessorProperties(p.getClass().getName());
@@ -114,11 +114,7 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 	}
 
 	public void init() {
-		// loadProperties();
-	}
-
-	public final void initProperties(ProcessorProperties properties) {
-		initProperties(this, properties);
+		this.initProperties(loadProperties());
 	}
 
 	public boolean isToBeProcessed(E candidate) {
@@ -128,26 +124,8 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 	/**
 	 * Helper method to initialize the properties of a given processor.
 	 */
-	public static void initProperties(Processor<?> p, ProcessorProperties properties) {
-		if (properties != null) {
-			for (Field f : RtHelper.getAllFields(p.getClass())) {
-				if (f.isAnnotationPresent(Property.class)) {
-					Object obj = properties.get(f.getType(), f.getName());
-					if (obj != null) {
-						f.setAccessible(true);
-						try {
-							f.set(p, obj);
-						} catch (Exception e) {
-							Launcher.LOGGER.error(e.getMessage(), e);
-						}
-					} else {
-						p.getFactory().getEnvironment().report(p, Level.WARN,
-								"No value found for property '" + f.getName() + "' in processor " + p.getClass()
-										.getName());
-					}
-				}
-			}
-		}
+	public void initProperties(ProcessorProperties properties) {
+		ProcessorUtils.initProperties(this, properties);
 	}
 
 	/**

--- a/src/main/java/spoon/support/QueueProcessingManager.java
+++ b/src/main/java/spoon/support/QueueProcessingManager.java
@@ -17,7 +17,6 @@
 package spoon.support;
 
 import spoon.SpoonException;
-import spoon.processing.AbstractProcessor;
 import spoon.processing.ProcessInterruption;
 import spoon.processing.ProcessingManager;
 import spoon.processing.Processor;
@@ -113,8 +112,7 @@ public class QueueProcessingManager implements ProcessingManager {
 			try {
 				getFactory().getEnvironment().reportProgressMessage(p.getClass().getName());
 				current = p;
-				p.initProperties(AbstractProcessor.loadProperties(p));
-				p.init();
+				p.init(); // load the properties
 				p.process();
 				for (CtElement e : new ArrayList<>(elements)) {
 					getVisitor().setProcessor(p);

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -444,10 +444,10 @@ class JDTCommentBuilder {
 	}
 
 	/**
-	 * @param element
+	 * @param e
 	 * @return body of element or null if this element has no body
 	 */
-	static CtElement getBody(CtElement e) {
+	private CtElement getBody(CtElement e) {
 		if (e instanceof CtBodyHolder) {
 			return ((CtBodyHolder) e).getBody();
 		}
@@ -466,7 +466,7 @@ class JDTCommentBuilder {
 		return cleanComment(new String(contents, start, end - start));
 	}
 
-	public static String cleanComment(String comment) {
+	public String cleanComment(String comment) {
 		StringBuffer ret = new StringBuffer();
 		String[] lines = comment.split("\n");
 		// limit case

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.visitor.java;
 
+import spoon.support.util.RtHelper;
 import spoon.support.visitor.java.reflect.RtMethod;
 import spoon.support.visitor.java.reflect.RtParameter;
 
@@ -316,10 +317,10 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	private <T> List<RtMethod> getDeclaredMethods(Class<T> clazz) {
 		final List<RtMethod> methods = new ArrayList<>();
-		methods.addAll(Arrays.asList(RtMethod.methodsOf(clazz)));
+		methods.addAll(Arrays.asList(RtHelper.methodsOf(clazz)));
 		final Class<?> superclass = clazz.getSuperclass();
 		if (superclass != null) {
-			methods.removeAll(Arrays.asList(RtMethod.sameMethodsWithDifferentTypeOf(superclass, methods)));
+			methods.removeAll(Arrays.asList(RtHelper.sameMethodsWithDifferentTypeOf(superclass, methods)));
 		}
 		return methods;
 	}

--- a/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
@@ -17,14 +17,9 @@
 package spoon.support.visitor.java.reflect;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.TypeVariable;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-
-import spoon.SpoonException;
 
 public class RtMethod {
 	private Class<?> clazz;
@@ -126,62 +121,7 @@ public class RtMethod {
 		return getDeclaringClass().getName().hashCode() ^ getName().hashCode();
 	}
 
-	public static RtMethod create(Method method) {
-		return new RtMethod(method.getDeclaringClass(), method.getName(), method.getReturnType(),
-				method.getTypeParameters(), method.getParameterTypes(), method.getExceptionTypes(), method.getModifiers(),
-				method.getDeclaredAnnotations(), method.getParameterAnnotations(), method.isVarArgs(),
-				//spoon is compatible with Java 7, so compilation fails here
-				//method.isDefault());
-				_java8_isDefault(method));
-	}
-
-	private static Method _method_isDefault;
-	static {
-		try {
-			_method_isDefault = Method.class.getMethod("isDefault");
-		} catch (NoSuchMethodException | SecurityException e) {
-			//spoon is running with java 7 JDK
-			_method_isDefault = null;
-		}
-	}
-
-	private static boolean _java8_isDefault(Method method) {
-		if (_method_isDefault == null) {
-			//spoon is running with java 7 JDK, all methods are not default, because java 7 does not have default methods
-			return false;
-		}
-		try {
-			return (Boolean) _method_isDefault.invoke(method);
-		} catch (IllegalAccessException | IllegalArgumentException e) {
-			throw new SpoonException("Calling of Java8 Method#isDefault() failed", e);
-		} catch (InvocationTargetException e) {
-			throw new SpoonException("Calling of Java8 Method#isDefault() failed", e.getTargetException());
-		}
-	}
-
-	public static <T> RtMethod[] methodsOf(Class<T> clazz) {
-		final RtMethod[] methods = new RtMethod[clazz.getDeclaredMethods().length];
-		int i = 0;
-		for (Method method : clazz.getDeclaredMethods()) {
-			methods[i++] = create(method);
-		}
-		return methods;
-	}
-
-	public static <T> RtMethod[] sameMethodsWithDifferentTypeOf(Class<T> superClass, List<RtMethod> comparedMethods) {
-		final List<RtMethod> methods = new ArrayList<>();
-		for (Method method : superClass.getDeclaredMethods()) {
-			final RtMethod rtMethod = create(method);
-			for (RtMethod potential : comparedMethods) {
-				if (potential.isLightEquals(rtMethod) && !rtMethod.returnType.equals(potential.returnType)) {
-					methods.add(rtMethod);
-				}
-			}
-		}
-		return methods.toArray(new RtMethod[methods.size()]);
-	}
-
-	private boolean isLightEquals(RtMethod rtMethod) {
+	public boolean isLightEquals(RtMethod rtMethod) {
 		if (this == rtMethod) {
 			return true;
 		}

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -16,11 +16,16 @@
  */
 package spoon.testing.utils;
 
+import org.apache.log4j.Level;
 import spoon.Launcher;
 import spoon.processing.Processor;
+import spoon.processing.ProcessorProperties;
+import spoon.processing.Property;
 import spoon.reflect.factory.Factory;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
+import spoon.support.util.RtHelper;
 
+import java.lang.reflect.Field;
 import java.util.Collection;
 
 public final class ProcessorUtils {
@@ -31,5 +36,27 @@ public final class ProcessorUtils {
 	public static void process(Factory factory, Collection<Processor<?>> processors) {
 		final JDTBasedSpoonCompiler compiler = (JDTBasedSpoonCompiler) new Launcher().createCompiler(factory);
 		compiler.process(processors);
+	}
+
+	public static void initProperties(Processor<?> p, ProcessorProperties properties) {
+		if (properties != null) {
+			for (Field f : RtHelper.getAllFields(p.getClass())) {
+				if (f.isAnnotationPresent(Property.class)) {
+					Object obj = properties.get(f.getType(), f.getName());
+					if (obj != null) {
+						f.setAccessible(true);
+						try {
+							f.set(p, obj);
+						} catch (Exception e) {
+							Launcher.LOGGER.error(e.getMessage(), e);
+						}
+					} else {
+						p.getFactory().getEnvironment().report(p, Level.WARN,
+								"No value found for property '" + f.getName() + "' in processor " + p.getClass()
+										.getName());
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
I had to move some recent methods from RtMethod (minor non-backward compatible change).