### PR TITLE
review: refactor SubstitutionVisitor

### DIFF
--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -22,6 +22,7 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtFieldReference;
@@ -36,6 +37,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,9 +71,8 @@ public abstract class Parameters {
 	 * Gets a template field parameter value.
 	 */
 	public static Object getValue(Template<?> template, String parameterName, Integer index) {
-		Object tparamValue = null;
+		Field rtField = null;
 		try {
-			Field rtField = null;
 			for (Field f : RtHelper.getAllFields(template.getClass())) {
 				if (isParameterSource(f)) {
 					if (parameterName.equals(getParameterName(f))) {
@@ -80,6 +81,20 @@ public abstract class Parameters {
 					}
 				}
 			}
+		} catch (Exception e) {
+			throw new UndefinedParameterException(e);
+		}
+		Object tparamValue = getValue(template, parameterName, rtField);
+		if (rtField.getType().isArray() && (index != null)) {
+			tparamValue = ((Object[]) tparamValue)[index];
+		}
+		return tparamValue;
+	}
+	private static Object getValue(Template<?> template, String parameterName, Field rtField) {
+		if (rtField == null) {
+			throw new UndefinedParameterException();
+		}
+		try {
 			if (Modifier.isFinal(rtField.getModifiers())) {
 				Map<String, Object> m = finals.get(template);
 				if (m == null) {
@@ -88,14 +103,10 @@ public abstract class Parameters {
 				return m.get(parameterName);
 			}
 			rtField.setAccessible(true);
-			tparamValue = rtField.get(template);
-			if (rtField.getType().isArray() && (index != null)) {
-				tparamValue = ((Object[]) tparamValue)[index];
-			}
+			return rtField.get(template);
 		} catch (Exception e) {
-			throw new UndefinedParameterException();
+			throw new UndefinedParameterException(e);
 		}
-		return tparamValue;
 	}
 
 	static Map<Template<?>, Map<String, Object>> finals = new HashMap<>();
@@ -191,6 +202,47 @@ public abstract class Parameters {
 			}
 		} catch (Exception e) {
 			throw new SpoonException("Getting of template parameters failed", e);
+		}
+		return params;
+	}
+	/**
+	 * Gets the Map of names to template parameter value for all the template parameters of a given template type
+	 * (including the ones defined by the super types).
+	 */
+	public static Map<String, Object> getNamesToValues(Template<?> template, CtClass<? extends Template<?>> templateType) {
+		//use linked hash map to assure same order of parameter names. There are cases during substitution of parameters when substitution order matters. E.g. SubstitutionVisitor#substituteName(...)
+		Map<String, Object> params = new LinkedHashMap<>();
+		try {
+			for (CtFieldReference<?> f : templateType.getAllFields()) {
+				if (isParameterSource(f)) {
+					String parameterName = getParameterName(f);
+					params.put(parameterName, getValue(template, parameterName, (Field) f.getActualField()));
+				}
+			}
+		} catch (Exception e) {
+			throw new SpoonException("Getting of template parameters failed", e);
+		}
+		return params;
+	}
+
+	/**
+	 * Gets the Map of names to template parameter values for all the template parameters of a given template type
+	 * + adds mapping of template model reference to target type as parameter too
+	 * @param f
+	 * 		the factory
+	 * @param targetType
+	 * 		the target type of the substitution (can be null), which will be done with result parameters
+	 * @param template
+	 * 		the template that holds the parameter values
+	 */
+	public static Map<String, Object> getTemplateParametersAsMap(Factory f, CtType<?> targetType, Template<?> template) {
+		Map<String, Object> params = new HashMap<>(Parameters.getNamesToValues(template, (CtClass) f.Class().get(template.getClass())));
+		if (targetType != null) {
+			/*
+			 * there is required to replace all template model references by target type reference.
+			 * Handle that request as template parameter too
+			 */
+			params.put(template.getClass().getSimpleName(), targetType.getReference());
 		}
 		return params;
 	}

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -18,10 +18,12 @@ package spoon.support.template;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import spoon.SpoonException;
-import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeElement;
@@ -34,26 +36,17 @@ import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThisAccess;
-import spoon.reflect.code.CtVariableAccess;
-import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
-import spoon.reflect.visitor.Query;
-import spoon.reflect.visitor.filter.VariableAccessFilter;
-import spoon.template.Local;
+import spoon.template.Parameter;
 import spoon.template.Template;
 import spoon.template.TemplateParameter;
 
@@ -74,52 +67,19 @@ class DoNotFurtherTemplateThisElement extends SpoonException {
  */
 public class SubstitutionVisitor extends CtScanner {
 
-	public class InheritanceSustitutionScanner extends CtInheritanceScanner {
+	private Context context;
 
-		SubstitutionVisitor parent = null;
+	private class InheritanceSustitutionScanner extends CtInheritanceScanner {
 
-		public InheritanceSustitutionScanner(SubstitutionVisitor parent) {
-			this.parent = parent;
+		InheritanceSustitutionScanner() {
 		}
 
-		/**
-		 * Replaces method parameters when defined as a list of
-		 * {@link CtParameter}.
-		 */
 		@Override
-		public <R> void scanCtExecutable(CtExecutable<R> e) {
-			// replace method parameters
-			for (CtParameter<?> parameter : new ArrayList<>(e.getParameters())) {
-				String name = parameter.getSimpleName();
-				for (String pname : parameterNames) {
-					if (name.equals(pname)) {
-						Object value = Parameters.getValue(template, pname, null);
-						int i = parameter.getParent().getParameters().indexOf(parameter);
-						if (value instanceof List) {
-							List<?> l = (List<?>) value;
-							for (Object p : l) {
-								CtParameter<?> p2 = ((CtParameter<?>) p).clone();
-								p2.setParent(parameter.getParent());
-								parameter.getParent().getParameters().add(i++, p2);
-							}
-							parameter.getParent().getParameters().remove(parameter);
-						}
-					}
-				}
+		public void scanCtElement(CtElement element) {
+			if (element.getDocComment() != null) {
+				element.setDocComment(context.substituteName(element.getDocComment()));
 			}
-			super.scanCtExecutable(e);
-		}
-
-		/**
-		 * Remove template-specific {@link Local} annotations.
-		 */
-		@Override
-		public void scanCtElement(CtElement e) {
-			CtAnnotation<?> a = e.getAnnotation(e.getFactory().Type().createReference(Local.class));
-			if (a != null) {
-				e.removeAnnotation(a);
-			}
-			super.scanCtElement(e);
+			super.scanCtElement(element);
 		}
 
 		/**
@@ -128,68 +88,90 @@ public class SubstitutionVisitor extends CtScanner {
 		 */
 		@Override
 		public void scanCtNamedElement(CtNamedElement element) {
-			if (element.getDocComment() != null) {
-				element.setDocComment(substituteInDocComment(element.getDocComment()));
+			Object value = context.getParameterValue(element.getSimpleName());
+			if (value != null) {
+				if (value instanceof String) {
+					//the parameter value is a String. It is the case of substitution of the name only
+					//replace parameter (sub)strings in simplename
+					element.setSimpleName(context.substituteName(element.getSimpleName()));
+				} else if (value instanceof CtTypeReference && element instanceof CtType) {
+					//the parameter value is a type reference and the element is a type. Replace name of the type
+					element.setSimpleName(((CtTypeReference) value).getSimpleName());
+				} else {
+					//this named element has to be replaced by zero one or more other elements
+					List<? extends CtNamedElement> values = getParameterValueAsListOfClones(element.getClass(), value);
+					throw context.replace(element, values);
+				}
 			}
-			// replace parameters in names
-			element.setSimpleName(substituteName(element.getSimpleName(), element));
 			super.scanCtNamedElement(element);
 		}
 
 		@Override
 		public void scanCtReference(CtReference reference) {
-			reference.setSimpleName(substituteName(reference.getSimpleName(), reference));
+			Object value = context.getParameterValue(reference.getSimpleName());
+			if (value != null) {
+				if (reference instanceof CtTypeReference) {
+					/**
+					 * Replaces type parameters and references to the template type with
+					 * references to the target type.
+					 */
+					// replace type parameters
+					CtTypeReference<?> typeReference = (CtTypeReference<?>) reference;
+					boolean paramHasActualTypeArguments = value instanceof CtTypeReference;
+					CtTypeReference<?> tr = getParameterValueAsTypeReference(factory, value);
+					if (paramHasActualTypeArguments) {
+						//the origin parameter has actual type arguments, apply them
+						typeReference.setActualTypeArguments(tr.getActualTypeArguments());
+					}
+					typeReference.setPackage(tr.getPackage());
+					typeReference.setSimpleName(tr.getSimpleName());
+					typeReference.setDeclaringType(tr.getDeclaringType());
+				} else {
+					if (value instanceof String) {
+						//the parameter value is a String. It is the case of substitution of the name only
+						//replace parameter (sub)strings in simplename
+						reference.setSimpleName(context.substituteName(reference.getSimpleName()));
+					} else {
+						//we have to replace the expression by another expression or statement
+						CtExpression<?> expr = reference.getParent(CtExpression.class);
+						List<CtCodeElement> values = getParameterValueAsListOfClones(CtCodeElement.class, value);
+						//TODO we might check consistency here, but we need to know context of the expr. Is it Statement or Expression?
+						//replace expression with statements or expressions
+						throw context.replace(expr, values);
+					}
+				}
+
+			}
 			super.scanCtReference(reference);
 		}
 
-		private String substituteName(String name, CtElement element) {
-			for (String pname : parameterNames) {
-				if (name.contains(pname)) {
-					Object value = Parameters.getValue(template, pname, null);
-					if (value instanceof String) {
-						// replace with the string value
-						name = name.replace(pname, (String) value);
-					} else if ((value instanceof CtTypeReference) && (element instanceof CtType)) {
-						// replace with the type reference's name
-						name = name.replace(pname, ((CtTypeReference<?>) value).getSimpleName());
-					}
-				}
-			}
-			return name;
-		}
-
-		private String substituteInDocComment(String docComment) {
-			String result = docComment;
-			for (String pname : parameterNames) {
-				Object value = Parameters.getValue(template, pname, null);
-				if (value instanceof String) {
-					result = result.replace(pname, (String) value);
-				}
-			}
-			return result;
-		}
-
 		/** statically inline foreach */
+		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Override
 		public void visitCtForEach(CtForEach foreach) {
 			if (foreach.getExpression() instanceof CtFieldAccess) {
 				CtFieldAccess<?> fa = (CtFieldAccess<?>) foreach.getExpression();
-				if (Parameters.isParameterSource(fa.getVariable())) {
-					Object[] value = (Object[]) Parameters.getValue(template, fa.getVariable().getSimpleName(), null);
-					CtBlock<?> l = foreach.getFactory().Core().createBlock();
+				Object value = context.getParameterValue(fa.getVariable().getSimpleName());
+				if (value != null) {
+					//create local context which holds local substitution parameter
+					Context localContext = createContext();
+					List<CtExpression> list = getParameterValueAsListOfClones(CtExpression.class, value);
 					CtStatement body = foreach.getBody();
-					for (Object element : value) {
-						CtStatement b = body.clone();
-						for (CtVariableAccess<?> va : Query.getElements(b, new VariableAccessFilter<>(foreach.getVariable().getReference()))) {
-							va.replace((CtExpression) element);
+					String newParamName = foreach.getVariable().getSimpleName();
+					List<CtStatement> newStatements = new ArrayList<>();
+					for (CtExpression element : list) {
+						//for each item of foreach expression copy foreach body and substitute it is using local context containing new parameter
+						localContext.putParameter(newParamName, element);
+						if (body instanceof CtBlock) {
+							CtBlock foreachBlock = (CtBlock) body;
+							for (CtStatement st : foreachBlock.getStatements()) {
+								newStatements.addAll(localContext.substitute(st.clone()));
+							}
+						} else {
+							newStatements.addAll(localContext.substitute(body.clone()));
 						}
-						if (b instanceof CtBlock && ((CtBlock) b).getStatements().size() == 1) {
-							b = ((CtBlock) b).getStatement(0);
-						}
-						l.addStatement(b);
 					}
-					foreach.replace(l);
-					throw new DoNotFurtherTemplateThisElement(foreach);
+					throw context.replace(foreach, newStatements);
 				}
 			}
 			super.visitCtForEach(foreach);
@@ -205,61 +187,47 @@ public class SubstitutionVisitor extends CtScanner {
 			visitFieldAccess(fieldWrite);
 		}
 
-		private <T> void visitFieldAccess(CtFieldAccess<T> fieldAccess) {
+		@SuppressWarnings({ "rawtypes" })
+		private <T> void visitFieldAccess(final CtFieldAccess<T> fieldAccess) {
 			CtFieldReference<?> ref = fieldAccess.getVariable();
 			if ("length".equals(ref.getSimpleName())) {
 				if (fieldAccess.getTarget() instanceof CtFieldAccess) {
 					ref = ((CtFieldAccess<?>) fieldAccess.getTarget()).getVariable();
-					if (Parameters.isParameterSource(ref)) {
-						Object[] value = (Object[]) Parameters.getValue(template, ref.getSimpleName(), null);
-						fieldAccess.replace((CtExpression) fieldAccess.getFactory().Code().createLiteral(value
-								.length));
-						throw new DoNotFurtherTemplateThisElement(fieldAccess);
+					Object value = context.getParameterValue(ref.getSimpleName());
+					if (value != null) {
+						//the items of this list are not cloned
+						List<Object> list = getParameterValueAsNewList(value);
+						throw context.replace(fieldAccess, (CtExpression) fieldAccess.getFactory().Code().createLiteral(list.size()));
 					}
 				}
 			}
-			if (Parameters.isParameterSource(ref)) {
+//			Object v = context.getParameterValue(Parameters.getParameterName(ref));
+			Object v = context.getParameterValue(ref.getSimpleName());
+			if (v != null) {
 				// replace direct field parameter accesses
-				Object value = Parameters.getValue(template, ref.getSimpleName(), Parameters.getIndex(fieldAccess));
+				Object value = getParameterValueAtIndex(Object.class, v, Parameters.getIndex(fieldAccess));
 				CtExpression toReplace = fieldAccess;
 				if (fieldAccess.getParent() instanceof CtArrayAccess) {
 					toReplace = (CtExpression) fieldAccess.getParent();
 				}
 				if (!(value instanceof TemplateParameter)) {
 					if (value instanceof Class) {
-						toReplace.replace(factory.Code()
+						throw context.replace(toReplace, factory.Code()
 								.createClassAccess(factory.Type().createReference(((Class<?>) value).getName())));
 					} else if (value instanceof Enum) {
 						CtTypeReference<?> enumType = factory.Type().createReference(value.getClass());
-						CtFieldRead<T> enumValueAccess = (CtFieldRead<T>) factory.Code().createVariableRead(
+						CtFieldRead<?> enumValueAccess = (CtFieldRead<?>) factory.Code().createVariableRead(
 								factory.Field().createReference(enumType, enumType, ((Enum<?>) value).name()), true);
 						enumValueAccess.setTarget(factory.Code().createTypeAccess(enumType));
-						toReplace.replace(enumValueAccess);
-					} else if (value instanceof List) {
-						// replace list of CtParameter for generic access to the
-						// parameters
-						List<CtParameter<?>> l = (List<CtParameter<?>>) value;
-						List<CtExpression<?>> vas = factory.Code().createVariableReads(l);
-						CtAbstractInvocation<?> inv = (CtAbstractInvocation<?>) fieldAccess.getParent();
-						int i = inv.getArguments().indexOf(fieldAccess);
-						inv.getArguments().remove(i);
-						inv.getExecutable().getActualTypeArguments().remove(i);
-						for (CtExpression<?> va : vas) {
-							va.setParent(fieldAccess.getParent());
-							inv.getArguments().add(i, va);
-							inv.getExecutable().getActualTypeArguments().add(i, va.getType());
-							i++;
-						}
+						throw context.replace(toReplace, enumValueAccess);
 					} else if ((value != null) && value.getClass().isArray()) {
-						toReplace.replace(factory.Code().createLiteralArray((Object[]) value));
+						throw context.replace(toReplace, factory.Code().createLiteralArray((Object[]) value));
 					} else {
-						toReplace.replace(factory.Code().createLiteral(value));
+						throw context.replace(toReplace, factory.Code().createLiteral(value));
 					}
 				} else {
-					toReplace.clone();
+					throw context.replace(toReplace, toReplace.clone());
 				}
-				// do not visit if replaced
-				throw new DoNotFurtherTemplateThisElement(fieldAccess);
 			}
 		}
 
@@ -280,188 +248,59 @@ public class SubstitutionVisitor extends CtScanner {
 					fa = (CtFieldAccess<?>) ((CtArrayAccess<?, CtExpression<?>>) invocation.getTarget()).getTarget();
 				}
 				if ((fa != null) && (fa.getTarget() == null || fa.getTarget() instanceof CtThisAccess)) {
-					TemplateParameter<?> tparamValue = (TemplateParameter<?>) Parameters
-							.getValue(template, fa.getVariable().getSimpleName(), Parameters.getIndex(fa));
-					CtCodeElement r = null;
-					if (tparamValue != null) {
-						r = ((CtCodeElement) tparamValue).clone();
-						// substitute in the replacement (for fixing type
-						// references
-						// and
-						// for recursive substitution)
-						r.accept(parent);
-					}
-					if ((invocation.getParent() instanceof CtReturn) && (r instanceof CtBlock)) {
-						// block template parameters in returns should
-						// replace
-						// the return
-						((CtReturn<?>) invocation.getParent()).replace((CtStatement) r);
+					CtCodeElement r = getParameterValueAtIndex(CtCodeElement.class,
+							context.getParameterValue(fa.getVariable().getSimpleName()), Parameters.getIndex(fa));
+					List<CtCodeElement> subst = null;
+					if (r != null) {
+						subst = createContext().substitute(r);
 					} else {
-						invocation.replace(r);
+						subst = Collections.<CtCodeElement>emptyList();
 					}
+					throw context.replace(invocation, subst);
 				}
-				// do not visit the invocation if replaced
-				throw new DoNotFurtherTemplateThisElement(invocation);
 			}
 			super.visitCtInvocation(invocation);
 		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public <T> void scanCtExpression(CtExpression<T> expression) {
-			for (int i = 0; i < expression.getTypeCasts().size(); i++) {
-				CtTypeReference<T> t = (CtTypeReference<T>) expression.getTypeCasts().get(i);
-				if (parameterNames.contains(t.getSimpleName())) {
-					// replace type parameters
-					// TODO: this would probably not work with inner classes!!!
-					Object o = Parameters.getValue(template, t.getSimpleName(), null);
-					if (o instanceof Class) {
-						t = factory.Type().createReference(((Class<T>) o));
-					} else if (o instanceof CtTypeReference) {
-						t = (CtTypeReference<T>) o;
-						expression.getTypeCasts().set(i, t);
-					} else {
-						throw new RuntimeException("unsupported reference substitution");
-					}
-				}
-			}
-			super.scanCtExpression(expression);
-		}
-
-		@SuppressWarnings("unchecked")
-		@Override
-		public <T> void scanCtTypedElement(CtTypedElement<T> e) {
-			if ((e.getType() != null) && parameterNames.contains(e.getType().getSimpleName())) {
-				// replace type parameters
-				// TODO: this would probably not work with inner classes!!!
-				CtTypeReference<T> t;
-				Object o = Parameters.getValue(template, e.getType().getSimpleName(), null);
-				if (o instanceof Class) {
-					o = factory.Type().createReference(((Class<T>) o));
-				}
-				if (o instanceof CtTypeReference) {
-					if ((e.getType() instanceof CtArrayTypeReference) && !(o instanceof CtArrayTypeReference)) {
-						t = (CtArrayTypeReference<T>) e.getFactory().Type().createArrayReference(
-								(CtTypeReference<?>) o,
-								((CtArrayTypeReference<?>) e.getType()).getDimensionCount());
-					} else {
-						t = (CtTypeReference<T>) o;
-					}
-					e.setType(t);
-				} else {
-					throw new RuntimeException("unsupported reference substitution");
-				}
-			}
-			super.scanCtTypedElement(e);
-		}
-
-		// fixes the references to executables in templates
-		@Override
-		public <T> void visitCtExecutableReference(CtExecutableReference<T> reference) {
-			scanCtReference(reference);
-			visitCtTypeReference(reference.getDeclaringType());
-			scanCtActualTypeContainer(reference);
-		}
-
-		/**
-		 * Replaces type parameters and references to the template type with
-		 * references to the target type (only if the referenced element exists
-		 * in the target).
-		 */
-		@Override
-		public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
-			// if (reference.equals(templateRef) || (!reference.isPrimitif() &&
-			// f.Type().createReference(Template.class).isAssignableFrom(reference)
-			// && reference.isAssignableFrom(templateRef))) {
-			if (reference.equals(templateRef)) {
-				// replace references to the template type with references
-				// to the targetType (only if the referenced element exists
-				// in the target)
-				reference.setDeclaringType(targetRef.getDeclaringType());
-				reference.setPackage(targetRef.getPackage());
-				reference.setSimpleName(targetRef.getSimpleName());
-			}
-			if (parameterNames.contains(reference.getSimpleName())) {
-				// replace type parameters
-				// TODO: this would probably not work with inner classes!!!
-				CtTypeReference<?> t;
-				Object o = Parameters.getValue(template, reference.getSimpleName(), null);
-				if (o instanceof Class) {
-					t = factory.Type().createReference(((Class<?>) o));
-				} else if (o instanceof CtTypeReference) {
-					t = ((CtTypeReference<?>) o).clone();
-					reference.setActualTypeArguments(t.getActualTypeArguments());
-				} else {
-					throw new RuntimeException(
-							"unsupported reference substitution: " + reference.getSimpleName() + " with value " + o);
-				}
-				reference.setPackage(t.getPackage());
-				reference.setSimpleName(t.getSimpleName());
-				reference.setDeclaringType(t.getDeclaringType());
-			} else if (templateTypeRef.isSubtypeOf(reference)) {
-				// this can only be a template inheritance case (to be verified)
-				CtTypeReference<?> sc = targetRef.getSuperclass();
-				if (sc != null) {
-					reference.setDeclaringType(sc.getDeclaringType());
-					reference.setPackage(sc.getPackage());
-					reference.setSimpleName(sc.getSimpleName());
-				} else {
-					reference.setDeclaringType(null);
-					reference.setPackage(factory.Package().createReference("java.lang"));
-					reference.setSimpleName("Object");
-				}
-			}
-			super.visitCtTypeReference(reference);
-		}
 	}
 
-	Factory factory;
+	private Factory factory;
 
-	InheritanceSustitutionScanner inheritanceScanner;
+	private InheritanceSustitutionScanner inheritanceScanner;
 
-	CtExecutableReference<?> S;
-
-	CtTypeReference<?> targetRef;
-
-	CtType<?> targetType;
-
-	Template<?> template;
-
-	CtTypeReference<? extends Template> templateRef;
-
-	CtTypeReference<Template> templateTypeRef;
-
-	CtClass<? extends Template<?>> templateType;
-
-	Collection<String> parameterNames;
+	private CtExecutableReference<?> S;
 
 	/**
-	 * Creates a new substitution visitor.
+	 * Creates new substitution visitor based on instance of Template,
+	 * which defines template model and template parameters
 	 *
 	 * @param f
 	 * 		the factory
 	 * @param targetType
-	 * 		the target type of the substitution
+	 * 		the target type of the substitution (can be null)
 	 * @param template
 	 * 		the template that holds the parameter values
 	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public SubstitutionVisitor(Factory f, CtType<?> targetType, Template<?> template) {
-		inheritanceScanner = new InheritanceSustitutionScanner(this);
-		this.factory = f;
-		this.template = template;
-		this.targetType = targetType;
-		S = f.Executable().createReference(f.Type().createReference(TemplateParameter.class),
-				f.Type().createTypeParameterReference("T"), "S");
-		templateRef = f.Type().createReference(template.getClass());
-		templateType = f.Class().get(templateRef.getQualifiedName());
-		parameterNames = Parameters.getNames(templateType);
-		templateTypeRef = f.Type().createReference(Template.class);
-		if (targetType != null) {
-			targetRef = f.Type().createReference(targetType);
-			// first substitute target ref
-			targetRef.accept(this);
-		}
+		this(f, Parameters.getTemplateParametersAsMap(f, targetType, template));
+	}
 
+	/**
+	 * Creates new substitution visitor
+	 * with substitution model (doesn't have to implement {@link Template}) type
+	 * and the substitution parameters (doesn't have to be bound to {@link TemplateParameter} or {@link Parameter}).
+	 *
+	 * @param f
+	 * 		the factory
+	 * @param templateParameters
+	 * 		the parameter names and values which will be used during substitution
+	 */
+	public SubstitutionVisitor(Factory f, Map<String, Object> templateParameters) {
+		this.inheritanceScanner = new InheritanceSustitutionScanner();
+		this.factory = f;
+		S = factory.Executable().createReference(factory.Type().createReference(TemplateParameter.class),
+				factory.Type().createTypeParameterReference("T"), "S");
+		this.context = new Context(null).putParameters(templateParameters);
 	}
 
 	/**
@@ -482,6 +321,286 @@ public class SubstitutionVisitor extends CtScanner {
 			// and then scan the children for doing the templating as well in them
 			super.scan(element);
 		} catch (DoNotFurtherTemplateThisElement ignore) {
+			if (element != ignore.skipped) {
+				//we have to skip more
+				throw ignore;
+			}
 		}
+	}
+
+	/**
+	 * Substitutes all template parameters of element and returns substituted element.
+	 *
+	 * @param element to be substituted model
+	 * @return substituted model
+	 */
+	public <E extends CtElement> List<E> substitute(E element) {
+		return createContext().substitute(element);
+	}
+
+	/**
+	 * 1) Converts `parameterValue` to List using these rules
+	 * <ul>
+	 * <li>Array is converted to List .
+	 * <li>{@link Iterable} is converted to List .
+	 * <li>Single item is add to list.
+	 * </ul>
+	 * 2) assures that each list item has expected type `itemClass`
+	 * 3) if itemClass is sub type of CtElement then clones it
+	 *
+	 * @param itemClass the type of the items of resulting list.
+	 * 	If some item cannot be converted to the itemClass then {@link SpoonException} is thrown
+	 * @param parameterValue a value of an template parameter
+	 * @return list where each item is assured to be of type itemClass
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T> List<T> getParameterValueAsListOfClones(Class<T> itemClass, Object parameterValue) {
+		List<Object> list = getParameterValueAsNewList(parameterValue);
+		for (int i = 0; i < list.size(); i++) {
+			list.set(i, getParameterValueAsClass(itemClass, list.get(i)));
+		}
+		return (List<T>) list;
+	}
+	private static List<Object> getParameterValueAsNewList(Object parameterValue) {
+		List<Object> list = new ArrayList<>();
+		if (parameterValue != null) {
+			if (parameterValue instanceof Object[]) {
+				for (Object item : (Object[]) parameterValue) {
+					list.add(item);
+				}
+			} else if (parameterValue instanceof Iterable) {
+				for (Object item : (Iterable<Object>) parameterValue) {
+					list.add(item);
+				}
+			} else {
+				list.add(parameterValue);
+			}
+		}
+		return list;
+	}
+	/**
+	 * 1) Assures that parameterValue has expected type `itemClass`
+	 * 2) if itemClass is sub type of CtElement then clones parameterValue
+	 *
+	 * @param itemClass required return class
+	 * @param parameterValue a value of an template parameter
+	 * @return parameterValue cast (in future potentially converted) to itemClass
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T> T getParameterValueAsClass(Class<T> itemClass, Object parameterValue) {
+		if (parameterValue == null) {
+			return null;
+		}
+
+		if (itemClass.isInstance(parameterValue)) {
+			if (CtElement.class.isAssignableFrom(itemClass)) {
+				/*
+				 * the cloning is defined by itemClass and not by parameterValue,
+				 * because there are cases when we do not want to clone parameterValue.
+				 * In this case itemClass == Object.class
+				 */
+				parameterValue = ((CtElement) parameterValue).clone();
+			}
+			return (T) parameterValue;
+		}
+		throw new SpoonException("Parameter value has unexpected class: " + parameterValue.getClass().getName() + ". Expected class is: " + itemClass.getName());
+	}
+	/**
+	 * @param parameterValue a value of an template parameter
+	 * @return parameter value converted to String
+	 */
+	private static String getParameterValueAsString(Object parameterValue) {
+		if (parameterValue == null) {
+			return null;
+		}
+		if (parameterValue instanceof String) {
+			return (String) parameterValue;
+		} else if (parameterValue instanceof CtNamedElement) {
+			return ((CtNamedElement) parameterValue).getSimpleName();
+		} else if (parameterValue instanceof CtReference) {
+			return ((CtReference) parameterValue).getSimpleName();
+		}
+		throw new SpoonException("Parameter value has unexpected class: " + parameterValue.getClass().getName() + ", whose conversion to String is not supported");
+	}
+
+	/**
+	 * Converts `parameterValue` to {@link CtTypeReference}.
+	 * It assures that new reference is returned.
+	 * If parameterValue is already a {@link CtTypeReference}, then it is cloned.
+	 *
+	 * @param factory a Spoon factory used to create CtTypeReference instance - if needed
+	 * @param parameterValue a value of an template parameter
+	 * @return parameter value converted to {@link CtTypeReference}
+	 */
+	@SuppressWarnings("unchecked")
+	private static <T> CtTypeReference<T> getParameterValueAsTypeReference(Factory factory, Object parameterValue) {
+		if (parameterValue == null) {
+			return null;
+		}
+		if (parameterValue instanceof Class) {
+			return factory.Type().createReference((Class<T>) parameterValue);
+		} else if (parameterValue instanceof CtTypeReference) {
+			return ((CtTypeReference<T>) parameterValue).clone();
+		} else if (parameterValue instanceof CtType) {
+			return ((CtType<T>) parameterValue).getReference();
+		} else if (parameterValue instanceof String) {
+			return factory.Type().createReference((String) parameterValue);
+		} else {
+			throw new RuntimeException("unsupported reference substitution");
+		}
+	}
+
+	/**
+	 * 1a) If index is null, then parameterValue must be a single item, which will be converted to itemClass
+	 * 1b) If index is a number, then parameterValue is converted to List, the index-th item is converted to itemClass
+	 * 2) if itemClass is sub type of CtElement then returned element is a clone
+	 *
+	 * @param itemClass required return class
+	 * @param parameterValue a value of an template parameter
+	 * @param index index of item from the list, or null if item is not expected to be a list
+	 * @return parameterValue (optionally item from the list) cast (in future potentially converted) to itemClass
+	 */
+	private static <T> T getParameterValueAtIndex(Class<T> itemClass, Object parameterValue, Integer index) {
+		if (index != null) {
+			//convert to list, but do not clone
+			List<Object> list = getParameterValueAsNewList(parameterValue);
+			if (list.size() > index) {
+				//convert and clone the returned item
+				return getParameterValueAsClass(itemClass, list.get(index));
+			}
+			return null;
+		}
+		//convert and clone the returned item
+		return getParameterValueAsClass(itemClass, parameterValue);
+	}
+
+	private Context createContext() {
+		//by default each new context has same input like parent and modifies same collection like parent context
+		return new Context(this.context);
+	}
+
+	private class Context {
+		private final Context parentContext;
+		/**
+		 * represents root element, which is target of the substitution.
+		 * It can be substituted too.
+		 */
+		private CtElement input;
+		/**
+		 * represents replacement of the `input`.
+		 * it is null if input was not replaced
+		 */
+		private List<CtElement> result;
+		private Map<String, Object> parameterNameToValue;
+
+		private Context(Context parent) {
+			this.parentContext = parent;
+		}
+
+		private Context putParameter(String name, Object value) {
+			if (parameterNameToValue == null) {
+				parameterNameToValue = new LinkedHashMap<>();
+			}
+			parameterNameToValue.put(name, value);
+			return this;
+		}
+
+		private Context putParameters(Map<String, Object> parameters) {
+			if (parameters != null && parameters.isEmpty() == false) {
+				if (parameterNameToValue == null) {
+					parameterNameToValue = new LinkedHashMap<>();
+				}
+				parameterNameToValue.putAll(parameters);
+			}
+			return this;
+		}
+
+		private Object getParameterValue(String parameterName) {
+			if (parameterNameToValue != null) {
+				Object value = parameterNameToValue.get(parameterName);
+				if (value != null) {
+					return value;
+				}
+			}
+			if (parentContext != null) {
+				return parentContext.getParameterValue(parameterName);
+			}
+			return null;
+		}
+
+		private <E extends CtElement> DoNotFurtherTemplateThisElement replace(CtElement toBeReplaced, E replacement) {
+			return replace(toBeReplaced, replacement == null ? Collections.<E>emptyList() : Collections.<E>singletonList(replacement));
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		private <E extends CtElement> DoNotFurtherTemplateThisElement replace(CtElement toBeReplaced, List<E> replacements) {
+			CtElement parentOfReplacement = toBeReplaced.isParentInitialized() ? toBeReplaced.getParent() : null;
+			if (parentOfReplacement instanceof CtReturn) {
+				if (replacements.size() == 1 && replacements.get(0) instanceof CtBlock) {
+					replacements = (List) ((CtBlock) replacements.get(0)).getStatements();
+				}
+				if (replacements.size() > 1) {
+					//replace return too, because return expression cannot contain more statements
+					return context._replace(parentOfReplacement, replacements);
+				} else if (replacements.size() == 1 && (replacements.get(0) instanceof CtExpression) == false) {
+					//replace return too, because return expression cannot contain CtBlock
+					return context._replace(parentOfReplacement, replacements);
+				}
+			}
+			return context._replace(toBeReplaced, replacements);
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		private <E extends CtElement> DoNotFurtherTemplateThisElement _replace(CtElement toBeReplaced, List<E> replacements) {
+			if (input == toBeReplaced) {
+				if (result != null) {
+					throw new SpoonException("Illegal state. SubstitutionVisitor.Context#result was already replaced!");
+				}
+				result = (List) replacements;
+			} else {
+				toBeReplaced.replace(replacements);
+			}
+			return new DoNotFurtherTemplateThisElement(toBeReplaced);
+		}
+
+		@SuppressWarnings("unchecked")
+		private <E extends CtElement> List<E> substitute(E element) {
+			if (input != null) {
+				throw new SpoonException("Illegal state. SubstitutionVisitor.Context#input is already set.");
+			}
+			input = element;
+			result = null;
+			if (context != parentContext) {
+				throw new SpoonException("Illegal state. Context != parentContext");
+			}
+			try {
+				context = this;
+				scan(element);
+				if (result != null) {
+					return (List<E>) result;
+				}
+				return Collections.<E>singletonList((E) input);
+			} finally {
+				context = this.parentContext;
+				input = null;
+			}
+		}
+
+		private String substituteName(String name) {
+			if (parameterNameToValue != null) {
+				for (Map.Entry<String, Object> e : parameterNameToValue.entrySet()) {
+					String pname = e.getKey();
+					if (name.contains(pname)) {
+						String value = getParameterValueAsString(e.getValue());
+						name = name.replace(pname, value);
+					}
+				}
+			}
+			if (parentContext != null) {
+				name = parentContext.substituteName(name);
+			}
+			return name;
+		}
+
 	}
 }

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -418,6 +418,8 @@ public class SubstitutionVisitor extends CtScanner {
 			return ((CtNamedElement) parameterValue).getSimpleName();
 		} else if (parameterValue instanceof CtReference) {
 			return ((CtReference) parameterValue).getSimpleName();
+		} else if (parameterValue instanceof Class) {
+			return ((Class) parameterValue).getSimpleName();
 		}
 		throw new SpoonException("Parameter value has unexpected class: " + parameterValue.getClass().getName() + ", whose conversion to String is not supported");
 	}

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -27,6 +27,7 @@ import spoon.SpoonException;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeElement;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
@@ -76,11 +77,9 @@ public class SubstitutionVisitor extends CtScanner {
 		}
 
 		@Override
-		public void scanCtElement(CtElement element) {
-			if (element.getDocComment() != null) {
-				element.setDocComment(context.substituteName(element.getDocComment()));
-			}
-			super.scanCtElement(element);
+		public void visitCtComment(CtComment e) {
+			e.setContent(context.substituteName(e.getContent()));
+			super.visitCtComment(e);
 		}
 
 		/**

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -156,19 +156,15 @@ public class SubstitutionVisitor extends CtScanner {
 					//create local context which holds local substitution parameter
 					Context localContext = createContext();
 					List<CtExpression> list = getParameterValueAsListOfClones(CtExpression.class, value);
-					CtStatement body = foreach.getBody();
+					//ForEach always contains CtBlock. In some cases it is implicit.
+					CtBlock<?> foreachBlock = (CtBlock<?>) foreach.getBody();
 					String newParamName = foreach.getVariable().getSimpleName();
 					List<CtStatement> newStatements = new ArrayList<>();
 					for (CtExpression element : list) {
 						//for each item of foreach expression copy foreach body and substitute it is using local context containing new parameter
 						localContext.putParameter(newParamName, element);
-						if (body instanceof CtBlock) {
-							CtBlock foreachBlock = (CtBlock) body;
-							for (CtStatement st : foreachBlock.getStatements()) {
-								newStatements.addAll(localContext.substitute(st.clone()));
-							}
-						} else {
-							newStatements.addAll(localContext.substitute(body.clone()));
+						for (CtStatement st : foreachBlock.getStatements()) {
+							newStatements.addAll(localContext.substitute(st.clone()));
 						}
 					}
 					throw context.replace(foreach, newStatements);

--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -38,6 +38,7 @@ import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -419,8 +420,21 @@ public class SubstitutionVisitor extends CtScanner {
 			return ((CtReference) parameterValue).getSimpleName();
 		} else if (parameterValue instanceof Class) {
 			return ((Class) parameterValue).getSimpleName();
+		} else if (parameterValue instanceof CtInvocation) {
+			return getShortSignature(((CtInvocation<?>) parameterValue).getExecutable().getSignature());
+		} else if (parameterValue instanceof CtExecutableReference) {
+			return getShortSignature(((CtExecutableReference<?>) parameterValue).getSignature());
+		} else if (parameterValue instanceof CtExecutable) {
+			return getShortSignature(((CtExecutable<?>) parameterValue).getSignature());
 		}
 		throw new SpoonException("Parameter value has unexpected class: " + parameterValue.getClass().getName() + ", whose conversion to String is not supported");
+	}
+
+	/*
+	 * cut the package name. We always convert types to simple names here
+	 */
+	private static String getShortSignature(String fullSignature) {
+		return fullSignature.substring(fullSignature.lastIndexOf('.') + 1);
 	}
 
 	/**

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -16,6 +16,9 @@
  */
 package spoon.template;
 
+import java.util.List;
+
+import spoon.SpoonException;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
@@ -43,8 +46,11 @@ public abstract class StatementTemplate extends AbstractTemplate<CtStatement> {
 		CtClass<?> c = Substitution.getTemplateCtClass(targetType, this);
 		// we substitute the first statement of method statement
 		CtStatement result = c.getMethod("statement").getBody().getStatements().get(0).clone();
-		new SubstitutionVisitor(c.getFactory(), targetType, this).scan(result);
-		return result;
+		List<CtStatement> statements = new SubstitutionVisitor(c.getFactory(), targetType, this).substitute(result);
+		if (statements.size() > 1) {
+			throw new SpoonException("StatementTemplate cannot return more then one statement");
+		}
+		return statements.isEmpty() ? null : statements.get(0);
 	}
 
 	public Void S() {

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -99,24 +99,24 @@ public abstract class Substitution {
 	 * in a special way, it means they all will be added to the generated type too.
 	 * If you do not want to add them then clone your templateOfType and remove these nodes from that model before.
 	 *
-	 * @param targetPackage
-	 * 		the package where the new type will be added
-	 * @param typeName
-	 * 		the simple name of the new type
+	 * @param qualifiedTypeName
+	 * 		the qualified name of the new type
 	 * @param templateOfType
 	 * 		the model used as source of generation.
 	 * @param templateParameters
 	 * 		the substitution parameters
 	 */
-	public static <T> CtType<T> insertType(CtPackage targetPackage, String typeName, CtType<T> templateOfType, Map<String, Object> templateParameters) {
+	public static <T> CtType<T> createTypeFromTemplate(String qualifiedTypeName, CtType<T> templateOfType, Map<String, Object> templateParameters) {
 		final Factory f = templateOfType.getFactory();
+		CtTypeReference<T> typeRef = f.Type().createReference(qualifiedTypeName);
+		CtPackage targetPackage = f.Package().getOrCreate(typeRef.getPackage().getSimpleName());
 		final Map<String, Object> extendedParams = new HashMap<String, Object>(templateParameters);
-		extendedParams.put(templateOfType.getSimpleName(), f.Type().createReference(targetPackage.getQualifiedName() + "." + typeName));
+		extendedParams.put(templateOfType.getSimpleName(), typeRef);
 		List<CtType<T>> generated = new SubstitutionVisitor(f, extendedParams).substitute(templateOfType.clone());
 		for (CtType<T> ctType : generated) {
 			targetPackage.addType(ctType);
 		}
-		return targetPackage.getType(typeName);
+		return typeRef.getTypeDeclaration();
 	}
 
 	/**

--- a/src/test/java/spoon/test/template/TemplateArrayAccessTest.java
+++ b/src/test/java/spoon/test/template/TemplateArrayAccessTest.java
@@ -24,8 +24,8 @@ public class TemplateArrayAccessTest {
 		Factory factory = spoon.getFactory();
 
 		CtClass<?> resultKlass = factory.Class().create("Result");
-		CtStatement result = new SubstituteArrayAccessTemplate(new String[]{"a","b"}).apply(resultKlass);
-		assertEquals("new java.lang.String[]{ \"a\" , \"b\" }.toString()", result.toString());
+		CtStatement result = new SubstituteArrayAccessTemplate(new String[]{"a",null,"b"}).apply(resultKlass);
+		assertEquals("new java.lang.String[]{ \"a\" , null , \"b\" }.toString()", result.toString());
 	}
 
 	@Test
@@ -38,7 +38,7 @@ public class TemplateArrayAccessTest {
 		Factory factory = spoon.getFactory();
 
 		CtClass<?> resultKlass = factory.Class().create("Result");
-		CtStatement result = new SubstituteArrayLengthTemplate(new String[]{"a","b"}).apply(resultKlass);
-		assertEquals("if (2 > 0);", result.toString());
+		CtStatement result = new SubstituteArrayLengthTemplate(new String[]{"a",null,"b"}).apply(resultKlass);
+		assertEquals("if (3 > 0);", result.toString());
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateArrayAccessTest.java
+++ b/src/test/java/spoon/test/template/TemplateArrayAccessTest.java
@@ -10,6 +10,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.factory.Factory;
 import spoon.support.compiler.FileSystemFile;
 import spoon.test.template.testclasses.SubstituteArrayAccessTemplate;
+import spoon.test.template.testclasses.SubstituteArrayLengthTemplate;
 
 public class TemplateArrayAccessTest {
 
@@ -27,4 +28,17 @@ public class TemplateArrayAccessTest {
 		assertEquals("new java.lang.String[]{ \"a\" , \"b\" }.toString()", result.toString());
 	}
 
+	@Test
+	public void testArrayLengthAccess() throws Exception {
+		//contract: the template engine replaces length of collection of parameter values by number
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubstituteArrayLengthTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtStatement result = new SubstituteArrayLengthTemplate(new String[]{"a","b"}).apply(resultKlass);
+		assertEquals("if (2 > 0);", result.toString());
+	}
 }

--- a/src/test/java/spoon/test/template/TemplateClassAccessTest.java
+++ b/src/test/java/spoon/test/template/TemplateClassAccessTest.java
@@ -25,6 +25,10 @@ public class TemplateClassAccessTest {
 		CtClass<?> resultKlass = factory.Class().create("Result");
 		CtStatement result = new ClassAccessTemplate(String.class).apply(resultKlass);
 		assertEquals("java.lang.String.class.getName()", result.toString());
+
+		//I do not know if it makes sense to use null. But this kind of null handling is probably the best
+		CtStatement result2 = new ClassAccessTemplate(null).apply(resultKlass);
+		assertEquals("null.getName()", result2.toString());
 	}
 
 }

--- a/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
+++ b/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
@@ -24,10 +24,10 @@ public class TemplateInvocationSubstitutionTest {
 		spoon.buildModel();
 		Factory factory = spoon.getFactory();
 
-		CtBlock<?> model = factory.Class().get(InvocationSubstitutionByStatementTemplate.class).getMethod("sample").getBody();
+		CtBlock<?> templateArg = factory.Class().get(InvocationSubstitutionByStatementTemplate.class).getMethod("sample").getBody();
 		
 		CtClass<?> resultKlass = factory.Class().create("Result");
-		CtStatement result = new InvocationSubstitutionByStatementTemplate(model).apply(resultKlass);
+		CtStatement result = new InvocationSubstitutionByStatementTemplate(templateArg).apply(resultKlass);
 		assertEquals("throw new java.lang.RuntimeException(\"Failed\")", result.toString());
 	}
 

--- a/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
+++ b/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
@@ -1,0 +1,48 @@
+package spoon.test.template;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.factory.Factory;
+import spoon.support.compiler.FileSystemFile;
+import spoon.test.template.testclasses.InvocationSubstitutionByExpressionTemplate;
+import spoon.test.template.testclasses.InvocationSubstitutionByStatementTemplate;
+
+public class TemplateInvocationSubstitutionTest {
+
+	@Test
+	public void testInvocationSubstitutionByStatement() throws Exception {
+		//contract: the template engine supports substitution of any method invocation
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByStatementTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtBlock<?> model = factory.Class().get(InvocationSubstitutionByStatementTemplate.class).getMethod("sample").getBody();
+		
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtStatement result = new InvocationSubstitutionByStatementTemplate(model).apply(resultKlass);
+		assertEquals("throw new java.lang.RuntimeException(\"Failed\")", result.toString());
+	}
+
+	@Test
+	public void testInvocationSubstitutionByExpression() throws Exception {
+		//contract: the template engine supports substitution of any method invocation
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByExpressionTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtBlock<?> result = new InvocationSubstitutionByExpressionTemplate(factory.createLiteral("abc")).apply(resultKlass);
+		assertEquals("java.lang.System.out.println(\"abc\".substring(1))", result.getStatement(0).toString());
+		assertEquals("java.lang.System.out.println(\"abc\".substring(1))", result.getStatement(1).toString());
+	}
+}

--- a/src/test/java/spoon/test/template/TemplateReplaceReturnTest.java
+++ b/src/test/java/spoon/test/template/TemplateReplaceReturnTest.java
@@ -30,7 +30,7 @@ public class TemplateReplaceReturnTest {
 		
 		CtClass<?> resultKlass = factory.Class().create(factory.Package().getOrCreate("spoon.test.template"), "ReturnReplaceResult");
 		new ReturnReplaceTemplate(model).apply(resultKlass);
-		assertEquals("{ { if (((java.lang.System.currentTimeMillis()) % 2L) == 0) { return \"Panna\"; }else { return \"Orel\"; } }}", resultKlass.getMethod("method").getBody().toString().replaceAll("[\\r\\n\\t]+", "").replaceAll("\\s{2,}", " "));
+		assertEquals("{ if (((java.lang.System.currentTimeMillis()) % 2L) == 0) { return \"Panna\"; }else { return \"Orel\"; }}", resultKlass.getMethod("method").getBody().toString().replaceAll("[\\r\\n\\t]+", "").replaceAll("\\s{2,}", " "));
 		launcher.setSourceOutputDirectory(new File("./target/spooned/"));
 		launcher.getModelBuilder().generateProcessedSourceFiles(OutputType.CLASSES);
 		ModelUtils.canBeBuilt(new File("./target/spooned/spoon/test/template/ReturnReplaceResult.java"), 8);

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -633,7 +633,8 @@ public class TemplateTest {
 	}
 
 	@Test
-	public void testInsertType() throws Exception {
+	public void createTypeFromTemplate() throws Exception {
+		//contract: the Substitution API provides a method createTypeFromTemplate
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {"--output-type", "nooutput" });
 		launcher.addTemplateResource(new FileSystemFolder("./src/test/java/spoon/test/template/testclasses/types"));
@@ -641,17 +642,13 @@ public class TemplateTest {
 		launcher.buildModel();
 		Factory factory = launcher.getFactory();
 		
-		CtPackage targetPackage = factory.Package().create(factory.getModel().getRootPackage(), "generated");
-		factory.getModel().getRootPackage().addPackage(targetPackage);
-
-		
 		Map<String, Object> parameters = new HashMap<>();
 		//replace someMethod with genMethod
 		parameters.put("someMethod", "genMethod");
 		
 		//contract: we can generate interface
 		final CtType<?> aIfaceModel = launcher.getFactory().Interface().get(AnIfaceModel.class);
-		CtType<?> genIface = Substitution.insertType(targetPackage, "GenIface", aIfaceModel, parameters);
+		CtType<?> genIface = Substitution.createTypeFromTemplate("generated.GenIface", aIfaceModel, parameters);
 		assertNotNull(genIface);
 		assertSame(genIface, factory.Type().get("generated.GenIface"));
 		CtMethod<?> generatedIfaceMethod = genIface.getMethod("genMethod");
@@ -662,7 +659,7 @@ public class TemplateTest {
 		parameters.put("AnIfaceModel", genIface.getReference());
 		//contract: we can generate class
 		final CtType<?> aClassModel = launcher.getFactory().Class().get(AClassModel.class);
-		CtType<?> genClass = Substitution.insertType(targetPackage, "GenClass", aClassModel, parameters);
+		CtType<?> genClass = Substitution.createTypeFromTemplate("generated.GenClass", aClassModel, parameters);
 		assertNotNull(genClass);
 		assertSame(genClass, factory.Type().get("generated.GenClass"));
 		CtMethod<?> generatedClassMethod = genClass.getMethod("genMethod");
@@ -675,7 +672,7 @@ public class TemplateTest {
 		parameters.put("case1", "GOOD");
 		parameters.put("case2", "BETTER");
 		final CtType<?> aEnumModel = launcher.getFactory().Type().get(AnEnumModel.class);
-		CtEnum<?> genEnum = (CtEnum<?>) Substitution.insertType(targetPackage, "GenEnum", aEnumModel, parameters);
+		CtEnum<?> genEnum = (CtEnum<?>) Substitution.createTypeFromTemplate("generated.GenEnum", aEnumModel, parameters);
 		assertNotNull(genEnum);
 		assertSame(genEnum, factory.Type().get("generated.GenEnum"));
 		assertEquals(2, genEnum.getEnumValues().size());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -5,6 +5,7 @@ import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
@@ -146,9 +147,21 @@ public class TemplateTest {
 		// contract: invocations are replaced by actual invocations
 		assertEquals("toBeOverriden()", methodWithTemplatedParameters.getBody().getStatement(3).toString());
 
-		// contract: foreach are inlined without extra block
-		assertEquals("java.lang.System.out.println(0)", methodWithTemplatedParameters.getBody().getStatement(4).toString());
-		assertEquals("java.lang.System.out.println(1)", methodWithTemplatedParameters.getBody().getStatement(5).toString());
+		// contract: foreach in block is inlined into that wrapping block
+		CtBlock templatedForEach = methodWithTemplatedParameters.getBody().getStatement(4);
+		assertEquals("java.lang.System.out.println(0)", templatedForEach.getStatement(0).toString());
+		assertEquals("java.lang.System.out.println(1)", templatedForEach.getStatement(1).toString());
+		// contract: foreach with single body block are inlined without extra block
+		assertEquals("java.lang.System.out.println(0)", methodWithTemplatedParameters.getBody().getStatement(5).toString());
+		assertEquals("java.lang.System.out.println(1)", methodWithTemplatedParameters.getBody().getStatement(6).toString());
+		// contract: foreach with double body block are inlined with one extra block for each inlined statement
+		assertEquals("java.lang.System.out.println(0)", ((CtBlock) methodWithTemplatedParameters.getBody().getStatement(7)).getStatement(0).toString());
+		assertEquals("java.lang.System.out.println(1)", ((CtBlock) methodWithTemplatedParameters.getBody().getStatement(8)).getStatement(0).toString());
+		// contract: foreach with statement are inlined without extra block
+		assertEquals("java.lang.System.out.println(0)", methodWithTemplatedParameters.getBody().getStatement(9).toString());
+		assertEquals("java.lang.System.out.println(1)", methodWithTemplatedParameters.getBody().getStatement(10).toString());
+		//contract: for each whose expression is not a template parameter is not inlined
+		assertTrue(methodWithTemplatedParameters.getBody().getStatement(11) instanceof CtForEach);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -140,8 +140,9 @@ public class TemplateTest {
 		assertEquals(1, subc.getMethodsByName("newVarName").size());
 		CtMethod<?> varMethod = subc.getMethodsByName("newVarName").get(0);
 		// contract: parameters are replaced in comments too. The Class parameter value is converted to String
-		CtComment comment = varMethod.getComments().get(0);
-		assertEquals("newVarName on {@link LinkedList}", comment.getContent());
+		assertEquals("newVarName", varMethod.getComments().get(0).getContent());
+		assertEquals("{@link LinkedList}", varMethod.getComments().get(1).getContent());
+		assertEquals("{@link SuperClass#toBeOverriden()}", varMethod.getComments().get(2).getContent());
 
 		// contract: variable are renamed
 		assertEquals("java.util.List newVarName = null", methodWithTemplatedParameters.getBody().getStatement(0).toString());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtIf;
@@ -134,6 +135,13 @@ public class TemplateTest {
 
 		// contract: nested types of the templates are copied
 		assertEquals(1, subc.getNestedTypes().size());
+		
+		// contract: methods are renamed
+		assertEquals(1, subc.getMethodsByName("newVarName").size());
+		CtMethod<?> varMethod = subc.getMethodsByName("newVarName").get(0);
+		// contract: parameters are replaced in comments too. The Class parameter value is converted to String
+		CtComment comment = varMethod.getComments().get(0);
+		assertEquals("newVarName on {@link LinkedList}", comment.getContent());
 
 		// contract: variable are renamed
 		assertEquals("java.util.List newVarName = null", methodWithTemplatedParameters.getBody().getStatement(0).toString());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -591,7 +591,7 @@ public class TemplateTest {
 		TemplateParameter[] params = templateClass.getMethod("sampleBlocks").getBody().getStatements().toArray(new TemplateParameter[0]);
 		new ArrayAccessTemplate(params).apply(resultKlass);
 		CtMethod<?> m = resultKlass.getMethod("method");
-		//check that both TemplateParameter usages were replaced by appropriate parameter value
+		//check that both TemplateParameter usages were replaced by appropriate parameter value and that substitution which miss the value is silently removed
 		assertEquals(2, m.getBody().getStatements().size());
 		assertTrue(m.getBody().getStatements().get(0) instanceof CtBlock);
 		assertEquals("int i = 0", ((CtBlock)m.getBody().getStatements().get(0)).getStatement(0).toString());
@@ -600,6 +600,8 @@ public class TemplateTest {
 		//check that both @Parameter usage was replaced by appropriate parameter value
 		CtMethod<?> m2 = resultKlass.getMethod("method2");
 		assertEquals("java.lang.System.out.println(\"second\")", m2.getBody().getStatement(0).toString());
+		//check that substitution by missing value correctly produces empty expression
+		assertEquals("java.lang.System.out.println(null)", m2.getBody().getStatement(1).toString());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -157,8 +157,10 @@ public class TemplateTest {
 		// contract: foreach with double body block are inlined with one extra block for each inlined statement
 		assertEquals("java.lang.System.out.println(0)", ((CtBlock) methodWithTemplatedParameters.getBody().getStatement(7)).getStatement(0).toString());
 		assertEquals("java.lang.System.out.println(1)", ((CtBlock) methodWithTemplatedParameters.getBody().getStatement(8)).getStatement(0).toString());
-		// contract: foreach with statement are inlined without extra block
+		// contract: foreach with statement are inlined without extra (implicit) block
+		assertFalse(methodWithTemplatedParameters.getBody().getStatement(9) instanceof CtBlock);
 		assertEquals("java.lang.System.out.println(0)", methodWithTemplatedParameters.getBody().getStatement(9).toString());
+		assertFalse(methodWithTemplatedParameters.getBody().getStatement(10) instanceof CtBlock);
 		assertEquals("java.lang.System.out.println(1)", methodWithTemplatedParameters.getBody().getStatement(10).toString());
 		//contract: for each whose expression is not a template parameter is not inlined
 		assertTrue(methodWithTemplatedParameters.getBody().getStatement(11) instanceof CtForEach);

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -11,21 +11,29 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.ModelConsistencyChecker;
 import spoon.reflect.visitor.filter.NameFilter;
 import spoon.support.compiler.FileSystemFile;
+import spoon.support.compiler.FileSystemFolder;
 import spoon.support.template.Parameters;
+import spoon.support.template.SubstitutionVisitor;
+import spoon.template.Substitution;
 import spoon.template.TemplateMatcher;
 import spoon.template.TemplateParameter;
 import spoon.test.template.testclasses.ArrayAccessTemplate;
 import spoon.test.template.testclasses.InvocationTemplate;
+import spoon.test.template.testclasses.LoggerModel;
 import spoon.test.template.testclasses.NtonCodeTemplate;
 import spoon.test.template.testclasses.SecurityCheckerTemplate;
 import spoon.test.template.testclasses.SimpleTemplate;
+import spoon.test.template.testclasses.SubstituteRootTemplate;
 import spoon.test.template.testclasses.bounds.CheckBound;
 import spoon.test.template.testclasses.bounds.CheckBoundMatcher;
 import spoon.test.template.testclasses.bounds.CheckBoundTemplate;
@@ -40,18 +48,26 @@ import spoon.test.template.testclasses.inheritance.SuperClass;
 import spoon.test.template.testclasses.inheritance.SuperTemplate;
 import spoon.test.template.testclasses.logger.Logger;
 import spoon.test.template.testclasses.logger.LoggerTemplateProcessor;
+import spoon.test.template.testclasses.types.AClassModel;
+import spoon.test.template.testclasses.types.AnEnumModel;
+import spoon.test.template.testclasses.types.AnIfaceModel;
 
 import java.io.File;
 import java.io.Serializable;
 import java.rmi.Remote;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -130,10 +146,9 @@ public class TemplateTest {
 		// contract: invocations are replaced by actual invocations
 		assertEquals("toBeOverriden()", methodWithTemplatedParameters.getBody().getStatement(3).toString());
 
-		// contract: foreach are inlined
-		CtBlock templatedForEach = methodWithTemplatedParameters.getBody().getStatement(4);
-		assertEquals("java.lang.System.out.println(0)", templatedForEach.getStatement(0).toString());
-		assertEquals("java.lang.System.out.println(1)", templatedForEach.getStatement(1).toString());
+		// contract: foreach are inlined without extra block
+		assertEquals("java.lang.System.out.println(0)", methodWithTemplatedParameters.getBody().getStatement(4).toString());
+		assertEquals("java.lang.System.out.println(1)", methodWithTemplatedParameters.getBody().getStatement(5).toString());
 	}
 
 	@Test
@@ -363,6 +378,39 @@ public class TemplateTest {
 	}
 
 	@Test
+	public void testExtensionDecoupledSubstitutionVisitor() throws Exception {
+		//contract: substitution can be done on model, which is not based on Template
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput" });
+		launcher.addInputResource("./src/test/java/spoon/test/template/testclasses/logger/Logger.java");
+		launcher.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/LoggerModel.java"));
+
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+
+		final CtClass<?> aTemplateModelType = launcher.getFactory().Class().get(LoggerModel.class);
+		final CtMethod<?> aTemplateModel = aTemplateModelType.getMethod("block");
+		final CtClass<?> aTargetType = launcher.getFactory().Class().get(Logger.class);
+		final CtMethod<?> toBeLoggedMethod = aTargetType.getMethodsByName("enter").get(0);
+
+		
+		Map<String, Object> params = new HashMap<>();
+		params.put("_classname_", aTargetType.getSimpleName()) ;
+		params.put("_methodName_", toBeLoggedMethod.getSimpleName());
+		params.put("_block_", toBeLoggedMethod.getBody());
+		final List<CtMethod<?>> aMethods = new SubstitutionVisitor(factory, params).substitute(aTemplateModel.clone());
+		assertEquals(1, aMethods.size());
+		final CtMethod<?> aMethod = aMethods.get(0);
+		assertTrue(aMethod.getBody().getStatement(0) instanceof CtTry);
+		final CtTry aTry = (CtTry) aMethod.getBody().getStatement(0);
+		assertTrue(aTry.getFinalizer().getStatement(0) instanceof CtInvocation);
+		assertEquals("spoon.test.template.testclasses.logger.Logger.exit(\"enter\")", aTry.getFinalizer().getStatement(0).toString());
+		assertTrue(aTry.getBody().getStatement(0) instanceof CtInvocation);
+		assertEquals("spoon.test.template.testclasses.logger.Logger.enter(\"Logger\", \"enter\")", aTry.getBody().getStatement(0).toString());
+		assertTrue(aTry.getBody().getStatements().size() > 1);
+	}
+
+	@Test
 	public void testTemplateInterfaces() throws Exception {
 		Launcher spoon = new Launcher();
 		Factory factory = spoon.getFactory();
@@ -539,5 +587,73 @@ public class TemplateTest {
 		//check that both @Parameter usage was replaced by appropriate parameter value
 		CtMethod<?> m2 = resultKlass.getMethod("method2");
 		assertEquals("java.lang.System.out.println(\"second\")", m2.getBody().getStatement(0).toString());
+	}
+
+	@Test
+	public void testStatementTemplateRootSubstitution() throws Exception {
+		//contract: the template engine supports substitution of root element
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> templateClass = factory.Class().get(SubstituteRootTemplate.class);
+		CtBlock<Void> templateParam = (CtBlock) templateClass.getMethod("sampleBlock").getBody();
+		
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtStatement result = new SubstituteRootTemplate(templateParam).apply(resultKlass);
+		assertEquals("java.lang.String s = \"Spoon is cool!\"", ((CtBlock)result).getStatement(0).toString());
+	}
+
+	@Test
+	public void testInsertType() throws Exception {
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput" });
+		launcher.addTemplateResource(new FileSystemFolder("./src/test/java/spoon/test/template/testclasses/types"));
+
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+		
+		CtPackage targetPackage = factory.Package().create(factory.getModel().getRootPackage(), "generated");
+		factory.getModel().getRootPackage().addPackage(targetPackage);
+
+		
+		Map<String, Object> parameters = new HashMap<>();
+		//replace someMethod with genMethod
+		parameters.put("someMethod", "genMethod");
+		
+		//contract: we can generate interface
+		final CtType<?> aIfaceModel = launcher.getFactory().Interface().get(AnIfaceModel.class);
+		CtType<?> genIface = Substitution.insertType(targetPackage, "GenIface", aIfaceModel, parameters);
+		assertNotNull(genIface);
+		assertSame(genIface, factory.Type().get("generated.GenIface"));
+		CtMethod<?> generatedIfaceMethod = genIface.getMethod("genMethod");
+		assertNotNull(generatedIfaceMethod);
+		assertNull(genIface.getMethod("someMethod"));
+
+		//add new substitution request - replace AnIfaceModel by GenIface
+		parameters.put("AnIfaceModel", genIface.getReference());
+		//contract: we can generate class
+		final CtType<?> aClassModel = launcher.getFactory().Class().get(AClassModel.class);
+		CtType<?> genClass = Substitution.insertType(targetPackage, "GenClass", aClassModel, parameters);
+		assertNotNull(genClass);
+		assertSame(genClass, factory.Type().get("generated.GenClass"));
+		CtMethod<?> generatedClassMethod = genClass.getMethod("genMethod");
+		assertNotNull(generatedClassMethod);
+		assertNull(genClass.getMethod("someMethod"));
+		assertTrue(generatedIfaceMethod!=generatedClassMethod);
+		assertTrue(generatedClassMethod.isOverriding(generatedIfaceMethod));
+		
+		//contract: we can generate enum
+		parameters.put("case1", "GOOD");
+		parameters.put("case2", "BETTER");
+		final CtType<?> aEnumModel = launcher.getFactory().Type().get(AnEnumModel.class);
+		CtEnum<?> genEnum = (CtEnum<?>) Substitution.insertType(targetPackage, "GenEnum", aEnumModel, parameters);
+		assertNotNull(genEnum);
+		assertSame(genEnum, factory.Type().get("generated.GenEnum"));
+		assertEquals(2, genEnum.getEnumValues().size());
+		assertEquals("GOOD", genEnum.getEnumValues().get(0).getSimpleName());
+		assertEquals("BETTER", genEnum.getEnumValues().get(1).getSimpleName());
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/ArrayAccessTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/ArrayAccessTemplate.java
@@ -10,11 +10,13 @@ public class ArrayAccessTemplate extends ExtensionTemplate {
 
 	public void method() throws Throwable {
 		blocks[0].S();
+		blocks[2].S();
 		blocks[1].S();
 	}
 	
 	public void method2() throws Throwable {
 		System.out.println(strings[1]);
+		System.out.println(strings[100]);
 	}
 
 	@Parameter

--- a/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByExpressionTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByExpressionTemplate.java
@@ -1,0 +1,28 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtExpression;
+import spoon.template.BlockTemplate;
+import spoon.template.Local;
+import spoon.template.Parameter;
+
+public class InvocationSubstitutionByExpressionTemplate extends BlockTemplate {
+
+	@Override
+	public void block() throws Throwable {
+		System.out.println(_expression_().substring(1));
+		System.out.println(_expression_.S().substring(1));
+	}
+	
+	@Parameter
+	CtExpression<String> _expression_;
+
+	@Local
+	public InvocationSubstitutionByExpressionTemplate(CtExpression<String> expr) {
+		this._expression_ = expr;
+	}
+	
+	@Local
+	String _expression_() {
+		return null;
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByStatementTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByStatementTemplate.java
@@ -1,0 +1,31 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtStatement;
+import spoon.template.Local;
+import spoon.template.Parameter;
+import spoon.template.StatementTemplate;
+
+public class InvocationSubstitutionByStatementTemplate extends StatementTemplate {
+
+	@Override
+	public void statement() throws Throwable {
+		_statement_();
+	}
+	
+	@Parameter("_statement_")
+	CtStatement statement;
+
+	@Local
+	public InvocationSubstitutionByStatementTemplate(CtStatement statement) {
+		this.statement = statement;
+	}
+	
+	@Local
+	void _statement_() {
+	}
+	
+	@Local
+	void sample() {
+		throw new RuntimeException("Failed");
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/LoggerModel.java
+++ b/src/test/java/spoon/test/template/testclasses/LoggerModel.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2006-2015 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtBlock;
+import spoon.test.template.testclasses.logger.Logger;
+
+public class LoggerModel {
+	private String _classname_;
+	private String _methodName_;
+	private CtBlock<?> _block_;
+
+	public void block() throws Throwable {
+		try {
+			Logger.enter(_classname_, _methodName_);
+			_block_.S();
+		} finally {
+			Logger.exit(_methodName_);
+		}
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/SubstituteArrayLengthTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubstituteArrayLengthTemplate.java
@@ -1,0 +1,21 @@
+package spoon.test.template.testclasses;
+
+import spoon.template.Local;
+import spoon.template.Parameter;
+import spoon.template.StatementTemplate;
+
+public class SubstituteArrayLengthTemplate extends StatementTemplate {
+
+	@Override
+	public void statement() throws Throwable {
+		if (anArray.length > 0);
+	}
+	
+	@Parameter
+	String[] anArray;
+
+	@Local
+	public SubstituteArrayLengthTemplate(String[] anArray) {
+		this.anArray = anArray;
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubstituteRootTemplate.java
@@ -1,0 +1,28 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtBlock;
+import spoon.template.Local;
+import spoon.template.Parameter;
+import spoon.template.StatementTemplate;
+import spoon.template.TemplateParameter;
+
+public class SubstituteRootTemplate extends StatementTemplate {
+
+	@Override
+	public void statement() throws Throwable {
+		block.S();
+	}
+	
+	@Parameter
+	TemplateParameter<Void> block;
+
+	@Local
+	public SubstituteRootTemplate(CtBlock<Void> block) {
+		this.block = block;
+	}
+	
+	@Local
+	void sampleBlock() {
+		String s="Spoon is cool!";
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
@@ -42,8 +42,12 @@ public class SubTemplate extends SuperTemplate {
 	}
 
 	/**
-	 *  var on {@link ArrayList}
+	 *  var
 	 */
+	/*
+	 *  {@link ArrayList}
+	 */
+	// {@link invocation}
 	void var() {}
 
 	// method parameter template

--- a/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
@@ -22,8 +22,22 @@ public class SubTemplate extends SuperTemplate {
 		ArrayList l = null; // will be replaced by LinkedList l = null;
 		List o = (ArrayList) new ArrayList(); // will be replaced by List o = (LinkedList) new LinkedList();
 		invocation.S();
+		{
+			for(Object x : intValues) {
+				System.out.println(x); // will be inlined
+			}
+		}
 		for(Object x : intValues) {
 			System.out.println(x); // will be inlined
+		}
+		for(Object x : intValues) {
+			{
+				System.out.println(x); // will be inlined
+			}
+		}
+		for(Object x : intValues) System.out.println(x); // will be inlined
+		for(Object x : o) {
+			System.out.println(x); // will be NOT inlined
 		}
 	}
 

--- a/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/inheritance/SubTemplate.java
@@ -41,7 +41,9 @@ public class SubTemplate extends SuperTemplate {
 		}
 	}
 
-	/** var */
+	/**
+	 *  var on {@link ArrayList}
+	 */
 	void var() {}
 
 	// method parameter template

--- a/src/test/java/spoon/test/template/testclasses/types/AClassModel.java
+++ b/src/test/java/spoon/test/template/testclasses/types/AClassModel.java
@@ -1,0 +1,23 @@
+package spoon.test.template.testclasses.types;
+
+import java.util.AbstractList;
+
+public class AClassModel<E> extends AbstractList<E> implements AnIfaceModel {
+
+	public AClassModel() {
+	}
+	
+	@Override
+	public E get(int index) {
+		throw new IndexOutOfBoundsException();
+	}
+
+	@Override
+	public int size() {
+		return 0;
+	}
+
+	@Override
+	public void someMethod() {
+	}
+}

--- a/src/test/java/spoon/test/template/testclasses/types/AnEnumModel.java
+++ b/src/test/java/spoon/test/template/testclasses/types/AnEnumModel.java
@@ -1,0 +1,5 @@
+package spoon.test.template.testclasses.types;
+
+public enum AnEnumModel {
+	case1, case2;
+}

--- a/src/test/java/spoon/test/template/testclasses/types/AnIfaceModel.java
+++ b/src/test/java/spoon/test/template/testclasses/types/AnIfaceModel.java
@@ -1,0 +1,7 @@
+package spoon.test.template.testclasses.types;
+
+import java.io.Serializable;
+
+public interface AnIfaceModel extends Serializable {
+	void someMethod();
+}


### PR DESCRIPTION
Here is refactored SubstitutionVisitor. There are following changes:

C1) The SubstitutionVisitor can be used on any Spoon model and Map<String, Object> parameters. It does not need `Template`, `TemplateParameter`, `Parameter`. Of course they may be still used if it makes sense for client. See new constructor `SubstitutionVisitor(Factory f, Map<String, Object> templateParameters)`

C2) The SubstitutionVisitor can substitute the root node of substitution model by zero, one or more nodes.
See new method `<E extends CtElement> List<E> SubstitutionVisitor#substitute(E element)`

C3) There is possible to directly generate new Class, Interface, Enum, ... thanks to (C1). See
`CtType<T> Substitution#insertType(CtPackage targetPackage, String typeName, CtType<T> templateOfType, Map<String, Object> templateParameters)`

C4) The SubstitutionVisitor use Context, which knows current substitution parameters. It is needed to correctly substitute all parameters of blocks generated by `SubstitutionVisitor#visitCtForEach`

C5) The SubstitutionVisitor has less scanning methods now. It does all substitutions here:
* scanCtElement - substitutes comments, which are on all elements
* scanCtNamedElement - substitutes names or part's of names. Or replaces whole nodes by zero, one or more other nodes. For example legacy CtExecutable one parameter replacement by many parameters, is implemented this more generic way. Now we can replace everything this way. For example: one Annotation by many annotations; one field by many fields; one enum value many enum values, ...
* scanCtReference - substitutes all kinds of references. See code for each case
* visitCtForEach - like before
* visitCtFieldRead, visitCtFieldWrite - like before
* visitCtInvocation - like before

C6) the package protected fields of SubstitutionVisitor were made private - may be it was public intentional? Then I will rollback this change

C7) the conversion of parameter values to required types were extracted to private methods and made more reliable. Missuses throws exception, and if conversion is possible then parameter value is automatically converted to required type. See SubstitutionVisitor#getParameterValueAsXxx methods.