### PR TITLE
refactor: DefaultJavaPrettyPrinter better uses OperatorHelper

### DIFF
--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -297,7 +297,7 @@ public class PrinterHelper {
 	 * @return the {@link ListPrinter} whose {@link ListPrinter#printSeparatorIfAppropriate()} has to be called
 	 * before printing of each item.
 	 */
-	public ListPrinter createListPrinter(String start, String next, String end) {
+	ListPrinter createListPrinter(String start, String next, String end) {
 		return new ListPrinter(this, start, next, end);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -229,6 +229,7 @@ public class PrinterHelper {
 	/**
 	 * Write a pre unary operator.
 	 */
+	@Deprecated
 	public void preWriteUnaryOperator(UnaryOperatorKind o) {
 		if (OperatorHelper.isPrefixOperator(o)) {
 			write(OperatorHelper.getOperatorText(o));
@@ -238,6 +239,7 @@ public class PrinterHelper {
 	/**
 	 * Write a post unary operator.
 	 */
+	@Deprecated
 	public void postWriteUnaryOperator(UnaryOperatorKind o) {
 		if (OperatorHelper.isSufixOperator(o)) {
 			write(OperatorHelper.getOperatorText(o));
@@ -247,17 +249,20 @@ public class PrinterHelper {
 	/**
 	 * Writes a binary operator.
 	 */
+	@Deprecated
 	public PrinterHelper writeOperator(BinaryOperatorKind o) {
 		write(OperatorHelper.getOperatorText(o));
 		return this;
 	}
 
+	@Deprecated
 	public void writeCharLiteral(Character c, boolean mayContainsSpecialCharacter) {
 		StringBuilder sb = new StringBuilder(10);
 		LiteralHelper.appendCharLiteral(sb, c, mayContainsSpecialCharacter);
 		write(sb.toString());
 	}
 
+	@Deprecated
 	public void writeStringLiteral(String value, boolean mayContainsSpecialCharacter) {
 		write(LiteralHelper.getStringLiteral(value, mayContainsSpecialCharacter));
 	}

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -17,8 +17,6 @@
 package spoon.reflect.visitor;
 
 import spoon.compiler.Environment;
-import spoon.reflect.code.BinaryOperatorKind;
-import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtElement;
 
@@ -224,47 +222,6 @@ public class PrinterHelper {
 
 	public void putLineNumberMapping(int valueLine) {
 		lineNumberMapping.put(this.line, valueLine);
-	}
-
-	/**
-	 * Write a pre unary operator.
-	 */
-	@Deprecated
-	public void preWriteUnaryOperator(UnaryOperatorKind o) {
-		if (OperatorHelper.isPrefixOperator(o)) {
-			write(OperatorHelper.getOperatorText(o));
-		}
-	}
-
-	/**
-	 * Write a post unary operator.
-	 */
-	@Deprecated
-	public void postWriteUnaryOperator(UnaryOperatorKind o) {
-		if (OperatorHelper.isSufixOperator(o)) {
-			write(OperatorHelper.getOperatorText(o));
-		}
-	}
-
-	/**
-	 * Writes a binary operator.
-	 */
-	@Deprecated
-	public PrinterHelper writeOperator(BinaryOperatorKind o) {
-		write(OperatorHelper.getOperatorText(o));
-		return this;
-	}
-
-	@Deprecated
-	public void writeCharLiteral(Character c, boolean mayContainsSpecialCharacter) {
-		StringBuilder sb = new StringBuilder(10);
-		LiteralHelper.appendCharLiteral(sb, c, mayContainsSpecialCharacter);
-		write(sb.toString());
-	}
-
-	@Deprecated
-	public void writeStringLiteral(String value, boolean mayContainsSpecialCharacter) {
-		write(LiteralHelper.getStringLiteral(value, mayContainsSpecialCharacter));
 	}
 
 	public Map<Integer, Integer> getLineNumberMapping() {


### PR DESCRIPTION
* DefaultJavaPrettyPrinter uses OperatorHelper instead of now deprecated PrinterHelper methods
* Some code of DefaultJavaPrettyPrinter is more friendly to future PrinterTokenWriter #1494