### PR TITLE
perf: Collect list of source files only once

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -50,6 +50,10 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 		this.files = files;
 	}
 
+	/*
+	 * This method is not used now, so let's get rid of it.
+	 */
+	@Deprecated
 	public FileCompilerConfig(SpoonFolder folder) {
 		this(folder.getAllJavaFiles());
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -384,7 +384,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			return EMPTY_RESULT;
 		}
 
-		JDTBatchCompiler batchCompiler = createBatchCompiler(new FileCompilerConfig(sourcesFolder));
+		JDTBatchCompiler batchCompiler = createBatchCompiler(new FileCompilerConfig(sourceFiles));
 
 		String[] args;
 		if (jdtBuilder == null) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -379,7 +379,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 	private static final CompilationUnitDeclaration[] EMPTY_RESULT = new CompilationUnitDeclaration[0];
 
 	protected CompilationUnitDeclaration[] buildUnits(JDTBuilder jdtBuilder, SpoonFolder sourcesFolder, String[] classpath, String debugMessagePrefix, boolean buildOnlyOutdatedFiles) {
-		List<SpoonFile> sourceFiles = sourcesFolder.getAllJavaFiles();
+		List<SpoonFile> sourceFiles = Collections.unmodifiableList(sourcesFolder.getAllJavaFiles());
 		if (sourceFiles.isEmpty()) {
 			return EMPTY_RESULT;
 		}
@@ -392,7 +392,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 					.classpathOptions(new ClasspathOptions().encoding(this.encoding).classpath(classpath)) //
 					.complianceOptions(new ComplianceOptions().compliance(javaCompliance)) //
 					.advancedOptions(new AdvancedOptions().preserveUnusedVars().continueExecution().enableJavadoc()) //
-					.sources(new SourceOptions().sources(sourcesFolder.getAllJavaFiles())) // no sources, handled by the JDTBatchCompiler
+					.sources(new SourceOptions().sources(sourceFiles)) // no sources, handled by the JDTBatchCompiler
 					.build();
 		} else {
 			args = jdtBuilder.build();


### PR DESCRIPTION
This is the implementation of FileCompilerConfig constructor which was originally called:
```java
public FileCompilerConfig(SpoonFolder folder) {
	this(folder.getAllJavaFiles());
}
```
That call can be avoided because we already have a list of all files in variable `sourceFiles`.