### PR TITLE
chore: remove checkstyle rule

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -37,7 +37,6 @@
     <module name="NoWhitespaceBefore"/>
     <module name="OperatorWrap"/>
     <module name="ParenPad"/>
-    <module name="TypecastParenPad"/>
     <module name="WhitespaceAfter"/>
     <module name="WhitespaceAround"/>
 


### PR DESCRIPTION
Too much convention is useless and no fun.
Julien Duribreux (@?) was right, we have to do something.