### PR TITLE
review: Fix NPE with union catch inside lambda in noclasspath

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -155,6 +155,7 @@ import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtArrayTypeReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.support.comparator.CtLineElementComparator;
@@ -1418,7 +1419,10 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		if (context.stack.peekFirst().node instanceof UnionTypeReference) {
 			if (singleTypeReference.resolvedType == null) {
-				context.enter(factory.Type().createReference(singleTypeReference.toString()), singleTypeReference);
+				CtTypeReference typeReference = factory.Type().createReference(singleTypeReference.toString());
+				CtReference ref = references.getDeclaringReferenceFromImports(singleTypeReference.getLastToken());
+				references.setPackageOrDeclaringType(typeReference, ref);
+				context.enter(typeReference, singleTypeReference);
 			} else {
 				context.enter(references.<Throwable>getTypeReference(singleTypeReference.resolvedType), singleTypeReference);
 			}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -116,6 +116,8 @@ import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
+import org.eclipse.jdt.internal.compiler.lookup.MissingTypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
@@ -1415,7 +1417,12 @@ public class JDTTreeBuilder extends ASTVisitor {
 			return true;
 		}
 		if (context.stack.peekFirst().node instanceof UnionTypeReference) {
-			context.enter(references.<Throwable>getTypeReference(singleTypeReference.resolvedType), singleTypeReference);
+			if (singleTypeReference.resolvedType == null) {
+				context.enter(factory.Type().createReference(singleTypeReference.toString()), singleTypeReference);
+			} else {
+				context.enter(references.<Throwable>getTypeReference(singleTypeReference.resolvedType), singleTypeReference);
+			}
+
 			return true;
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
 			context.enter(helper.createCatchVariable(singleTypeReference), singleTypeReference);

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -116,8 +116,6 @@ import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
-import org.eclipse.jdt.internal.compiler.lookup.MissingTypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;

--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -125,7 +125,7 @@ public class ExceptionTest {
 		assertEquals(variable1.getMultiTypes(), variable2.getMultiTypes());
 
 		// for now the type of CtCatchVariable is not the same
-		// this should be fix in the future (see:
+		// this should be fix in the future (see: https://github.com/INRIA/spoon/issues/1420)
 		//assertEquals(variable2, variable1);
 	}
 

--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -6,10 +6,15 @@ import spoon.SpoonModelBuilder;
 import spoon.compiler.InvalidClassPathException;
 import spoon.compiler.ModelBuildingException;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.io.FileNotFoundException;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -99,6 +104,19 @@ public class ExceptionTest {
 					SpoonResourceHelper
 							.resources("./src/test/resources/spoon/test/duplicateclasses/Foo.java", "./src/test/resources/spoon/test/duplicateclasses/Bar.java"))
 					.build();
+	}
+
+	@Test
+	public void testUnionCatchExceptionInsideLambdaInNoClasspath() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/noclasspath/UnionCatch.java");
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.buildModel();
+
+		List<CtCatch> catches = launcher.getFactory().getModel().getElements(new TypeFilter<>(CtCatch.class));
+		assertEquals(1, catches.size());
+
+		CtCatchVariable variable = catches.get(0).getParameter();
 	}
 
 }

--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -15,6 +15,7 @@ import java.io.FileNotFoundException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -108,15 +109,20 @@ public class ExceptionTest {
 
 	@Test
 	public void testUnionCatchExceptionInsideLambdaInNoClasspath() {
+		// contract: the model should be built when defining a union catch inside a lambda which is not known (noclasspath)
+		// and the catch variable should be the same than outside a lambda
 		Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/resources/noclasspath/UnionCatch.java");
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.buildModel();
 
 		List<CtCatch> catches = launcher.getFactory().getModel().getElements(new TypeFilter<>(CtCatch.class));
-		assertEquals(1, catches.size());
+		assertEquals(2, catches.size());
 
-		CtCatchVariable variable = catches.get(0).getParameter();
+		CtCatchVariable variable1 = catches.get(0).getParameter(); // inside a lambda
+		CtCatchVariable variable2 = catches.get(1).getParameter(); // outside the lambda
+
+		assertEquals(variable2, variable1);
 	}
 
 }

--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -110,7 +110,7 @@ public class ExceptionTest {
 	@Test
 	public void testUnionCatchExceptionInsideLambdaInNoClasspath() {
 		// contract: the model should be built when defining a union catch inside a lambda which is not known (noclasspath)
-		// and the catch variable should be the same than outside a lambda
+		// and the catch variable types should be the same than outside a lambda
 		Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/resources/noclasspath/UnionCatch.java");
 		launcher.getEnvironment().setNoClasspath(true);
@@ -122,7 +122,11 @@ public class ExceptionTest {
 		CtCatchVariable variable1 = catches.get(0).getParameter(); // inside a lambda
 		CtCatchVariable variable2 = catches.get(1).getParameter(); // outside the lambda
 
-		assertEquals(variable2, variable1);
+		assertEquals(variable1.getMultiTypes(), variable2.getMultiTypes());
+
+		// for now the type of CtCatchVariable is not the same
+		// this should be fix in the future (see:
+		//assertEquals(variable2, variable1);
 	}
 
 }

--- a/src/test/resources/noclasspath/UnionCatch.java
+++ b/src/test/resources/noclasspath/UnionCatch.java
@@ -12,17 +12,29 @@ import toto.NbpOperator;
 public class UnionCatch {
     public void toto() {
         bla((NbpOperator) t -> {
-                try {
-                    Reader reader = new StringReader("machin");
-                    int i = -1;
-                    while (reader.ready()) {
-                        i = reader.read();
-                    }
-                    return i;
-                } catch (IOException | NullPointerException e) {
-                    System.out.printf("Error");
-                    return 0;
+            try {
+                Reader reader = new StringReader("machin");
+                int i = -1;
+                while (reader.ready()) {
+                    i = reader.read();
                 }
-            });
+                return i;
+            } catch (IOException | NullPointerException e) {
+                System.out.printf("Error");
+                return 0;
+            }
+        });
+
+        try {
+            Reader reader = new StringReader("machin");
+            int i = -1;
+            while (reader.ready()) {
+                i = reader.read();
+            }
+            return i;
+        } catch (IOException | NullPointerException e) {
+            System.out.printf("Error");
+            return 0;
+        }
     }
 }

--- a/src/test/resources/noclasspath/UnionCatch.java
+++ b/src/test/resources/noclasspath/UnionCatch.java
@@ -1,0 +1,28 @@
+package spoon.test.exceptions.testclasses;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.function.Function;
+import toto.NbpOperator;
+
+/**
+ * Created by urli on 23/06/2017.
+ */
+public class UnionCatch {
+    public void toto() {
+        bla((NbpOperator) t -> {
+                try {
+                    Reader reader = new StringReader("machin");
+                    int i = -1;
+                    while (reader.ready()) {
+                        i = reader.read();
+                    }
+                    return i;
+                } catch (IOException | NullPointerException e) {
+                    System.out.printf("Error");
+                    return 0;
+                }
+            });
+    }
+}


### PR DESCRIPTION
This PR fix a NPE we had when spooning a catch with multi exception inside a lambda in no classpath mode, as explained in #1415. 
However the bug is not completely solved in that PR, in that sense that the model is not exactly the same as if the try catch was outside the lambda. I decided to concentrate on getting information from multi types (which was causing the NPE). But to complete it, we should also compute the type of CtCatchVariable from the multitypes (it's normally done by JDT). I opened an issue for that and I propose to solve it in a separate PR (see #1420) 