### PR TITLE
fix: java compliance to 8 - allow lambdas in spoon code

### DIFF
--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -67,7 +67,7 @@ public class MainTest {
 				"--destination","target/spooned-build",
 				"--source-classpath", systemClassPath,
 				"--compile", // compiling Spoon code itself on the fly
-				"--compliance", "7",
+				"--compliance", "8",
 				"--level", "OFF"
 		});
 


### PR DESCRIPTION
I would like to use lambdas in spoon code now, but this test fails on it.