### PR TITLE
fix Template substitution of CtExecutableReference#simpleName

### DIFF
--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -47,6 +47,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
@@ -131,22 +132,30 @@ public class SubstitutionVisitor extends CtScanner {
 				element.setDocComment(substituteInDocComment(element.getDocComment()));
 			}
 			// replace parameters in names
-			String name = element.getSimpleName();
+			element.setSimpleName(substituteName(element.getSimpleName(), element));
+			super.scanCtNamedElement(element);
+		}
+
+		@Override
+		public void scanCtReference(CtReference reference) {
+			reference.setSimpleName(substituteName(reference.getSimpleName(), reference));
+			super.scanCtReference(reference);
+		}
+
+		private String substituteName(String name, CtElement element) {
 			for (String pname : parameterNames) {
 				if (name.contains(pname)) {
 					Object value = Parameters.getValue(template, pname, null);
 					if (value instanceof String) {
 						// replace with the string value
 						name = name.replace(pname, (String) value);
-						element.setSimpleName(name);
 					} else if ((value instanceof CtTypeReference) && (element instanceof CtType)) {
 						// replace with the type reference's name
 						name = name.replace(pname, ((CtTypeReference<?>) value).getSimpleName());
-						element.setSimpleName(name);
 					}
 				}
 			}
-			super.scanCtNamedElement(element);
+			return name;
 		}
 
 		private String substituteInDocComment(String docComment) {

--- a/src/test/java/spoon/test/template/InvocationTemplate.java
+++ b/src/test/java/spoon/test/template/InvocationTemplate.java
@@ -1,0 +1,34 @@
+package spoon.test.template;
+
+import spoon.reflect.reference.CtTypeReference;
+import spoon.template.ExtensionTemplate;
+import spoon.template.Local;
+import spoon.template.Parameter;
+
+public class InvocationTemplate extends ExtensionTemplate {
+
+	IFace iface;
+	
+	void invoke() {
+		iface.$method$();
+	}
+	
+	@Local
+	public InvocationTemplate(CtTypeReference<?> ifaceType, String methodName) {
+		this.ifaceType = ifaceType;
+		this.methodName = methodName;
+	}
+
+	@Parameter("IFace")
+	CtTypeReference<?> ifaceType;
+	
+	@Parameter("$method$")
+	String methodName;
+
+	
+	
+	@Local
+	interface IFace {
+		void $method$();
+	}
+}

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -438,6 +438,7 @@ public class TemplateTest {
 	}
 	@Test
 	public void testTemplateInvocationSubstitution() throws Exception {
+		//contract: the template engine supports substitution of method names in method calls.
 		Launcher spoon = new Launcher();
 		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/InvocationTemplate.java"));
 
@@ -448,6 +449,7 @@ public class TemplateTest {
 		new InvocationTemplate(factory.Type().OBJECT, "hashCode").apply(resultKlass);
 		CtMethod<?> templateMethod = (CtMethod<?>) resultKlass.getElements(new NameFilter("invoke")).get(0);
 		CtStatement templateRoot = (CtStatement) templateMethod.getBody().getStatement(0);
+		//iface.$method$() becomes iface.hashCode()
 		assertEquals("iface.hashCode()", templateRoot.toString());
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -436,4 +436,18 @@ public class TemplateTest {
 
 		assertTrue(match1.equals(match2));
 	}
+	@Test
+	public void testTemplateInvocationSubstitution() throws Exception {
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/InvocationTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		new InvocationTemplate(factory.Type().OBJECT, "hashCode").apply(resultKlass);
+		CtMethod<?> templateMethod = (CtMethod<?>) resultKlass.getElements(new NameFilter("invoke")).get(0);
+		CtStatement templateRoot = (CtStatement) templateMethod.getBody().getStatement(0);
+		assertEquals("iface.hashCode()", templateRoot.toString());
+	}
 }


### PR DESCRIPTION
There was not possible to substitute name of invoked method.

Example template:
```java
public class InvocationTemplate extends ExtensionTemplate {

	IFace iface;
	
	void invoke() {
//this method name was not substituted. This PR fixes it
		iface.$method$();
	}
	
	@Local
	public InvocationTemplate(CtTypeReference<?> ifaceType, String methodName) {
		this.ifaceType = ifaceType;
		this.methodName = methodName;
	}

	@Parameter("IFace")
	CtTypeReference<?> ifaceType;
	
	@Parameter("$method$")
	String methodName;

	@Local
	interface IFace {
		void $method$();
	}
}
```