### PR TITLE
review fix: Invalid use of type access generics

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -485,7 +485,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.write(" ");
 		try (Writable _context = context.modify()) {
 			if (operator.getKind() == BinaryOperatorKind.INSTANCEOF) {
-				_context.ignoreGenerics(true);
+				_context.forceWildcardGenerics(true);
 			}
 			scan(operator.getRightHandOperand());
 		}

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -232,7 +232,11 @@ public class ElementPrinterHelper {
 				for (CtTypeReference<?> argument : arguments) {
 					if (!argument.isImplicit()) {
 						lp.printSeparatorIfAppropriate();
-						prettyPrinter.scan(argument);
+						if (prettyPrinter.context.forceWildcardGenerics()) {
+							printer.write('?');
+						} else {
+							prettyPrinter.scan(argument);
+						}
 					}
 				}
 			}

--- a/src/main/java/spoon/reflect/visitor/PrintingContext.java
+++ b/src/main/java/spoon/reflect/visitor/PrintingContext.java
@@ -31,6 +31,7 @@ public class PrintingContext {
 	private long SKIP_ARRAY 			= 1 << 2;
 	private long IGNORE_STATIC_ACCESS   = 1 << 3;
 	private long IGNORE_ENCLOSING_CLASS = 1 << 4;
+	private long FORCE_WILDCARD_GENERICS = 1 << 5;
 
 	private long state;
 
@@ -48,6 +49,9 @@ public class PrintingContext {
 	}
 	public boolean ignoreEnclosingClass() {
 		return (state & IGNORE_ENCLOSING_CLASS) != 0L;
+	}
+	public boolean forceWildcardGenerics() {
+		return (state & FORCE_WILDCARD_GENERICS) != 0L;
 	}
 
 	public class Writable implements AutoCloseable {
@@ -79,6 +83,10 @@ public class PrintingContext {
 		}
 		public <T extends Writable> T ignoreEnclosingClass(boolean v) {
 			setState(IGNORE_ENCLOSING_CLASS, v);
+			return (T) this;
+		}
+		public <T extends Writable> T forceWildcardGenerics(boolean v) {
+			setState(FORCE_WILDCARD_GENERICS, v);
 			return (T) this;
 		}
 		private void setState(long mask, boolean v) {

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -1043,7 +1043,7 @@ public class TemplateTest {
 		assertEquals("spoon.test.template.TypeReferenceClassAccess.Example<java.util.Date> ret = new spoon.test.template.TypeReferenceClassAccess.Example<java.util.Date>()", method.getBody().getStatement(1).toString());
 		assertEquals("o = spoon.test.template.TypeReferenceClassAccess.Example.currentTimeMillis()", method.getBody().getStatement(2).toString());
 		assertEquals("o = spoon.test.template.TypeReferenceClassAccess.Example.class", method.getBody().getStatement(3).toString());
-		assertEquals("o = (o) instanceof spoon.test.template.TypeReferenceClassAccess.Example", method.getBody().getStatement(4).toString());
+		assertEquals("o = (o) instanceof spoon.test.template.TypeReferenceClassAccess.Example<?>", method.getBody().getStatement(4).toString());
 		assertEquals("java.util.function.Supplier<java.lang.Long> p = spoon.test.template.TypeReferenceClassAccess.Example::currentTimeMillis", method.getBody().getStatement(5).toString());
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -1041,5 +1041,9 @@ public class TemplateTest {
 		assertEquals("spoon.test.template.TypeReferenceClassAccess.Example<java.util.Date>", method.getParameters().get(0).getType().toString());
 		assertEquals("o = spoon.test.template.TypeReferenceClassAccess.Example.out", method.getBody().getStatement(0).toString());
 		assertEquals("spoon.test.template.TypeReferenceClassAccess.Example<java.util.Date> ret = new spoon.test.template.TypeReferenceClassAccess.Example<java.util.Date>()", method.getBody().getStatement(1).toString());
+		assertEquals("o = spoon.test.template.TypeReferenceClassAccess.Example.currentTimeMillis()", method.getBody().getStatement(2).toString());
+		assertEquals("o = spoon.test.template.TypeReferenceClassAccess.Example.class", method.getBody().getStatement(3).toString());
+		assertEquals("o = (o) instanceof spoon.test.template.TypeReferenceClassAccess.Example", method.getBody().getStatement(4).toString());
+		assertEquals("java.util.function.Supplier<java.lang.Long> p = spoon.test.template.TypeReferenceClassAccess.Example::currentTimeMillis", method.getBody().getStatement(5).toString());
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/TypeReferenceClassAccessTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/TypeReferenceClassAccessTemplate.java
@@ -1,5 +1,7 @@
 package spoon.test.template.testclasses;
 
+import java.util.function.Supplier;
+
 import spoon.reflect.reference.CtTypeReference;
 import spoon.template.ExtensionTemplate;
 import spoon.template.Local;
@@ -11,6 +13,10 @@ public class TypeReferenceClassAccessTemplate extends ExtensionTemplate {
 	$Type$ someMethod($Type$ param) {
 		o = $Type$.out;
 		$Type$ ret = new $Type$();
+		o = $Type$.currentTimeMillis();
+		o = $Type$.class;
+		o = o instanceof $Type$;
+		Supplier<Long> p = $Type$::currentTimeMillis;
 		return ret;
 	}
 	


### PR DESCRIPTION
Here is the failing test, which shows that Spoon prints actual type arguments in class access: `List<Object>.class`

Is it problem of pretty printer or SubstitutionVisitor?
