### PR TITLE
fix Substitution#createTypeFromTemplate return type

### DIFF
--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -19,9 +19,7 @@ package spoon.template;
 import spoon.SpoonException;
 import spoon.processing.FactoryAccessor;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
@@ -37,17 +35,13 @@ import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
-import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.support.template.Parameters;
 import spoon.support.template.SubstitutionVisitor;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -91,7 +85,7 @@ public abstract class Substitution {
 			}
 		}
 	}
-	
+
 	/**
 	 * Generates a type (class, interface, enum, ...) from the template model `templateOfType`
 	 * by by substituting all the template parameters by their values.
@@ -214,7 +208,6 @@ public abstract class Substitution {
 	 * 		the model of source template
 	 */
 	static void insertAllMethods(CtType<?> targetType, Template<?> template, CtClass<?> sourceClass) {
-
 		Set<CtMethod<?>> methodsOfTemplate = sourceClass.getFactory().Type().get(Template.class).getMethods();
 		// insert all the methods
 		for (CtMethod<?> m : sourceClass.getMethods()) {

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -119,7 +119,7 @@ public abstract class Substitution {
 		CtPackage targetPackage = f.Package().getOrCreate(typeRef.getPackage().getSimpleName());
 		final Map<String, Object> extendedParams = new HashMap<String, Object>(templateParameters);
 		extendedParams.put(templateOfType.getSimpleName(), typeRef);
-		List<CtType<?>> generated = new SubstitutionVisitor(f, extendedParams).substitute(templateOfType.clone());
+		List<CtType<?>> generated = (List) new SubstitutionVisitor(f, extendedParams).substitute(templateOfType.clone());
 		for (CtType<?> ctType : generated) {
 			targetPackage.addType(ctType);
 		}


### PR DESCRIPTION
It can be used without need to cast return value now.