### PR TITLE
review: feature ExecutableReferenceFilter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/ExecutableReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ExecutableReferenceFilter.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import spoon.SpoonException;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.visitor.Filter;
+
+/**
+ * This filter matches all the {@link CtExecutableReference} referencing defined one or more {@link CtExecutable}s.
+ */
+public class ExecutableReferenceFilter implements Filter<CtExecutableReference<?>> {
+
+	private Map<CtExecutable<?>, CtExecutable<?>> executables = new IdentityHashMap<>();
+	private Set<String> typeQualifiedNames = new HashSet<>();
+	private Set<String> methodNames = new HashSet<>();
+
+	/**
+	 * Creates a new executable reference filter.
+	 *
+	 * Call {@link #addExecutable(CtExecutable)} to define executables
+	 * whose references it matches.
+	 */
+	public ExecutableReferenceFilter() {
+	}
+
+	/**
+	 * Creates a new executable reference filter.
+	 *
+	 * @param executable
+	 * 		the executable whose references it matches
+	 */
+	public ExecutableReferenceFilter(CtExecutable<?> executable) {
+		addExecutable(executable);
+	}
+
+	/**
+	 * Add next {@link CtExecutable} whose {@link CtExecutableReference}s has to be matched
+	 *
+	 * @param executable searched {@link CtExecutable} instance
+	 * @return this to support fluent API
+	 */
+	public ExecutableReferenceFilter addExecutable(CtExecutable<?> executable) {
+		executables.put(executable, executable);
+		if (executable instanceof CtTypeMember) {
+			CtType<?> declType = ((CtTypeMember) executable).getDeclaringType();
+			if (declType == null) {
+				throw new SpoonException("Cannot search for executable reference, which has no declaring type");
+			}
+			typeQualifiedNames.add(declType.getQualifiedName());
+			if (executable instanceof CtMethod<?>) {
+				methodNames.add(((CtMethod<?>) executable).getSimpleName());
+			}
+		}
+		return this;
+	}
+
+	@Override
+	public boolean matches(CtExecutableReference<?> execRef) {
+		if (execRef.getSimpleName().startsWith(CtExecutableReference.LAMBDA_NAME_PREFIX)) {
+			//reference to lambda
+			return executables.containsKey(execRef.getDeclaration());
+		} else {
+			//reference to constructor or method
+			if (typeQualifiedNames.contains(execRef.getDeclaringType().getQualifiedName())) {
+				if (CtExecutableReference.CONSTRUCTOR_NAME.equals(execRef.getSimpleName()) || methodNames.contains(execRef.getSimpleName())) {
+					return executables.containsKey(execRef.getDeclaration());
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -3,8 +3,10 @@ package spoon.test.refactoring;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -19,7 +21,9 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.filter.AllMethodsSameSignatureFunction;
+import spoon.reflect.visitor.filter.ExecutableReferenceFilter;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.reflect.visitor.filter.SubInheritanceHierarchyFunction;
 import spoon.reflect.visitor.filter.TypeFilter;
@@ -235,6 +239,39 @@ public class MethodsRefactoringTest {
 		}).list();
 	}
 
+	@Test
+	public void testExecutableReferenceFilter() {
+		Factory factory = ModelUtils.build(new File("./src/test/java/spoon/test/refactoring/parameter/testclasses"));
+		
+		List<CtExecutable<?>> executables = factory.getModel().getRootPackage().filterChildren((CtExecutable<?> e)->true).list();
+		int nrExecRefsTotal = 0;
+		//contract check that ExecutableReferenceFilter found CtExecutableReferences of each executable individually 
+		for (CtExecutable<?> executable : executables) {
+			nrExecRefsTotal += checkExecutableReferenceFilter(factory, Collections.singletonList(executable));
+		}
+		//contract check that ExecutableReferenceFilter found CtExecutableReferences of all executables together 
+		int nrExecRefsTotal2 = checkExecutableReferenceFilter(factory, executables);
+		assertSame(nrExecRefsTotal, nrExecRefsTotal2);
+	}
+
+	private int checkExecutableReferenceFilter(Factory factory, List<CtExecutable<?>> executables) {
+		assertTrue(executables.size()>0);
+		ExecutableReferenceFilter execRefFilter = new ExecutableReferenceFilter();
+		executables.forEach((CtExecutable<?> e)->execRefFilter.addExecutable(e));
+		final List<CtExecutableReference<?>> refs = new ArrayList<>(factory.getModel().getRootPackage().filterChildren(execRefFilter).list());
+		int nrExecRefs = refs.size();
+		//use different (slower, but straight forward) algorithm to search for all executable references to check if ExecutableReferenceFilter returns correct results
+		factory.getModel().getRootPackage().filterChildren((CtExecutableReference er)->{
+			return containsSame(executables, er.getDeclaration());
+		}).forEach((CtExecutableReference er)->{
+			//check that each expected reference was found by ExecutableReferenceFilter and remove it from that list
+			assertTrue("Executable reference: "+er+" not found.", refs.remove(er));
+		});
+		//check that no other reference was found by ExecutableReferenceFilter
+		assertSame(0, refs.size());
+		return nrExecRefs;
+	}
+	
 	private boolean containsSame(Collection list, Object item) {
 		for (Object object : list) {
 			if(object==item) {

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -251,7 +251,17 @@ public class MethodsRefactoringTest {
 		}
 		//contract check that ExecutableReferenceFilter found CtExecutableReferences of all executables together 
 		int nrExecRefsTotal2 = checkExecutableReferenceFilter(factory, executables);
+		
 		assertSame(nrExecRefsTotal, nrExecRefsTotal2);
+
+		//contract check that it found lambdas too
+		CtLambda lambda = factory.getModel().getRootPackage().filterChildren((CtLambda<?> e)->true).first();
+		assertNotNull(lambda);
+		//this test case is quite wild, because there is normally lambda reference in spoon model. So make one lambda reference here:
+		CtExecutableReference<?> lambdaRef = lambda.getReference();
+		List<CtExecutableReference<?>> refs = lambdaRef.filterChildren(null).select(new ExecutableReferenceFilter(lambda)).list();
+		assertEquals(1, refs.size());
+		assertSame(lambdaRef, refs.get(0));
 	}
 
 	private int checkExecutableReferenceFilter(Factory factory, List<CtExecutable<?>> executables) {


### PR DESCRIPTION
A `ExecutableReferenceFilter` provides fast matching for all `CtExecutableReference`s of defined set of `CtExecutable`s.
It is used to found all invocations of `CtExecutable`s in future method refactoring PRs.

This filter is much faster and has different contract then legacy InvocationFilter, which 
1) is able to search only for one CtExecutable
2) searches not only for exact reference to one executable (like ExecutableReferenceFilter), but it matches each reference, which overrides input executable.

If you do not like contract of ExecutableReferenceFilter, then optional solution would be to refactor legacy InvocationFilter by way it can be configured to support contract of this ExecutableReferenceFilter - to return (if configured so) exact (not overriding) invocations of more then one executable.