### PR TITLE
review1: fix generic type adapting

### DIFF
--- a/src/main/java/spoon/support/visitor/AbstractTypingContext.java
+++ b/src/main/java/spoon/support/visitor/AbstractTypingContext.java
@@ -84,5 +84,14 @@ abstract class AbstractTypingContext implements GenericTypeAdapter {
 		return typeParamRefAdapted;
 	}
 
+	/**
+	 * adapts `typeParam` to the {@link CtTypeReference}
+	 * of scope of this {@link GenericTypeAdapter}
+	 * In can be {@link CtTypeParameterReference} again - depending actual type arguments of this {@link GenericTypeAdapter}.
+	 *
+	 * @param typeParam to be resolved {@link CtTypeParameter}
+	 * @return {@link CtTypeReference} or {@link CtTypeParameterReference} adapted to scope of this {@link GenericTypeAdapter}
+	 *  or null if `typeParam` cannot be adapted to target `scope`
+	 */
 	protected abstract CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam);
 }

--- a/src/main/java/spoon/support/visitor/AbstractTypingContext.java
+++ b/src/main/java/spoon/support/visitor/AbstractTypingContext.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.visitor;
+
+import java.util.List;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtWildcardReference;
+
+/**
+ * Implements common adapting algorithm of {@link ClassTypingContext} and {@link MethodTypingContext}
+ */
+abstract class AbstractTypingContext implements GenericTypeAdapter {
+
+	protected AbstractTypingContext() {
+	}
+
+	@Override
+	public CtTypeReference<?> adaptType(CtTypeInformation type) {
+		CtTypeReference<?> result;
+		boolean isCopy = false;
+		if (type instanceof CtTypeReference<?>) {
+			if (type instanceof CtTypeParameterReference) {
+				return adaptTypeParameterReference((CtTypeParameterReference) type);
+			}
+			result = (CtTypeReference<?>) type;
+		} else {
+			if (type instanceof CtTypeParameter) {
+				return adaptTypeParameter((CtTypeParameter) type);
+			}
+			CtType<?> t = (CtType<?>) type;
+			result = t.getFactory().Type().createReference(t, true);
+			isCopy = true;
+		}
+		if (result.getActualTypeArguments().size() > 0) {
+			//we have to adapt actual type arguments recursive too
+			if (isCopy == false) {
+				CtElement parent = result.getParent();
+				result = result.clone();
+				result.setParent(parent);
+				List<CtTypeReference<?>> actTypeArgs = result.getActualTypeArguments();
+				for (int i = 0; i < actTypeArgs.size(); i++) {
+					actTypeArgs.set(i, adaptType(actTypeArgs.get(i)));
+				}
+			}
+		}
+		return result;
+	}
+
+	private CtTypeReference<?> adaptTypeParameterReference(CtTypeParameterReference typeParamRef) {
+		if ((typeParamRef instanceof CtWildcardReference)) {
+			return adaptTypeParameterReferenceBoundingType(typeParamRef, typeParamRef.getBoundingType());
+		}
+		CtTypeReference<?> typeRefAdapted = adaptTypeParameter(typeParamRef.getDeclaration());
+		if (typeRefAdapted instanceof CtTypeParameterReference) {
+			return adaptTypeParameterReferenceBoundingType((CtTypeParameterReference) typeRefAdapted, typeParamRef.getBoundingType());
+		}
+		return typeRefAdapted;
+	}
+
+	private CtTypeReference<?> adaptTypeParameterReferenceBoundingType(CtTypeParameterReference typeParamRef, CtTypeReference<?> boundingType) {
+		CtTypeParameterReference typeParamRefAdapted = typeParamRef.clone();
+		typeParamRefAdapted.setParent(typeParamRef.getParent());
+		typeParamRefAdapted.setBoundingType(boundingType == null ? null : adaptType(boundingType));
+		return typeParamRefAdapted;
+	}
+
+	protected abstract CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam);
+}

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -54,7 +54,7 @@ import spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction;
  * assertEquals(Integer.class.getName(), typeParamE_adaptedTo_arrayListRef.getQualifiedName());
  * </pre>
  */
-public class ClassTypingContext implements GenericTypeAdapter {
+public class ClassTypingContext extends AbstractTypingContext {
 	/*
 	 * super type hierarchy of the enclosing class
 	 */
@@ -97,20 +97,6 @@ public class ClassTypingContext implements GenericTypeAdapter {
 			enclosingClassTypingContext = createEnclosingHierarchy(enclosing);
 		}
 		typeToArguments.put(type.getQualifiedName(), getTypeReferences(type.getFormalCtTypeParameters()));
-	}
-
-	@Override
-	public CtTypeReference<?> adaptType(CtTypeInformation type) {
-		if (type instanceof CtTypeReference<?>) {
-			if (type instanceof CtTypeParameterReference) {
-				return adaptTypeParameter(((CtTypeParameterReference) type).getDeclaration());
-			}
-			return (CtTypeReference<?>) type;
-		}
-		if (type instanceof CtTypeParameter) {
-			return adaptTypeParameter((CtTypeParameter) type);
-		}
-		return ((CtType<?>) type).getReference();
 	}
 
 	/**
@@ -293,7 +279,8 @@ public class ClassTypingContext implements GenericTypeAdapter {
 	 * @return {@link CtTypeReference} or {@link CtTypeParameterReference} adapted to scope of this {@link ClassTypingContext}
 	 *  or null if `typeParam` cannot be adapted to target `scope`
 	 */
-	private CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
+	@Override
+	protected CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
 		CtFormalTypeDeclarer declarer = typeParam.getTypeParameterDeclarer();
 		if ((declarer instanceof CtType<?>) == false) {
 			return null;

--- a/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
+++ b/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
@@ -26,11 +26,13 @@ import spoon.reflect.reference.CtTypeReference;
 public interface GenericTypeAdapter {
 	/**
 	 * adapts `type` to the {@link CtTypeReference}
-	 * of the scope of this {@link ClassTypingContext}
+	 * of the scope of this {@link GenericTypeAdapter}
 	 *
 	 * This mapping function is able to resolve {@link CtTypeParameter} of:<br>
 	 * A) input type or any super class or any enclosing class of input type or it's super class<br>
 	 * B) super interfaces of input type or super interfaces of it's super classes.<br>
+	 *
+	 * The type reference is adapted recursive including all it's actual type arguments and bounds.
 	 *
 	 * @param type to be adapted type
 	 * @return {@link CtTypeReference} adapted to scope of this {@link ClassTypingContext}
@@ -42,4 +44,5 @@ public interface GenericTypeAdapter {
 	 * @return the {@link GenericTypeAdapter}, which adapts generic types of enclosing type
 	 */
 	GenericTypeAdapter getEnclosingGenericTypeAdapter();
+
 }

--- a/src/test/java/spoon/test/generics/testclasses/Orange.java
+++ b/src/test/java/spoon/test/generics/testclasses/Orange.java
@@ -1,0 +1,14 @@
+package spoon.test.generics.testclasses;
+
+import java.util.List;
+
+public class Orange<K,L> {
+
+	class A<O extends K, M extends O> {
+		List<List<M>> list2m;
+		void method(List<? extends M> param) {}
+	}
+	
+	class B<N extends K, P extends N> extends A<N, P> {
+	}
+}


### PR DESCRIPTION
Here are fixed other bugs found during implementing of CtMethod#isOverriding(CtMethod).
Following problems are tested and fixed by this PR:
* The generic types are now adapted recursive into actual type arguments. E.g. `List<List<T>>` is adapted to `List<List<M>>`
* The generic types are now adapted recursive into their bounds. E.g. `List<? extendsT>` is adapted to `List<? extends M>`
* The adapting of wildcard type E.g. `List<? extendsT>` does not fail with NullPointerException
* The MethodTypingContext correctly detects isOverriding for child method whose generic types are replaced by concrete types.