### PR TITLE
fix failing CtExecutableReference#getActualMethod

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -19,9 +19,11 @@ package spoon.support.reflect.reference;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtActualTypeContainer;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -173,15 +175,28 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 			return null;
 		}
 
+		CtElement e = this;
+		CtElement parent = getParent();
+		if (parent instanceof CtExecutableReference) {
+			CtElement parent2 = parent.getParent();
+			if (parent2 instanceof CtMethod) {
+				e = parent2;
+			} else {
+				e = ((CtExecutableReference<?>) parent).getDeclaringType().getTypeDeclaration();
+			}
+		} else {
+			e = e.getParent(CtFormalTypeDeclarer.class);
+		}
+
 		// case #1: we're a type of a method parameter, a local variable, ...
 		// the strategy is to look in the parents
 		// collecting all formal type declarers of the hierarchy
-		CtElement e = this;
-		while ((e = e.getParent(CtFormalTypeDeclarer.class)) != null) {
+		while (e != null) {
 			CtTypeParameter result = findTypeParamDeclaration((CtFormalTypeDeclarer) e, this.getSimpleName());
 			if (result != null) {
 				return result;
 			}
+			e = e.getParent(CtFormalTypeDeclarer.class);
 		}
 		return null;
 	}

--- a/src/test/java/spoon/test/methodreference/testclasses/Cloud.java
+++ b/src/test/java/spoon/test/methodreference/testclasses/Cloud.java
@@ -1,0 +1,13 @@
+package spoon.test.methodreference.testclasses;
+
+public class Cloud<T> {
+
+	void method(T param) {}
+}
+
+class Sun {
+	void foo() {
+		Cloud<String> cc = new Cloud<>();
+		cc.method("x");
+	}
+}


### PR DESCRIPTION
should fix #1256, but I am not sure that it is correct solution. May be we should think about having reference to Formal Type declarer directly in `CtTypePareameterReference` (which would be added by compiler?) instead of searching for the declarer in all possible contexts where it might occur. How many place we need to fix next to this one?