### PR TITLE
refactor: change ImportScanner interface to add getAllImports

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -262,7 +262,8 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	 */
 	public Collection<CtReference> computeImports(CtType<?> type) {
 		context.currentTopLevel = type;
-		return importsContext.computeAllImports(context.currentTopLevel);
+		importsContext.computeAllImports(context.currentTopLevel);
+		return importsContext.getAllImports();
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -34,6 +34,7 @@ public interface ImportScanner {
 	 * @return class imports computed by Spoon, it does not contain static imports
 	 * @deprecated This method signature will change to return void in order to improve encapsulation: Use getAllImports to get the imports after calling it.
 	 */
+	@Deprecated
 	Collection<CtTypeReference<?>> computeImports(CtElement element);
 
 	/**
@@ -43,6 +44,7 @@ public interface ImportScanner {
 	 * @return imports computed by Spoon, it can be CtTypeReference (for classes), but also CtFieldReference (static field) or CtExecutableReference (static methods)
 	 * @deprecated This method signature will change to return void in order to improve encapsulation: Use getAllImports to get the imports after calling it.
 	 */
+	@Deprecated
 	Collection<CtReference> computeAllImports(CtType<?> simpleType);
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -19,6 +19,7 @@ package spoon.reflect.visitor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeReference;
 
 import java.util.Collection;
 
@@ -31,16 +32,16 @@ public interface ImportScanner {
 	 * Computes import of a {@link spoon.reflect.declaration.CtElement}
 	 *
 	 * @return class imports computed by Spoon, it does not contain static imports
-	 * @deprecated This method signature will change to return void: Use getAllImports to get the imports after calling it.
+	 * @deprecated This method signature will change to return void in order to improve encapsulation: Use getAllImports to get the imports after calling it.
 	 */
-	Collection<CtReference> computeImports(CtElement element);
+	Collection<CtTypeReference<?>> computeImports(CtElement element);
 
 	/**
 	 * Computes import of a {@link spoon.reflect.declaration.CtType}
 	 * (represent a class).
 	 *
 	 * @return imports computed by Spoon, it can be CtTypeReference (for classes), but also CtFieldReference (static field) or CtExecutableReference (static methods)
-	 * @deprecated This method signature will change to return void: Use getAllImports to get the imports after calling it.
+	 * @deprecated This method signature will change to return void in order to improve encapsulation: Use getAllImports to get the imports after calling it.
 	 */
 	Collection<CtReference> computeAllImports(CtType<?> simpleType);
 

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -19,7 +19,6 @@ package spoon.reflect.visitor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtReference;
-import spoon.reflect.reference.CtTypeReference;
 
 import java.util.Collection;
 
@@ -32,16 +31,25 @@ public interface ImportScanner {
 	 * Computes import of a {@link spoon.reflect.declaration.CtElement}
 	 *
 	 * @return class imports computed by Spoon, it does not contain static imports
+	 * @deprecated This method signature will change to return void: Use getAllImports to get the imports after calling it.
 	 */
-	Collection<CtTypeReference<?>> computeImports(CtElement element);
+	Collection<CtReference> computeImports(CtElement element);
 
 	/**
 	 * Computes import of a {@link spoon.reflect.declaration.CtType}
 	 * (represent a class).
 	 *
 	 * @return imports computed by Spoon, it can be CtTypeReference (for classes), but also CtFieldReference (static field) or CtExecutableReference (static methods)
+	 * @deprecated This method signature will change to return void: Use getAllImports to get the imports after calling it.
 	 */
 	Collection<CtReference> computeAllImports(CtType<?> simpleType);
+
+	/**
+	 * Use computeImports or computeAllImports before getting the different imports.
+	 *
+	 * @return the list of computed imports or an empty collection if not imports has been computed.
+	 */
+	Collection<CtReference> getAllImports();
 
 	/**
 	 * Checks if the type is already imported.

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -200,7 +200,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	}
 
 	@Override
-	public Collection<CtReference> computeImports(CtElement element) {
+	public Collection<CtTypeReference<?>> computeImports(CtElement element) {
 		//look for top declaring type of that simpleType
 		if (element instanceof CtType) {
 			CtType simpleType = (CtType) element;
@@ -212,7 +212,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 			targetType = type == null ? null : type.getReference().getTopLevelType();
 			scan(element);
 		}
-		return this.getAllImports();
+		return this.classImports.values();
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -187,7 +187,11 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 		targetType = simpleType.getReference().getTopLevelType();
 		addClassImport(simpleType.getReference());
 		scan(simpleType);
+		return this.getAllImports();
+	}
 
+	@Override
+	public Collection<CtReference> getAllImports() {
 		Collection<CtReference> listallImports = new ArrayList<>();
 		listallImports.addAll(this.classImports.values());
 		listallImports.addAll(this.fieldImports.values());
@@ -196,7 +200,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 	}
 
 	@Override
-	public Collection<CtTypeReference<?>> computeImports(CtElement element) {
+	public Collection<CtReference> computeImports(CtElement element) {
 		//look for top declaring type of that simpleType
 		if (element instanceof CtType) {
 			CtType simpleType = (CtType) element;
@@ -208,7 +212,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 			targetType = type == null ? null : type.getReference().getTopLevelType();
 			scan(element);
 		}
-		return this.classImports.values();
+		return this.getAllImports();
 	}
 
 	@Override

--- a/src/test/java/spoon/test/imports/ImportScannerTest.java
+++ b/src/test/java/spoon/test/imports/ImportScannerTest.java
@@ -8,6 +8,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.ImportScanner;
 import spoon.reflect.visitor.ImportScannerImpl;
@@ -38,7 +39,8 @@ public class ImportScannerTest {
 		CtType<?> theClass = aFactory.Type().get(qualifiedName);
 
 		ImportScanner importContext = new MinimalImportScanner();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(theClass);
+		importContext.computeImports(theClass);
+		Collection<CtReference> imports = importContext.getAllImports();
 
 		assertTrue(imports.isEmpty());
 	}
@@ -53,7 +55,8 @@ public class ImportScannerTest {
 		CtType<?> theClass = aFactory.Type().get(qualifiedName);
 
 		ImportScanner importContext = new ImportScannerImpl();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(theClass);
+		importContext.computeImports(theClass);
+		Collection<CtReference> imports = importContext.getAllImports();
 
 		// java.lang are also computed
 		assertEquals(4, imports.size());
@@ -69,7 +72,8 @@ public class ImportScannerTest {
 		CtType<?> theClass = aFactory.Type().get(qualifiedName);
 
 		ImportScanner importContext = new ImportScannerImpl();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(theClass);
+		importContext.computeImports(theClass);
+		Collection<CtReference> imports = importContext.getAllImports();
 
 		assertEquals(0, imports.size());
 	}
@@ -105,5 +109,9 @@ public class ImportScannerTest {
 
 		ImportScanner importScanner = new MinimalImportScanner();
 		importScanner.computeImports(fieldRef);
+
+		Collection<CtReference> imports = importScanner.getAllImports();
+
+		assertEquals(0, imports.size());
 	}
 }

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -20,6 +20,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.ImportScanner;
 import spoon.reflect.visitor.ImportScannerImpl;
@@ -248,18 +249,20 @@ public class ImportTest {
 		final CtClass<ImportTest> classWithInvocation = launcher.getFactory().Class().get(ClassWithInvocation.class);
 
 		ImportScanner importScanner = new ImportScannerImpl();
-		final Collection<CtTypeReference<?>> imports = importScanner.computeImports(aClass);
-		assertEquals(2, imports.size());
+		importScanner.computeImports(aClass);
+		assertEquals(2, importScanner.getAllImports().size());
+
 		importScanner = new ImportScannerImpl();
-		final Collection<CtTypeReference<?>> imports1 = importScanner.computeImports(anotherClass);
+		importScanner.computeImports(anotherClass);
 		//ClientClass needs 2 imports: ChildClass, PublicInterface2
-		assertEquals(2, imports1.size());
+		assertEquals(2, importScanner.getAllImports().size());
+
 		//check that printer did not used the package protected class like "SuperClass.InnerClassProtected"
 		assertTrue(anotherClass.toString().indexOf("InnerClass extends ChildClass.InnerClassProtected")>0);
 		importScanner = new ImportScannerImpl();
-		final Collection<CtTypeReference<?>> imports2 = importScanner.computeImports(classWithInvocation);
+		importScanner.computeImports(classWithInvocation);
 		// java.lang imports are also computed
-		assertEquals("Spoon ignores the arguments of CtInvocations", 3, imports2.size());
+		assertEquals("Spoon ignores the arguments of CtInvocations", 3, importScanner.getAllImports().size());
 	}
 
 	@Test
@@ -333,7 +336,9 @@ public class ImportTest {
 				"./src/test/java/spoon/test/imports/testclasses/Mole.java");
 
 		ImportScanner importContext = new ImportScannerImpl();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(factory.Class().get(Mole.class));
+		importContext.computeImports(factory.Class().get(Mole.class));
+
+		Collection<CtReference> imports = importContext.getAllImports();
 
 		assertEquals(1, imports.size());
 		assertEquals("spoon.test.imports.testclasses.internal2.Chimichanga", imports.toArray()[0].toString());
@@ -347,13 +352,15 @@ public class ImportTest {
 				"./src/test/java/spoon/test/imports/testclasses/NotImportExecutableType.java");
 
 		ImportScanner importContext = new ImportScannerImpl();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(factory.Class().get(NotImportExecutableType.class));
+		importContext.computeImports(factory.Class().get(NotImportExecutableType.class));
 
-		// java.lang.Object is considered as imported but it will never be output
+		Collection<CtReference> imports = importContext.getAllImports();
+
+				// java.lang.Object is considered as imported but it will never be output
 		assertEquals(3, imports.size());
 		Set<String> expectedImports = new HashSet<>(
 				Arrays.asList("spoon.test.imports.testclasses.internal3.Foo", "java.io.File", "java.lang.Object"));
-		Set<String> actualImports = imports.stream().map(CtTypeReference::toString).collect(Collectors.toSet());
+		Set<String> actualImports = imports.stream().map(CtReference::toString).collect(Collectors.toSet());
 		assertEquals(expectedImports, actualImports);
 	}
 
@@ -364,7 +371,9 @@ public class ImportTest {
 				"./src/test/java/spoon/test/imports/testclasses/Pozole.java");
 
 		ImportScanner importContext = new ImportScannerImpl();
-		Collection<CtTypeReference<?>> imports = importContext.computeImports(factory.Class().get(Pozole.class));
+		importContext.computeImports(factory.Class().get(Pozole.class));
+
+		Collection<CtReference> imports = importContext.getAllImports();
 
 		assertEquals(1, imports.size());
 		assertEquals("spoon.test.imports.testclasses.internal2.Menudo", imports.toArray()[0].toString());


### PR DESCRIPTION
This PR fixes #1329 by adding a new method `getAllImports` and by deprecating `computeImports` and `computeAllImports` because their return type will change in the future to void.