### PR TITLE
review: refactor MethodTypingContext#adaptMethod moved to ClassTypingContext

### DIFF
--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -25,11 +25,15 @@ import java.util.Set;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
@@ -211,6 +215,53 @@ public class ClassTypingContext extends AbstractTypingContext {
 			}
 		});
 		return listener.foundArguments;
+	}
+
+	/**
+	 * @param method to be adapted to this context
+	 * @return new method whose parameters are adapted to `this context` or the same`method` if there is no need to adapt it
+	 */
+	public <T> CtMethod<T> adaptMethod(CtMethod<T> method) {
+		CtType<?> declType = method.getDeclaringType();
+		if (declType == null) {
+			throw new SpoonException("Cannot adapt method, which has no declaringType");
+		}
+		if (getAdaptationScope() == declType) {
+			return method;
+		}
+		//the scope method is declared in different type then scope of assigned classTypingContext
+		if (isSubtypeOf(declType.getReference()) == false) {
+			throw new SpoonException("Cannot create MethodTypingContext for method declared in different ClassTypingContext");
+		}
+		/*
+		 * The method is declared in an supertype of classTypingContext.
+		 * Create virtual scope method by adapting generic types of supertype method to required scope
+		 */
+		Factory factory = method.getFactory();
+		//create new method
+		CtMethod<T> adaptedMethod = factory.Core().createMethod();
+		adaptedMethod.setParent(getAdaptationScope());
+		adaptedMethod.setModifiers(method.getModifiers());
+		adaptedMethod.setSimpleName(method.getSimpleName());
+		for (CtTypeReference<? extends Throwable> thrownType : method.getThrownTypes()) {
+			adaptedMethod.addThrownType(thrownType.clone());
+		}
+		for (CtTypeParameter typeParam : method.getFormalCtTypeParameters()) {
+			CtTypeParameter newTypeParam = typeParam.clone();
+			newTypeParam.setSuperclass(adaptTypeForNewMethod(typeParam.getSuperclass()));
+			adaptedMethod.addFormalCtTypeParameter(newTypeParam);
+		}
+		//adapt return type
+		adaptedMethod.setType((CtTypeReference) adaptTypeForNewMethod(method.getType()));
+		//adapt parameters
+		List<CtParameter<?>> adaptedParams = new ArrayList<>(method.getParameters().size());
+		for (CtParameter<?> parameter : method.getParameters()) {
+			adaptedParams.add(factory.Executable().createParameter(null,
+					adaptTypeForNewMethod(parameter.getType()),
+					parameter.getSimpleName()));
+		}
+		adaptedMethod.setParameters(adaptedParams);
+		return adaptedMethod;
 	}
 
 	@Override
@@ -496,5 +547,20 @@ public class ClassTypingContext extends AbstractTypingContext {
 		}
 		//superArg is not a wildcard. Only same type is matching
 		return subArg.equals(superArg);
+	}
+
+	private CtTypeReference<?> adaptTypeForNewMethod(CtTypeReference<?> typeRef) {
+		if (typeRef == null) {
+			return null;
+		}
+		if (typeRef instanceof CtTypeParameterReference) {
+			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
+			CtTypeParameter typeParam = typeParamRef.getDeclaration();
+			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
+				//the parameter is declared in scope of Method or Constructor
+				return typeRef.clone();
+			}
+		}
+		return adaptType(typeRef);
 	}
 }

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -32,7 +32,6 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -59,7 +58,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 	public MethodTypingContext setMethod(CtMethod<?> scopeMethod) {
 		if (classTypingContext != null) {
 			//assure that scopeMethod fits to required classTypingContext
-			scopeMethod = adaptMethod(scopeMethod);
+			scopeMethod = classTypingContext.adaptMethod(scopeMethod);
 		}
 		setScopeMethod(scopeMethod);
 		actualTypeArguments = getTypeReferences(scopeMethod.getFormalCtTypeParameters());
@@ -320,70 +319,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 		return types;
 	}
 
-	/**
-	 * @param method to be adapted to this context
-	 * @return new method whose parameters are adapted to `this context` or the same`method` if there is no need to adapt it
-	 */
-	public <T> CtMethod<T> adaptMethod(CtMethod<T> method) {
-		CtType<?> declType = method.getDeclaringType();
-		if (declType == null) {
-			throw new SpoonException("Cannot adapt method, which has no declaringType");
-		}
-		if (classTypingContext == null) {
-			throw new SpoonException("Cannot adapt method becasue target classTypingContext was not set");
-		}
-		if (classTypingContext.getAdaptationScope() == declType) {
-			return method;
-		}
-		//the scope method is declared in different type then scope of assigned classTypingContext
-		if (classTypingContext.isSubtypeOf(declType.getReference()) == false) {
-			throw new SpoonException("Cannot create MethodTypingContext for method declared in different ClassTypingContext");
-		}
-		/*
-		 * The method is declared in an supertype of classTypingContext.
-		 * Create virtual scope method by adapting generic types of supertype method to required scope
-		 */
-		Factory factory = method.getFactory();
-		//create new method
-		CtMethod<T> adaptedMethod = factory.Core().createMethod();
-		adaptedMethod.setParent(classTypingContext.getAdaptationScope());
-		adaptedMethod.setModifiers(method.getModifiers());
-		adaptedMethod.setSimpleName(method.getSimpleName());
-		for (CtTypeReference<? extends Throwable> thrownType : method.getThrownTypes()) {
-			adaptedMethod.addThrownType(thrownType.clone());
-		}
-		for (CtTypeParameter typeParam : method.getFormalCtTypeParameters()) {
-			CtTypeParameter newTypeParam = typeParam.clone();
-			newTypeParam.setSuperclass(adaptTypeForNewMethod(typeParam.getSuperclass()));
-			adaptedMethod.addFormalCtTypeParameter(newTypeParam);
-		}
-		//adapt return type
-		adaptedMethod.setType((CtTypeReference) adaptTypeForNewMethod(method.getType()));
-		//adapt parameters
-		List<CtParameter<?>> adaptedParams = new ArrayList<>(method.getParameters().size());
-		for (CtParameter<?> parameter : method.getParameters()) {
-			adaptedParams.add(factory.Executable().createParameter(null,
-					adaptTypeForNewMethod(parameter.getType()),
-					parameter.getSimpleName()));
-		}
-		adaptedMethod.setParameters(adaptedParams);
-		return adaptedMethod;
-	}
 
-	private CtTypeReference<?> adaptTypeForNewMethod(CtTypeReference<?> typeRef) {
-		if (typeRef == null) {
-			return null;
-		}
-		if (typeRef instanceof CtTypeParameterReference) {
-			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
-			CtTypeParameter typeParam = typeParamRef.getDeclaration();
-			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
-				//the parameter is declared in scope of Method or Constructor
-				return typeRef.clone();
-			}
-		}
-		return adaptType(typeRef);
-	}
 
 	private CtType<?> getScopeMethodDeclaringType() {
 		if (scopeMethod != null) {

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -884,9 +884,10 @@ public class GenericsTest {
 		CtMethod<?> trLunch_eatMe = ctClassLunch.filterChildren(new NameFilter<>("eatMe")).first();
 		CtClass<?> ctClassWeddingLunch = factory.Class().get(WeddingLunch.class);
 
+		ClassTypingContext ctcWeddingLunch = new ClassTypingContext(ctClassWeddingLunch);
 		// we all analyze new methods
-		final MethodTypingContext methodSTH = new MethodTypingContext().setClassTypingContext(new ClassTypingContext(ctClassWeddingLunch));
-		CtMethod<?> adaptedLunchEatMe = methodSTH.adaptMethod(trLunch_eatMe);
+		final MethodTypingContext methodSTH = new MethodTypingContext().setClassTypingContext(ctcWeddingLunch);
+		CtMethod<?> adaptedLunchEatMe = ctcWeddingLunch.adaptMethod(trLunch_eatMe);
 
 		//contract: adapting of method declared in different scope, returns new method
 		assertTrue(adaptedLunchEatMe != trLunch_eatMe);
@@ -915,7 +916,7 @@ public class GenericsTest {
 		assertEquals("C", adaptedLunchEatMe.getParameters().get(2).getType().getQualifiedName());
 
 		//contract: adapting of adapted method returns input method
-		assertSame(adaptedLunchEatMe, methodSTH.adaptMethod(adaptedLunchEatMe));
+		assertSame(adaptedLunchEatMe, ctcWeddingLunch.adaptMethod(adaptedLunchEatMe));
 
 		//contract: method typing context creates adapted method automatically
 		methodSTH.setMethod(trLunch_eatMe);
@@ -931,7 +932,7 @@ public class GenericsTest {
 		//contract: use method from correct scope and check whether it has same signature like adapted method
 		methodSTH.setMethod(trWeddingLunch_eatMe);
 		//contract: check that adapting of methods still produces same results, even when scopeMethod is already assigned
-		assertEquals(adaptedLunchEatMe, methodSTH.adaptMethod(trLunch_eatMe));
+		assertEquals(adaptedLunchEatMe, ctcWeddingLunch.adaptMethod(trLunch_eatMe));
 		assertTrue(methodSTH.isOverriding(trLunch_eatMe));
 		assertTrue(methodSTH.isOverriding(trWeddingLunch_eatMe));
 		assertTrue(methodSTH.isSubSignature(trWeddingLunch_eatMe));


### PR DESCRIPTION
As discussed in #1292. Here is C1 + C2. It was simplest.
`MethodTypingContext#adaptMethod` moved to ClassTypingContext#adaptMethod`