### PR TITLE
review:Fix travis issue by using the last image on Travis #1414

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 
 sudo: required
+dist: trusty
+
+group: edge
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
We can now use the Trusty image proposed by Travis, see: https://blog.travis-ci.com/2017-06-19-trusty-updates-2017-Q2

Fix #1414 