### PR TITLE
fix(test): wrong number of dependency MavenLauncherTest

### DIFF
--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -12,7 +12,7 @@ public class MavenLauncherTest {
 
 		assertEquals(8, launcher.getEnvironment().getComplianceLevel());
 
-		assertEquals(6, launcher.getEnvironment().getSourceClasspath().length);
+		assertEquals(5, launcher.getEnvironment().getSourceClasspath().length);
 		// 54 because of the sub folders of src/main/java
 		assertEquals(54, launcher.getModelBuilder().getInputSources().size());
 


### PR DESCRIPTION
The ant dependency was removed so the test should be changed