### PR TITLE
chore: fix revapi bug

### DIFF
--- a/chore/revapi_tpl.ftl
+++ b/chore/revapi_tpl.ftl
@@ -16,7 +16,7 @@ Detected changes: ${reports?size}.
 | New | ${report.newElement!"none"} |
 | Code | ${diff.code} |
 | Description | ${diff.description!"none"} |
-| Breaking | <#list diff.classification?keys as compat>${compat?lower_case}: ${diff.classification?api.get(compat)?lower_case}<#sep>, </#list> |
+| Breaking | <#list diff.classification?keys as compat><#if compat?lower_case=="source">${compat?lower_case}: ${diff.classification?api.get(compat)?lower_case}<#sep>, </#if></#list> |
 </#list>
 <#sep>
 

--- a/revapi.json
+++ b/revapi.json
@@ -10,7 +10,7 @@
         // specify which package to filter
         "packages": {
           "regex": true,
-          "include": ["spoon\\..*"],
+          "include": ["spoon.*"],
           "exclude": ["spoon\\..*\\.test(\\..*)?"]
         },
 


### PR DESCRIPTION
Bug: the classes directly in package "spoon" were not considered
+
Improvement: only the main type of breakage is shown as Github comment for simplifying understanding 