### PR TITLE
review: Fix null in substitution visitor

### DIFF
--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -630,6 +630,9 @@ public class SubstitutionVisitor extends CtScanner {
 		}
 
 		private String substituteName(String name) {
+			if (name == null) {
+				return null;
+			}
 			if (parameterNameToValue != null) {
 				for (Map.Entry<String, Object> e : parameterNameToValue.entrySet()) {
 					String pname = e.getKey();


### PR DESCRIPTION
This can happen when another Spoon code is buggy and delivers null strings instead of "". See #1442.

There is not possible to create test if other code is fixed