### PR TITLE
review: feature: MethodTypingContext#adaptMethod

### DIFF
--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -21,6 +21,7 @@ import static spoon.support.visitor.ClassTypingContext.getTypeReferences;
 import java.util.ArrayList;
 import java.util.List;
 
+import spoon.SpoonException;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtConstructor;
@@ -31,6 +32,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -55,13 +57,17 @@ public class MethodTypingContext extends AbstractTypingContext {
 	}
 
 	public MethodTypingContext setMethod(CtMethod<?> scopeMethod) {
-		this.scopeMethod = scopeMethod;
+		if (classTypingContext != null) {
+			//assure that scopeMethod fits to required classTypingContext
+			scopeMethod = adaptMethod(scopeMethod);
+		}
+		setScopeMethod(scopeMethod);
 		actualTypeArguments = getTypeReferences(scopeMethod.getFormalCtTypeParameters());
 		return this;
 	}
 
 	public MethodTypingContext setConstructor(CtConstructor<?> scopeConstructor) {
-		this.scopeMethod = scopeConstructor;
+		setScopeMethod(scopeConstructor);
 		actualTypeArguments = getTypeReferences(scopeConstructor.getFormalCtTypeParameters());
 		return this;
 	}
@@ -69,12 +75,13 @@ public class MethodTypingContext extends AbstractTypingContext {
 	@Override
 	public ClassTypingContext getEnclosingGenericTypeAdapter() {
 		if (classTypingContext == null && scopeMethod != null) {
-			classTypingContext = new ClassTypingContext(((CtTypeMember) scopeMethod).getDeclaringType());
+			classTypingContext = new ClassTypingContext(getScopeMethodDeclaringType());
 		}
 		return classTypingContext;
 	}
 
 	public MethodTypingContext setClassTypingContext(ClassTypingContext classTypingContext) {
+		checkSameTypingContext(classTypingContext, scopeMethod);
 		this.classTypingContext = classTypingContext;
 		return this;
 	}
@@ -95,7 +102,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 
 	public MethodTypingContext setExecutableReference(CtExecutableReference<?> execRef) {
 		this.actualTypeArguments = execRef.getActualTypeArguments();
-		this.scopeMethod = execRef.getExecutableDeclaration();
+		setScopeMethod(execRef.getExecutableDeclaration());
 		if (classTypingContext == null) {
 			CtTypeReference<?> declaringTypeRef = execRef.getDeclaringType();
 			if (declaringTypeRef != null) {
@@ -115,13 +122,11 @@ public class MethodTypingContext extends AbstractTypingContext {
 			return true;
 		}
 		CtType<?> thatDeclType = thatMethod.getDeclaringType();
-		CtType<?> thisDeclType = ((CtTypeMember) scopeMethod).getDeclaringType();
-		if (thatDeclType == thisDeclType) {
-			//both methods has same declarer, they cannot override.
-			return false;
-		}
-		if (getEnclosingGenericTypeAdapter().isSubtypeOf(thatDeclType.getReference()) == false) {
-			return false;
+		CtType<?> thisDeclType = getScopeMethodDeclaringType();
+		if (thatDeclType != thisDeclType) {
+			if (getEnclosingGenericTypeAdapter().isSubtypeOf(thatDeclType.getReference()) == false) {
+				return false;
+			}
 		}
 		return isSubSignature(thatMethod);
 	}
@@ -313,5 +318,94 @@ public class MethodTypingContext extends AbstractTypingContext {
 			types.add(param.getType());
 		}
 		return types;
+	}
+
+	/**
+	 * @param method to be adapted method
+	 * @return new method whose parameters are adapted to `classTypingContext` or origin `method` if it is already declared there
+	 */
+	public <T> CtMethod<T> adaptMethod(CtMethod<T> method) {
+		CtType<?> declType = method.getDeclaringType();
+		if (declType == null) {
+			throw new SpoonException("Cannot adapt method, which has no declaringType");
+		}
+		if (classTypingContext == null) {
+			throw new SpoonException("Cannot adapt method becasue target classTypingContext was not set");
+		}
+		if (classTypingContext.getAdaptationScope() == declType) {
+			return method;
+		}
+		//the scope method is declared in different type then scope of assigned classTypingContext
+		if (classTypingContext.isSubtypeOf(declType.getReference()) == false) {
+			throw new SpoonException("Cannot create MethodTypingContext for method declared in different ClassTypingContext");
+		}
+		/*
+		 * The method is declared in an supertype of classTypingContext.
+		 * Create virtual scope method by adapting generic types of supertype method to required scope
+		 */
+		Factory factory = method.getFactory();
+		//create new method
+		CtMethod<T> adaptedMethod = factory.Core().createMethod();
+		adaptedMethod.setParent(classTypingContext.getAdaptationScope());
+		adaptedMethod.setModifiers(method.getModifiers());
+		adaptedMethod.setSimpleName(method.getSimpleName());
+		for (CtTypeReference<? extends Throwable> thrownType : method.getThrownTypes()) {
+			adaptedMethod.addThrownType(thrownType.clone());
+		}
+		for (CtTypeParameter typeParam : method.getFormalCtTypeParameters()) {
+			CtTypeParameter newTypeParam = typeParam.clone();
+			newTypeParam.setSuperclass(adaptTypeForNewMethod(typeParam.getSuperclass()));
+			adaptedMethod.addFormalCtTypeParameter(newTypeParam);
+		}
+		//adapt return type
+		adaptedMethod.setType((CtTypeReference) adaptTypeForNewMethod(method.getType()));
+		//adapt parameters
+		List<CtParameter<?>> adaptedParams = new ArrayList<>(method.getParameters().size());
+		for (CtParameter<?> parameter : method.getParameters()) {
+			adaptedParams.add(factory.Executable().createParameter(null,
+					adaptTypeForNewMethod(parameter.getType()),
+					parameter.getSimpleName()));
+		}
+		adaptedMethod.setParameters(adaptedParams);
+		return adaptedMethod;
+	}
+
+	private CtTypeReference<?> adaptTypeForNewMethod(CtTypeReference<?> typeRef) {
+		if (typeRef == null) {
+			return null;
+		}
+		if (typeRef instanceof CtTypeParameterReference) {
+			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
+			CtTypeParameter typeParam = typeParamRef.getDeclaration();
+			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
+				//the parameter is declared in scope of Method or Constructor
+				return typeRef.clone();
+			}
+		}
+		return adaptType(typeRef);
+	}
+
+	private CtType<?> getScopeMethodDeclaringType() {
+		if (scopeMethod != null) {
+			return ((CtTypeMember) scopeMethod).getDeclaringType();
+		}
+		throw new SpoonException("scopeMethod is not assigned");
+	}
+
+	private void setScopeMethod(CtExecutable<?> executable) {
+		checkSameTypingContext(classTypingContext, executable);
+		scopeMethod = executable;
+	}
+
+	private void checkSameTypingContext(ClassTypingContext ctc, CtExecutable<?> executable) {
+		if (ctc != null && executable != null) {
+			CtType<?> scope = ((CtTypeMember) executable).getDeclaringType();
+			if (scope == null) {
+				throw new SpoonException("Cannot use executable without declaring type as scope of method typing context");
+			}
+			if (scope != ctc.getAdaptationScope()) {
+				throw new SpoonException("Declaring type of executable is not same like scope of classTypingContext provided for method typing context");
+			}
+		}
 	}
 }

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -321,8 +321,8 @@ public class MethodTypingContext extends AbstractTypingContext {
 	}
 
 	/**
-	 * @param method to be adapted method
-	 * @return new method whose parameters are adapted to `classTypingContext` or origin `method` if it is already declared there
+	 * @param method to be adapted to this context
+	 * @return new method whose parameters are adapted to `this context` or the same`method` if there is no need to adapt it
 	 */
 	public <T> CtMethod<T> adaptMethod(CtMethod<T> method) {
 		CtType<?> declType = method.getDeclaringType();

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -921,9 +921,7 @@ public class GenericsTest {
 		methodSTH.setMethod(trLunch_eatMe);
 		//contract: method typing context creates adapted method automatically, which is equal to manually adapted one
 		assertEquals(adaptedLunchEatMe, methodSTH.getAdaptationScope());
-
-		//contract: check that adapted method in role of method typing context can be used
-		//contract: check that adapted method in role of method typing context can be used
+		
 		// represents <C> void eatMe(M paramA, K paramB, C paramC)
 		CtMethod<?> trWeddingLunch_eatMe = ctClassWeddingLunch.filterChildren(new NameFilter<>("eatMe")).first();
 		assertTrue(methodSTH.isOverriding(trLunch_eatMe));

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -56,7 +56,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import static javafx.scene.input.KeyCode.M;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
I am implementing the algorithm, which searches for all methods, which has to be modified when changing method signature (e.g. remove method parameter). This algorithm needs to be able to search in all super types of sub types of declaring type of target methods, for methods with equal `sub signature`... yes, it is tricky sentence ... so see Example:
```java
class A {
 void method() {}
}
interface IB {
 void method();
}
class B extends A implements IB {
//note that B does not declares `method`. It inherits it from `A`.
}
class C implements IB {
 void method();
}
```
If `A#method()` has to be refactored, then that algorithm has to found `C#method()` too. But note that `C#method()`, does not overrides `A#method()`, so it is not enough to use existing overriding filter.
The algorithm first needs to detect that `IB#method()` is overridden by `B#method()` (which does not exists, but is inherited from `A`). 
We can do that by new feature implemented in this PR like this:
```java
MethodTypingContext mtc = new MethodTypingContext()
   .setClassTypingContext(new ClassTypingContext(classB));
//create a clone of `A#method` whose generic types are adapted to scope of class `B`
CtMethod classB_method = mtc.adaptMethod(classA_method);
mtc.setMethod(classB_method);
assertTrue(mtc.isOverriding(ifaceB_method));
```
or shortly like this:
```java
MethodTypingContext mtc = new MethodTypingContext()
   .setClassTypingContext(new ClassTypingContext(classB))
   .setMethod(classA_method); //it detects that method is declared in different scope and adapts it automatically
assertTrue(mtc.isOverriding(ifaceB_method));
```
The example above is simplified. There are no generic parameters in method, so it might be solved different way. But with generic parameters and longer type hierarchies, the adapting of method parameters is necessary, because `A#method` and `C#method` might have different parameter types, but they can be still related, thanks to some generic method(s) in between ...

Note: review only second commit. The first commit comes from another PR. I will rebase after first commit is merged.