### PR TITLE
review: fix splitting of comment by EOL

### DIFF
--- a/src/main/java/spoon/reflect/code/CtComment.java
+++ b/src/main/java/spoon/reflect/code/CtComment.java
@@ -52,6 +52,13 @@ public interface CtComment extends CtStatement {
 	}
 
 	/**
+	 * This line separator is used in comments returned by {@link #getContent()}.
+	 * It is OS independent.
+	 * It has no influence to pretty printed comments, which uses by default OS dependent line separator
+	 */
+	String LINE_SEPARATOR = "\n";
+
+	/**
 	 * Get the content of the comment
 	 * @return the content of the comment
 	 */

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -169,11 +169,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public static final String BLOCK_COMMENT_START = "/* ";
 
 	/**
-	 * RegExp which matches all possible line separators
-	 */
-	private static final String LINE_SEPARATORS_RE = "\\n\\r|\\n|\\r";
-
-	/**
 	 * The printing context.
 	 */
 	public PrintingContext context = new PrintingContext();
@@ -904,7 +899,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.write(docTag.getParam()).writeln().writeTabs();
 		}
 
-		String[] tagLines = docTag.getContent().split(LINE_SEPARATORS_RE);
+		String[] tagLines = docTag.getContent().split(CtComment.LINE_SEPARATOR);
 		for (int i = 0; i < tagLines.length; i++) {
 			String com = tagLines[i];
 			if (i > 0 || docTag.getType().hasParam()) {
@@ -942,7 +937,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				printer.write(content);
 				break;
 			default:
-				String[] lines = content.split(LINE_SEPARATORS_RE);
+				String[] lines = content.split(CtComment.LINE_SEPARATOR);
 				for (int i = 0; i < lines.length; i++) {
 					String com = lines[i];
 					if (comment.getCommentType() == CtComment.CommentType.BLOCK) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -20,6 +20,8 @@ import org.apache.log4j.Logger;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+
+import spoon.SpoonException;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
@@ -51,15 +53,20 @@ import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 
+import java.io.BufferedReader;
+import java.io.CharArrayReader;
 import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * The comment builder that will insert all element of a CompilationUnitDeclaration into the Spoon AST
  */
-@SuppressWarnings("unchecked")
 class JDTCommentBuilder {
 
 	private static final Logger LOGGER = Logger.getLogger(JDTCommentBuilder.class);
@@ -526,38 +533,60 @@ class JDTCommentBuilder {
 	 * @return the content of the comment
 	 */
 	private String getCommentContent(int start, int end) {
-		//skip comment prefix
-		start += 2;
-		return cleanComment(new String(contents, start, end - start));
+		return cleanComment(new CharArrayReader(contents, start, end - start));
 	}
 
 	public static String cleanComment(String comment) {
-		StringBuffer ret = new StringBuffer();
-		String[] lines = comment.split("\n");
-		// limit case
-		if (lines.length == 1) {
-			return lines[0].replaceAll("^/\\*+ ?", "").replaceAll("\\*+/$", "").trim();
-		}
+		return cleanComment(new StringReader(comment));
+	}
 
-		for (String s : lines) {
-			String cleanUpLine = s.trim();
-			if (cleanUpLine.startsWith("/**")) {
-				cleanUpLine = cleanUpLine.replaceAll("/\\*+ ?", "");
-			} else if (cleanUpLine.endsWith("*/")) {
-				cleanUpLine = cleanUpLine.replaceAll("\\*+/$", "").replaceAll("^[ \t]*\\*+ ?", "");
+	private static final Pattern startCommentRE = Pattern.compile("^/\\*{1,2} ?");
+	private static final Pattern middleCommentRE = Pattern.compile("^[ \t]*\\*? ?");
+	private static final Pattern endCommentRE = Pattern.compile("\\*/$");
+
+	private static String cleanComment(Reader comment) {
+		StringBuilder ret = new StringBuilder();
+		try (BufferedReader br = new BufferedReader(comment)) {
+			String line = br.readLine();
+			if (line.length() < 2 || line.charAt(0) != '/') {
+				throw new SpoonException("Unexpected beginning of comment");
+			}
+			boolean isLastLine = false;
+			if (line.charAt(1) == '/') {
+				//it is single line comment, which starts with "//"
+				isLastLine = true;
+				line = line.substring(2);
 			} else {
-				cleanUpLine = cleanUpLine.replaceAll("^[ \t]*\\*+ ?", "");
+				//it is potentially multiline comment, which starts with "/*" or "/**"
+				//check end first
+				if (line.endsWith("*/")) {
+					//it is last line
+					line = endCommentRE.matcher(line).replaceFirst("");
+					isLastLine = true;
+				}
+				//skip beginning
+				line = startCommentRE.matcher(line).replaceFirst("");
 			}
-			ret.append(cleanUpLine);
-			ret.append("\n");
-		}
-		// clean '\r'
-		StringBuffer ret2 = new StringBuffer();
-		for (int i = 0; i < ret.length(); i++) {
-			if (ret.charAt(i) != '\r') {
-				ret2.append(ret.charAt(i));
+			//append first line
+			ret.append(line);
+			while ((line = br.readLine()) != null) {
+				if (isLastLine) {
+					throw new SpoonException("Unexpected next line after last line");
+				}
+				if (line.endsWith("*/")) {
+					//it is last line
+					line = endCommentRE.matcher(line).replaceFirst("");
+					isLastLine = true;
+				}
+				//always clean middle comment, but after end comment is detected
+				line = middleCommentRE.matcher(line).replaceFirst("");
+				//write next line - Note that Spoon model comment's lines are always separated by "\n"
+				ret.append(CtComment.LINE_SEPARATOR);
+				ret.append(line);
 			}
+			return ret.toString().trim();
+		} catch (IOException e) {
+			throw new SpoonException(e);
 		}
-		return ret2.toString().trim();
 	}
 }

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -15,6 +15,7 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtReturn;
@@ -47,6 +48,7 @@ import spoon.test.comment.testclasses.Comment2;
 import spoon.test.comment.testclasses.InlineComment;
 import spoon.test.comment.testclasses.JavaDocComment;
 import spoon.test.comment.testclasses.JavaDocEmptyCommentAndTags;
+import spoon.test.comment.testclasses.WildComments;
 import spoon.test.comment.testclasses.WindowsEOL;
 
 import java.io.File;
@@ -58,6 +60,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
@@ -860,5 +863,23 @@ public class CommentTest {
 		assertEquals("This file contains MS Windows EOL.\n"
 				+ "It is here to test whether comments are printed well\n"
 				+ "in this case", classJavaDoc.getContent());
+	}
+
+	@Test
+	public void testWildComments() {
+		//contract: tests that value of comment is correct even for wild combinations of characters. See WildComments class for details
+		Factory f = getSpoonFactory();
+		CtClass<?> type = (CtClass<?>) f.Type().get(WildComments.class);
+		List<CtLiteral<String>> literals = (List)((CtNewArray<?>)type.getField("comments").getDefaultExpression()).getElements();
+		assertTrue(literals.size()>10);
+		/*
+		 * each string literal has a comment and string value, which defines expected value of it's comment
+		 */
+		for (CtLiteral<String> literal : literals) {
+			assertEquals(1, literal.getComments().size());
+			CtComment comment = literal.getComments().get(0);
+			String expected = literal.getValue();
+			assertEquals(literal.getPosition().toString(), expected, comment.getContent());
+		}
 	}
 }

--- a/src/test/java/spoon/test/comment/testclasses/WildComments.java
+++ b/src/test/java/spoon/test/comment/testclasses/WildComments.java
@@ -1,0 +1,119 @@
+package spoon.test.comment.testclasses;
+
+public class WildComments {
+	/*
+	 * each string literal below is a pair of a comment and a string value.
+	 * The string literal value defines expected value of `CtComment#getContent()` of it's comment
+	 */
+	String[] comments = new String[]{
+			///* test single line comments with nested * and */ and **/
+			"/* test single line comments with nested * and */ and **/",
+			//* starts with *
+			"* starts with *",
+			///* starts with /*
+			"/* starts with /*",
+			//*/ starts with */
+			"*/ starts with */",
+			// */ starts with space and */
+			"*/ starts with space and */",
+			/// starts with /
+			"/ starts with /",
+			//// starts with //
+			"// starts with //",
+
+			/* test wild multiline comments */
+			"test wild multiline comments",
+			/*/ starts with /*/
+			"/ starts with /",
+			/* / starts with space and /*/
+			"/ starts with space and /",
+			/*// starts with //*/
+			"// starts with //",
+			/* // starts with space and // */
+			"// starts with space and //",
+			/*/* starts with /* */
+			"/* starts with /*",
+			/*
+			 * /* second line starts with /* */
+			"/* second line starts with /*",
+			/*
+			 * /* second line starts with /* and ends with /*
+			 * /* */
+			"/* second line starts with /* and ends with /*\n/*",
+			/*
+			 * 
+			 * 
+			 * trim all empty lines?
+			 * 
+			 * 
+			 */
+			"trim all empty lines?",
+			/*
+			 * 
+			 * 
+			 * trim all empty lines,
+			 * but not in the middle
+			 * 
+			 * 
+			 * of the comment!
+			 *  this line keeps prefix and trailing space 
+			 * 	but it was not last line, whose trailing space is ignored 
+			 * 
+			 */
+			"trim all empty lines,\nbut not in the middle\n\n\nof the comment!\n this line keeps prefix and trailing space \n	but it was not last line, whose trailing space is ignored",
+			/*
+			 // 1 second line starts with // */
+			"// 1 second line starts with //",
+			/*
+			 * // 2 second line starts with // */
+			"// 2 second line starts with //",
+			/*
+			 * // 3 second line starts with // 
+			 */
+			"// 3 second line starts with //",
+			/*
+			 * // 4 second line starts with // 
+			 * */
+			"// 4 second line starts with //",
+			/**/
+			"",
+			/***/
+			"",
+			/****/
+			"*",
+			/*****/
+			"**",
+			/* */
+			"",
+			/** */
+			"",
+			/** **/
+			"*",
+			/*
+			 */
+			"",
+			/*
+			 * 
+			 */
+			"",
+			/*
+			  
+			 */
+			"",
+
+			/** test wild javadoc comments */
+			"test wild javadoc comments",
+			/** / starts with space and /*/
+			"/ starts with space and /",
+			/** // starts with space and //*/
+			"// starts with space and //",
+			/** /* starts with space and /* */
+			"/* starts with space and /*",
+
+			/*** starts and ends with 3 * ***/
+			"* starts and ends with 3 * **",
+			/**** starts and ends with 4 * ****/
+			"** starts and ends with 4 * ***"
+	};
+}
+ 

--- a/src/test/java/spoon/test/comment/testclasses/WindowsEOL.java
+++ b/src/test/java/spoon/test/comment/testclasses/WindowsEOL.java
@@ -1,0 +1,11 @@
+package spoon.test.comment.testclasses;
+
+/**
+ * This file contains MS Windows EOL.
+ * It is here to test whether comments are printed well
+ * in this case
+ * 
+ * @author pvojtechovsky
+ */
+public class WindowsEOL {
+}


### PR DESCRIPTION
The RegExp for splitting of comments by EOL was wrong. MS Windows is using `\r\n` and not `\n\r` like it was wrong before