### PR TITLE
WiP: refactor SubstitutionVisitor. Unify conversion of template parameters

### DIFF
--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -489,10 +489,16 @@ public class SubstitutionVisitor extends CtScanner {
 		}
 	}
 
-	public CtElement substitute(CtElement element) {
+	/**
+	 * Substitutes all template parameters of element and returns substituted element.
+	 *
+	 * @param element to be substituted model
+	 * @return substituted model
+	 */
+	public <E extends CtElement> E substitute(E element) {
 		result = element;
 		scan(element);
-		return result;
+		return (E) result;
 	}
 
 	private void replace(CtElement toBeReplaced, CtElement replacement) {

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -188,7 +188,7 @@ public class SubstitutionVisitor extends CtScanner {
 						}
 						l.addStatement(b);
 					}
-					foreach.replace(l);
+					replace(foreach, l);
 					throw new DoNotFurtherTemplateThisElement(foreach);
 				}
 			}
@@ -212,7 +212,7 @@ public class SubstitutionVisitor extends CtScanner {
 					ref = ((CtFieldAccess<?>) fieldAccess.getTarget()).getVariable();
 					if (Parameters.isParameterSource(ref)) {
 						Object[] value = (Object[]) Parameters.getValue(template, ref.getSimpleName(), null);
-						fieldAccess.replace((CtExpression) fieldAccess.getFactory().Code().createLiteral(value
+						replace(fieldAccess, (CtExpression) fieldAccess.getFactory().Code().createLiteral(value
 								.length));
 						throw new DoNotFurtherTemplateThisElement(fieldAccess);
 					}
@@ -227,11 +227,11 @@ public class SubstitutionVisitor extends CtScanner {
 				}
 				if (!(value instanceof TemplateParameter)) {
 					if (value instanceof Class) {
-						toReplace.replace(factory.Code()
+						replace(toReplace, factory.Code()
 								.createClassAccess(factory.Type().createReference(((Class<?>) value).getName())));
 					} else if (value instanceof Enum) {
 						CtTypeReference<?> enumType = factory.Type().createReference(value.getClass());
-						toReplace.replace(factory.Code().createVariableRead(
+						replace(toReplace, factory.Code().createVariableRead(
 								factory.Field().createReference(enumType, enumType, ((Enum<?>) value).name()), true));
 					} else if (value instanceof List) {
 						// replace list of CtParameter for generic access to the
@@ -249,12 +249,12 @@ public class SubstitutionVisitor extends CtScanner {
 							i++;
 						}
 					} else if ((value != null) && value.getClass().isArray()) {
-						toReplace.replace(factory.Code().createLiteralArray((Object[]) value));
+						replace(toReplace, factory.Code().createLiteralArray((Object[]) value));
 					} else {
-						toReplace.replace(factory.Code().createLiteral(value));
+						replace(toReplace, factory.Code().createLiteral(value));
 					}
 				} else {
-					toReplace.clone();
+					replace(toReplace, toReplace.clone());
 				}
 				// do not visit if replaced
 				throw new DoNotFurtherTemplateThisElement(fieldAccess);
@@ -289,13 +289,13 @@ public class SubstitutionVisitor extends CtScanner {
 						// for recursive substitution)
 						r.accept(parent);
 					}
-					if ((invocation.getParent() instanceof CtReturn) && (r instanceof CtBlock)) {
+					if (invocation.isParentInitialized() && (invocation.getParent() instanceof CtReturn) && (r instanceof CtBlock)) {
 						// block template parameters in returns should
 						// replace
 						// the return
 						((CtReturn<?>) invocation.getParent()).replace((CtStatement) r);
 					} else {
-						invocation.replace(r);
+						replace(invocation, r);
 					}
 				}
 				// do not visit the invocation if replaced
@@ -434,6 +434,12 @@ public class SubstitutionVisitor extends CtScanner {
 	Collection<String> parameterNames;
 
 	/**
+	 * represents root element, which is target of the substitution.
+	 * It can be substituted too.
+	 */
+	CtElement result;
+
+	/**
 	 * Creates a new substitution visitor.
 	 *
 	 * @param f
@@ -480,6 +486,20 @@ public class SubstitutionVisitor extends CtScanner {
 			// and then scan the children for doing the templating as well in them
 			super.scan(element);
 		} catch (DoNotFurtherTemplateThisElement ignore) {
+		}
+	}
+
+	public CtElement substitute(CtElement element) {
+		result = element;
+		scan(element);
+		return result;
+	}
+
+	private void replace(CtElement toBeReplaced, CtElement replacement) {
+		if (result == toBeReplaced) {
+			result = replacement;
+		} else {
+			toBeReplaced.replace(replacement);
 		}
 	}
 }

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -43,7 +43,7 @@ public abstract class StatementTemplate extends AbstractTemplate<CtStatement> {
 		CtClass<?> c = Substitution.getTemplateCtClass(targetType, this);
 		// we substitute the first statement of method statement
 		CtStatement result = c.getMethod("statement").getBody().getStatements().get(0).clone();
-		return (CtStatement) new SubstitutionVisitor(c.getFactory(), targetType, this).substitute(result);
+		return new SubstitutionVisitor(c.getFactory(), targetType, this).substitute(result);
 	}
 
 	public Void S() {

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -43,8 +43,7 @@ public abstract class StatementTemplate extends AbstractTemplate<CtStatement> {
 		CtClass<?> c = Substitution.getTemplateCtClass(targetType, this);
 		// we substitute the first statement of method statement
 		CtStatement result = c.getMethod("statement").getBody().getStatements().get(0).clone();
-		new SubstitutionVisitor(c.getFactory(), targetType, this).scan(result);
-		return result;
+		return (CtStatement) new SubstitutionVisitor(c.getFactory(), targetType, this).substitute(result);
 	}
 
 	public Void S() {

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -484,8 +484,7 @@ public abstract class Substitution {
 			throw new RuntimeException("target is null in substitution");
 		}
 		E result = (E) code.clone();
-		new SubstitutionVisitor(targetType.getFactory(), targetType, template).scan(result);
-		return result;
+		return new SubstitutionVisitor(targetType.getFactory(), targetType, template).substitute(result);
 	}
 
 	/**
@@ -532,8 +531,7 @@ public abstract class Substitution {
 		T result = (T) templateType.clone();
 		result.setPositions(null);
 		// result.setParent(templateType.getParent());
-		new SubstitutionVisitor(templateType.getFactory(), result, template).scan(result);
-		return result;
+		return new SubstitutionVisitor(templateType.getFactory(), result, template).substitute(result);
 	}
 
 	/**

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -24,6 +24,7 @@ import spoon.template.TemplateParameter;
 import spoon.test.template.testclasses.ArrayAccessTemplate;
 import spoon.test.template.testclasses.InvocationTemplate;
 import spoon.test.template.testclasses.SecurityCheckerTemplate;
+import spoon.test.template.testclasses.SubstituteRootTemplate;
 import spoon.test.template.testclasses.bounds.CheckBound;
 import spoon.test.template.testclasses.bounds.CheckBoundMatcher;
 import spoon.test.template.testclasses.bounds.CheckBoundTemplate;
@@ -502,5 +503,22 @@ public class TemplateTest {
 		//check that both @Parameter usage was replaced by appropriate parameter value
 		CtMethod<?> m2 = resultKlass.getMethod("method2");
 		assertEquals("java.lang.System.out.println(\"second\")", m2.getBody().getStatement(0).toString());
+	}
+
+	@Test
+	public void testStatementTemplateRootSubstitution() throws Exception {
+		//contract: the template engine supports substitution of root element
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> templateClass = factory.Class().get(SubstituteRootTemplate.class);
+		CtBlock<Void> param = (CtBlock) templateClass.getMethod("sampleBlock").getBody();
+		
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtStatement result = new SubstituteRootTemplate(param).apply(resultKlass);
+		assertEquals("java.lang.String s = \"Spoon is cool!\"", ((CtBlock)result).getStatement(0).toString());
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java
@@ -1,0 +1,28 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtBlock;
+import spoon.template.Local;
+import spoon.template.Parameter;
+import spoon.template.StatementTemplate;
+import spoon.template.TemplateParameter;
+
+public class SubstituteRootTemplate extends StatementTemplate {
+
+	@Override
+	public void statement() throws Throwable {
+		block.S();
+	}
+	
+	@Parameter
+	TemplateParameter<Void> block;
+
+	@Local
+	public SubstituteRootTemplate(CtBlock<Void> block) {
+		this.block = block;
+	}
+	
+	@Local
+	void sampleBlock() {
+		String s="Spoon is cool!";
+	}
+}


### PR DESCRIPTION
Motivation: clean and simplify code of `SubstitutionVisitor`, before next refactoring, which will support decoupled `template model` and 'template parameters', which allows even more powerful templates.

Following changes were done on `SubstitutionVisitor` in this PR:
* the list of parameter names, was replaced by Map of parameter names mapped to parameter values - is faster and is first step on the way to decouple template model and template parameters.
* the conversion of template parameter values was unified and extracted into new `Parameters#getParameterValueAsXXX` methods - it is now cleaner what it does, corner cases are handled consistently, errors are reported. duplicate code was removed.
* few bugs were fixed

TODO: refactor array access (the places which still use `Parameters#getValue(...)`)