### PR TITLE
review: performance of DoNotFurtherTemplateThisElement

### DIFF
--- a/src/main/java/spoon/support/template/SubstitutionVisitor.java
+++ b/src/main/java/spoon/support/template/SubstitutionVisitor.java
@@ -58,8 +58,10 @@ class DoNotFurtherTemplateThisElement extends SpoonException {
 
 	Object skipped;
 
-	DoNotFurtherTemplateThisElement(Object e) {
-		super("skipping " + e.toString());
+	DoNotFurtherTemplateThisElement(CtElement e) {
+		//Do not use e.toString(), which computes expensive String representation of whole element,
+		//which is sometime impossible to compute correctly in the middle of the substitution process
+		super("Skipping " + e.getClass().getName());
 		skipped = e;
 	}
 


### PR DESCRIPTION
The SubstitutionVisitor throws DoNotFurtherTemplateThisElement, which internally pretty printed the to be skipped element. It is not good idea because:
* it needs time to pretty print that element - why to do it that if nobody ever needs this information?
* it happened to me that printing failed, because the model is substituted only partially at this time. It happened during development of #1444, but it was probably side effect of bug fixed by #1477, so it does not fail anymore. Therefore I am not able to create failing test for this PR.
