### PR TITLE
review: fix: ignore only expected ClassCastException

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -339,9 +339,15 @@ public class CtQueryImpl implements CtQuery {
 			try {
 				nextStep.accept(element);
 			} catch (ClassCastException e) {
-				if (Launcher.LOGGER.isTraceEnabled()) {
-					//log expected CCE ... there might be some unexpected too!
-					Launcher.LOGGER.trace(e);
+				StackTraceElement[] stackEles = e.getStackTrace();
+				if (stackEles.length > 1 && stackEles[0].getClassName().equals(getClass().getName()) && stackEles[0].getMethodName().equals("accept")) {
+					if (Launcher.LOGGER.isTraceEnabled()) {
+						//log expected CCE ... there might be some unexpected too!
+						Launcher.LOGGER.trace(e);
+					}
+				} else {
+					//Do not ignore this exception it is not expected!
+					throw new SpoonException("Execution of query callback failed", e);
 				}
 			}
 		}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -878,12 +878,28 @@ public class FilterTest {
 			int count = 0;
 		}
 		
-		Context context = new Context();
-		//contract: if the query produces elements which cannot be cast to forEach consumer, then they are ignored
-		launcher.getFactory().Package().getRootPackage().filterChildren(f->{return true;}).forEach((CtType t)->{
-			context.count++;
-		});
-		assertTrue(context.count>0);
+		{
+			Context context = new Context();
+			//contract: if the query produces elements which cannot be cast to forEach consumer, then they are ignored
+			launcher.getFactory().Package().getRootPackage().filterChildren(f->{return true;}).forEach((CtType t)->{
+				context.count++;
+			});
+			assertTrue(context.count>0);
+		}
+		{
+			Context context = new Context();
+			//contract: if the for each implementation throws CCE then it is reported
+			try {
+				launcher.getFactory().Package().getRootPackage().filterChildren(f->{return true;}).forEach((CtType t)->{
+					context.count++;
+					throw new ClassCastException("TEST");
+				});
+				fail("It must fail, because body of forEach should be called and thrown CCE");
+			} catch (SpoonException e) {
+				assertTrue(context.count>0);
+				assertEquals("TEST", e.getCause().getMessage());
+			}
+		}
 	}
 	
 	@Test


### PR DESCRIPTION
If the client's code called in query callback fails with ClassCastException then this exception is actually silently ignored, because of one Spoon query contract.
This PR fixes this behavior by way that it distinguish between expected CCE in spoon code, which is still ignored as specified in contract, but client's CCEs are not ignored - s/he need to know about them, of course.

Something similar should be implemented into all Query callbacks too.