### PR TITLE
fix printing of comments on MS Windows

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -860,7 +860,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.write(docTag.getParam()).writeln().writeTabs();
 		}
 
-		String[] tagLines = docTag.getContent().split(LINE_SEPARATOR);
+		String[] tagLines = docTag.getContent().split("\\n\\r|\\n|\\r");
 		for (int i = 0; i < tagLines.length; i++) {
 			String com = tagLines[i];
 			if (i > 0 || docTag.getType().hasParam()) {
@@ -898,7 +898,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				printer.write(content);
 				break;
 			default:
-				String[] lines = content.split(LINE_SEPARATOR);
+				String[] lines = content.split("\\n\\r|\\n|\\r");
 				for (int i = 0; i < lines.length; i++) {
 					String com = lines[i];
 					if (comment.getCommentType() == CtComment.CommentType.BLOCK) {

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -167,6 +167,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public static final String BLOCK_COMMENT_START = "/* ";
 
 	/**
+	 * RegExp which matches all possible line separators
+	 */
+	private static final String LINE_SEPARATORS_RE = "\\n\\r|\\n|\\r";
+
+	/**
 	 * The printing context.
 	 */
 	public PrintingContext context = new PrintingContext();
@@ -860,7 +865,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.write(docTag.getParam()).writeln().writeTabs();
 		}
 
-		String[] tagLines = docTag.getContent().split("\\n\\r|\\n|\\r");
+		String[] tagLines = docTag.getContent().split(LINE_SEPARATORS_RE);
 		for (int i = 0; i < tagLines.length; i++) {
 			String com = tagLines[i];
 			if (i > 0 || docTag.getType().hasParam()) {
@@ -898,7 +903,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				printer.write(content);
 				break;
 			default:
-				String[] lines = content.split("\\n\\r|\\n|\\r");
+				String[] lines = content.split(LINE_SEPARATORS_RE);
 				for (int i = 0; i < lines.length; i++) {
 					String com = lines[i];
 					if (comment.getCommentType() == CtComment.CommentType.BLOCK) {

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -51,6 +51,7 @@ import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -110,12 +111,37 @@ public class CommentTest {
 
 	@Test
 	public void testJavaDocComment() {
-		String EOL = System.getProperty("line.separator");
+		//the EOL is taken from JavaDocComment.java, which is commited in git with linux \n
+		//that is true on Windows too.
+		String EOL = "\n";
 
 		Factory f = getSpoonFactory();
 		CtClass<?> type = (CtClass<?>) f.Type().get(JavaDocComment.class);
 
 		CtJavaDoc classJavaDoc = (CtJavaDoc) type.getComments().get(0);
+		//contract: test that java doc is printed correctly
+		String str = classJavaDoc.toString();
+		StringTokenizer st = new StringTokenizer(str, "\n\r");
+		boolean first = true;
+		while(st.hasMoreTokens()) {
+			String line = st.nextToken();
+			if(first) {
+				//first
+				first = false;
+				assertTrue(line.length()==3);
+				assertEquals("/**", line); 
+			} else {
+				if(st.hasMoreTokens()) {
+					//in the middle
+					assertTrue(line.length()>=2);
+					assertEquals(" *", line.substring(0, 2)); 
+				} else {
+					//last
+					assertTrue(line.length()==3);
+					assertEquals(" */", line.substring(0, 3)); 
+				}
+			}
+		}
 		assertEquals("JavaDoc test class."+EOL+EOL
 				+ "Long description", classJavaDoc.getContent());
 

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -111,7 +111,7 @@ public class CommentTest {
 
 	@Test
 	public void testJavaDocComment() {
-		//the EOL is taken from JavaDocComment.java, which is commited in git with linux \n
+		//the EOL is taken from JavaDocComment.java, which is committed in git with linux \n
 		//that is true on Windows too.
 		String EOL = "\n";
 
@@ -121,7 +121,7 @@ public class CommentTest {
 		CtJavaDoc classJavaDoc = (CtJavaDoc) type.getComments().get(0);
 		//contract: test that java doc is printed correctly
 		String str = classJavaDoc.toString();
-		StringTokenizer st = new StringTokenizer(str, "\n\r");
+		StringTokenizer st = new StringTokenizer(str, System.getProperty("line.separator"));
 		boolean first = true;
 		while(st.hasMoreTokens()) {
 			String line = st.nextToken();


### PR DESCRIPTION
The comments were printed wrong on MS Windows, when java source lines are separated by "\n" (it is case of sources which are checked out from GIT), while MS Windows EOL is "\n\r".

The new algorithm should split lines of comments independent on current OS.