### PR TITLE
review: replace string literals by constants

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -33,6 +33,8 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 
 	String CONSTRUCTOR_NAME = "<init>";
 
+	String LAMBDA_NAME_PREFIX = "lambda$";
+
 	String UNKNOWN_TYPE = "<unknown>";
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/JavaIdentifiers.java
+++ b/src/main/java/spoon/reflect/visitor/JavaIdentifiers.java
@@ -21,6 +21,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import spoon.reflect.reference.CtExecutableReference;
+
 /**
  * This enum defines the Java keywords and some helper method to determine if
  * some strings are Java identifiers.
@@ -99,7 +101,7 @@ public enum JavaIdentifiers {
 		if (string == null) {
 			return false;
 		}
-		if (string.equals("<init>")) {
+		if (string.equals(CtExecutableReference.CONSTRUCTOR_NAME)) {
 			return true;
 		}
 		return isLegalJavaIdentifier(string);

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -29,6 +29,7 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 
 import java.util.ArrayList;
@@ -69,7 +70,7 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 		}
 		try {
 			if (target.getParent(CtConstructor.class) != null) {
-				if (target instanceof CtInvocation && ((CtInvocation<?>) target).getExecutable().getSimpleName().startsWith("<init>")) {
+				if (target instanceof CtInvocation && ((CtInvocation<?>) target).getExecutable().getSimpleName().startsWith(CtExecutableReference.CONSTRUCTOR_NAME)) {
 					throw new SpoonException("cannot insert a statement before a super or this invocation.");
 				}
 			}

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -25,6 +25,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -60,7 +61,7 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 
 	@Override
 	public String getSimpleName() {
-		return "<init>";
+		return CtExecutableReference.CONSTRUCTOR_NAME;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -49,6 +49,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.eval.PartialEvaluator;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
@@ -380,7 +381,7 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 			i.addArgument(re);
 		}
 		// do not partially evaluate super(...)
-		if (i.getExecutable().getSimpleName().equals("<init>")) {
+		if (i.getExecutable().getSimpleName().equals(CtExecutableReference.CONSTRUCTOR_NAME)) {
 			setResult(i);
 			return;
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -158,13 +158,13 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 			return null;
 		}
 		CtExecutable<T> method = typeDecl.getMethod(getSimpleName(), parameters.toArray(new CtTypeReferenceImpl<?>[parameters.size()]));
-		if ((method == null) && (typeDecl instanceof CtClass) && (getSimpleName().equals("<init>"))) {
+		if ((method == null) && (typeDecl instanceof CtClass) && (getSimpleName().equals(CtExecutableReference.CONSTRUCTOR_NAME))) {
 			try {
 				return (CtExecutable<T>) ((CtClass<?>) typeDecl).getConstructor(parameters.toArray(new CtTypeReferenceImpl<?>[parameters.size()]));
 			} catch (ClassCastException e) {
 				Launcher.LOGGER.error(e.getMessage(), e);
 			}
-		} else if (method == null && getSimpleName().startsWith("lambda$")) {
+		} else if (method == null && getSimpleName().startsWith(CtExecutableReference.LAMBDA_NAME_PREFIX)) {
 			final List<CtLambda<T>> elements = (List<CtLambda<T>>) typeDecl.getElements(new NameFilter<CtLambda<T>>(getSimpleName()));
 			if (elements.size() == 0) {
 				return null;


### PR DESCRIPTION
replaces all "<init>" by CtExecutableReference.CONSTRUCTOR_NAME.
replaces all "lambda$" by CtExecutableReference.LAMBDA_NAME_PREFIX.