### PR TITLE
review: refactor printing of lists in Spoon pretty printer

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -342,7 +342,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				}
 			}
 		}
-		printer.writeln().writeTabs();
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1773,10 +1773,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		elementPrinterHelper = new ElementPrinterHelper(printer, this, env);
 
 		elementPrinterHelper.writeComment(pack);
-
-		for (CtAnnotation<?> a : pack.getAnnotations()) {
-			a.accept(this);
-		}
+		elementPrinterHelper.writeAnnotations(pack);
 
 		if (!pack.isUnnamedPackage()) {
 			printer.write("package " + pack.getQualifiedName() + ";");

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -109,6 +109,7 @@ import spoon.reflect.visitor.PrintingContext.Writable;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 import spoon.reflect.visitor.printer.CommentOffset;
 import spoon.reflect.visitor.printer.ElementPrinterHelper;
+import spoon.reflect.visitor.printer.ListPrinter;
 import spoon.reflect.visitor.printer.PrinterHelper;
 
 import java.lang.annotation.Annotation;
@@ -333,14 +334,13 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.write("@");
 		scan(annotation.getAnnotationType());
 		if (annotation.getValues().size() > 0) {
-			printer.write("(");
-			for (Entry<String, CtExpression> e : annotation.getValues().entrySet()) {
-				printer.write(e.getKey() + " = ");
-				elementPrinterHelper.writeAnnotationElement(annotation.getFactory(), e.getValue());
-				printer.write(", ");
+			try (ListPrinter lp = printer.createListPrinter("(", ", ", ")")) {
+				for (Entry<String, CtExpression> e : annotation.getValues().entrySet()) {
+					lp.printSeparatorIfAppropriate();
+					printer.write(e.getKey() + " = ");
+					elementPrinterHelper.writeAnnotationElement(annotation.getFactory(), e.getValue());
+				}
 			}
-			printer.removeLastChar();
-			printer.write(")");
 		}
 		printer.writeln().writeTabs();
 	}
@@ -643,12 +643,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (ctEnum.getEnumValues().size() == 0) {
 			printer.writeTabs().write(";").writeln();
 		} else {
-			for (CtEnumValue<?> enumValue : ctEnum.getEnumValues()) {
-				scan(enumValue);
-				printer.write(", ");
+			try (ListPrinter lp = printer.createListPrinter(null, ", ", ";")) {
+				for (CtEnumValue<?> enumValue : ctEnum.getEnumValues()) {
+					lp.printSeparatorIfAppropriate();
+					scan(enumValue);
+				}
 			}
-			printer.removeLastChar();
-			printer.write(";");
 		}
 
 		elementPrinterHelper.writeElementList(ctEnum.getTypeMembers());
@@ -1006,12 +1006,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (!forLoop.getForUpdate().isEmpty()) {
 			printer.write(" ");
 		}
-		for (CtStatement s : forLoop.getForUpdate()) {
-			scan(s);
-			printer.write(" , ");
-		}
-		if (forLoop.getForUpdate().size() > 0) {
-			printer.removeLastChar();
+		try (ListPrinter lp = printer.createListPrinter(null, " , ", null)) {
+			for (CtStatement s : forLoop.getForUpdate()) {
+				lp.printSeparatorIfAppropriate();
+				scan(s);
+			}
 		}
 		printer.write(")");
 		elementPrinterHelper.writeIfOrLoopBlock(forLoop.getBody());
@@ -1058,12 +1057,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 
 		if (intrface.getSuperInterfaces().size() > 0) {
-			printer.write(" extends ");
-			for (CtTypeReference<?> ref : intrface.getSuperInterfaces()) {
-				scan(ref);
-				printer.write(" , ");
+			try (ListPrinter lp = printer.createListPrinter(" extends ", " , ", null)) {
+				for (CtTypeReference<?> ref : intrface.getSuperInterfaces()) {
+					lp.printSeparatorIfAppropriate();
+					scan(ref);
+				}
 			}
-			printer.removeLastChar();
 		}
 		context.pushCurrentThis(intrface);
 		printer.write(" {").incTab();
@@ -1117,17 +1116,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			}
 			printer.write(invocation.getExecutable().getSimpleName());
 		}
-		printer.write("(");
-		boolean remove = false;
-		for (CtExpression<?> e : invocation.getArguments()) {
-			scan(e);
-			printer.write(", ");
-			remove = true;
+		try (ListPrinter lp = printer.createListPrinter("(", ", ", ")")) {
+			for (CtExpression<?> e : invocation.getArguments()) {
+				lp.printSeparatorIfAppropriate();
+				scan(e);
+			}
 		}
-		if (remove) {
-			printer.removeLastChar();
-		}
-		printer.write(")");
 		exitCtExpression(invocation);
 	}
 
@@ -1306,25 +1300,13 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			}
 		}
 		if (newArray.getDimensionExpressions().size() == 0) {
-			printer.write("{ ");
-			List<CtExpression<?>> l_elements = newArray.getElements();
-			for (int i = 0; i < l_elements.size(); i++) {
-				CtExpression e = l_elements.get(i);
-				scan(e);
-				printer.write(" , ");
-				if (i + 1 == l_elements.size()) {
-					printer.removeLastChar();
-					// if the last element c
-					List<CtComment> comments = elementPrinterHelper.getComments(e, CommentOffset.AFTER);
-					// if the last element contains an inline comment, print a new line before closing the array
-					if (!comments.isEmpty() && comments.get(comments.size() - 1).getCommentType() == CtComment.CommentType.INLINE) {
-						printer.writeln();
-					}
+			try (ListPrinter lp = printer.createListPrinter("{ ", " , ", " }")) {
+				for (CtExpression e : newArray.getElements()) {
+					lp.printSeparatorIfAppropriate();
+					scan(e);
 				}
+				elementPrinterHelper.writeComment(newArray, CommentOffset.INSIDE);
 			}
-
-			elementPrinterHelper.writeComment(newArray, CommentOffset.INSIDE);
-			printer.write(" }");
 		}
 		elementPrinterHelper.writeComment(newArray, CommentOffset.AFTER);
 		exitCtExpression(newArray);
@@ -1373,15 +1355,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(ctConstructorCall.getType());
 		}
 
-		printer.write("(");
-		for (CtCodeElement exp : ctConstructorCall.getArguments()) {
-			scan(exp);
-			printer.write(", ");
+		try (ListPrinter lp = printer.createListPrinter("(", ", ", ")")) {
+			for (CtCodeElement exp : ctConstructorCall.getArguments()) {
+				lp.printSeparatorIfAppropriate();
+				scan(exp);
+			}
 		}
-		if (ctConstructorCall.getArguments().size() > 0) {
-			printer.removeLastChar();
-		}
-		printer.write(")");
 	}
 
 	/**
@@ -1417,15 +1396,14 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public <T> void visitCtLambda(CtLambda<T> lambda) {
 		enterCtExpression(lambda);
 
-		printer.write("(");
-		if (lambda.getParameters().size() > 0) {
-			for (CtParameter<?> parameter : lambda.getParameters()) {
-				scan(parameter);
-				printer.write(",");
+		try (ListPrinter lp = printer.createListPrinter("(", ",", ") -> ")) {
+			if (lambda.getParameters().size() > 0) {
+				for (CtParameter<?> parameter : lambda.getParameters()) {
+					lp.printSeparatorIfAppropriate();
+					scan(parameter);
+				}
 			}
-			printer.removeLastChar();
 		}
-		printer.write(") -> ");
 
 		if (lambda.getBody() != null) {
 			scan(lambda.getBody());
@@ -1574,13 +1552,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		enterCtStatement(tryWithResource);
 		printer.write("try ");
 		if (tryWithResource.getResources() != null && !tryWithResource.getResources().isEmpty()) {
-			printer.write("(");
-			for (CtLocalVariable<?> r : tryWithResource.getResources()) {
-				scan(r);
-				printer.write(";");
+			try (ListPrinter lp = printer.createListPrinter("(", ";", ") ")) {
+				for (CtLocalVariable<?> r : tryWithResource.getResources()) {
+					lp.printSeparatorIfAppropriate();
+					scan(r);
+				}
 			}
-			printer.removeLastChar();
-			printer.write(") ");
 		}
 		scan(tryWithResource.getBody());
 		for (CtCatch c : tryWithResource.getCatchers()) {
@@ -1651,11 +1628,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public <T> void visitCtIntersectionTypeReference(CtIntersectionTypeReference<T> reference) {
-		for (CtTypeReference<?> bound : reference.getBounds()) {
-			scan(bound);
-			printer.write(" & ");
+		try (ListPrinter lp = printer.createListPrinter(null, " & ", null)) {
+			for (CtTypeReference<?> bound : reference.getBounds()) {
+				lp.printSeparatorIfAppropriate();
+				scan(bound);
+			}
 		}
-		printer.removeLastChar();
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -76,6 +76,7 @@ public class ElementPrinterHelper {
 	public void writeAnnotations(CtElement element) {
 		for (CtAnnotation<?> annotation : element.getAnnotations()) {
 			prettyPrinter.scan(annotation);
+			printer.writeln().writeTabs();
 		}
 	}
 

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -234,19 +234,14 @@ public class ElementPrinterHelper {
 	public void writeActualTypeArguments(CtActualTypeContainer ctGenericElementReference) {
 		final Collection<CtTypeReference<?>> arguments = ctGenericElementReference.getActualTypeArguments();
 		if (arguments != null && arguments.size() > 0) {
-			printer.write("<");
-			boolean isImplicitTypeReference = true;
-			for (CtTypeReference<?> argument : arguments) {
-				if (!argument.isImplicit()) {
-					isImplicitTypeReference = false;
-					prettyPrinter.scan(argument);
-					printer.write(", ");
+			try (ListPrinter lp = printer.createListPrinter("<", ", ", ">")) {
+				for (CtTypeReference<?> argument : arguments) {
+					if (!argument.isImplicit()) {
+						lp.itemStart();
+						prettyPrinter.scan(argument);
+					}
 				}
 			}
-			if (!isImplicitTypeReference) {
-				printer.removeLastChar();
-			}
-			printer.write(">");
 		}
 	}
 

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -101,35 +101,32 @@ public class ElementPrinterHelper {
 
 	public void writeImplementsClause(CtType<?> type) {
 		if (type.getSuperInterfaces().size() > 0) {
-			printer.write(" implements ");
-			for (CtTypeReference<?> ref : type.getSuperInterfaces()) {
-				prettyPrinter.scan(ref);
-				printer.write(" , ");
+			try (ListPrinter lp = printer.createListPrinter(" implements ", " , ", null)) {
+				for (CtTypeReference<?> ref : type.getSuperInterfaces()) {
+					lp.printSeparatorIfAppropriate();
+					prettyPrinter.scan(ref);
+				}
 			}
-			printer.removeLastChar();
 		}
 	}
 
 	public void writeExecutableParameters(CtExecutable<?> executable) {
-		printer.write("(");
-		if (executable.getParameters().size() > 0) {
+		try (ListPrinter lp = printer.createListPrinter("(", ", ", ")")) {
 			for (CtParameter<?> p : executable.getParameters()) {
+				lp.printSeparatorIfAppropriate();
 				prettyPrinter.scan(p);
-				printer.write(", ");
 			}
-			printer.removeLastChar();
 		}
-		printer.write(")");
 	}
 
 	public void writeThrowsClause(CtExecutable<?> executable) {
 		if (executable.getThrownTypes().size() > 0) {
-			printer.write(" throws ");
-			for (CtTypeReference<?> ref : executable.getThrownTypes()) {
-				prettyPrinter.scan(ref);
-				printer.write(", ");
+			try (ListPrinter lp = printer.createListPrinter(" throws ", ", ", null)) {
+				for (CtTypeReference<?> ref : executable.getThrownTypes()) {
+					lp.printSeparatorIfAppropriate();
+					prettyPrinter.scan(ref);
+				}
 			}
-			printer.removeLastChar();
 		}
 	}
 
@@ -173,25 +170,19 @@ public class ElementPrinterHelper {
 		} else if (value instanceof String) {
 			printer.write("\"" + value.toString() + "\"");
 		} else if (value instanceof Collection) {
-			printer.write("{");
-			if (!((Collection<?>) value).isEmpty()) {
+			try (ListPrinter lp = printer.createListPrinter("{", " ,", "}")) {
 				for (Object obj : (Collection<?>) value) {
+					lp.printSeparatorIfAppropriate();
 					writeAnnotationElement(factory, obj);
-					printer.write(" ,");
 				}
-				printer.removeLastChar();
 			}
-			printer.write("}");
 		} else if (value instanceof Object[]) {
-			printer.write("{");
-			if (((Object[]) value).length > 0) {
+			try (ListPrinter lp = printer.createListPrinter("{", " ,", "}")) {
 				for (Object obj : (Object[]) value) {
+					lp.printSeparatorIfAppropriate();
 					writeAnnotationElement(factory, obj);
-					printer.write(" ,");
 				}
-				printer.removeLastChar();
 			}
-			printer.write("}");
 		} else if (value instanceof Enum) {
 			try (Writable c = prettyPrinter.getContext().modify().ignoreGenerics(true)) {
 				prettyPrinter.scan(factory.Type().createReference(((Enum<?>) value).getDeclaringClass()));
@@ -215,13 +206,12 @@ public class ElementPrinterHelper {
 			return;
 		}
 		if (parameters.size() > 0) {
-			printer.write('<');
-			for (CtTypeParameter parameter : parameters) {
-				prettyPrinter.scan(parameter);
-				printer.write(", ");
+			try (ListPrinter lp = printer.createListPrinter("<", ", ", ">")) {
+				for (CtTypeParameter parameter : parameters) {
+					lp.printSeparatorIfAppropriate();
+					prettyPrinter.scan(parameter);
+				}
 			}
-			printer.removeLastChar();
-			printer.write('>');
 		}
 	}
 
@@ -237,7 +227,7 @@ public class ElementPrinterHelper {
 			try (ListPrinter lp = printer.createListPrinter("<", ", ", ">")) {
 				for (CtTypeReference<?> argument : arguments) {
 					if (!argument.isImplicit()) {
-						lp.itemStart();
+						lp.printSeparatorIfAppropriate();
 						prettyPrinter.scan(argument);
 					}
 				}

--- a/src/main/java/spoon/reflect/visitor/printer/ListPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ListPrinter.java
@@ -46,7 +46,7 @@ public class ListPrinter implements Closeable {
 	/**
 	 * Call that before printing of list item starts
 	 */
-	public void itemStart() {
+	public void printSeparatorIfAppropriate() {
 		if (isFirst) {
 			/*
 			 * we are starting first item. Do not print `next` separator yet

--- a/src/main/java/spoon/reflect/visitor/printer/ListPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ListPrinter.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.printer;
+
+import java.io.Closeable;
+
+/**
+ * Helper which assures consistent printing of lists
+ * prefixed with `start`, separated by `next` and suffixed by `end`.<br>
+ * If there is no item in the list then it prints `start` and then `end`<br>
+ * If there is one item in the list then it prints `start`, item and then `end`<br>
+ * If there is more then one items in the list then it prints `start`, items separated by `next` and then `end`
+ */
+public class ListPrinter implements Closeable {
+
+	private final PrinterHelper printerHelper;
+	private final String next;
+	private final String end;
+	private boolean isFirst = true;
+
+	ListPrinter(PrinterHelper printerHelper, String start, String next, String end) {
+		super();
+		this.printerHelper = printerHelper;
+		this.next = next;
+		this.end = end;
+
+		if (start != null && start.length() > 0) {
+			printerHelper.write(start);
+		}
+	}
+
+	/**
+	 * Call that before printing of list item starts
+	 */
+	public void itemStart() {
+		if (isFirst) {
+			/*
+			 * we are starting first item. Do not print `next` separator yet
+			 */
+			isFirst = false;
+		} else {
+			/*
+			 * we are starting next item. Print `next` separator now
+			 */
+			if (next != null && next.length() > 0) {
+				printerHelper.write(next);
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		if (end != null && end.length() > 0) {
+			printerHelper.write(end);
+		}
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
@@ -207,7 +207,9 @@ public class PrinterHelper {
 
 	/**
 	 * Removes the last non-white character.
+	 * Use {@link PrinterHelper#createListPrinter(String, String, String)} to print separators only when needed
 	 */
+	@Deprecated
 	public PrinterHelper removeLastChar() {
 		while (isWhite(sbf.charAt(sbf.length() - 1))) {
 			if (sbf.charAt(sbf.length() - 1) == '\n') {
@@ -421,7 +423,7 @@ public class PrinterHelper {
 	 * @param start the string which has to be printed at the beginning of the list
 	 * @param next the string which has to be used as separator before each next item
 	 * @param end the string which has to be printed after the list
-	 * @return the {@link ListPrinter} whose {@link ListPrinter#itemStart()} has to be called
+	 * @return the {@link ListPrinter} whose {@link ListPrinter#printSeparatorIfAppropriate()} has to be called
 	 * before printing of each item.
 	 */
 	public ListPrinter createListPrinter(String start, String next, String end) {

--- a/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
@@ -414,4 +414,17 @@ public class PrinterHelper {
 	public boolean hasNewContent() {
 		return lengths.pollLast() < toString().length();
 	}
+
+	/**
+	 * Creates new handler which assures consistent printing of lists
+	 * prefixed with `start`, separated by `next` and suffixed by `end`
+	 * @param start the string which has to be printed at the beginning of the list
+	 * @param next the string which has to be used as separator before each next item
+	 * @param end the string which has to be printed after the list
+	 * @return the {@link ListPrinter} whose {@link ListPrinter#itemStart()} has to be called
+	 * before printing of each item.
+	 */
+	public ListPrinter createListPrinter(String start, String next, String end) {
+		return new ListPrinter(this, start, next, end);
+	}
 }

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -118,8 +118,7 @@ public class AnnotationTest {
 	@Test
 	public void testWritingAnnotParamArray() throws Exception {
 		CtType<?> type = this.factory.Type().get("spoon.test.annotation.testclasses.AnnotParam");
-		assertEquals("@java.lang.SuppressWarnings(value = { \"unused\" , \"rawtypes\" })"
-						+ DefaultJavaPrettyPrinter.LINE_SEPARATOR,
+		assertEquals("@java.lang.SuppressWarnings(value = { \"unused\" , \"rawtypes\" })",
 				type.getElements(new TypeFilter<>(CtAnnotation.class)).get(0).toString());
 	}
 
@@ -650,7 +649,7 @@ public class AnnotationTest {
 		final String arrayAnnotationParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(ias = { @spoon.test.annotation.testclasses.InnerAnnot(value = \"\") })" + System.lineSeparator() + "T> list10";
 		assertEquals("array of annotations parameter in type annotation", arrayAnnotationParam, method.getBody().getStatement(9).toString());
 
-		final String complexArrayParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(inceptions = { @spoon.test.annotation.testclasses.Inception(value = @spoon.test.annotation.testclasses.InnerAnnot(value = \"\")" + System.lineSeparator() + ", values = { @spoon.test.annotation.testclasses.InnerAnnot(value = \"\") }) })" + System.lineSeparator() + "T> list11";
+		final String complexArrayParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(inceptions = { @spoon.test.annotation.testclasses.Inception(value = @spoon.test.annotation.testclasses.InnerAnnot(value = \"\"), values = { @spoon.test.annotation.testclasses.InnerAnnot(value = \"\") }) })" + System.lineSeparator() + "T> list11";
 		assertEquals("array of complexes parameters in type annotation", complexArrayParam, method.getBody().getStatement(10).toString());
 	}
 

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -132,8 +132,8 @@ public class AnnotationValuesTest {
 
 	private static final String nl = System.lineSeparator();
 
-	private static final String strCtClassOracle = "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES, p = 1701, f = 11.1, m = { 9 , 8 , 1 }, l = java.lang.Override.class, j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA" + nl +
-			", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(value = \"bar\")" + nl +
+	private static final String strCtClassOracle = "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES, p = 1701, f = 11.1, m = { 9 , 8 , 1 }, l = java.lang.Override.class, j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA" +
+			", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(value = \"bar\")" +
 			", r = { java.lang.Float.class , java.lang.Double.class })" + nl +
 			"public class IsAnnotated {}";
 

--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -27,7 +27,7 @@ public class ArraysTest {
 		assertEquals(3, ((CtArrayTypeReference<?>) type.getField("i").getType()).getDimensionCount());
 		final CtArrayTypeReference<?> arrayTypeReference = (CtArrayTypeReference<?>) type.getField("i").getDefaultExpression().getType();
 		assertEquals(1, arrayTypeReference.getArrayType().getAnnotations().size());
-		assertEquals("@spoon.test.arrays.ArrayClass.TypeAnnotation(integer = 1)" + System.lineSeparator(), arrayTypeReference.getArrayType().getAnnotations().get(0).toString());
+		assertEquals("@spoon.test.arrays.ArrayClass.TypeAnnotation(integer = 1)", arrayTypeReference.getArrayType().getAnnotations().get(0).toString());
 
 		CtField<?> x = type.getField("x");
 		assertTrue(x.getType() instanceof CtArrayTypeReference);

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -96,7 +96,7 @@ public class FilterTest {
 		CtClass<?> foo = factory.Package().get("spoon.test.filters").getType("Foo");
 		assertEquals("Foo", foo.getSimpleName());
 		List<CtExpression<?>> expressions = foo.getElements(new RegexFilter<CtExpression<?>>(".* = .*"));
-		assertEquals(2, expressions.size());
+		assertEquals(4, expressions.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -429,7 +429,7 @@ public class TypeReferenceTest {
 		final CtMethod run = anonymousClass.getMethod("run");
 		assertNotNull(run);
 		assertEquals(1, run.getAnnotations().size());
-		assertEquals("@java.lang.Override" + System.lineSeparator(), run.getAnnotations().get(0).toString());
+		assertEquals("@java.lang.Override", run.getAnnotations().get(0).toString());
 	}
 
 	@Test


### PR DESCRIPTION
I am thinking of some enhancements of DefaultJavaPrettyPrinter and this would be the first BS.

@monperrus , do not merge this PR now, but please give me first a feedback whether you will merge the similar refactorings on all 16 places where `PrinterHelper#removeLastChar` is used.

Why to like it? ;-)
* it is shorter code - 6 lines instead of 11.
* there is less places for mistakes
* the PrinterHelper is not asked to print something and then to remove it - this bad approach makes future extensions of PrinterHelper more complicated...

Why to not like it?
* developer must know how the ListPrinter works to understand how it works. But then I think it is much more readable... so I hope it is not an issue.

WDYT? 

The suggestions for better names of new classes and methods are always welcome ;-)