### PR TITLE
review: feat: sort imports alphabetically

### DIFF
--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -53,6 +53,7 @@ import spoon.reflect.visitor.PrintingContext.Writable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 
 public class ElementPrinterHelper {
@@ -240,6 +241,13 @@ public class ElementPrinterHelper {
 		return importType.matches("^(java\\.lang\\.)[^.]*$");
 	}
 
+	private static final Comparator<String> stringComparator = new Comparator<String>() {
+		@Override
+		public int compare(String o1, String o2) {
+			return o1.compareTo(o2);
+		}
+	};
+
 	/**
 	 * Write the compilation unit header.
 	 */
@@ -253,6 +261,7 @@ public class ElementPrinterHelper {
 				printer.write("package " + types.get(0).getPackage().getQualifiedName() + ";");
 			}
 			printer.writeln().writeln().writeTabs();
+			List<String> sortedImports = new ArrayList<>(imports.size());
 			for (CtReference ref : imports) {
 				String importStr = "import";
 				String importTypeStr = "";
@@ -273,8 +282,12 @@ public class ElementPrinterHelper {
 				}
 
 				if (!importTypeStr.equals("") && !isJavaLangClasses(importTypeStr)) {
-					printer.write(importStr + " " + importTypeStr + ";").writeln().writeTabs();
+					sortedImports.add(importStr + " " + importTypeStr + ";");
 				}
+			}
+			sortedImports.sort(stringComparator);
+			for (String importLine : sortedImports) {
+				printer.write(importLine).writeln().writeTabs();
 			}
 			printer.writeln().writeTabs();
 		}

--- a/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/ElementPrinterHelper.java
@@ -53,7 +53,7 @@ import spoon.reflect.visitor.PrintingContext.Writable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 
 public class ElementPrinterHelper {
@@ -241,13 +241,6 @@ public class ElementPrinterHelper {
 		return importType.matches("^(java\\.lang\\.)[^.]*$");
 	}
 
-	private static final Comparator<String> stringComparator = new Comparator<String>() {
-		@Override
-		public int compare(String o1, String o2) {
-			return o1.compareTo(o2);
-		}
-	};
-
 	/**
 	 * Write the compilation unit header.
 	 */
@@ -285,7 +278,7 @@ public class ElementPrinterHelper {
 					sortedImports.add(importStr + " " + importTypeStr + ";");
 				}
 			}
-			sortedImports.sort(stringComparator);
+			Collections.sort(sortedImports);
 			for (String importLine : sortedImports) {
 				printer.write(importLine).writeln().writeTabs();
 			}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -22,6 +22,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.ImportScanner;
 import spoon.reflect.visitor.ImportScannerImpl;
 import spoon.reflect.visitor.PrettyPrinter;
@@ -56,6 +57,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -1117,4 +1119,45 @@ public class ImportTest {
 		canBeBuilt(outputDir, 3);
 	}
 
+	@Test
+	public void testSortingOfImports() {
+		// contract: imports are sorted alphabetically
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(true);
+		String outputDir = "./target/spooned";
+		launcher.addInputResource("./src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java");
+		launcher.setSourceOutputDirectory(outputDir);
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.run();
+		PrettyPrinter prettyPrinter = launcher.createPrettyPrinter();
+
+		CtType element = launcher.getFactory().Class().get(DefaultJavaPrettyPrinter.class);
+		List<CtType<?>> toPrint = new ArrayList<>();
+		toPrint.add(element);
+
+		prettyPrinter.calculate(element.getPosition().getCompilationUnit(), toPrint);
+		String output = prettyPrinter.getResult();
+
+		StringTokenizer st = new StringTokenizer(output, System.getProperty("line.separator"));
+		String lastImport = null;
+		int countOfImports = 0;
+		while(st.hasMoreTokens()) {
+			String line = st.nextToken();
+			if(line.startsWith("import")) {
+				countOfImports++;
+				if(lastImport!=null) {
+					//check that next import is alphabetically higher then last import
+					assertTrue(lastImport.compareTo(line)<0);
+				}
+				lastImport = line;
+			} else {
+				if(lastImport!=null) {
+					//there are no more imports. Finish
+					break;
+				}
+				//no import found yet. Continue with next line
+			}
+		}
+		assertTrue(countOfImports>10);
+	}
 }


### PR DESCRIPTION
The imports generated by Spoon pretty printer are sorted alphabetically now.

The main advantage is that Spoon produces same content with each printing now. Before the imports were randomly mixed (because of HashSet).