### PR TITLE
Fixes file resource leak

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -516,7 +516,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				// the path must be given relatively to to the working directory
 				try (InputStream is = getCompilationUnitInputStream(cu.getFile().getPath());
 					FileOutputStream outFile = new FileOutputStream(file);) {
-					
+
 					IOUtils.copy(is, outFile);
 				}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -515,10 +515,10 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 
 				// the path must be given relatively to to the working directory
 				try (InputStream is = getCompilationUnitInputStream(cu.getFile().getPath());
-                        		FileOutputStream outFile = new FileOutputStream(file);) {
-
-                    			IOUtils.copy(is, outFile);
-                		}
+					FileOutputStream outFile = new FileOutputStream(file);) {
+					
+					IOUtils.copy(is, outFile);
+				}
 
 				if (!printedFiles.contains(file)) {
 					printedFiles.add(file);

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -514,10 +514,11 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				file.createNewFile();
 
 				// the path must be given relatively to to the working directory
-				InputStream is = getCompilationUnitInputStream(cu.getFile().getPath());
+				try (InputStream is = getCompilationUnitInputStream(cu.getFile().getPath());
+                        		FileOutputStream outFile = new FileOutputStream(file);) {
 
-				IOUtils.copy(is, new FileOutputStream(file));
-
+                    			IOUtils.copy(is, outFile);
+                		}
 
 				if (!printedFiles.contains(file)) {
 					printedFiles.add(file);


### PR DESCRIPTION
Wrap the output streams for the generated files inside a try-with-resources. Was preventing generated files from being deleted/moved while Spoon was still executing.