### PR TITLE
refactor: remove call to deprecated File#toURL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,10 @@
           <target>${java.src.version}</target>
           <testSource>${java.test.version}</testSource>
           <testTarget>${java.test.version}</testTarget>
+          <showWarnings>true</showWarnings>
+          <compilerArgs>
+              <arg>-Xlint:deprecation</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
 

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -256,7 +256,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 
 	private class NewInstanceClassloader extends URLClassLoader {
 		NewInstanceClassloader(File binaryOutputDirectory) throws MalformedURLException {
-			super(new URL[] { binaryOutputDirectory.toURL()});
+			super(new URL[] { binaryOutputDirectory.toURI().toURL()});
 		}
 
 		@Override


### PR DESCRIPTION
remove 

    [WARNING] /home/martin/martin-no-backup/spoon/spoon-core/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java:[259,64] toURL() in java.io.File has been deprecated
