### PR TITLE
review: refactor: remove unused and wrong PrettyPrinter#getPackageDeclaration

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1806,6 +1806,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	@Override
+	@Deprecated
 	public String getPackageDeclaration() {
 		return printPackageInfo(context.currentTopLevel.getPackage());
 	}

--- a/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
@@ -31,6 +31,7 @@ public interface PrettyPrinter {
 	/**
 	 * Gets the package declaration contents.
 	 */
+	@Deprecated
 	String getPackageDeclaration();
 
 	/**


### PR DESCRIPTION
This method is unused and unusable. It's existence avoids refactoring of PrettyPrinter concerning #1460 too.