### PR TITLE
review: feature sub inheritance hierarchy function

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+import spoon.reflect.visitor.chain.CtQuery;
+import spoon.reflect.visitor.chain.CtQueryAware;
+import spoon.support.visitor.SubInheritanceHierarchyResolver;
+
+/**
+ * Expects a {@link CtTypeInformation} as input
+ * and produces all sub classes and sub interfaces recursively.<br>
+ * The output is produced in arbitrary order.
+ */
+public class SubInheritanceHierarchyFunction implements CtConsumableFunction<CtTypeInformation>, CtQueryAware {
+
+	private boolean includingSelf = false;
+	private boolean includingInterfaces = true;
+	private CtQuery query;
+	private boolean failOnClassNotFound = false;
+
+	/**
+	 * The mapping function created using this constructor
+	 * will visit each super class and super interface
+	 * following super hierarchy. It can happen
+	 * that some interfaces will be visited more then once
+	 * if they are in super inheritance hierarchy more then once.<br>
+	 * Use second constructor if you want to visit each interface only once.
+	 */
+	public SubInheritanceHierarchyFunction() {
+	}
+
+	/**
+	 * @param includingSelf if true then input element is sent to output too. By default it is false.
+	 */
+	public SubInheritanceHierarchyFunction includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
+	}
+
+	/**
+	 * @param includingInterfaces if false then interfaces are not visited - only super classes. By default it is true.
+	 */
+	public SubInheritanceHierarchyFunction includingInterfaces(boolean includingInterfaces) {
+		this.includingInterfaces = includingInterfaces;
+		return this;
+	}
+
+	/**
+	 * @param failOnClassNotFound sets whether processing should throw an exception if class is missing in noClassPath mode
+	 */
+	public SubInheritanceHierarchyFunction failOnClassNotFound(boolean failOnClassNotFound) {
+		this.failOnClassNotFound = failOnClassNotFound;
+		return this;
+	}
+
+	@Override
+	public void apply(CtTypeInformation input, final CtConsumer<Object> outputConsumer) {
+		final SubInheritanceHierarchyResolver fnc = new SubInheritanceHierarchyResolver(((CtElement) input).getFactory().getModel().getRootPackage())
+			.failOnClassNotFound(failOnClassNotFound)
+			.includingInterfaces(includingInterfaces);
+		if (includingSelf) {
+			if (input instanceof CtTypeReference) {
+				outputConsumer.accept(((CtTypeReference<?>) input).getTypeDeclaration());
+			} else {
+				outputConsumer.accept(((CtType<?>) input));
+			}
+		}
+		fnc.addSuperType(input);
+		fnc.forEachSubTypeInPackage(new CtConsumer<CtType>() {
+			@Override
+			public void accept(CtType typeInfo) {
+				outputConsumer.accept(typeInfo);
+				if (query.isTerminated()) {
+					//Cannot terminate, because it's support was removed.
+//					fnc.terminate();
+				}
+			}
+		});
+	}
+
+	@Override
+	public void setQuery(CtQuery query) {
+		this.query = query;
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
@@ -92,6 +92,7 @@ public class SubInheritanceHierarchyFunction implements CtConsumableFunction<CtT
 				outputConsumer.accept(typeInfo);
 				if (query.isTerminated()) {
 					//Cannot terminate, because it's support was removed.
+					//I think there are cases where it might be useful.
 //					fnc.terminate();
 				}
 			}

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -1,0 +1,76 @@
+package spoon.test.refactoring;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.Test;
+
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.SubInheritanceHierarchyFunction;
+import spoon.test.refactoring.parameter.testclasses.IFaceB;
+import spoon.test.refactoring.parameter.testclasses.IFaceK;
+import spoon.test.refactoring.parameter.testclasses.IFaceL;
+import spoon.test.refactoring.parameter.testclasses.TypeA;
+import spoon.test.refactoring.parameter.testclasses.TypeB;
+import spoon.test.refactoring.parameter.testclasses.TypeC;
+import spoon.testing.utils.ModelUtils;
+
+public class MethodsRefactoringTest {
+
+	@Test
+	public void testSubInheritanceHierarchyFunction() {
+		Factory factory = ModelUtils.build(new File("./src/test/java/spoon/test/refactoring/parameter/testclasses"));
+		
+		List<String> allSubtypes = factory.Class().get(TypeA.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		checkContainsOnly(allSubtypes, 
+				"spoon.test.refactoring.parameter.testclasses.TypeB",
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1",
+				"spoon.test.refactoring.parameter.testclasses.TypeC");
+
+		allSubtypes = factory.Class().get(TypeB.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		checkContainsOnly(allSubtypes, 
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1",
+				"spoon.test.refactoring.parameter.testclasses.TypeC");
+		
+		allSubtypes = factory.Class().get(TypeC.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		assertEquals(0, allSubtypes.size());
+
+		allSubtypes = factory.Interface().get(IFaceB.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		checkContainsOnly(allSubtypes, 
+				"spoon.test.refactoring.parameter.testclasses.TypeB",
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1",
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1Local",
+				"spoon.test.refactoring.parameter.testclasses.TypeC",
+				"spoon.test.refactoring.parameter.testclasses.IFaceL",
+				"spoon.test.refactoring.parameter.testclasses.TypeL",
+				"spoon.test.refactoring.parameter.testclasses.TypeM"
+				);
+		
+		allSubtypes = factory.Interface().get(IFaceL.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		checkContainsOnly(allSubtypes, 
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1Local",
+				"spoon.test.refactoring.parameter.testclasses.TypeL",
+				"spoon.test.refactoring.parameter.testclasses.TypeM"
+				);
+		
+		allSubtypes = factory.Interface().get(IFaceK.class).map(new SubInheritanceHierarchyFunction()).map((CtType type)->type.getQualifiedName()).list();
+		checkContainsOnly(allSubtypes, 
+				"spoon.test.refactoring.parameter.testclasses.TypeB$1Local",
+				"spoon.test.refactoring.parameter.testclasses.TypeL",
+				"spoon.test.refactoring.parameter.testclasses.TypeM",
+				"spoon.test.refactoring.parameter.testclasses.TypeK",
+				"spoon.test.refactoring.parameter.testclasses.TypeR",
+				"spoon.test.refactoring.parameter.testclasses.TypeS"
+				);
+	}
+
+	private void checkContainsOnly(List<String> foundNames, String... expectedNames) {
+		for (String name : expectedNames) {
+			assertTrue("The "+name+" not found", foundNames.remove(name));
+		}
+		assertTrue("Unexpected names found: "+foundNames, foundNames.isEmpty());
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceB.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceB.java
@@ -1,0 +1,6 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public interface IFaceB<T> {
+	@TestHierarchy("A_method1")
+	void method1(T p1);
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceK.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceK.java
@@ -1,0 +1,5 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public interface IFaceK {
+
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceL.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceL.java
@@ -1,0 +1,5 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public interface IFaceL extends IFaceB<Double> {
+
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TestHierarchy.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TestHierarchy.java
@@ -1,0 +1,15 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.LOCAL_VARIABLE})
+public @interface TestHierarchy {
+    /**
+     * @return the list of hierarchy names where this method belongs to.
+     */
+    String[] value();
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeA.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeA.java
@@ -1,0 +1,11 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeA {
+
+	public TypeA() {
+	}
+	
+	@TestHierarchy("A_method1")
+	public void method1(Exception p1) {
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeB.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeB.java
@@ -1,0 +1,37 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeB extends TypeA implements IFaceB<Exception> {
+
+	public TypeB() {
+	}
+	
+	private void anMethodWithAnonymousClass() {
+		new TypeB() {
+			@Override
+			@TestHierarchy("A_method1")
+			public void method1(Exception p1) {
+				super.method1(p1);
+			}
+		};
+	}
+
+	private void anMethodWithLambdaByParam(IFaceB ifaceB) {
+		//this lambda is an implementation IFaceB#method1
+		anMethodWithLambdaByParam(/*A_method1*/p->{});
+	}
+	private void anMethodWithLambda() {
+		//this lambda is an implementation IFaceB#method1
+		@TestHierarchy("A_method1")
+		IFaceB ifaceB = p->{};
+		ifaceB.method1(1);
+	}
+	private void anMethodWithLocalClass() {
+		class Local extends TypeL {
+			@Override
+			@TestHierarchy("A_method1")
+			public void method1(Double p1) {
+				super.method1(p1);
+			}
+		}
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeC.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeC.java
@@ -1,0 +1,9 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeC extends TypeB {
+	@Override
+	@TestHierarchy("A_method1")
+	public void method1(Exception p1) {
+		super.method1(p1);
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeK.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeK.java
@@ -1,0 +1,8 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeK implements IFaceK {
+
+	public TypeK() {
+	}
+
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeL.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeL.java
@@ -1,0 +1,8 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeL extends TypeK implements IFaceL {
+	@Override
+	@TestHierarchy("A_method1")
+	public void method1(Double p1) {
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeM.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeM.java
@@ -1,0 +1,5 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeM extends TypeL {
+
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeR.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeR.java
@@ -1,0 +1,7 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeR extends TypeK {
+	@TestHierarchy("R_method1")
+	public void method1(Double p1) {
+	}
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeS.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeS.java
@@ -1,0 +1,8 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public class TypeS extends TypeR {
+	@Override
+	@TestHierarchy("R_method1")
+	public void method1(Double p1) {
+	}
+}


### PR DESCRIPTION
The `SubInheritanceHierarchyFunction` is created and configured with one or more types. This mapping function returns all sub types of configured types, which are found in packages, which are input for this mapping function.
This mapping function is more efficient then filtering all types using 'SubtypeFilter', because:
* it allows searching for subtypes of more then one super type
* it visits each type of spoon model only once, during inheritance hierarchy checking.
* if new super type is added (configured), then next scanning always returns only newly found sub types

This new mapping function is used by #1291, which
* needs to scan sub inheritance hierarchy of more types in more iterations, where each iteration needs to scan similar sub hierarchy,  but with some new types.
* each next iteration has to return only newly found subtypes
* it should be fast, because I need to refactor nearly all methods of model of my project.