### PR TITLE
review: fix issue related with overridden methods retrieved from getAllMethods

### DIFF
--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -118,7 +118,7 @@ public class ExecutableFactory extends SubFactory {
 			return createReference(((CtMethod<T>) e).getDeclaringType().getReference(), isStatic, ((CtMethod<T>) e).getType().clone(), executableName, refs);
 		} else if (e instanceof CtLambda) {
 			CtMethod<T> lambdaMethod = ((CtLambda) e).getOverriddenMethod();
-			return createReference(e.getParent(CtType.class).getReference(), lambdaMethod == null ? null : lambdaMethod.getType(), executableName, refs);
+			return createReference(e.getParent(CtType.class).getReference(), lambdaMethod == null ? null : lambdaMethod.getType().clone(), executableName, refs);
 		} else if (e instanceof CtAnonymousExecutable) {
 			return createReference(((CtAnonymousExecutable) e).getDeclaringType().getReference(), e.getType().clone(), executableName);
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -900,14 +900,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		final ClassTypingContext ctc = new ClassTypingContext(this);
 		map(new AllTypeMembersFunction(CtMethod.class)).forEach(new CtConsumer<CtMethod<?>>() {
 			@Override
-			public void accept(CtMethod<?> method) {
-				for (CtMethod<?> methods : l) {
-					if (ctc.isSameSignature(methods, method)) {
+			public void accept(CtMethod<?> currentMethod) {
+				for (CtMethod<?> alreadyVisitedMethod : l) {
+					if (ctc.isSameSignature(currentMethod, alreadyVisitedMethod)) {
 						return;
 					}
 				}
 
-				l.add(method);
+				l.add(currentMethod);
 			}
 		});
 		return Collections.unmodifiableSet(l);

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -50,6 +50,7 @@ import spoon.support.UnsettableProperty;
 import spoon.support.compiler.SnippetCompilationHelper;
 import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.util.SignatureBasedSortedSet;
+import spoon.support.visitor.ClassTypingContext;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -894,6 +895,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		map(new AllTypeMembersFunction(CtMethod.class)).forEach(new CtConsumer<CtMethod<?>>() {
 			@Override
 			public void accept(CtMethod<?> method) {
+				ClassTypingContext ctc = new ClassTypingContext(CtTypeImpl.this);
+
+				for (CtMethod<?> methods : l) {
+					if (ctc.isSameSignature(methods, method)) {
+						return;
+					}
+				}
+
 				if (distinctSignatures.add(method.getSignature())) {
 					l.add(method);
 				}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -896,8 +896,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public Set<CtMethod<?>> getAllMethods() {
-		final Set<String> distinctSignatures = new HashSet<>();
-		final Set<CtMethod<?>> l = new SignatureBasedSortedSet<>();
+		final Set<CtMethod<?>> l = new HashSet<>();
 		final ClassTypingContext ctc = new ClassTypingContext(this);
 		map(new AllTypeMembersFunction(CtMethod.class)).forEach(new CtConsumer<CtMethod<?>>() {
 			@Override
@@ -908,9 +907,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 					}
 				}
 
-				if (distinctSignatures.add(method.getSignature())) {
-					l.add(method);
-				}
+				l.add(method);
 			}
 		});
 		return Collections.unmodifiableSet(l);

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -424,7 +424,7 @@ public class ClassTypingContext extends AbstractTypingContext {
 	@Override
 	protected CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
 		if (typeParam == null) {
-			return null;
+			throw new SpoonException("You cannot adapt a null type parameter.");
 		}
 		CtFormalTypeDeclarer declarer = typeParam.getTypeParameterDeclarer();
 		if ((declarer instanceof CtType<?>) == false) {
@@ -646,7 +646,11 @@ public class ClassTypingContext extends AbstractTypingContext {
 		if (typeRef instanceof CtTypeParameterReference) {
 			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
 			CtTypeParameter typeParam = typeParamRef.getDeclaration();
-			if (typeParam != null && typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
+			if (typeParam == null) {
+				throw new SpoonException("Declaration of the CtTypeParameter should not be null.");
+			}
+
+			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
 				//the parameter is declared in scope of Method or Constructor
 				return typeRef.clone();
 			}

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -423,6 +423,9 @@ public class ClassTypingContext extends AbstractTypingContext {
 	 */
 	@Override
 	protected CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
+		if (typeParam == null) {
+			return null;
+		}
 		CtFormalTypeDeclarer declarer = typeParam.getTypeParameterDeclarer();
 		if ((declarer instanceof CtType<?>) == false) {
 			return null;
@@ -643,7 +646,7 @@ public class ClassTypingContext extends AbstractTypingContext {
 		if (typeRef instanceof CtTypeParameterReference) {
 			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
 			CtTypeParameter typeParam = typeParamRef.getDeclaration();
-			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
+			if (typeParam != null && typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
 				//the parameter is declared in scope of Method or Constructor
 				return typeRef.clone();
 			}

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -137,13 +137,18 @@ public class CtTypeInformationTest {
 
 		// + 48 of ArrayList (in library)
 		// + 12 of java.lang.Object
-		Assert.assertEquals(1+12+48, extendObject.getAllMethods().size());
+		// The final +1 is the result of the only usage of `ClassTypingContext#isSameSignature` in `getAllMethods`
+		// (see: https://github.com/INRIA/spoon/pull/1375)
+		// now it gets both `ArrayList#forEach` and `Iterable#forEach`
+		// this has been spotted as an issue in https://github.com/INRIA/spoon/issues/1407
+		Assert.assertEquals(1+12+48+1, extendObject.getAllMethods().size());
 
 		final CtType<?> subClass = this.factory.Type().get(Subclass.class);
 		assertEquals(2, subClass.getMethods().size());
 
 		// the abstract method from Comparable which is overridden should not be present in the model
-		assertEquals(61+2, subClass.getAllMethods().size());
+		// The +1 happens for the same reason as below
+		assertEquals(61+2+1, subClass.getAllMethods().size());
 
 		CtTypeReference<?> superclass = subClass.getSuperclass();
 		Assert.assertEquals(ExtendsObject.class.getName(), superclass.getQualifiedName());

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -84,7 +84,7 @@ public class CtTypeInformationTest {
 		for (CtMethod<?> ctMethod : listCtMethods) {
 			if (ctMethod.getSimpleName().equals("compareTo")) {
 				assertFalse(ctMethod.hasModifier(ModifierKind.ABSTRACT));
-				assertFalse(ctMethod.getType() instanceof CtTypeParameter);
+				assertFalse(ctMethod.getParameters().get(0).getType() instanceof CtTypeParameter);
 				detectedCompareTo = true;
 			}
 		}

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -1,8 +1,11 @@
 package spoon.reflect.declaration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -39,8 +42,8 @@ public class CtTypeInformationTest {
 		final CtType<?> subClass = this.factory.Type().get(Subclass.class);
 		assertEquals(2, subClass.getMethods().size());
 
-		// the abstract method from Comparable which is overridden is also present in the model
-		assertEquals(61+3, subClass.getAllMethods().size());
+		// the abstract method from Comparable which is overridden should not be present in the model
+		assertEquals(61+2, subClass.getAllMethods().size());
 
 		CtTypeReference<?> superclass = subClass.getSuperclass();
 		Assert.assertEquals(ExtendsObject.class.getName(), superclass.getQualifiedName());
@@ -70,5 +73,22 @@ public class CtTypeInformationTest {
 		assertEquals(subClass.getMethodsByName("foo").get(0).getSignature(),
 				type2.getMethodsByName("foo").get(0).getSignature());
 
+	}
+
+	@Test
+	public void testGetAllMethodsWontReturnOverriddenMethod() {
+		final CtType<?> subClass = this.factory.Type().get(Subclass.class);
+		Set<CtMethod<?>> listCtMethods = subClass.getAllMethods();
+
+		boolean detectedCompareTo = false;
+		for (CtMethod<?> ctMethod : listCtMethods) {
+			if (ctMethod.getSimpleName().equals("compareTo")) {
+				assertFalse(ctMethod.hasModifier(ModifierKind.ABSTRACT));
+				assertFalse(ctMethod.getType() instanceof CtTypeParameter);
+				detectedCompareTo = true;
+			}
+		}
+
+		assertTrue(detectedCompareTo);
 	}
 }


### PR DESCRIPTION
`getAllMethods` should not retrieve a parent method if an overridden method is defined, even if the signature is different. 

For example, if a class implements the method `public int compareTo(T o);` with object it will have the following signature: `public int compareTo(Object o)` and `getAllMethod` should only retrieve this one.