### PR TITLE
review: fix: replace wrong CtTypeInformation by CtType

### DIFF
--- a/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
+++ b/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
@@ -114,7 +114,7 @@ public class SubInheritanceHierarchyResolver {
 	 * 	If this method is called again with same input and configuration, nothing in sent to outputConsumer
 	 * @param outputConsumer the consumer for found sub types
 	 */
-	public <T extends CtTypeInformation> void forEachSubTypeInPackage(final CtConsumer<T> outputConsumer) {
+	public <T extends CtType<?>> void forEachSubTypeInPackage(final CtConsumer<T> outputConsumer) {
 		/*
 		 * Set of qualified names of all visited types, independent on whether they are sub types or not.
 		 */

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -39,7 +39,6 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
@@ -1059,9 +1058,9 @@ public class FilterTest {
 		SubInheritanceHierarchyResolver resolver = new SubInheritanceHierarchyResolver(launcher.getModel().getRootPackage());
 
 		// contract: by default, nothing is sent to the consumer
-		resolver.forEachSubTypeInPackage(new CtConsumer<CtTypeInformation>() {
+		resolver.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {
 			@Override
-			public void accept(CtTypeInformation ctTypeInformation) {
+			public void accept(CtType<?> ctType) {
 				fail();
 			}
 		});
@@ -1070,9 +1069,9 @@ public class FilterTest {
 		resolver.addSuperType(launcher.getFactory().Type().createReference(AbstractTostada.class));
 		class Counter { int counter =0;}
 		Counter c = new Counter();
-		resolver.forEachSubTypeInPackage(new CtConsumer<CtTypeInformation>() {
+		resolver.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {
 			@Override
-			public void accept(CtTypeInformation ctTypeInformation) {
+			public void accept(CtType<?> ctType) {
 				c.counter++;
 			}
 		});
@@ -1083,9 +1082,9 @@ public class FilterTest {
 		// we add a type already visited
 		resolver.addSuperType(launcher.getFactory().Type().createReference(Tostada.class));
 		// nothing is sent to the consumer
-		resolver.forEachSubTypeInPackage(new CtConsumer<CtTypeInformation>() {
+		resolver.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {
 			@Override
-			public void accept(CtTypeInformation ctTypeInformation) {
+			public void accept(CtType<?> ctType) {
 				fail();
 			}
 		});
@@ -1093,11 +1092,11 @@ public class FilterTest {
 		// we add a new type
 		resolver.addSuperType(launcher.getFactory().Type().createReference(ITostada.class));
 		Counter c2 = new Counter();
-		resolver.forEachSubTypeInPackage(new CtConsumer<CtTypeInformation>() {
+		resolver.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {
 			@Override
-			public void accept(CtTypeInformation ctTypeInformation) {
+			public void accept(CtType<?> ctType) {
 				c2.counter++;
-				assertEquals("spoon.test.filters.testclasses.Tacos", ctTypeInformation.getQualifiedName());
+				assertEquals("spoon.test.filters.testclasses.Tacos", ctType.getQualifiedName());
 			}
 		});
 


### PR DESCRIPTION
After simplifications of SubInheritanceHierarchyResolver (remove of `#returnTypeReferences(boolean)` method) there remained `CtConsumer<CtTypeInformation>`, but there should be `CtConsumer<CtType>`