### PR TITLE
fix: clarifies the contract of proxy template parameters

### DIFF
--- a/src/main/java/spoon/template/Parameter.java
+++ b/src/main/java/spoon/template/Parameter.java
@@ -37,11 +37,24 @@ import spoon.support.template.ParameterMatcher;
 public @interface Parameter {
 	/**
 	 * Defines the name of the parameter (optional, mostly to avoid name
-	 * clashes). By default, the name of a template parameter is the simple name
-	 * of the annotated field. However, in some cases, it can be useful to set a
-	 * different name to a parameter in order to avoid name clashes, in
-	 * particular when a parameter represents the name of a templated field. For
-	 * instance:
+	 * clashes). In most cases, the annotation does not have a "value" and the name of a template parameter is the simple name
+	 * of the annotated field.
+	 *
+	 * <pre>
+	 * class T extends Template {
+	 * 	\@Parameter
+	 * 	CtExpression&lt;String&gt; $i;
+	 *
+	 * 	String s = $i.S();
+	 * }
+	 * </pre>
+	 *
+	 * However, in rare cases, eg to rename named elements that are in the same scope
+	 * as the template parameter, such as renaming of fields or nested types, the annotation value
+	 * is used to set a
+	 * template parameter name (aka a proxy). In this case:
+	 * contract 1: if "value" is set, then the template field type must be String
+	 * contract 2: if "value" is set, then the actual name of the field must be the name of the template parameter prefixed by "_"
 	 *
 	 * <pre>
 	 * class T extends Template {
@@ -49,7 +62,7 @@ public @interface Parameter {
 	 * 	\@Parameter(&quot;_i_&quot;)
 	 * 	String __i_;
 	 *
-	 * 	int _i_;
+	 * 	int _i_; // the field to be renamed
 	 * }
 	 * </pre>
 	 */

--- a/src/main/java/spoon/template/Parameter.java
+++ b/src/main/java/spoon/template/Parameter.java
@@ -54,7 +54,7 @@ public @interface Parameter {
 	 * is used to set a
 	 * template parameter name (aka a proxy). In this case:
 	 * contract 1: if "value" is set, then the template field type must be String
-	 * contract 2: if "value" is set, then the actual name of the field must be the name of the template parameter prefixed by "_"
+	 * contract 2: if a proxy parameter is declared and named "x" (@Parameter("x")), then a type member named "x" must exist (the one to be renamed).
 	 *
 	 * <pre>
 	 * class T extends Template {

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -669,15 +669,30 @@ public abstract class Substitution {
 
 	private static <T> void checkTemplateContracts(CtClass<T> c) {
 		for (CtField f : c.getFields()) {
-			if (f.getAnnotation(Parameter.class) != null && !f.getAnnotation(Parameter.class).value().equals("")) {
+			Parameter templateParamAnnotation = f.getAnnotation(Parameter.class);
+			if (templateParamAnnotation != null && !templateParamAnnotation.value().equals("")) {
+				String proxyName = templateParamAnnotation.value();
 				// contract: if value, then the field type must be String
 				if (!f.getType().equals(c.getFactory().Type().STRING)) {
 					throw new TemplateException("proxy template parameter must be typed as String " +  f.getType().getQualifiedName());
 				}
 
 				// contract: the name of the template parameter must correspond to the name of the field
-				if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
-					throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
+				// as found, by Pavel, this is not good contract because it prevents easy refactoring of templates
+				// we remove it but keep th commented code in case somebody would come up with this bad idae
+//				if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
+//					throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
+//				}
+
+				// contract: if a proxy parameter is declared and named "x" (@Parameter("x")), then a type member named "x" must exist.
+				boolean found=false;
+				for(CtTypeMember member: c.getTypeMembers()) {
+					if (member.getSimpleName().equals(proxyName)) {
+						found = true;
+					}
+				}
+				if (!found) {
+					throw new TemplateException("if a proxy parameter is declared and named \"x\", then a type member named \"x\" must exist.");
 				}
 
 			}

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -692,7 +692,7 @@ public abstract class Substitution {
 					}
 				}
 				if (!found) {
-					throw new TemplateException("if a proxy parameter is declared and named \"x\", then a type member named \"x\" must exist.");
+					throw new TemplateException("if a proxy parameter is declared and named \""+proxyName+"\", then a type member named \"\"+proxyName+\"\" must exist.");
 				}
 
 			}

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -663,7 +663,25 @@ public abstract class Substitution {
 		if (c.isShadow()) {
 			throw new SpoonException("The template " + template.getClass().getName() + " is not part of model. Add template sources to spoon template path.");
 		}
+		checkTemplateContracts(c);
 		return c;
+	}
+
+	private static <T> void checkTemplateContracts(CtClass<T> c) {
+		for (CtField f : c.getFields()) {
+			if (f.getAnnotation(Parameter.class) != null && !f.getAnnotation(Parameter.class).value().equals("")) {
+				// contract: if value, then the field type must be String
+				if (!f.getType().equals(c.getFactory().Type().STRING)) {
+					throw new TemplateException("proxy template parameter must be typed as String " +  f.getType().getQualifiedName());
+				}
+
+				// contract: the name of the template parameter must correspond to the name of the field
+				if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
+					throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
+				}
+
+			}
+		}
 	}
 
 	/**

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -685,14 +685,14 @@ public abstract class Substitution {
 //				}
 
 				// contract: if a proxy parameter is declared and named "x" (@Parameter("x")), then a type member named "x" must exist.
-				boolean found=false;
-				for(CtTypeMember member: c.getTypeMembers()) {
+				boolean found = false;
+				for (CtTypeMember member: c.getTypeMembers()) {
 					if (member.getSimpleName().equals(proxyName)) {
 						found = true;
 					}
 				}
 				if (!found) {
-					throw new TemplateException("if a proxy parameter is declared and named \""+proxyName+"\", then a type member named \"\"+proxyName+\"\" must exist.");
+					throw new TemplateException("if a proxy parameter is declared and named \"" + proxyName + "\", then a type member named \"\" + proxyName + \"\" must exist.");
 				}
 
 			}

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -743,48 +743,5 @@ public class TemplateTest {
 			assertEquals("this.m_A = p_A", method1.getBody().getStatement(0).toString());
 			assertEquals("setA(\"The A is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
 		}
-		{
-			//contract: Type value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
-			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
-			assertEquals("setObject", method1.getSimpleName());
-			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
-			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: Type reference value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
-			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
-			assertEquals("setObject", method1.getSimpleName());
-			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
-			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: String literal value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.createLiteral("Xxx")).apply(factory.createClass());
-			assertEquals("java.lang.String m_Xxx = \"Xxx is here more times: Xxx\";", result.getField("m_Xxx").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setXxx").get(0);
-			assertEquals("setXxx", method1.getSimpleName());
-			assertEquals("java.lang.String p_Xxx", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Xxx = p_Xxx", method1.getBody().getStatement(0).toString());
-			assertEquals("setXxx(\"The Xxx is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: The elements which cannot be converted to String should throw exception
-			SubStringTemplate template = new SubStringTemplate(factory.createSwitch());
-			try {
-				template.apply(factory.createClass());
-				fail();
-			} catch(SpoonException e) {
-				//OK
-			}
-		}
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -743,5 +743,48 @@ public class TemplateTest {
 			assertEquals("this.m_A = p_A", method1.getBody().getStatement(0).toString());
 			assertEquals("setA(\"The A is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
 		}
+		{
+			//contract: Type value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
+			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
+			assertEquals("setObject", method1.getSimpleName());
+			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
+			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: Type reference value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
+			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
+			assertEquals("setObject", method1.getSimpleName());
+			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
+			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: String literal value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.createLiteral("Xxx")).apply(factory.createClass());
+			assertEquals("java.lang.String m_Xxx = \"Xxx is here more times: Xxx\";", result.getField("m_Xxx").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setXxx").get(0);
+			assertEquals("setXxx", method1.getSimpleName());
+			assertEquals("java.lang.String p_Xxx", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Xxx = p_Xxx", method1.getBody().getStatement(0).toString());
+			assertEquals("setXxx(\"The Xxx is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: The elements which cannot be converted to String should throw exception
+			SubStringTemplate template = new SubStringTemplate(factory.createSwitch());
+			try {
+				template.apply(factory.createClass());
+				fail();
+			} catch(SpoonException e) {
+				//OK
+			}
+		}
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/EnumAccessTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/EnumAccessTemplate.java
@@ -1,7 +1,6 @@
 package spoon.test.template.testclasses;
 
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeReference;
 import spoon.template.ExtensionTemplate;
 import spoon.template.Local;
 import spoon.template.Parameter;
@@ -13,7 +12,7 @@ public class EnumAccessTemplate extends ExtensionTemplate {
 	}
 	
 	@Parameter("_AnEnum_")
-	CtTypeReference<?> anEnum;
+	String __AnEnum_;
 	
 	@Parameter
 	Enum _value_;
@@ -21,7 +20,7 @@ public class EnumAccessTemplate extends ExtensionTemplate {
 	@Local
 	public EnumAccessTemplate(Enum enumValue, Factory factory) {
 		this._value_ = enumValue;
-		this.anEnum = factory.Type().createReference(enumValue.getClass()); 
+		this.__AnEnum_ = enumValue.getClass().getCanonicalName();
 	}
 	
 	@Local

--- a/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByStatementTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/InvocationSubstitutionByStatementTemplate.java
@@ -12,12 +12,12 @@ public class InvocationSubstitutionByStatementTemplate extends StatementTemplate
 		_statement_();
 	}
 	
-	@Parameter("_statement_")
-	CtStatement statement;
+	@Parameter
+	CtStatement _statement_;
 
 	@Local
 	public InvocationSubstitutionByStatementTemplate(CtStatement statement) {
-		this.statement = statement;
+		this._statement_ = statement;
 	}
 	
 	@Local

--- a/src/test/java/spoon/test/template/testclasses/InvocationTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/InvocationTemplate.java
@@ -16,14 +16,14 @@ public class InvocationTemplate extends ExtensionTemplate {
 	@Local
 	public InvocationTemplate(CtTypeReference<?> ifaceType, String methodName) {
 		this._IFace = ifaceType.getSimpleName();
-		this._$method$ = methodName;
+		this.$method$ = methodName;
 	}
 
 	@Parameter("IFace")
 	String _IFace;
 	
-	@Parameter("$method$")
-	String _$method$;
+	@Parameter
+	String $method$;
 
 	
 	

--- a/src/test/java/spoon/test/template/testclasses/InvocationTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/InvocationTemplate.java
@@ -15,15 +15,15 @@ public class InvocationTemplate extends ExtensionTemplate {
 	
 	@Local
 	public InvocationTemplate(CtTypeReference<?> ifaceType, String methodName) {
-		this.ifaceType = ifaceType;
-		this.methodName = methodName;
+		this._IFace = ifaceType.getSimpleName();
+		this._$method$ = methodName;
 	}
 
 	@Parameter("IFace")
-	CtTypeReference<?> ifaceType;
+	String _IFace;
 	
 	@Parameter("$method$")
-	String methodName;
+	String _$method$;
 
 	
 	

--- a/src/test/java/spoon/test/template/testclasses/SubStringTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubStringTemplate.java
@@ -16,11 +16,11 @@ public class SubStringTemplate extends ExtensionTemplate{
 		set$name$("The $name$ is here too");
 	}
 	
-	@Parameter("$name$")
-	Object name;
+	@Parameter
+	String $name$;
 	
 	@Local
-	public SubStringTemplate(Object name) {
-		this.name = name;
+	public SubStringTemplate(String name) {
+		this.$name$ = name.toString();
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/SubStringTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubStringTemplate.java
@@ -17,10 +17,10 @@ public class SubStringTemplate extends ExtensionTemplate{
 	}
 	
 	@Parameter
-	String $name$;
+	Object $name$;
 	
 	@Local
-	public SubStringTemplate(String name) {
-		this.$name$ = name.toString();
+	public SubStringTemplate(Object o) {
+		this.$name$ = o;
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/SubstituteLiteralTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubstituteLiteralTemplate.java
@@ -13,12 +13,12 @@ public class SubstituteLiteralTemplate extends ExtensionTemplate{
 		System.out.println(Params.$param1$());
 	}
 	
-	@Parameter("$param1$")
-	Object param;
+	@Parameter
+	Object $param1$;
 	
 	@Local
 	public SubstituteLiteralTemplate(Object param) {
-		this.param = param;
+		this.$param1$ = param;
 	}
 }
 


### PR DESCRIPTION
@pvojtechovsky in #1444 has uncovered foggy parts in the template engine.

this PR is a first clarification about proxy template parameters (those with a value, eg `@Parameter("$name$")`.
 