### PR TITLE
review: Bug fix when using a URLClassLoader with file: URLs.

### DIFF
--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -353,13 +353,22 @@ public class StandardEnvironment implements Serializable, Environment {
 		if (aClassLoader instanceof URLClassLoader) {
 			final URL[] urls = ((URLClassLoader) aClassLoader).getURLs();
 			if (urls != null && urls.length > 0) {
-				List<String> classpath = new ArrayList<>();
+				// Check that the URLs are only file URLs
+				boolean onlyFileURLs = true;
 				for (URL url : urls) {
-					classpath.add(url.toString());
+					if( ! url.getProtocol().equals("file")) {
+						onlyFileURLs = false;
+					}
 				}
-				setSourceClasspath(classpath.toArray(new String[0]));
+				if( onlyFileURLs ) {
+					List<String> classpath = new ArrayList<>();
+					for (URL url : urls) {
+						classpath.add(url.getPath());
+					}
+					setSourceClasspath(classpath.toArray(new String[0]));
+				}
+				return;
 			}
-			return;
 		}
 		this.classloader = aClassLoader;
 	}

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -366,6 +366,8 @@ public class StandardEnvironment implements Serializable, Environment {
 						classpath.add(url.getPath());
 					}
 					setSourceClasspath(classpath.toArray(new String[0]));
+				} else {
+					throw new SpoonException("Spoon does not support a URLClassLoader containing other resources than local file.");
 				}
 			}
 			return;

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -356,19 +356,19 @@ public class StandardEnvironment implements Serializable, Environment {
 				// Check that the URLs are only file URLs
 				boolean onlyFileURLs = true;
 				for (URL url : urls) {
-					if( ! url.getProtocol().equals("file")) {
+					if (!url.getProtocol().equals("file")) {
 						onlyFileURLs = false;
 					}
 				}
-				if( onlyFileURLs ) {
+				if (onlyFileURLs) {
 					List<String> classpath = new ArrayList<>();
 					for (URL url : urls) {
 						classpath.add(url.getPath());
 					}
 					setSourceClasspath(classpath.toArray(new String[0]));
 				}
-				return;
 			}
+			return;
 		}
 		this.classloader = aClassLoader;
 	}

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -380,6 +380,7 @@ public class CompilationTest {
 
 		assertEquals(3, l.size());
 		assertTrue(l.contains("KJHKY"));
+		assertEquals(MyClassLoader.class, launcher.getEnvironment().getInputClassLoader().getClass());
 	}
 	
 	@Test

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -22,6 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import spoon.Launcher;
+import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
@@ -414,10 +415,12 @@ public class CompilationTest {
 		URL[] urls = new URL[]{ f.toURL(), url };
 		URLClassLoader urlClassLoader = new URLClassLoader(urls);
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setInputClassLoader(urlClassLoader);
-
-		String[] sourceClassPath = launcher.getEnvironment().getSourceClasspath();
-		assertNull(sourceClassPath);
+		try {
+			launcher.getEnvironment().setInputClassLoader(urlClassLoader);
+			fail();
+		} catch (SpoonException e) {
+			assertTrue(e.getMessage().contains("Spoon does not support a URLClassLoader containing other resources than local file."));
+		}
 	}
 
 	@Test

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -1,8 +1,25 @@
 package spoon.test.compilation;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
 import org.junit.Assert;
 import org.junit.Test;
+
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -19,29 +36,13 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.SpoonClassNotFoundException;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.support.compiler.jdt.JDTBatchCompiler;
-import spoon.support.SpoonClassNotFoundException;
 import spoon.test.compilation.testclasses.Bar;
 import spoon.test.compilation.testclasses.IBar;
 import spoon.testing.utils.ModelUtils;
-
-import java.io.File;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 public class CompilationTest {
 
@@ -379,6 +380,24 @@ public class CompilationTest {
 
 		assertEquals(3, l.size());
 		assertTrue(l.contains("KJHKY"));
+	}
+	
+	@Test
+	public void testURLClassLoader() throws Exception {
+		// contract: Spoon handles URLClassLoader and retrieves path elements
+		
+		String expected = "target/classes/";
+
+		File f = new File(expected);
+		URL[] urls = new URL[]{f.toURL()};
+		URLClassLoader urlClassLoader = new URLClassLoader(urls);
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setInputClassLoader(urlClassLoader);
+		
+		String[] sourceClassPath = launcher.getEnvironment().getSourceClasspath();
+		assertEquals(1, sourceClassPath.length);
+		String tail = sourceClassPath[0].substring(sourceClassPath[0].length()-expected.length());
+		assertEquals(expected, tail);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -3,6 +3,7 @@ package spoon.test.compilation;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -399,6 +400,24 @@ public class CompilationTest {
 		assertEquals(1, sourceClassPath.length);
 		String tail = sourceClassPath[0].substring(sourceClassPath[0].length()-expected.length());
 		assertEquals(expected, tail);
+	}
+
+	@Test
+	public void testURLClassLoaderWithOtherResourcesThanOnlyFiles() throws Exception {
+		// contract: Spoon handles URLClassLoader which contain other resources than only files by not adding anything
+
+		String file = "target/classes/";
+		String distantJar = "http://central.maven.org/maven2/fr/inria/gforge/spoon/spoon-core/5.8.0/spoon-core-5.8.0.jar";
+
+		File f = new File(file);
+		URL url = new URL(distantJar);
+		URL[] urls = new URL[]{ f.toURL(), url };
+		URLClassLoader urlClassLoader = new URLClassLoader(urls);
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setInputClassLoader(urlClassLoader);
+
+		String[] sourceClassPath = launcher.getEnvironment().getSourceClasspath();
+		assertNull(sourceClassPath);
 	}
 
 	@Test


### PR DESCRIPTION
setInputClassLoader was failing when the URLs retrieved from the specified URLClassLoader were file URLs. The URLs were transmitted to verifySourceClasspath that is expected path elements, not URLs.

This PR fixes this bug by retrieving path elements from the file URLs.