### PR TITLE
chore: Upgrade to org.eclipse.jdt:org.eclipse.jdt.core:3.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
     <dependency>
       <groupId>org.eclipse.tycho</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.12.0.v20160516-2131</version>
+      <version>3.13.0.v20170516-1929</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
This JDT is newer and has published sources in maven repository, so it is easier to debug...