### PR TITLE
review: fix, improve and document TemplateMatcher

### DIFF
--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -184,7 +184,7 @@ public abstract class Parameters {
 	public static List<String> getNames(CtClass<? extends Template<?>> templateType) {
 		List<String> params = new ArrayList<>();
 		try {
-			for (CtFieldReference<?> f : templateType.getReference().getAllFields()) {
+			for (CtFieldReference<?> f : templateType.getAllFields()) {
 				if (isParameterSource(f)) {
 					params.add(getParameterName(f));
 				}

--- a/src/main/java/spoon/template/TemplateMatcher.java
+++ b/src/main/java/spoon/template/TemplateMatcher.java
@@ -62,12 +62,9 @@ import java.util.regex.Pattern;
 public class TemplateMatcher implements Filter<CtElement> {
 
 	/**
-	 * Collects all AST nodes, which has to be substituted, because they represents a template parameter declared by {@link TemplateParameter}
+	 * Searches for all invocations of {@link TemplateParameter#S()} in "root", a CtClass model of {@link Template}
 	 *
-	 * Searches for all invocations of {@link TemplateParameter#S()} in CtClass model of {@link Template}
 	 * @param root CtClass model of {@link Template}
-	 * @return List of all variables - only these parameters which are declared by {@link TemplateParameter}.
-	 * It doesn't includes references to parameters annotated by {@link Parameter}
 	 */
 	private List<CtInvocation<?>> getMethods(CtClass<? extends Template<?>> root) {
 		CtExecutableReference<?> methodRef = root.getFactory().Executable()
@@ -80,7 +77,7 @@ public class TemplateMatcher implements Filter<CtElement> {
 	/**
 	 * @param templateType CtClass model of {@link Template}
 	 * @return list of all names of template parameters.
-	 * It includes parameters defined by {@link TemplateParameter} and parameters with annotation {@link Parameter}.
+	 * It includes parameters typed by {@link TemplateParameter} and parameters with annotation {@link Parameter}.
 	 */
 	private List<String> getTemplateNameParameters(CtClass<? extends Template<?>> templateType) {
 		return Parameters.getNames(templateType);

--- a/src/main/java/spoon/template/TemplateMatcher.java
+++ b/src/main/java/spoon/template/TemplateMatcher.java
@@ -345,7 +345,7 @@ public class TemplateMatcher implements Filter<CtElement> {
 	 * @param template actually checked AST node from template
 	 *
 	 * @return true if template matches this node, false if it does not matches
-	 * 
+	 *
 	 * note: Made private to hide the Objects.
 	 */
 	private boolean helperMatch(Object target, Object template) {


### PR DESCRIPTION
I am trying to understand how TemplateMatcher works and here are some
* javadoc added - which helps me and others to understand it better
* comments added about bugs - to plan future refactoring
* refactoring (removed some useless calls of `CtType#getReference`, which is immediately followed by `CtTypeReference#getDeclaringType`

@monperrus please have a look at it, even if it is WiP. This PR is more like list of TODO topics for future PRs. Are my changes on good way?