### PR TITLE
community: @pvojtechovsky gets merge honor and responsibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Current integrators (alphabetical order):
 - Thomas Durieux @tdurieux
 - Martin Monperrus @monperrus
 - Simon Urli @surli
+- Pavel Vojtechovsky @pvojtechovsky
 
 Guidelines for pull requests
 ----------------------------


### PR DESCRIPTION
I propose that Pavel @pvojtechovsky gets write access to the repo, so that he can review and merge other PRs.

For months, Pavel has done deep contributions to Spoon, and knows the design, the testing practices and the way we communicate and find consensus in the community.

I'm sure that Pavel will do a great integrator job.

@pvojtechovsky do you agree with the [integrator code of conduct](https://github.com/INRIA/spoon/blob/master/CONTRIBUTING.md) ?

@tdurieux @surli @danglotb do you agree that @pvojtechovsky joins the integrator committee? 