### PR TITLE
review1: refactor Method overriding/overriden filters

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
@@ -17,14 +17,16 @@
 package spoon.reflect.visitor.filter;
 
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.Filter;
+import spoon.support.visitor.MethodTypingContext;
 
 /**
  * Gets all overridden method from the method given.
  */
 public class OverriddenMethodFilter implements Filter<CtMethod<?>> {
 	private final CtMethod<?> method;
+	private final MethodTypingContext context;
+	private boolean includingSelf = false;
 
 	/**
 	 * Creates a new overridden method filter.
@@ -34,14 +36,23 @@ public class OverriddenMethodFilter implements Filter<CtMethod<?>> {
 	 */
 	public OverriddenMethodFilter(CtMethod<?> method) {
 		this.method = method;
+		context = new MethodTypingContext().setMethod(method);
+	}
+
+	/**
+	 * @param includingSelf if false then element which is equal to the #method is not matching.
+	 * false is default behavior
+	 */
+	public OverriddenMethodFilter includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
 	}
 
 	@Override
 	public boolean matches(CtMethod<?> element) {
-		final CtType expectedParent = method.getParent(CtType.class);
-		final CtType<?> currentParent = element.getParent(CtType.class);
-		return expectedParent.isSubtypeOf(currentParent.getReference()) //
-				&& !currentParent.equals(expectedParent) //
-				&& method.getReference().isOverriding(element.getReference());
+		if (method == element) {
+			return this.includingSelf;
+		}
+		return context.isOverriding(element);
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
@@ -17,7 +17,6 @@
 package spoon.reflect.visitor.filter;
 
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.Filter;
 
 /**
@@ -25,6 +24,7 @@ import spoon.reflect.visitor.Filter;
  */
 public class OverridingMethodFilter implements Filter<CtMethod<?>> {
 	private final CtMethod<?> method;
+	private boolean includingSelf = false;
 
 	/**
 	 * Creates a new overriding method filter.
@@ -36,12 +36,20 @@ public class OverridingMethodFilter implements Filter<CtMethod<?>> {
 		this.method = method;
 	}
 
+	/**
+	 * @param includingSelf if false then element which is equal to the #method is not matching.
+	 * false is default behavior
+	 */
+	public OverridingMethodFilter includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
+	}
+
 	@Override
 	public boolean matches(CtMethod<?> element) {
-		final CtType expectedParent = method.getParent(CtType.class);
-		final CtType<?> currentParent = element.getParent(CtType.class);
-		return currentParent.isSubtypeOf(expectedParent.getReference()) //
-				&& !currentParent.equals(expectedParent) //
-				&& element.getReference().isOverriding(method.getReference());
+		if (method == element) {
+			return this.includingSelf;
+		}
+		return element.isOverriding(method);
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
@@ -274,7 +274,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 			//this method is called only for classes (not for interfaces) so we know we can visit java.lang.Object now too
 			superClassRef = superTypeRef.getFactory().Type().OBJECT;
 		}
-		ScanningMode mode = enter(superClassRef, false);
+		ScanningMode mode = enter(superClassRef, true);
 		if (mode == SKIP_ALL) {
 			return;
 		}
@@ -282,7 +282,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 		if (mode == NORMAL && query.isTerminated() == false) {
 			visitSuperClasses(superClassRef, outputConsumer, includingInterfaces);
 		}
-		exit(superClassRef, false);
+		exit(superClassRef, true);
 	}
 
 	/**
@@ -301,7 +301,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 			return;
 		}
 		for (CtTypeReference<?> ifaceRef : superInterfaces) {
-			ScanningMode mode = enter(ifaceRef, true);
+			ScanningMode mode = enter(ifaceRef, false);
 			if (mode == SKIP_ALL) {
 				continue;
 			}
@@ -309,7 +309,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 			if (mode == NORMAL && query.isTerminated() == false) {
 				visitSuperInterfaces(ifaceRef, outputConsumer);
 			}
-			exit(ifaceRef, true);
+			exit(ifaceRef, false);
 			if (query.isTerminated()) {
 				return;
 			}


### PR DESCRIPTION
New MethodTypingContext is used to implement these two filters.

I added also method `#includingSelf(boolean)`, which can be used to configure the behavior of these filters.