### PR TITLE
fix: fix the declaration in getAllFields and getAllExecutables

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -515,7 +515,9 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		map(new AllTypeMembersFunction(CtField.class)).forEach(new CtConsumer<CtField<?>>() {
 			@Override
 			public void accept(CtField<?> field) {
-				fields.add(field.getReference());
+				CtFieldReference<?> reference = field.getReference();
+				reference.setDeclaringType(CtTypeImpl.this.getReference());
+				fields.add(reference);
 			}
 		});
 		return fields;
@@ -888,7 +890,9 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	public Collection<CtExecutableReference<?>> getAllExecutables() {
 		Set<CtExecutableReference<?>> l = new SignatureBasedSortedSet();
 		for (CtMethod<?> m : getAllMethods()) {
-			l.add((CtExecutableReference<?>) m.getReference());
+			CtExecutableReference<?> reference = m.getReference();
+			reference.setDeclaringType(CtTypeImpl.this.getReference());
+			l.add(reference);
 		}
 		return l;
 	}

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -7,6 +7,7 @@ import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 
 import java.util.Collection;
@@ -34,6 +35,13 @@ public class TypeTest {
 		// we have 3  methods in Foo + 2 in Baz - 1 common in Foo.bar (m) + 12 in Object + 1 explicit constructor in Foo
 		Collection<CtExecutableReference<?>> allExecutables = type.getAllExecutables();
 		assertEquals(17, allExecutables.size());
+
+		for (CtFieldReference<?> ref : type.getAllFields()) {
+			assertEquals(type.getReference(), ref.getDeclaringType());
+		}
+		for (CtExecutableReference<?> ref : type.getAllExecutables()) {
+			assertEquals(type.getReference(), ref.getDeclaringType());
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Fix this use case:

# Context
```java
public class Parent {
  private class A {
    int i = 0;
  }
  private class B {
  }
}
```
# Spoon

```java
CtClass c = getFactory().Class().get("Parent$B");
for (CtFieldReference f in c.getAllFields()) {
  CtVariableAccess vr = getFactory().Code().createVariableRead(f, isStatic); 
  // Parent.B.this.i (valid in B) instead of Parent.A.this.i (invalid in B)
}

```
