### PR TITLE
review: feature: all executables same signature function

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import spoon.SpoonException;
+import spoon.reflect.code.CtLambda;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtConsumer;
+import spoon.reflect.visitor.chain.CtQuery;
+import spoon.reflect.visitor.chain.CtQueryAware;
+import spoon.support.visitor.ClassTypingContext;
+import spoon.support.visitor.SubInheritanceHierarchyResolver;
+
+/**
+ * Returns all methods/lambdas with same signature in related inheritance hierarchies.
+ * It can be be used to found all other methods, which has to be changed if signature of method or lambda expression has to be changed.<br>
+ *
+ * Expects {@link CtExecutable} as input
+ * and produces all {@link CtExecutable}s,
+ * which have same signature and are declared in sub/super classes or sub/super interfaces of this or related inheritance hierarchy.<br>
+ *
+ * It makes sense to call this mapping functions for {@link CtMethod} and {@link CtLambda} instances
+ * and then it returns {@link CtMethod} and {@link CtLambda} instance which overrides each other or have same signature.
+ */
+public class AllMethodsSameSignatureFunction implements CtConsumableFunction<CtExecutable<?>>, CtQueryAware {
+
+	private boolean includingSelf = false;
+	private CtQuery query;
+
+	public AllMethodsSameSignatureFunction() {
+	}
+
+	/**
+	 * @param includingSelf if true then input element is sent to output too. By default it is false.
+	 */
+	public AllMethodsSameSignatureFunction includingSelf(boolean includingSelf) {
+		this.includingSelf = includingSelf;
+		return this;
+	}
+
+	@Override
+	public void apply(CtExecutable<?> targetExecutable, final CtConsumer<Object> outputConsumer) {
+		final List<CtExecutable<?>> targetMethods = new ArrayList<>();
+		targetMethods.add(targetExecutable);
+		if (includingSelf) {
+			outputConsumer.accept(targetExecutable);
+			if (query.isTerminated()) {
+				return;
+			}
+		}
+		CtMethod<?> targetMethod;
+		if (targetExecutable instanceof CtLambda) {
+			targetMethod = ((CtLambda) targetExecutable).getOverriddenMethod();
+		} else if (targetExecutable instanceof CtMethod) {
+			targetMethod = (CtMethod<?>) targetExecutable;
+		} else {
+			//CtConstructor or CtAnonymousExecutable never overrides other executable. We are done
+			return;
+		}
+		CtType<?> declaringType = targetMethod.getDeclaringType();
+		//search for all declarations and implementations of this method in sub and super classes and interfaces of all related hierarchies.
+		class Context {
+			boolean haveToSearchForSubtypes;
+		}
+		final Context context = new Context();
+		//at the beginning we know that we have to always search for sub types too. 
+		context.haveToSearchForSubtypes = true;
+		//Sub inheritance hierarchy function, which remembers visited sub types and does not returns/visits them again
+		final SubInheritanceHierarchyResolver subHierarchyFnc = new SubInheritanceHierarchyResolver(declaringType.getFactory().getModel().getRootPackage());
+		//add hierarchy of `targetMethod` as to be checked for sub types of declaring type
+		subHierarchyFnc.addSuperType(declaringType);
+		//unique names of all types whose super inheritance hierarchy was searched for rootType
+		Set<String> typesCheckedForRootType = new HashSet<>();
+		//list of sub types whose inheritance hierarchy has to be checked
+		final List<CtType<?>> toBeCheckedSubTypes = new ArrayList<>();
+		//add hierarchy of `targetMethod` as to be checked for super types of declaring type
+		toBeCheckedSubTypes.add(declaringType);
+		while (toBeCheckedSubTypes.size() > 0) {
+			for (CtType<?> subType : toBeCheckedSubTypes) {
+				ClassTypingContext ctc = new ClassTypingContext(subType);
+				//search for first target method from the same type inheritance hierarchy
+				targetMethod = getTargetMethodOfHierarchy(targetMethods, ctc);
+				//search for all methods with same signature in inheritance hierarchy of `subType`
+				forEachOverridenMethod(ctc, targetMethod, typesCheckedForRootType, new CtConsumer<CtMethod<?>>() {
+					@Override
+					public void accept(CtMethod<?> overriddenMethod) {
+						targetMethods.add(overriddenMethod);
+						outputConsumer.accept(overriddenMethod);
+						CtType<?> type = overriddenMethod.getDeclaringType();
+						subHierarchyFnc.addSuperType(type);
+						//mark that new super type was added, so we have to search for sub types again
+						context.haveToSearchForSubtypes = true;
+					}
+				});
+				if (query.isTerminated()) {
+					return;
+				}
+			}
+			toBeCheckedSubTypes.clear();
+			if (context.haveToSearchForSubtypes) {
+				context.haveToSearchForSubtypes = false;
+				//there are some new super types, whose sub inheritance hierarchy has to be checked
+				//search their inheritance hierarchy for sub types
+				subHierarchyFnc.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {
+					@Override
+					public void accept(CtType<?> type) {
+						toBeCheckedSubTypes.add(type);
+					}
+				});
+			}
+		}
+	}
+
+	/**
+	 * calls outputConsumer for each method which is overridden by 'thisMethod' in scope of `ctc`.
+	 * There is assured that each method is returned only once.
+	 *
+	 * @param ctc - class typing context whose scope is searched for overridden methods
+	 * @param thisMethod - the
+	 * @param distintTypesSet set of qualified names of types which were already visited
+	 * @param outputConsumer result handling consumer
+	 */
+	private void forEachOverridenMethod(final ClassTypingContext ctc, final CtMethod<?> thisMethod, Set<String> distintTypesSet, final CtConsumer<CtMethod<?>> outputConsumer) {
+		final CtQuery q = ctc.getAdaptationScope()
+			.map(new AllTypeMembersFunction(CtMethod.class).distinctSet(distintTypesSet));
+		q.forEach(new CtConsumer<CtMethod<?>>() {
+			@Override
+			public void accept(CtMethod<?> thatMethod) {
+				if (thisMethod == thatMethod) {
+					//do not return scope method
+					return;
+				}
+				//check whether method is overridden by searched method
+				/*
+				 * note: we are in super inheritance hierarchy of type declaring input `method`, so we do not have to check isSubTypeOf.
+				 * Check for isSubSignature is enough
+				 */
+				if (ctc.isSubSignature(thisMethod, thatMethod)) {
+					outputConsumer.accept(thatMethod);
+					if (query.isTerminated()) {
+						q.terminate();
+					}
+				}
+			}
+		});
+	}
+
+	private CtMethod<?> getTargetMethodOfHierarchy(List<CtExecutable<?>> targetMethods, ClassTypingContext ctc) {
+		for (CtExecutable<?> ctExecutable : targetMethods) {
+			if (ctExecutable instanceof CtMethod) {
+				CtMethod<?> method = (CtMethod<?>) ctExecutable;
+				CtType<?> declaringType = method.getDeclaringType();
+				if (ctc.isSubtypeOf(declaringType.getReference())) {
+					return method;
+				}
+			}
+		}
+		//this should never happen
+		throw new SpoonException("No target executable was found in super type hiearchy of class typing context");
+	}
+
+	@Override
+	public void setQuery(CtQuery query) {
+		this.query = query;
+	}
+}

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -3,19 +3,33 @@ package spoon.test.refactoring;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
 
+import spoon.reflect.code.CtLambda;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.AllMethodsSameSignatureFunction;
+import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.SubInheritanceHierarchyFunction;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.refactoring.parameter.testclasses.IFaceB;
 import spoon.test.refactoring.parameter.testclasses.IFaceK;
 import spoon.test.refactoring.parameter.testclasses.IFaceL;
+import spoon.test.refactoring.parameter.testclasses.TestHierarchy;
 import spoon.test.refactoring.parameter.testclasses.TypeA;
 import spoon.test.refactoring.parameter.testclasses.TypeB;
 import spoon.test.refactoring.parameter.testclasses.TypeC;
+import spoon.test.refactoring.parameter.testclasses.TypeL;
+import spoon.test.refactoring.parameter.testclasses.TypeR;
+import spoon.test.refactoring.parameter.testclasses.TypeS;
 import spoon.testing.utils.ModelUtils;
 
 public class MethodsRefactoringTest {
@@ -73,4 +87,109 @@ public class MethodsRefactoringTest {
 		}
 		assertTrue("Unexpected names found: "+foundNames, foundNames.isEmpty());
 	}
+
+	@Test
+	public void testAllMethodsSameSignatureFunction() {
+		Factory factory = ModelUtils.build(new File("./src/test/java/spoon/test/refactoring/parameter/testclasses"));
+		
+		//each executable in test classes is marked with a annotation TestHierarchy,
+		//which defines the name of the hierarchy where this executable belongs to. 
+		List<CtExecutable<?>> executablesOfHierarchyA = getExecutablesOfHierarchy(factory, "A_method1");
+		
+		//contract: check that found methods does not depend on the starting point
+		checkMethodHierarchy(executablesOfHierarchyA, factory.Class().get(TypeA.class).getMethodsByName("method1").get(0));
+		checkMethodHierarchy(executablesOfHierarchyA, factory.Class().get(TypeC.class).getMethodsByName("method1").get(0));
+		checkMethodHierarchy(executablesOfHierarchyA, factory.Interface().get(IFaceB.class).getMethodsByName("method1").get(0));
+		checkMethodHierarchy(executablesOfHierarchyA, factory.Class().get(TypeL.class).getMethodsByName("method1").get(0));
+		checkMethodHierarchy(executablesOfHierarchyA, ((CtClass<?>)factory.Class().get(TypeB.class).filterChildren(new NameFilter<>("1Local")).first()).getMethodsByName("method1").get(0));
+
+		List<CtExecutable<?>> executablesOfHierarchyR = getExecutablesOfHierarchy(factory, "R_method1");
+		
+		checkMethodHierarchy(executablesOfHierarchyR, factory.Class().get(TypeR.class).getMethodsByName("method1").get(0));
+		checkMethodHierarchy(executablesOfHierarchyR, factory.Class().get(TypeS.class).getMethodsByName("method1").get(0));
+	}
+	
+	private void checkMethodHierarchy(List<CtExecutable<?>> expectedExecutables, CtMethod startMethod) {
+		//contract: check that by default it does not includes self
+		//contract: check that by default it returns lambdas
+		{
+			final List<CtExecutable<?>> executables = startMethod.map(new AllMethodsSameSignatureFunction()).list();
+			assertFalse(executables.contains(startMethod));
+			//check that some method was found
+			assertTrue(executables.size()>0);
+			//check that expected methods were found and remove them 
+			expectedExecutables.forEach(m->{
+				boolean found = executables.remove(m);
+				if(startMethod==m) {
+					//it is start method. It should not be there
+					assertFalse("The signature "+getQSignature(m)+" was returned too", found);
+				} else {
+					assertTrue("The signature "+getQSignature(m)+" not found", found);
+				}
+			});
+			//check that there is no unexpected executable
+			assertTrue("Unexpected executables: "+executables, executables.isEmpty());
+		}
+		
+		//contract: check that includingSelf(true) returns startMethod too
+		//contract: check that by default it still returns lambdas
+		{
+			final List<CtExecutable<?>> executables = startMethod.map(new AllMethodsSameSignatureFunction().includingSelf(true)).list();
+			assertTrue(executables.contains(startMethod));
+			//check that some method was found
+			assertTrue(executables.size()>0);
+			//check that expected methods were found and remove them 
+			expectedExecutables.forEach(m->{
+				assertTrue("The signature "+getQSignature(m)+" not found", executables.remove(m));
+			});
+			//check that there is no unexpected executable
+			assertTrue("Unexpected executables: "+executables, executables.isEmpty());
+		}
+		
+		//contract: check that includingLambdas(false) returns no lambda expressions
+		{
+			final List<CtExecutable<?>> executables = startMethod.map(new AllMethodsSameSignatureFunction().includingSelf(true).includingLambdas(false)).list();
+			assertTrue(executables.contains(startMethod));
+			//check that some method was found
+			assertTrue(executables.size()>0);
+			//check that expected methods were found and remove them 
+			expectedExecutables.forEach(m->{
+				if(m instanceof CtLambda) {
+					//the lambdas are not expected. Do not ask for them
+					return;
+				}
+				assertTrue("The signature "+getQSignature(m)+" not found", executables.remove(m));
+			});
+			//check that there is no unexpected executable or lambda
+			assertTrue("Unexepcted executables "+executables, executables.isEmpty());
+		}
+	}
+	
+	private String getQSignature(CtExecutable e) {
+		if (e instanceof CtMethod<?>) {
+			CtMethod<?> m = (CtMethod<?>) e;
+			return m.getDeclaringType().getQualifiedName()+"#"+m.getSignature();
+		}
+		return e.getShortRepresentation();
+	}
+
+	private List<CtExecutable<?>> getExecutablesOfHierarchy(Factory factory, String hierarchyName) {
+		return factory.getModel().getRootPackage().filterChildren(new TypeFilter(CtExecutable.class)).select((CtExecutable<?> exec)->{
+			//detect if found executable belongs to hierarchy 'hierarchyName'
+			CtElement ele = exec;
+			if (exec instanceof CtLambda) {
+				//lambda is marked by annotation on the first statement of the lambda body.
+				List<CtStatement> stats = exec.getBody().getStatements();
+				if(stats.size()>0) {
+					ele = stats.get(0);
+				}
+			}
+			TestHierarchy th = ele.getAnnotation(TestHierarchy.class);
+			if (th!=null) {
+				return Arrays.asList(th.value()).indexOf(hierarchyName)>=0;
+			}
+			return false;
+		}).list();
+	}
+
 }

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceT.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/IFaceT.java
@@ -1,0 +1,6 @@
+package spoon.test.refactoring.parameter.testclasses;
+
+public interface IFaceT {
+	@TestHierarchy("R_method1")
+	void method1(Double p1);
+}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeB.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeB.java
@@ -17,12 +17,17 @@ public class TypeB extends TypeA implements IFaceB<Exception> {
 
 	private void anMethodWithLambdaByParam(IFaceB ifaceB) {
 		//this lambda is an implementation IFaceB#method1
-		anMethodWithLambdaByParam(/*A_method1*/p->{});
+		anMethodWithLambdaByParam(p->{
+			@TestHierarchy("A_method1")
+			int x;
+		});
 	}
 	private void anMethodWithLambda() {
 		//this lambda is an implementation IFaceB#method1
-		@TestHierarchy("A_method1")
-		IFaceB ifaceB = p->{};
+		IFaceB ifaceB = p->{
+			@TestHierarchy("A_method1")
+			int x;
+		};
 		ifaceB.method1(1);
 	}
 	private void anMethodWithLocalClass() {

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeR.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeR.java
@@ -1,6 +1,6 @@
 package spoon.test.refactoring.parameter.testclasses;
 
-public class TypeR extends TypeK {
+public class TypeR extends TypeK implements IFaceT {
 	@TestHierarchy("R_method1")
 	public void method1(Double p1) {
 	}

--- a/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeS.java
+++ b/src/test/java/spoon/test/refactoring/parameter/testclasses/TypeS.java
@@ -5,4 +5,20 @@ public class TypeS extends TypeR {
 	@TestHierarchy("R_method1")
 	public void method1(Double p1) {
 	}
+	
+	private void methodWithLambdaOf_A() {
+		IFaceB ifaceB = p->{
+			@TestHierarchy("A_method1")
+			int x;
+		};
+		ifaceB.method1(1);
+	}
+
+	private void methodWithLambdaOf_R() {
+		IFaceT ifaceT = p->{
+			@TestHierarchy("R_method1")
+			int x;
+		};
+		ifaceT.method1(1.0);
+	}
 }


### PR DESCRIPTION
Whenever anybody needs to refactor method signature, it is necessary to found all methods and lambdas in sub and super class/interface hierarchies, which overrides/are overridden by the refactored method.
Note: it is not primitive operation, because it needs to correctly detect generic methods and methods in related inheritance hierarchies.
Example:
```java
class A {
 void toBeRefactored(InputStream is) {}
}

class IFace<T> {
 void toBeRefactored(T param) {}
}

class B extends A implements IFaceC {}

class D implements IFaceC<Writer> {
 void toBeRefactored(Writer w) {}
}
class E {
 void toBeRefactored(InputStream is) {}
}
```
Note that there are 2 inheritance hierarchies with roots:
1) A, with sub type B
2) IFaceC, with sub types B and D
But they are related because they share type B. If one needs to refactor method signature of A#toBeRefactored, then s/he must refactor IFace#toBeRefactored and D#toBeRefactored too.
Note that E#toBeRefactored is not touched, because it is not member of any related inheritance hierarchy.

The mapping function `AllMethodsSameSignatureFunction` of this PR, searches for all CtMethods in all related inheritance hiearchies, which are overriding/overriden by input CtMethod.

The algorithm of this mapping function has to recursively scan sub and super inheritance hierarchies of each found sub/super type. It uses `SubInheritanceHiearchyResolver ` from #1290, which efficiently supports such recursive, iterative searching for subtypes.