### PR TITLE
review: fix continue algorithm of ClassTypingContext

### DIFF
--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -42,6 +42,7 @@ import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.ScanningMode;
 import spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction;
+import spoon.support.SpoonClassNotFoundException;
 
 /**
  * Helper class created from type X or reference to X.
@@ -189,6 +190,11 @@ public class ClassTypingContext extends AbstractTypingContext {
 		}
 		final HierarchyListener listener = new HierarchyListener(getVisitedSet());
 		/*
+		 * remove last resolved class from the list of visited,
+		 * because it would avoid visiting it's super hierarchy
+		 */
+		getVisitedSet().remove(lastResolvedSuperclass.getQualifiedName());
+		/*
 		 * visit super inheritance class hierarchy of lastResolve type of level of `type` to found it's actual type arguments.
 		 */
 		((CtElement) lastResolvedSuperclass).map(new SuperInheritanceHierarchyFunction()
@@ -204,7 +210,29 @@ public class ClassTypingContext extends AbstractTypingContext {
 				 * which are going to be substituted as arguments to formal type parameters of super type
 				 */
 				String superTypeQualifiedName = typeRef.getQualifiedName();
-				List<CtTypeReference<?>> superTypeActualTypeArgumentsResolvedFromSubType = resolveTypeParameters(typeRef.getActualTypeArguments());
+				List<CtTypeReference<?>> actualTypeArguments = typeRef.getActualTypeArguments();
+				if (actualTypeArguments.isEmpty()) {
+					//may be they are not set - check whether type declares some generic parameters
+					List<CtTypeParameter> typeParams;
+					try {
+						CtType<?> type = typeRef.getTypeDeclaration();
+						typeParams = type.getFormalCtTypeParameters();
+					} catch (final SpoonClassNotFoundException e) {
+						if (typeRef.getFactory().getEnvironment().getNoClasspath()) {
+							typeParams = Collections.emptyList();
+						} else {
+							throw e;
+						}
+					}
+					if (typeParams.size() > 0) {
+						//yes, there are generic type parameters. Reference should use actualTypeArguments computed from their bounds
+						actualTypeArguments = new ArrayList<>(typeParams.size());
+						for (CtTypeParameter typeParam : typeParams) {
+							actualTypeArguments.add(typeParam.getTypeErasure());
+						}
+					}
+				}
+				List<CtTypeReference<?>> superTypeActualTypeArgumentsResolvedFromSubType = resolveTypeParameters(actualTypeArguments);
 				//Remember actual type arguments of `type`
 				typeToArguments.put(superTypeQualifiedName, superTypeActualTypeArgumentsResolvedFromSubType);
 				if (typeQualifiedName.equals(superTypeQualifiedName)) {
@@ -216,6 +244,12 @@ public class ClassTypingContext extends AbstractTypingContext {
 				}
 			}
 		});
+		if (listener.foundArguments == null) {
+			/*
+			 * superclass was not found. We have scanned whole hierarchy
+			 */
+			lastResolvedSuperclass = null;
+		}
 		return listener.foundArguments;
 	}
 
@@ -427,12 +461,11 @@ public class ClassTypingContext extends AbstractTypingContext {
 		}
 		@Override
 		public ScanningMode enter(CtTypeReference<?> typeRef, boolean isClass) {
-			ScanningMode mode = super.enter(typeRef);
-			if (mode == ScanningMode.SKIP_ALL) {
-				//this interface was already visited. Do not visit it again
-				return mode;
-			}
 			if (isClass) {
+				/*
+				 * test foundArguments and skip all before call of super.enter,
+				 * which would add that not visited type into visitedSet
+				 */
 				if (foundArguments != null) {
 					//we have found result then we can finish before entering super class. All interfaces of found type should be still visited
 					//skip before super class (and it's interfaces) of found type is visited
@@ -444,6 +477,11 @@ public class ClassTypingContext extends AbstractTypingContext {
 				 * If we enter class, then this listener assures that that class and all it's not yet visited interfaces are visited
 				 */
 				lastResolvedSuperclass = typeRef;
+			}
+			ScanningMode mode = super.enter(typeRef);
+			if (mode == ScanningMode.SKIP_ALL) {
+				//this interface was already visited. Do not visit it again
+				return mode;
 			}
 			//this type was not visited yet. Visit it normally
 			return ScanningMode.NORMAL;

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -3,6 +3,11 @@ package spoon.reflect.declaration;
 import static org.junit.Assert.assertEquals;
 import static spoon.testing.utils.ModelUtils.build;
 
+import java.lang.reflect.Field;
+import java.util.AbstractCollection;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.RandomAccess;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -15,6 +20,7 @@ import spoon.reflect.declaration.testclasses.Subinterface;
 import spoon.reflect.declaration.testclasses.TestInterface;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.visitor.ClassTypingContext;
 
 public class CtTypeInformationTest {
 	private Factory factory;
@@ -22,6 +28,101 @@ public class CtTypeInformationTest {
 	@Before
 	public void setUp() throws Exception {
 		factory = build(ExtendsObject.class, Subclass.class, Subinterface.class, TestInterface.class);
+	}
+
+	@Test
+	public void testClassTypingContextContinueScanning() throws Exception {
+
+		final CtType<?> subClass = this.factory.Type().get(Subclass.class);
+		final CtTypeReference<?> subinterface = this.factory.Type().createReference(Subinterface.class);
+		final CtTypeReference<?> testInterface = this.factory.Type().createReference(TestInterface.class);
+		final CtTypeReference<?> extendObject = this.factory.Type().createReference(ExtendsObject.class);
+		final CtTypeReference<?> arrayList = this.factory.Type().createReference(ArrayList.class);
+		final CtTypeReference<?> abstractList = this.factory.Type().createReference(AbstractList.class);
+		final CtTypeReference<?> abstractCollection = this.factory.Type().createReference(AbstractCollection.class);
+		final CtTypeReference<?> object = this.factory.Type().createReference(Object.class);
+
+		{
+			final ClassTypingContext ctc = (ClassTypingContext) this.factory.createTypeAdapter(subClass);
+			//contract: at the beginning, the last resolved class is a subClass
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			//contract: this.isSubttypeOf(this) == true
+			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+
+			Assert.assertTrue(ctc.isSubtypeOf(subinterface));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+
+			Assert.assertTrue(ctc.isSubtypeOf(testInterface));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+
+			Assert.assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(Comparable.class)));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+
+			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(extendObject.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
+			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+			
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			Assert.assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(RandomAccess.class)));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			Assert.assertTrue(ctc.isSubtypeOf(abstractList));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(abstractList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			Assert.assertTrue(ctc.isSubtypeOf(abstractCollection));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(abstractCollection.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			Assert.assertTrue(ctc.isSubtypeOf(object));
+			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class - even on java.lang.Object, which was needed to agree on isSubtypeOf
+			Assert.assertEquals(object.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			
+			//contract: ClassTypingContext returns false on a type which is not a sub type of ctc scope.
+			Assert.assertFalse(ctc.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
+			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
+			Assert.assertNull(getLastResolvedSuperclass(ctc));
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
+			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
+			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+		}
+		
+		{
+			//now try directly a type which is not a supertype
+			final ClassTypingContext ctc2 = (ClassTypingContext) this.factory.createTypeAdapter(subClass);
+			//contract: at the beginning, the last resolved class is a subClass
+			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc2).getQualifiedName());
+			//contract: ClassTypingContext returns false on a type which is not a sub type of ctc scope.
+			Assert.assertFalse(ctc2.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
+			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
+			Assert.assertNull(getLastResolvedSuperclass(ctc2));
+			
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			Assert.assertTrue(ctc2.isSubtypeOf(arrayList));
+			Assert.assertTrue(ctc2.isSubtypeOf(extendObject));
+			Assert.assertTrue(ctc2.isSubtypeOf(subClass.getReference()));
+		}
+	}
+	
+	private CtTypeInformation getLastResolvedSuperclass(ClassTypingContext ctc) throws Exception {
+		Field f = ClassTypingContext.class.getDeclaredField("lastResolvedSuperclass");
+		f.setAccessible(true);
+		return (CtTypeInformation) f.get(ctc);
 	}
 
 	@Test


### PR DESCRIPTION
ClassTypingContext early finishes scanning of class hierarchy when a target supertype is found. That worked well. But this PR fixes bugs, which was visible when ClassTypingContext was asked to continue scanning.

There is a failing test case in it. 

This PR fixes problem originally found by Simon in PR #1375