### PR TITLE
review: Fix template parameter constraint

### DIFF
--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -671,29 +671,31 @@ public abstract class Substitution {
 			Parameter templateParamAnnotation = f.getAnnotation(Parameter.class);
 			if (templateParamAnnotation != null && !templateParamAnnotation.value().equals("")) {
 				String proxyName = templateParamAnnotation.value();
-				// contract: if value, then the field type must be String
-				if (!f.getType().equals(c.getFactory().Type().STRING)) {
-					throw new TemplateException("proxy template parameter must be typed as String " +  f.getType().getQualifiedName());
-				}
+				// contract: if value, then the field type must be String or CtTypeReference
+				String fieldTypeQName = f.getType().getQualifiedName();
+				if (fieldTypeQName.equals(String.class.getName())) {
+					// contract: the name of the template parameter must correspond to the name of the field
+					// as found, by Pavel, this is not good contract because it prevents easy refactoring of templates
+					// we remove it but keep th commented code in case somebody would come up with this bad idae
+//					if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
+//						throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
+//					}
 
-				// contract: the name of the template parameter must correspond to the name of the field
-				// as found, by Pavel, this is not good contract because it prevents easy refactoring of templates
-				// we remove it but keep th commented code in case somebody would come up with this bad idae
-//				if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
-//					throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
-//				}
-
-				// contract: if a proxy parameter is declared and named "x" (@Parameter("x")), then a type member named "x" must exist.
-				boolean found = false;
-				for (CtTypeMember member: c.getTypeMembers()) {
-					if (member.getSimpleName().equals(proxyName)) {
-						found = true;
+					// contract: if a proxy parameter is declared and named "x" (@Parameter("x")), then a type member named "x" must exist.
+					boolean found = false;
+					for (CtTypeMember member: c.getTypeMembers()) {
+						if (member.getSimpleName().equals(proxyName)) {
+							found = true;
+						}
 					}
+					if (!found) {
+						throw new TemplateException("if a proxy parameter is declared and named \"" + proxyName + "\", then a type member named \"\" + proxyName + \"\" must exist.");
+					}
+				} else if (fieldTypeQName.equals(CtTypeReference.class.getName())) {
+					//OK it is CtTypeReference
+				} else {
+					throw new TemplateException("proxy template parameter must be typed as String or CtTypeReference, but it is " + fieldTypeQName);
 				}
-				if (!found) {
-					throw new TemplateException("if a proxy parameter is declared and named \"" + proxyName + "\", then a type member named \"\" + proxyName + \"\" must exist.");
-				}
-
 			}
 		}
 	}

--- a/src/test/java/spoon/test/template/testclasses/TypeReferenceClassAccessTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/TypeReferenceClassAccessTemplate.java
@@ -1,0 +1,39 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.reference.CtTypeReference;
+import spoon.template.ExtensionTemplate;
+import spoon.template.Local;
+import spoon.template.Parameter;
+
+public class TypeReferenceClassAccessTemplate extends ExtensionTemplate {
+	Object o;
+
+	$Type$ someMethod($Type$ param) {
+		o = $Type$.out;
+		$Type$ ret = new $Type$();
+		return ret;
+	}
+	
+	@Local
+	public TypeReferenceClassAccessTemplate(CtTypeReference<?> typeRef) {
+		this.typeRef = typeRef;
+	}
+	
+	@Parameter("$Type$")
+	CtTypeReference<?> typeRef;
+
+	@Local
+	static class $Type$ {
+		static final String out = "";
+		static long currentTimeMillis(){
+			return 0;
+		}
+	}
+
+	public static class Example<T> {
+		static final String out = "";
+		static long currentTimeMillis(){
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
As found by implementation of #1454, there is not possible to implement Templates, which are using template parameter of type CtTypeReference, which should substitute local class.

This PR relaxes the constraint by way the CtTypeReference may use proxy parameter value too