### PR TITLE
review: fix object is not an template parameter implicitly

### DIFF
--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -268,8 +268,8 @@ public abstract class Parameters {
 			//the reference to this is not template parameter
 			return false;
 		}
-		if (getTemplateParameterType(ref.getFactory()).isSubtypeOf(ref.getType())) {
-			//the type of template field is or extends from class TemplateParameter.
+		if (TemplateParameter.class.getName().equals(ref.getType().getQualifiedName())) {
+			//the type of template field is TemplateParameter.
 			return true;
 		}
 		return false;

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -32,6 +32,7 @@ import spoon.test.template.testclasses.ArrayAccessTemplate;
 import spoon.test.template.testclasses.InvocationTemplate;
 import spoon.test.template.testclasses.LoggerModel;
 import spoon.test.template.testclasses.NtonCodeTemplate;
+import spoon.test.template.testclasses.ObjectIsNotParamTemplate;
 import spoon.test.template.testclasses.SecurityCheckerTemplate;
 import spoon.test.template.testclasses.SimpleTemplate;
 import spoon.test.template.testclasses.SubStringTemplate;
@@ -786,5 +787,18 @@ public class TemplateTest {
 				//OK
 			}
 		}
+	}
+
+	@Test
+	public void testObjectIsNotParamTemplate() throws Exception {
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/ObjectIsNotParamTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+		//contract: String value is substituted in substring of literal, named element and reference
+		final CtClass<?> result = (CtClass<?>) new ObjectIsNotParamTemplate().apply(factory.createClass());
+		assertEquals(0, result.getMethodsByName("methXXXd").size());
+		assertEquals(1, result.getMethodsByName("method").size());
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -32,7 +32,6 @@ import spoon.test.template.testclasses.ArrayAccessTemplate;
 import spoon.test.template.testclasses.InvocationTemplate;
 import spoon.test.template.testclasses.LoggerModel;
 import spoon.test.template.testclasses.NtonCodeTemplate;
-import spoon.test.template.testclasses.ObjectIsNotParamTemplate;
 import spoon.test.template.testclasses.SecurityCheckerTemplate;
 import spoon.test.template.testclasses.SimpleTemplate;
 import spoon.test.template.testclasses.SubStringTemplate;
@@ -728,14 +727,64 @@ public class TemplateTest {
 	public void substituteSubString() throws Exception {
 		//contract: the substitution of substrings works on named elements and references too
 		Launcher spoon = new Launcher();
-		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/ObjectIsNotParamTemplate.java"));
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubStringTemplate.java"));
 
 		spoon.buildModel();
 		Factory factory = spoon.getFactory();
 
-		//contract: String value is substituted in substring of literal, named element and reference
-		final CtClass<?> result = (CtClass<?>) new ObjectIsNotParamTemplate().apply(factory.createClass());
-		assertEquals(0, result.getMethodsByName("methXXXd").size());
-		assertEquals(1, result.getMethodsByName("method").size());
+		{
+			//contract: String value is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate("A").apply(factory.createClass());
+			assertEquals("java.lang.String m_A = \"A is here more times: A\";", result.getField("m_A").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setA").get(0);
+			assertEquals("setA", method1.getSimpleName());
+			assertEquals("java.lang.String p_A", method1.getParameters().get(0).toString());
+			assertEquals("this.m_A = p_A", method1.getBody().getStatement(0).toString());
+			assertEquals("setA(\"The A is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: Type value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
+			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
+			assertEquals("setObject", method1.getSimpleName());
+			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
+			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: Type reference value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
+			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
+			assertEquals("setObject", method1.getSimpleName());
+			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
+			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: String literal value name is substituted in substring of literal, named element and reference
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.createLiteral("Xxx")).apply(factory.createClass());
+			assertEquals("java.lang.String m_Xxx = \"Xxx is here more times: Xxx\";", result.getField("m_Xxx").toString());
+			//contract: the parameter of type string replaces substring in method name
+			CtMethod<?> method1 = result.getMethodsByName("setXxx").get(0);
+			assertEquals("setXxx", method1.getSimpleName());
+			assertEquals("java.lang.String p_Xxx", method1.getParameters().get(0).toString());
+			assertEquals("this.m_Xxx = p_Xxx", method1.getBody().getStatement(0).toString());
+			assertEquals("setXxx(\"The Xxx is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
+		}
+		{
+			//contract: The elements which cannot be converted to String should throw exception
+			SubStringTemplate template = new SubStringTemplate(factory.createSwitch());
+			try {
+				template.apply(factory.createClass());
+				fail();
+			} catch(SpoonException e) {
+				//OK
+			}
+		}
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -32,6 +32,7 @@ import spoon.test.template.testclasses.ArrayAccessTemplate;
 import spoon.test.template.testclasses.InvocationTemplate;
 import spoon.test.template.testclasses.LoggerModel;
 import spoon.test.template.testclasses.NtonCodeTemplate;
+import spoon.test.template.testclasses.ObjectIsNotParamTemplate;
 import spoon.test.template.testclasses.SecurityCheckerTemplate;
 import spoon.test.template.testclasses.SimpleTemplate;
 import spoon.test.template.testclasses.SubStringTemplate;
@@ -727,64 +728,14 @@ public class TemplateTest {
 	public void substituteSubString() throws Exception {
 		//contract: the substitution of substrings works on named elements and references too
 		Launcher spoon = new Launcher();
-		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubStringTemplate.java"));
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/ObjectIsNotParamTemplate.java"));
 
 		spoon.buildModel();
 		Factory factory = spoon.getFactory();
 
-		{
-			//contract: String value is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate("A").apply(factory.createClass());
-			assertEquals("java.lang.String m_A = \"A is here more times: A\";", result.getField("m_A").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setA").get(0);
-			assertEquals("setA", method1.getSimpleName());
-			assertEquals("java.lang.String p_A", method1.getParameters().get(0).toString());
-			assertEquals("this.m_A = p_A", method1.getBody().getStatement(0).toString());
-			assertEquals("setA(\"The A is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: Type value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
-			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
-			assertEquals("setObject", method1.getSimpleName());
-			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
-			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: Type reference value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
-			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
-			assertEquals("setObject", method1.getSimpleName());
-			assertEquals("java.lang.String p_Object", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Object = p_Object", method1.getBody().getStatement(0).toString());
-			assertEquals("setObject(\"The Object is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: String literal value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.createLiteral("Xxx")).apply(factory.createClass());
-			assertEquals("java.lang.String m_Xxx = \"Xxx is here more times: Xxx\";", result.getField("m_Xxx").toString());
-			//contract: the parameter of type string replaces substring in method name
-			CtMethod<?> method1 = result.getMethodsByName("setXxx").get(0);
-			assertEquals("setXxx", method1.getSimpleName());
-			assertEquals("java.lang.String p_Xxx", method1.getParameters().get(0).toString());
-			assertEquals("this.m_Xxx = p_Xxx", method1.getBody().getStatement(0).toString());
-			assertEquals("setXxx(\"The Xxx is here too\")", result.getMethodsByName("m").get(0).getBody().getStatements().get(0).toString());
-		}
-		{
-			//contract: The elements which cannot be converted to String should throw exception
-			SubStringTemplate template = new SubStringTemplate(factory.createSwitch());
-			try {
-				template.apply(factory.createClass());
-				fail();
-			} catch(SpoonException e) {
-				//OK
-			}
-		}
+		//contract: String value is substituted in substring of literal, named element and reference
+		final CtClass<?> result = (CtClass<?>) new ObjectIsNotParamTemplate().apply(factory.createClass());
+		assertEquals(0, result.getMethodsByName("methXXXd").size());
+		assertEquals(1, result.getMethodsByName("method").size());
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/ObjectIsNotParamTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/ObjectIsNotParamTemplate.java
@@ -1,0 +1,17 @@
+package spoon.test.template.testclasses;
+
+import spoon.template.ExtensionTemplate;
+import spoon.template.Local;
+
+public class ObjectIsNotParamTemplate extends ExtensionTemplate {
+
+	//this is normal field of type Object - it must not be considered as template parameter automatically
+	Object o = "XXX";
+	
+	//the "o" in the method name must not be substituted
+	void method() {}
+	
+	@Local
+	public ObjectIsNotParamTemplate() {
+	}
+}


### PR DESCRIPTION
```java
public class ObjectIsNotParamTemplate extends ExtensionTemplate {

	//this is normal field of type Object - it must not be considered as template parameter automatically
	Object o = "XXX";
	
	//the "o" in the method name must not be substituted
	void method() {}
	
	@Local
	public ObjectIsNotParamTemplate() {
	}
}
```
This template generated method with name `methXXXd` and it is of course wrong. This PR fixes this behavior.

May be the origin idea of the author was that each field whose type is subtype of TemplateParameter is automatically a template parameter. If you think that this contract is correct then implement it in another PR. I will have no time to continue on this PR in near future, so please merge it as it is - with fix only.