### PR TITLE
review: feature LambdaFilter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/LambdaFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LambdaFilter.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import spoon.reflect.code.CtLambda;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Filter;
+
+/**
+ * This filter matches all the {@link CtLambda} elements, which implements defined interface(s)
+ */
+public class LambdaFilter implements Filter<CtLambda<?>> {
+
+	private Set<String> qualifiedNamesOfInterfaces = new HashSet<>();
+
+	/**
+	 * Use {@link #addImplementingInterface(CtTypeInformation)} to define set of interfaces whose lambdas it is search for
+	 */
+	public LambdaFilter() {
+	}
+
+	/**
+	 * Matches all lambdas implementing `iface`
+	 * Use {@link #addImplementingInterface(CtTypeInformation)} to define set of interfaces whose lambdas it is search for
+	 */
+	public LambdaFilter(CtInterface<?> iface) {
+		addImplementingInterface(iface);
+	}
+
+	/**
+	 * Matches all lambdas implementing `iface`
+	 * Use {@link #addImplementingInterface(CtTypeInformation)} to define set of interfaces whose lambdas it is search for
+	 */
+	public LambdaFilter(CtTypeReference<?> iface) {
+		addImplementingInterface(iface);
+	}
+
+	/**
+	 * Allows to search for lambdas implemented by different interfaces.
+	 * @param typeInfo interface whose lambda implementations it is searching for
+	 */
+	public LambdaFilter addImplementingInterface(CtTypeInformation typeInfo) {
+		if (typeInfo instanceof CtType) {
+			if (typeInfo instanceof CtInterface) {
+				qualifiedNamesOfInterfaces.add(typeInfo.getQualifiedName());
+			} //else ignore that request, because lambda can implement only interfaces
+		} else {
+			//do not check if it is interface or not. That check needs CtType in model and it might be not available in some modes
+			//it is OK to search for non interface types. It simply founds no lambda implementing that
+			qualifiedNamesOfInterfaces.add(typeInfo.getQualifiedName());
+		}
+		return this;
+	}
+
+	@Override
+	public boolean matches(CtLambda<?> lambda) {
+		return qualifiedNamesOfInterfaces.contains(lambda.getType().getQualifiedName());
+	}
+}

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -386,13 +386,17 @@ public class LambdaTest {
 
 	@Test
 	public void testLambdaFilter() throws Exception {
+		//check constructor with CtInterface
 		List<String> methodNames = foo.filterChildren(new LambdaFilter((CtInterface<?>) foo.getNestedType("CheckPerson"))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
 		assertHasStrings(methodNames);
-		methodNames = foo.filterChildren(new LambdaFilter((CtInterface<?>) foo.getNestedType("Check"))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
+		//check constructor with CtTypeReference
+		methodNames = foo.filterChildren(new LambdaFilter(foo.getNestedType("Check").getReference())).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
 		assertHasStrings(methodNames, "m", "m6");
-		methodNames = foo.filterChildren(new LambdaFilter((CtInterface<?>) foo.getNestedType("CheckPersons"))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
+		//check empty constructor and addImplementingInterface with Interface
+		methodNames = foo.filterChildren(new LambdaFilter().addImplementingInterface((CtInterface<?>) foo.getNestedType("CheckPersons"))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
 		assertHasStrings(methodNames, "m3", "m5");
-		methodNames = foo.filterChildren(new LambdaFilter(factory.Interface().get(Predicate.class))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
+		//check empty constructor and addImplementingInterface with CtTypeReference
+		methodNames = foo.filterChildren(new LambdaFilter().addImplementingInterface(factory.createCtTypeReference(Predicate.class))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
 		assertHasStrings(methodNames, "m2", "m4", "m7", "m8");
 	}
 


### PR DESCRIPTION
This Filter matches all CtLambdas which are implementing one of defined interfaces.

It will be used by #1291 to found all lambdas of all methods with same signature.