### PR TITLE
review: feat: DefaultJavaPrettyPrinter#setLineSeparator(String)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -218,6 +218,23 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	/**
+	 * @return current line separator. By default there is CR LF, LF or CR depending on the Operation system
+	 * defined by System.getProperty("line.separator")
+	 */
+	public String getLineSeparator() {
+		return printer.getLineSeparator();
+	}
+
+	/**
+	 * @param lineSeparator characters which will be printed as End of line.
+	 * By default there is System.getProperty("line.separator")
+	 */
+	public DefaultJavaPrettyPrinter setLineSeparator(String lineSeparator) {
+		printer.setLineSeparator(lineSeparator);
+		return this;
+	}
+
+	/**
 	 * Enters an expression.
 	 */
 	protected void enterCtExpression(CtExpression<?> e) {
@@ -1812,22 +1829,14 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public String printPackageInfo(CtPackage pack) {
-		PrinterHelper bck = printer;
-		ElementPrinterHelper bck2 = elementPrinterHelper;
-		printer = new PrinterHelper(env);
-		elementPrinterHelper = new ElementPrinterHelper(printer, this, env);
-
+		reset();
 		elementPrinterHelper.writeComment(pack);
 		elementPrinterHelper.writeAnnotations(pack);
 
 		if (!pack.isUnnamedPackage()) {
 			printer.write("package " + pack.getQualifiedName() + ";");
 		}
-		String ret = printer.toString();
-		elementPrinterHelper = bck2;
-		printer = bck;
-
-		return ret;
+		return printer.toString();
 	}
 
 	@Override
@@ -1837,8 +1846,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public void reset() {
-		printer = new PrinterHelper(env);
-		elementPrinterHelper.setPrinter(printer);
+		printer.reset();
 		context = new PrintingContext();
 		if (env.isAutoImports()) {
 			this.importsContext = new ImportScannerImpl();
@@ -1849,14 +1857,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public void calculate(CompilationUnit sourceCompilationUnit, List<CtType<?>> types) {
-		this.sourceCompilationUnit = sourceCompilationUnit;
-
 		// reset the importsContext to avoid errors with multiple CU
-		if (env.isAutoImports()) {
-			this.importsContext = new ImportScannerImpl();
-		} else {
-			this.importsContext = new MinimalImportScanner();
-		}
+		reset();
+
+		this.sourceCompilationUnit = sourceCompilationUnit;
 
 		Set<CtReference> imports = new HashSet<>();
 		for (CtType<?> t : types) {

--- a/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
@@ -35,6 +35,7 @@ public interface PrettyPrinter {
 
 	/**
 	 * Prints the package info.
+	 * It always resets the printing context at the beginning of this process.
 	 */
 	String printPackageInfo(CtPackage pack);
 
@@ -44,13 +45,17 @@ public interface PrettyPrinter {
 	String getResult();
 
 	/**
-	 * Resets the buffering of results
+	 * It does not have to be called by clients now.
+	 * The printing buffer is reset automatically at the beginning of #printPackageInfo or #calculate call
+	 * So this method can be removed from the API, but should be kept in internal implementation and inherited PrettyPrinters
 	 */
+	@Deprecated
 	void reset();
 
 	/**
 	 * Calculates the resulting source file for a list of types. The source
 	 * compilation unit is required for calculating the line numbers mapping.
+	 * It always resets the printing context at the beginning of this process.
 	 */
 	void calculate(CompilationUnit sourceCompilationUnit, List<CtType<?>> types);
 

--- a/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/printer/PrinterHelper.java
@@ -23,14 +23,16 @@ import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtElement;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class PrinterHelper {
 	/**
-	 * Line separator which is used by the system
+	 * Line separator which is used by the printer helper.
+	 * By default the system line separator is used
 	 */
-	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+	private String lineSeparator = System.getProperty("line.separator");
 
 	/**
 	 * Environment which Spoon is executed.
@@ -69,6 +71,18 @@ public class PrinterHelper {
 	}
 
 	/**
+	 * resets to the initial state
+	 */
+	public void reset() {
+		sbf.setLength(0);
+		nbTabs = 0;
+		line = 1;
+		column = 1;
+		//create new map, because clients keeps reference to it
+		lineNumberMapping = new HashMap<>();
+	}
+
+	/**
 	 * Outputs a string.
 	 */
 	public PrinterHelper write(String s) {
@@ -92,7 +106,7 @@ public class PrinterHelper {
 	 * Generates a new line.
 	 */
 	public PrinterHelper writeln() {
-		write(LINE_SEPARATOR);
+		write(lineSeparator);
 		line++;
 		// reset the column index
 		column = 1;
@@ -137,7 +151,7 @@ public class PrinterHelper {
 	}
 
 	public boolean removeLine() {
-		String ls = LINE_SEPARATOR;
+		String ls = lineSeparator;
 		int i = sbf.length() - ls.length();
 		boolean hasWhite = false;
 		while (i > 0 && !ls.equals(sbf.substring(i, i + ls.length()))) {
@@ -375,7 +389,7 @@ public class PrinterHelper {
 	}
 
 	public Map<Integer, Integer> getLineNumberMapping() {
-		return lineNumberMapping;
+		return Collections.unmodifiableMap(lineNumberMapping);
 	}
 
 	@Override
@@ -406,5 +420,21 @@ public class PrinterHelper {
 	 */
 	public ListPrinter createListPrinter(String start, String next, String end) {
 		return new ListPrinter(this, start, next, end);
+	}
+
+	/**
+	 * @return current line separator. By default there is CR LF, LF or CR depending on the Operation system
+	 * defined by System.getProperty("line.separator")
+	 */
+	public String getLineSeparator() {
+		return lineSeparator;
+	}
+
+	/**
+	 * @param lineSeparator characters which will be printed as End of line.
+	 * By default there is System.getProperty("line.separator")
+	 */
+	public void setLineSeparator(String lineSeparator) {
+		this.lineSeparator = lineSeparator;
 	}
 }

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -175,7 +175,6 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 		} else if (nameElement instanceof CtPackage) {
 			createPackageFile((CtPackage) nameElement);
 		}
-		printer.reset();
 	}
 
 	private void createPackageFile(CtPackage pack) {


### PR DESCRIPTION
Added method `DefaultJavaPrettyPrinter#setLineSeparator(String)`, as one step of the solution suggested in #1460 - to be able to define line separator used by spoon pretty printer.

This PR contains also necessary refactoring and cleaning of DefaultJavaPrettyPrinter.