### PR TITLE
review fix: NameFilter of T also return elements of other types

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
@@ -19,6 +19,7 @@ package spoon.reflect.visitor.filter;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.visitor.Filter;
 
+
 /**
  * Filters elements by name (for instance to find a method). Example:
  *
@@ -29,6 +30,7 @@ import spoon.reflect.visitor.Filter;
  */
 public class NameFilter<T extends CtNamedElement> implements Filter<T> {
 	private final String name;
+	private Class<T> acceptedClass;
 
 	public NameFilter(String name) {
 		if (name == null) {
@@ -37,9 +39,18 @@ public class NameFilter<T extends CtNamedElement> implements Filter<T> {
 		this.name = name;
 	}
 
+	public NameFilter(String name, Class<T> acceptedClass) {
+		this(name);
+		this.acceptedClass = acceptedClass;
+	}
+
+	public void setAcceptedClass(Class<T> zeClass) {
+		this.acceptedClass = zeClass;
+	}
+
 	public boolean matches(T element) {
 		try {
-			return name.equals(element.getSimpleName());
+			return (acceptedClass == null || acceptedClass.isAssignableFrom(element.getClass())) && name.equals(element.getSimpleName());
 		} catch (UnsupportedOperationException e) {
 			return false;
 		}

--- a/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
@@ -32,6 +32,12 @@ public class NameFilter<T extends CtNamedElement> implements Filter<T> {
 	private final String name;
 	private Class<T> acceptedClass;
 
+	/**
+	 *
+	 * @param name Name of the expected element
+	 * @deprecated Prefer to use the constructor with a class to check the type of the results
+	 */
+	@Deprecated
 	public NameFilter(String name) {
 		if (name == null) {
 			throw new IllegalArgumentException();

--- a/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
@@ -28,7 +28,7 @@ import spoon.reflect.visitor.Filter;
  * 		new NameFilter&lt;CtMethod&lt;?&gt;&gt;(&quot;normalFor&quot;)).get(0);
  * </pre>
  *
- * @deprecated Use {@link NamedElementFilter} instead
+ * @deprecated Use {@link NamedElementFilter} instead: the actual NameFilter could return wrongly typed results. NamedElementFilter explicit the use of a type.
  */
 @Deprecated
 public class NameFilter<T extends CtNamedElement> implements Filter<T> {

--- a/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NameFilter.java
@@ -27,17 +27,17 @@ import spoon.reflect.visitor.Filter;
  * CtMethod&lt;?&gt; normalFor = type.getElements(
  * 		new NameFilter&lt;CtMethod&lt;?&gt;&gt;(&quot;normalFor&quot;)).get(0);
  * </pre>
+ *
+ * @deprecated Use {@link NamedElementFilter} instead
  */
+@Deprecated
 public class NameFilter<T extends CtNamedElement> implements Filter<T> {
 	private final String name;
-	private Class<T> acceptedClass;
 
 	/**
 	 *
 	 * @param name Name of the expected element
-	 * @deprecated Prefer to use the constructor with a class to check the type of the results
 	 */
-	@Deprecated
 	public NameFilter(String name) {
 		if (name == null) {
 			throw new IllegalArgumentException();
@@ -45,18 +45,9 @@ public class NameFilter<T extends CtNamedElement> implements Filter<T> {
 		this.name = name;
 	}
 
-	public NameFilter(String name, Class<T> acceptedClass) {
-		this(name);
-		this.acceptedClass = acceptedClass;
-	}
-
-	public void setAcceptedClass(Class<T> zeClass) {
-		this.acceptedClass = zeClass;
-	}
-
 	public boolean matches(T element) {
 		try {
-			return (acceptedClass == null || acceptedClass.isAssignableFrom(element.getClass())) && name.equals(element.getSimpleName());
+			return name.equals(element.getSimpleName());
 		} catch (UnsupportedOperationException e) {
 			return false;
 		}

--- a/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
@@ -24,7 +24,7 @@ import spoon.reflect.visitor.Filter;
  *
  * <pre>
  * CtMethod&lt;?&gt; normalFor = type.getElements(
- * 		new NamedElementFilter&lt;CtMethod&lt;?&gt;&gt;(&quot;normalFor&quot;, CtMethod.class)).get(0);
+ * 		new NamedElementFilter&lt;CtMethod&lt;?&gt;&gt;(CtMethod.class, &quot;normalFor&quot;)).get(0);
  * </pre>
  */
 public class NamedElementFilter<T extends CtNamedElement> implements Filter<T> {
@@ -36,7 +36,7 @@ public class NamedElementFilter<T extends CtNamedElement> implements Filter<T> {
 	 * @param name Name of the expected element
 	 * @param acceptedClass Expected class of the results
 	 */
-	public NamedElementFilter(String name, Class<T> acceptedClass) {
+	public NamedElementFilter(Class<T> acceptedClass, String name) {
 		if (name == null || acceptedClass == null) {
 			throw new IllegalArgumentException();
 		}

--- a/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
@@ -28,40 +28,40 @@ import spoon.reflect.visitor.Filter;
  * </pre>
  */
 public class NamedElementFilter implements Filter<CtNamedElement> {
-    private final String name;
-    private Class<? extends CtNamedElement> acceptedClass;
+	private final String name;
+	private Class<? extends CtNamedElement> acceptedClass;
 
-    /**
-     *
-     * @param name Name of the expected element
-     */
-    public NamedElementFilter(String name) {
-        this(name, CtNamedElement.class);
-    }
+	/**
+	 *
+	 * @param name Name of the expected element
+	 */
+	public NamedElementFilter(String name) {
+		this(name, CtNamedElement.class);
+	}
 
-    /**
-     *
-     * @param name Name of the expected element
-     * @param acceptedClass Expected class of the results
-     */
-    public NamedElementFilter(String name, Class<? extends CtNamedElement> acceptedClass) {
-        if (name == null || acceptedClass == null) {
-            throw new IllegalArgumentException();
-        }
-        this.name = name;
-        this.acceptedClass = acceptedClass;
-    }
+	/**
+	 *
+	 * @param name Name of the expected element
+	 * @param acceptedClass Expected class of the results
+	 */
+	public NamedElementFilter(String name, Class<? extends CtNamedElement> acceptedClass) {
+		if (name == null || acceptedClass == null) {
+			throw new IllegalArgumentException();
+		}
+		this.name = name;
+		this.acceptedClass = acceptedClass;
+	}
 
-    public boolean matches(CtNamedElement element) {
-        try {
-            return acceptedClass.isAssignableFrom(element.getClass()) && name.equals(element.getSimpleName());
-        } catch (UnsupportedOperationException e) {
-            return false;
-        }
-    }
+	public boolean matches(CtNamedElement element) {
+		try {
+			return acceptedClass.isAssignableFrom(element.getClass()) && name.equals(element.getSimpleName());
+		} catch (UnsupportedOperationException e) {
+			return false;
+		}
+	}
 
-    @SuppressWarnings("unchecked")
-    public Class<? extends CtNamedElement> getType() {
-        return acceptedClass;
-    }
+	@SuppressWarnings("unchecked")
+	public Class<? extends CtNamedElement> getType() {
+		return acceptedClass;
+	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
@@ -24,27 +24,19 @@ import spoon.reflect.visitor.Filter;
  *
  * <pre>
  * CtMethod&lt;?&gt; normalFor = type.getElements(
- * 		new NamedElementFilter(&quot;normalFor&quot;, CtMethod.class)).get(0);
+ * 		new NamedElementFilter&lt;CtMethod&lt;?&gt;&gt;(&quot;normalFor&quot;, CtMethod.class)).get(0);
  * </pre>
  */
-public class NamedElementFilter implements Filter<CtNamedElement> {
+public class NamedElementFilter<T extends CtNamedElement> implements Filter<T> {
 	private final String name;
-	private Class<? extends CtNamedElement> acceptedClass;
-
-	/**
-	 *
-	 * @param name Name of the expected element
-	 */
-	public NamedElementFilter(String name) {
-		this(name, CtNamedElement.class);
-	}
+	private Class<T> acceptedClass;
 
 	/**
 	 *
 	 * @param name Name of the expected element
 	 * @param acceptedClass Expected class of the results
 	 */
-	public NamedElementFilter(String name, Class<? extends CtNamedElement> acceptedClass) {
+	public NamedElementFilter(String name, Class<T> acceptedClass) {
 		if (name == null || acceptedClass == null) {
 			throw new IllegalArgumentException();
 		}
@@ -52,7 +44,7 @@ public class NamedElementFilter implements Filter<CtNamedElement> {
 		this.acceptedClass = acceptedClass;
 	}
 
-	public boolean matches(CtNamedElement element) {
+	public boolean matches(T element) {
 		try {
 			return acceptedClass.isAssignableFrom(element.getClass()) && name.equals(element.getSimpleName());
 		} catch (UnsupportedOperationException e) {
@@ -61,7 +53,7 @@ public class NamedElementFilter implements Filter<CtNamedElement> {
 	}
 
 	@SuppressWarnings("unchecked")
-	public Class<? extends CtNamedElement> getType() {
+	public Class<T> getType() {
 		return acceptedClass;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor.filter;
+
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.visitor.Filter;
+
+/**
+ * Filters elements by name and by type (for instance to find a method). Example:
+ *
+ * <pre>
+ * CtMethod&lt;?&gt; normalFor = type.getElements(
+ * 		new NamedElementFilter(&quot;normalFor&quot;, CtMethod.class)).get(0);
+ * </pre>
+ */
+public class NamedElementFilter implements Filter<CtNamedElement> {
+    private final String name;
+    private Class<? extends CtNamedElement> acceptedClass;
+
+    /**
+     *
+     * @param name Name of the expected element
+     */
+    public NamedElementFilter(String name) {
+        this(name, CtNamedElement.class);
+    }
+
+    /**
+     *
+     * @param name Name of the expected element
+     * @param acceptedClass Expected class of the results
+     */
+    public NamedElementFilter(String name, Class<? extends CtNamedElement> acceptedClass) {
+        if (name == null || acceptedClass == null) {
+            throw new IllegalArgumentException();
+        }
+        this.name = name;
+        this.acceptedClass = acceptedClass;
+    }
+
+    public boolean matches(CtNamedElement element) {
+        try {
+            return acceptedClass.isAssignableFrom(element.getClass()) && name.equals(element.getSimpleName());
+        } catch (UnsupportedOperationException e) {
+            return false;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public Class<? extends CtNamedElement> getType() {
+        return acceptedClass;
+    }
+}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -1136,10 +1136,10 @@ public class FilterTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Constants.class);
-		List<CtMethod> ctMethods = type.getElements(new NamedElementFilter<>("CONSTANT", CtMethod.class));
+		List<CtMethod> ctMethods = type.getElements(new NamedElementFilter<>(CtMethod.class, "CONSTANT"));
 		assertTrue(ctMethods.isEmpty());
 
-		List<CtField> ctFields = type.getElements(new NamedElementFilter<>("CONSTANT", CtField.class));
+		List<CtField> ctFields = type.getElements(new NamedElementFilter<>(CtField.class, "CONSTANT"));
 		assertEquals(1, ctFields.size());
 		assertTrue(ctFields.get(0) instanceof CtField);
 	}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -1135,7 +1135,7 @@ public class FilterTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Constants.class);
-		List<CtMethod> ctMethods = type.getElements(new NameFilter<CtMethod>("CONSTANT"));
+		List<CtMethod> ctMethods = type.getElements(new NameFilter<CtMethod>("CONSTANT", CtMethod.class));
 		assertTrue(ctMethods.isEmpty());
 	}
 }

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -63,6 +63,7 @@ import spoon.reflect.visitor.filter.FilteringOperator;
 import spoon.reflect.visitor.filter.InvocationFilter;
 import spoon.reflect.visitor.filter.LineFilter;
 import spoon.reflect.visitor.filter.NameFilter;
+import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.OverriddenMethodFilter;
 import spoon.reflect.visitor.filter.OverriddenMethodQuery;
 import spoon.reflect.visitor.filter.OverridingMethodFilter;
@@ -1135,7 +1136,11 @@ public class FilterTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Constants.class);
-		List<CtMethod> ctMethods = type.getElements(new NameFilter<CtMethod>("CONSTANT", CtMethod.class));
-		assertTrue(ctMethods.isEmpty());
+		List<CtNamedElement> ctFiltered = type.getElements(new NamedElementFilter("CONSTANT", CtMethod.class));
+		assertTrue(ctFiltered.isEmpty());
+
+		ctFiltered = type.getElements(new NamedElementFilter("CONSTANT", CtField.class));
+		assertEquals(1, ctFiltered.size());
+		assertTrue(ctFiltered.get(0) instanceof CtField);
 	}
 }

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -1129,18 +1129,18 @@ public class FilterTest {
 
 	@Test
 	public void testNameFilterWithGenericType() {
-		// contract: NameFilter of T should only return T elements
+		// contract: NamedElementFilter of T should only return T elements
 
 		Launcher spoon = new Launcher();
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal4/Constants.java");
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Constants.class);
-		List<CtNamedElement> ctFiltered = type.getElements(new NamedElementFilter("CONSTANT", CtMethod.class));
-		assertTrue(ctFiltered.isEmpty());
+		List<CtMethod> ctMethods = type.getElements(new NamedElementFilter<>("CONSTANT", CtMethod.class));
+		assertTrue(ctMethods.isEmpty());
 
-		ctFiltered = type.getElements(new NamedElementFilter("CONSTANT", CtField.class));
-		assertEquals(1, ctFiltered.size());
-		assertTrue(ctFiltered.get(0) instanceof CtField);
+		List<CtField> ctFields = type.getElements(new NamedElementFilter<>("CONSTANT", CtField.class));
+		assertEquals(1, ctFields.size());
+		assertTrue(ctFields.get(0) instanceof CtField);
 	}
 }

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -80,6 +80,7 @@ import spoon.test.filters.testclasses.ITostada;
 import spoon.test.filters.testclasses.SubTostada;
 import spoon.test.filters.testclasses.Tacos;
 import spoon.test.filters.testclasses.Tostada;
+import spoon.test.imports.testclasses.internal4.Constants;
 import spoon.testing.utils.ModelUtils;
 
 public class FilterTest {
@@ -1123,5 +1124,18 @@ public class FilterTest {
 
 		// only one subtype remains unvisited
 		assertEquals(1, c2.counter);
+	}
+
+	@Test
+	public void testNameFilterWithGenericType() {
+		// contract: NameFilter of T should only return T elements
+
+		Launcher spoon = new Launcher();
+		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal4/Constants.java");
+		spoon.buildModel();
+
+		CtType type = spoon.getFactory().Type().get(Constants.class);
+		List<CtMethod> ctMethods = type.getElements(new NameFilter<CtMethod>("CONSTANT"));
+		assertTrue(ctMethods.isEmpty());
 	}
 }


### PR DESCRIPTION
There is a global problem with generic which prevent from type checking: you cannot use at runtime information about generic types and we often lose the generic type inside operation in Spoon. 
So I propose to solve a bug with generic type in NameFilter by adding a new constructor with a parameter wich is the class of the type we finally want. It's the only solution I can see to prevent an eventual ClassCastException when iterating on the result list. 
I also deprecate the old NameFilter constructor as it cannot guarantee the type of the results.