### PR TITLE
review bug: some Override annotations are retrieved without information by JDT 

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -913,8 +913,18 @@ public class ReferenceBuilder {
 		} else if (declaring instanceof CtTypeReference) {
 			ref.setDeclaringType((CtTypeReference) declaring);
 		} else if (declaring == null) {
-			// in that case we consider the package should be the same as the current one. Fix #1293
-			ref.setPackage(jdtTreeBuilder.getContextBuilder().compilationUnitSpoon.getDeclaredPackage().getReference());
+			try {
+				// sometimes JDT does not provide the information that ref comes from java.lang
+				// it seems to occurs in particular with anonymous inner classes: see #1307
+				// In that case, we try to load the class to check if it belongs to java.lang
+				Class.forName("java.lang." + ref.getSimpleName());
+				CtPackageReference javaLangPackageReference = this.jdtTreeBuilder.getFactory().Core().createPackageReference();
+				javaLangPackageReference.setSimpleName("java.lang");
+				ref.setPackage(javaLangPackageReference);
+			} catch (ClassNotFoundException e) {
+				// in that case we consider the package should be the same as the current one. Fix #1293
+				ref.setPackage(jdtTreeBuilder.getContextBuilder().compilationUnitSpoon.getDeclaredPackage().getReference());
+			}
 		} else {
 			throw new AssertionError("unexpected declaring type: " + declaring.getClass() + " of " + declaring);
 		}

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -975,6 +975,7 @@ public class AnnotationTest {
 	@Test
 	public void annotationAddValue() {
 		Launcher spoon = new Launcher();
+
 		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Bar.java");
 		spoon.buildModel();
 
@@ -989,5 +990,25 @@ public class AnnotationTest {
 
 		CtAnnotation anno = factory.Annotation().annotate(methods.get(0), TypeAnnotation.class).addValue("params", new String[0]);
 		assertThat(anno.getValue("params").getType(), is(factory.Type().createReference(String[].class)));
+	}
+
+	@Test
+	public void annotationOverrideFQNIsOK() {
+		Launcher spoon = new Launcher();
+		factory = spoon.getFactory();
+		factory.getEnvironment().setNoClasspath(true);
+		spoon.addInputResource("./src/test/resources/noclasspath/annotation/issue1307/SpecIterator.java");
+		spoon.buildModel();
+
+
+
+		List<CtAnnotation> overrideAnnotations = factory.getModel().getElements(new TypeFilter<CtAnnotation>(CtAnnotation.class));
+
+		for (CtAnnotation annotation : overrideAnnotations) {
+			CtTypeReference typeRef = annotation.getAnnotationType();
+			if (typeRef.getSimpleName().equals("Override")) {
+				assertThat(typeRef.getQualifiedName(), is("java.lang.Override"));
+			}
+		}
 	}
 }

--- a/src/test/resources/noclasspath/annotation/issue1307/SpecIterator.java
+++ b/src/test/resources/noclasspath/annotation/issue1307/SpecIterator.java
@@ -1,0 +1,73 @@
+package org.ehcache.core;
+
+import org.ehcache.Cache;
+import org.ehcache.core.spi.store.Store;
+import org.ehcache.core.spi.store.StoreAccessException;
+
+import java.util.Iterator;
+
+/**
+ * This implementation could change depending on <a href="https://github.com/jsr107/jsr107spec/issues/337">jsr107spec issue #337</a>
+ * as letting next() return true might not be such a great idea, and too strict accounting of stats in the TCK
+ * preventing a look-ahead iterator implementation.
+ *
+ * @author Ludovic Orban
+ */
+class SpecIterator<K, V> implements Iterator<Cache.Entry<K, V>> {
+
+    private final Jsr107Cache<K, V> cache;
+    private final Store.Iterator<Cache.Entry<K, Store.ValueHolder<V>>> iterator;
+    private Cache.Entry<K, Store.ValueHolder<V>> current;
+
+    public SpecIterator(Jsr107Cache<K, V> cache, Store<K, V> store) {
+        this.cache = cache;
+        this.iterator = store.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public Cache.Entry<K, V> next() {
+        try {
+            Cache.Entry<K, Store.ValueHolder<V>> next = iterator.next();
+            final K nextKey = next.getKey();
+            Store.ValueHolder<V> nextValueHolder = next.getValue();
+
+            // call Cache.get() here to check for expiry *and* account for a get in the stats, without using the loader
+            if (cache.getNoLoader(nextKey) == null) {
+                current = null;
+                return null;
+            }
+
+            current = next;
+
+            final V nextValue = nextValueHolder.value();
+            return new Cache.Entry<K, V>() {
+                @Override
+                public K getKey() {
+                    return nextKey;
+                }
+
+                @Override
+                public V getValue() {
+                    return nextValue;
+                }
+            };
+        } catch (StoreAccessException sae) {
+            current = null;
+            return null;
+        }
+    }
+
+    @Override
+    public void remove() {
+        if (current == null) {
+            throw new IllegalStateException();
+        }
+        cache.remove(current.getKey());
+        current = null;
+    }
+}


### PR DESCRIPTION
In some anonymous inner classes, in noClassPath, JDT does not provide information about Override annotation: by default the ReferenceBuilder assume that if a type does not have any import and has no package, it belongs to the current package. 
So I added a check to verify if the current type belongs to the java.lang package.
Fix #1307 