### PR TITLE
review: refactor(label): remove labelledStatement that was not used

### DIFF
--- a/src/main/java/spoon/Metamodel.java
+++ b/src/main/java/spoon/Metamodel.java
@@ -74,6 +74,7 @@ public class Metamodel {
 		result.add(factory.Type().get(spoon.reflect.code.CtInvocation.class));
 		result.add(factory.Type().get(spoon.reflect.code.CtJavaDoc.class));
 		result.add(factory.Type().get(spoon.reflect.code.CtJavaDocTag.class));
+		result.add(factory.Type().get(spoon.reflect.code.CtLabelledFlowBreak.class));
 		result.add(factory.Type().get(spoon.reflect.code.CtLambda.class));
 		result.add(factory.Type().get(spoon.reflect.code.CtLiteral.class));
 		result.add(factory.Type().get(spoon.reflect.code.CtLocalVariable.class));

--- a/src/main/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/main/java/spoon/generating/CloneVisitorGenerator.java
@@ -194,7 +194,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 			private final List<String> excludesAST = Arrays.asList(//
 					"spoon.support.reflect.declaration.CtTypeInformationImpl", "spoon.support.reflect.code.CtAbstractInvocationImpl", //
 					"spoon.support.reflect.declaration.CtTypedElementImpl", "spoon.support.reflect.declaration.CtVariableImpl", //
-					"spoon.support.reflect.reference.CtActualTypeContainerImpl", "spoon.support.reflect.code.CtCFlowBreakImpl", //
+					"spoon.support.reflect.reference.CtActualTypeContainerImpl", "spoon.support.reflect.code.CtCFlowBreakImpl", "spoon.support.reflect.code.CtLabelledFlowBreakImpl", //
 					"spoon.support.reflect.declaration.CtCodeSnippetImpl", "spoon.support.reflect.declaration.CtFormalTypeDeclarerImpl", //
 					"spoon.support.reflect.declaration.CtGenericElementImpl", "spoon.support.reflect.reference.CtGenericElementReferenceImpl", //
 					"spoon.support.reflect.declaration.CtModifiableImpl", "spoon.support.reflect.declaration.CtMultiTypedElementImpl", //

--- a/src/main/java/spoon/reflect/code/CtBreak.java
+++ b/src/main/java/spoon/reflect/code/CtBreak.java
@@ -16,12 +16,6 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import static spoon.reflect.path.CtRole.TARGET_LABEL;
-
-
 /**
  * This code element defines a break statement.
  * Example:
@@ -33,20 +27,7 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
  *     }
  * </pre>
  */
-public interface CtBreak extends CtCFlowBreak {
-	/**
-	 * Gets the label from which the control flow breaks (null if no label
-	 * defined).
-	 */
-	@PropertyGetter(role = TARGET_LABEL)
-	String getTargetLabel();
-
-	/**
-	 * Sets the label from which the control flow breaks (null if no label
-	 * defined).
-	 */
-	@PropertySetter(role = TARGET_LABEL)
-	<T extends CtBreak> T setTargetLabel(String targetLabel);
+public interface CtBreak extends CtLabelledFlowBreak {
 
 	@Override
 	CtBreak clone();

--- a/src/main/java/spoon/reflect/code/CtContinue.java
+++ b/src/main/java/spoon/reflect/code/CtContinue.java
@@ -35,18 +35,6 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
  */
 public interface CtContinue extends CtCFlowBreak {
 	/**
-	 * Gets the statement where the control flow continues (null if no label
-	 * defined).
-	 */
-	CtStatement getLabelledStatement();
-
-	/**
-	 * Sets the statement where the control flow continues (null if no label
-	 * defined).
-	 */
-	<T extends CtContinue> T setLabelledStatement(CtStatement labelledStatement);
-
-	/**
 	 * Gets the label from which the control flow breaks (null if no label
 	 * defined).
 	 */

--- a/src/main/java/spoon/reflect/code/CtContinue.java
+++ b/src/main/java/spoon/reflect/code/CtContinue.java
@@ -16,12 +16,6 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import static spoon.reflect.path.CtRole.TARGET_LABEL;
-
-
 /**
  * This code element defines the continue statement.
  * Example:
@@ -33,20 +27,7 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
  *     }
  * </pre>
  */
-public interface CtContinue extends CtCFlowBreak {
-	/**
-	 * Gets the label from which the control flow breaks (null if no label
-	 * defined).
-	 */
-	@PropertyGetter(role = TARGET_LABEL)
-	String getTargetLabel();
-
-	/**
-	 * Sets the label from which the control flow breaks (null if no label
-	 * defined).
-	 */
-	@PropertySetter(role = TARGET_LABEL)
-	<T extends CtContinue> T setTargetLabel(String targetLabel);
+public interface CtContinue extends CtLabelledFlowBreak {
 
 	@Override
 	CtContinue clone();

--- a/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
 package spoon.reflect.code;
 
 import spoon.reflect.annotations.PropertyGetter;
@@ -11,20 +27,20 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
  * control flow of the program and which can support a label.
  */
 public interface CtLabelledFlowBreak extends CtCFlowBreak {
-    /**
-     * Gets the label from which the control flow breaks (null if no label
-     * defined).
-     */
-    @PropertyGetter(role = TARGET_LABEL)
-    String getTargetLabel();
+	/**
+	 * Gets the label from which the control flow breaks (null if no label
+	 * defined).
+	 */
+	@PropertyGetter(role = TARGET_LABEL)
+	String getTargetLabel();
 
-    /**
-     * Sets the label from which the control flow breaks (null if no label
-     * defined).
-     */
-    @PropertySetter(role = TARGET_LABEL)
-    <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel);
+	/**
+	 * Sets the label from which the control flow breaks (null if no label
+	 * defined).
+	 */
+	@PropertySetter(role = TARGET_LABEL)
+	<T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel);
 
-    @DerivedProperty
-    CtStatement getLabelledStatement();
+	@DerivedProperty
+	CtStatement getLabelledStatement();
 }

--- a/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
@@ -1,0 +1,30 @@
+package spoon.reflect.code;
+
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.support.DerivedProperty;
+
+import static spoon.reflect.path.CtRole.TARGET_LABEL;
+
+/**
+ * This abstract code element represents all the statements that break the
+ * control flow of the program and which can support a label.
+ */
+public interface CtLabelledFlowBreak extends CtCFlowBreak {
+    /**
+     * Gets the label from which the control flow breaks (null if no label
+     * defined).
+     */
+    @PropertyGetter(role = TARGET_LABEL)
+    String getTargetLabel();
+
+    /**
+     * Sets the label from which the control flow breaks (null if no label
+     * defined).
+     */
+    @PropertySetter(role = TARGET_LABEL)
+    <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel);
+
+    @DerivedProperty
+    CtStatement getLabelledStatement();
+}

--- a/src/main/java/spoon/reflect/path/CtRole.java
+++ b/src/main/java/spoon/reflect/path/CtRole.java
@@ -118,9 +118,6 @@ public enum CtRole {
 		if ("cases".equals(name)) {
 			return CASE;
 		}
-		if ("labelledstatement".equals(name)) {
-			return LABEL;
-		}
 		if ("enumvalues".equals(name) || "elementvalues".equals(name)) {
 			return VALUE;
 		}

--- a/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
+++ b/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
@@ -238,7 +238,6 @@ public abstract class CtBiScannerDefault extends spoon.reflect.visitor.CtAbstrac
 		spoon.reflect.code.CtContinue other = ((spoon.reflect.code.CtContinue) (this.stack.peek()));
 		enter(continueStatement);
 		biScan(continueStatement.getAnnotations(), other.getAnnotations());
-		biScan(continueStatement.getLabelledStatement(), other.getLabelledStatement());
 		biScan(continueStatement.getComments(), other.getComments());
 		exit(continueStatement);
 	}

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -49,6 +49,7 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
+import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
@@ -180,6 +181,12 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	 * Scans an abstract control flow break.
 	 */
 	public void scanCtCFlowBreak(CtCFlowBreak flowBreak) {
+	}
+
+	/**
+	 * Scans a labelled control flow break.
+	 */
+	public void scanCtLabelledFlowBreak(CtLabelledFlowBreak labelledFlowBreak) {
 	}
 
 	/**
@@ -430,6 +437,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	}
 
 	public void visitCtBreak(CtBreak e) {
+		scanCtLabelledFlowBreak(e);
 		scanCtCFlowBreak(e);
 		scanCtStatement(e);
 		scanCtCodeElement(e);
@@ -493,6 +501,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	}
 
 	public void visitCtContinue(CtContinue e) {
+		scanCtLabelledFlowBreak(e);
 		scanCtCFlowBreak(e);
 		scanCtStatement(e);
 		scanCtCodeElement(e);

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -345,7 +345,6 @@ public abstract class CtScanner implements CtVisitor {
 	public void visitCtContinue(final CtContinue continueStatement) {
 		enter(continueStatement);
 		scan(continueStatement.getAnnotations());
-		scan(continueStatement.getLabelledStatement());
 		scan(continueStatement.getComments());
 		exit(continueStatement);
 	}

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -19,6 +19,7 @@ package spoon.support.reflect.code;
 import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -50,11 +51,15 @@ public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 
 	@Override
 	public CtStatement getLabelledStatement() {
-		List<CtStatement> listParents = this.map(new ParentFunction()).list();
+		List<CtStatement> listParents = this.map(new ParentFunction().includingSelf(true)).list();
 
-		for (CtStatement statement : listParents) {
-			if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
-				return statement;
+		for (CtElement parent : listParents) {
+			if (parent instanceof CtStatement) {
+				CtStatement statement = (CtStatement) parent;
+
+				if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
+					return statement;
+				}
 			}
 		}
 		return null;

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -16,7 +16,9 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -38,9 +40,14 @@ public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 	}
 
 	@Override
-	public <T extends CtBreak> T setTargetLabel(String targetLabel) {
+	public <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel) {
 		this.targetLabel = targetLabel;
 		return (T) this;
+	}
+
+	@Override
+	public CtStatement getLabelledStatement() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -22,6 +22,9 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.visitor.filter.ParentFunction;
+
+import java.util.List;
 
 public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 	private static final long serialVersionUID = 1L;
@@ -47,6 +50,13 @@ public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 
 	@Override
 	public CtStatement getLabelledStatement() {
+		List<CtStatement> listParents = this.map(new ParentFunction()).list();
+
+		for (CtStatement statement : listParents) {
+			if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
+				return statement;
+			}
+		}
 		return null;
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -16,8 +16,10 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtContinue;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
@@ -38,9 +40,14 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	}
 
 	@Override
-	public <T extends CtContinue> T setTargetLabel(String targetLabel) {
+	public <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel) {
 		this.targetLabel = targetLabel;
 		return (T) this;
+	}
+
+	@Override
+	public CtStatement getLabelledStatement() {
+		return null;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -20,6 +20,7 @@ import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtContinue;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.ParentFunction;
@@ -50,11 +51,15 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 
 	@Override
 	public CtStatement getLabelledStatement() {
-		List<CtStatement> listParents = this.map(new ParentFunction()).list();
+		List<CtStatement> listParents = this.map(new ParentFunction().includingSelf(true)).list();
 
-		for (CtStatement statement : listParents) {
-			if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
-				return statement;
+		for (CtElement parent : listParents) {
+			if (parent instanceof CtStatement) {
+				CtStatement statement = (CtStatement) parent;
+
+				if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
+					return statement;
+				}
 			}
 		}
 		return null;

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -16,17 +16,13 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtContinue;
-import spoon.reflect.code.CtStatement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
-import spoon.reflect.annotations.MetamodelPropertyField;
 
 public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	private static final long serialVersionUID = 1L;
-
-	@MetamodelPropertyField(role = CtRole.LABEL)
-	CtStatement labelledStatement;
 
 	@MetamodelPropertyField(role = CtRole.TARGET_LABEL)
 	String targetLabel;
@@ -34,20 +30,6 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	@Override
 	public void accept(CtVisitor visitor) {
 		visitor.visitCtContinue(this);
-	}
-
-	@Override
-	public CtStatement getLabelledStatement() {
-		return labelledStatement;
-	}
-
-	@Override
-	public <T extends CtContinue> T setLabelledStatement(CtStatement labelledStatement) {
-		if (labelledStatement != null) {
-			labelledStatement.setParent(this);
-		}
-		this.labelledStatement = labelledStatement;
-		return (T) this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -22,6 +22,9 @@ import spoon.reflect.code.CtContinue;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.filter.ParentFunction;
+
+import java.util.List;
 
 public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	private static final long serialVersionUID = 1L;
@@ -47,6 +50,13 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 
 	@Override
 	public CtStatement getLabelledStatement() {
+		List<CtStatement> listParents = this.map(new ParentFunction()).list();
+
+		for (CtStatement statement : listParents) {
+			if (statement.getLabel() != null && statement.getLabel().equals(this.getTargetLabel())) {
+				return statement;
+			}
+		}
 		return null;
 	}
 

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -221,7 +221,6 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	public void visitCtContinue(final spoon.reflect.code.CtContinue continueStatement) {
 		spoon.reflect.code.CtContinue aCtContinue = spoon.support.visitor.clone.CloneBuilder.build(this.builder, continueStatement, continueStatement.getFactory().Core().createContinue());
 		aCtContinue.setAnnotations(spoon.support.visitor.equals.CloneHelper.clone(continueStatement.getAnnotations()));
-		aCtContinue.setLabelledStatement(spoon.support.visitor.equals.CloneHelper.clone(continueStatement.getLabelledStatement()));
 		aCtContinue.setComments(spoon.support.visitor.equals.CloneHelper.clone(continueStatement.getComments()));
 		this.other = aCtContinue;
 	}

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -746,24 +746,9 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	}
 
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
-	class CtContinueLabelledStatementReplaceListener implements spoon.generating.replace.ReplaceListener<spoon.reflect.code.CtStatement> {
-		private final spoon.reflect.code.CtContinue element;
-
-		CtContinueLabelledStatementReplaceListener(spoon.reflect.code.CtContinue element) {
-			this.element = element;
-		}
-
-		@java.lang.Override
-		public void set(spoon.reflect.code.CtStatement replace) {
-			this.element.setLabelledStatement(replace);
-		}
-	}
-
-	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public void visitCtContinue(final spoon.reflect.code.CtContinue continueStatement) {
 		replaceInListIfExist(continueStatement.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(continueStatement));
-		replaceElementIfExist(continueStatement.getLabelledStatement(), new spoon.support.visitor.replace.ReplacementVisitor.CtContinueLabelledStatementReplaceListener(continueStatement));
 		replaceInListIfExist(continueStatement.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(continueStatement));
 	}
 

--- a/src/test/java/spoon/test/labels/TestLabels.java
+++ b/src/test/java/spoon/test/labels/TestLabels.java
@@ -4,12 +4,22 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtContinue;
+import spoon.reflect.code.CtDo;
+import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtIf;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtWhile;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.filter.NameFilter;
 
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -27,11 +37,11 @@ public class TestLabels {
         CtBlock body = mainMethod.getBody();
         assertEquals(2, body.getStatements().size());
 
-        assertEquals("labelBlock", body.getStatement(0).getLabel());
-        assertEquals("sw", body.getStatement(1).getLabel());
-
         CtBlock block = (CtBlock) body.getStatement(0);
         CtSwitch ctSwitch = (CtSwitch) body.getStatement(1);
+
+        assertEquals("labelBlock",block.getLabel());
+        assertEquals("sw", ctSwitch.getLabel());
 
         assertTrue(block.getStatement(1) instanceof CtIf);
 
@@ -41,6 +51,66 @@ public class TestLabels {
         CtBreak firstBreak = (CtBreak) then.getStatement(1);
 
         assertEquals("labelBlock", firstBreak.getTargetLabel());
-        assertEquals(block, firstBreak.getLabelledStatement());
+        assertSame(block, firstBreak.getLabelledStatement());
+
+        CtIf secondIf = (CtIf) block.getStatement(2);
+        assertEquals("labelIf", secondIf.getLabel());
+
+        CtBlock thenBlock = secondIf.getThenStatement();
+        CtIf innerIf = (CtIf) thenBlock.getStatement(0);
+
+        CtBlock innerThenBlock = innerIf.getThenStatement();
+        CtBreak breakInnerIf = (CtBreak) innerThenBlock.getStatement(0);
+        assertSame(secondIf, breakInnerIf.getLabelledStatement());
+
+        CtCase firstCase = (CtCase) ctSwitch.getCases().get(0);
+        List<CtStatement> statementList = firstCase.getStatements();
+
+        assertEquals(2, statementList.size());
+
+        CtDo ctDo = (CtDo) statementList.get(0);
+        assertEquals("label", ctDo.getLabel());
+
+        CtBreak finalBreak = (CtBreak) statementList.get(1);
+        assertNull(finalBreak.getTargetLabel());
+        assertNull(finalBreak.getLabelledStatement());
+
+        CtBlock doBlock = (CtBlock) ctDo.getBody();
+        CtWhile ctWhile = (CtWhile) doBlock.getStatement(1);
+        assertEquals("lWhile", ctWhile.getLabel());
+
+        CtBlock whileBlock = (CtBlock) ctWhile.getBody();
+        CtFor forLoop = (CtFor) whileBlock.getStatement(0);
+        CtBreak breakSwitch = (CtBreak) whileBlock.getStatement(1);
+
+        assertEquals("sw", breakSwitch.getTargetLabel());
+        assertSame(ctSwitch, breakSwitch.getLabelledStatement());
+
+        assertEquals("forloop", forLoop.getLabel());
+        CtBlock forBlock = (CtBlock) forLoop.getBody();
+
+        assertEquals(7, forBlock.getStatements().size());
+        CtIf firstForIf = (CtIf) forBlock.getStatement(1);
+        CtIf secondForIf = (CtIf) forBlock.getStatement(2);
+        CtIf thirdForIf = (CtIf) forBlock.getStatement(3);
+        CtIf fourthForIf = (CtIf) forBlock.getStatement(4);
+
+        CtBreak breakItself = (CtBreak) forBlock.getStatement(6);
+
+        CtContinue continueFor = (CtContinue) ((CtBlock) firstForIf.getThenStatement()).getStatement(0);
+        assertSame(forLoop, continueFor.getLabelledStatement());
+
+        CtContinue continueWhile = (CtContinue) ((CtBlock) secondForIf.getThenStatement()).getStatement(0);
+        assertSame(ctWhile, continueWhile.getLabelledStatement());
+
+        CtContinue continueDo = (CtContinue) ((CtBlock) thirdForIf.getThenStatement()).getStatement(0);
+        assertSame(ctDo, continueDo.getLabelledStatement());
+
+        CtBreak breakDo = (CtBreak) ((CtBlock) fourthForIf.getThenStatement()).getStatement(0);
+        assertSame(ctDo, breakDo.getLabelledStatement());
+
+        assertEquals("labelbreak", breakItself.getLabel());
+        assertEquals("labelbreak", breakItself.getTargetLabel());
+        assertSame(breakItself, breakItself.getLabelledStatement());
     }
 }

--- a/src/test/java/spoon/test/labels/TestLabels.java
+++ b/src/test/java/spoon/test/labels/TestLabels.java
@@ -1,0 +1,46 @@
+package spoon.test.labels;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtIf;
+import spoon.reflect.code.CtSwitch;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.visitor.filter.NameFilter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by urli on 19/06/2017.
+ */
+public class TestLabels {
+    @Test
+    public void testLabelsAreDetected() {
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("./src/test/java/spoon/test/labels/testclasses/ManyLabels.java");
+        launcher.buildModel();
+
+        CtMethod mainMethod = launcher.getFactory().getModel().getElements(new NameFilter<CtMethod>("main")).get(0);
+
+        CtBlock body = mainMethod.getBody();
+        assertEquals(2, body.getStatements().size());
+
+        assertEquals("labelBlock", body.getStatement(0).getLabel());
+        assertEquals("sw", body.getStatement(1).getLabel());
+
+        CtBlock block = (CtBlock) body.getStatement(0);
+        CtSwitch ctSwitch = (CtSwitch) body.getStatement(1);
+
+        assertTrue(block.getStatement(1) instanceof CtIf);
+
+        CtIf firstIf = (CtIf) block.getStatement(1);
+
+        CtBlock then = firstIf.getThenStatement();
+        CtBreak firstBreak = (CtBreak) then.getStatement(1);
+
+        assertEquals("labelBlock", firstBreak.getTargetLabel());
+        assertEquals(block, firstBreak.getLabelledStatement());
+    }
+}

--- a/src/test/java/spoon/test/labels/testclasses/ManyLabels.java
+++ b/src/test/java/spoon/test/labels/testclasses/ManyLabels.java
@@ -29,15 +29,28 @@ public class ManyLabels {
                 label:
                 do {
                     System.out.println("do");
+                    lWhile:
                     while (true) {
-                        for (int i = 0; i < 4; i++) {
+                        forloop:
+                        for (int i = 0; i < 10; i++) {
                             System.out.println("for");
                             if (i % 2 == 0) {
-                                break label;
-                            } else if (i == 3) {
+                                continue forloop;
+                            }
+                            if (i == 9) {
+                                continue lWhile;
+                            }
+
+                            if (i < 8) {
                                 continue label;
                             }
+                            if (i == 8) {
+                                break label;
+                            }
+
                             System.out.println("for 1");
+                            labelbreak:
+                            break labelbreak;
                         }
                         break sw;
                     }

--- a/src/test/java/spoon/test/labels/testclasses/ManyLabels.java
+++ b/src/test/java/spoon/test/labels/testclasses/ManyLabels.java
@@ -1,0 +1,48 @@
+package spoon.test.labels.testclasses;
+
+/**
+ * Created by urli on 19/06/2017.
+ */
+public class ManyLabels {
+    public static void main(String[] args) {
+        labelBlock:
+        {
+            System.out.println("block");
+            if (args.length != 0 && args[0].equals("test")) {
+                System.out.println("block after break3");
+                break labelBlock;
+            }
+
+            labelIf:
+            if (args.length > 1 && args[0].equals("test")) {
+                if (args.length == 2) {
+                    break labelIf;
+                }
+                System.out.println("block after break1");
+            }
+            System.out.println("block after break");
+        }
+
+        sw:
+        switch ("f") {
+            case "f":
+                label:
+                do {
+                    System.out.println("do");
+                    while (true) {
+                        for (int i = 0; i < 4; i++) {
+                            System.out.println("for");
+                            if (i % 2 == 0) {
+                                break label;
+                            } else if (i == 3) {
+                                continue label;
+                            }
+                            System.out.println("for 1");
+                        }
+                        break sw;
+                    }
+                } while (true);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
The property labelledStatement was always equals to null.

Fix #1381