### PR TITLE
review: refactor: PrinterHelper prints tabs automatically

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -58,7 +58,7 @@ class CommentHelper {
 			printer.write(JAVADOC_START).writeln();
 			break;
 		case JAVADOC:
-			printer.write(JAVADOC_START).writeln().writeTabs();
+			printer.write(JAVADOC_START).writeln();
 			break;
 		case INLINE:
 			printer.write(INLINE_COMMENT_START);
@@ -78,18 +78,18 @@ class CommentHelper {
 					if (commentType == CtComment.CommentType.BLOCK) {
 						printer.write(com);
 						if (lines.length > 1) {
-							printer.writeln().writeTabs();
+							printer.writeln();
 						}
 					} else {
 						if (com.length() > 0) {
-							printer.write(COMMENT_STAR + com).writeln().writeTabs();
+							printer.write(COMMENT_STAR + com).writeln();
 						} else {
-							printer.write(" *" /* no trailing space */ + com).writeln().writeTabs();
+							printer.write(" *" /* no trailing space */ + com).writeln();
 						}
 					}
 				}
 				if (javaDocTags != null && javaDocTags.isEmpty() == false) {
-					printer.write(" *").writeln().writeTabs();
+					printer.write(" *").writeln();
 					for (CtJavaDocTag docTag : javaDocTags) {
 						printJavaDocTag(printer, docTag);
 					}
@@ -115,7 +115,7 @@ class CommentHelper {
 		printer.write(docTag.getType().name().toLowerCase());
 		printer.write(" ");
 		if (docTag.getType().hasParam()) {
-			printer.write(docTag.getParam()).writeln().writeTabs();
+			printer.write(docTag.getParam()).writeln();
 		}
 
 		String[] tagLines = LINE_SEPARATORS_RE.split(docTag.getContent());
@@ -127,7 +127,7 @@ class CommentHelper {
 			if (docTag.getType().hasParam()) {
 				printer.write("\t\t");
 			}
-			printer.write(com.trim()).writeln().writeTabs();
+			printer.write(com.trim()).writeln();
 		}
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -415,7 +415,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			.writeSpace().writeSeparator("{").incTab();
 
 		elementPrinterHelper.writeElementList(annotationType.getTypeMembers());
-		printer.decTab().writeTabs().writeSeparator("}");
+		printer.decTab().writeSeparator("}");
 	}
 
 	@Override
@@ -503,7 +503,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.incTab();
 		for (CtStatement statement : block.getStatements()) {
 			if (!statement.isImplicit()) {
-				printer.writeln().writeTabs();
+				printer.writeln();
 				elementPrinterHelper.writeStatement(statement);
 			}
 		}
@@ -511,10 +511,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		getPrinterHelper().adjustEndPosition(block);
 		if (env.isPreserveLineNumbers()) {
 			if (!block.isImplicit()) {
-				printer.writeTabs().writeSeparator("}");
+				printer.writeSeparator("}");
 			}
 		} else {
-			printer.writeln().writeTabs();
+			printer.writeln();
 			if (!block.isImplicit()) {
 				printer.writeSeparator("}");
 			}
@@ -556,7 +556,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeSeparator(":").incTab();
 
 		for (CtStatement statement : caseStatement.getStatements()) {
-			printer.writeln().writeTabs();
+			printer.writeln();
 			elementPrinterHelper.writeStatement(statement);
 		}
 		printer.decTab();
@@ -602,7 +602,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeSeparator("{").incTab();
 		elementPrinterHelper.writeElementList(ctClass.getTypeMembers());
 		getPrinterHelper().adjustEndPosition(ctClass);
-		printer.decTab().writeTabs().writeSeparator("}");
+		printer.decTab().writeSeparator("}");
 		context.popCurrentThis();
 	}
 
@@ -713,7 +713,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeSeparator("{").incTab().writeln();
 
 		if (ctEnum.getEnumValues().size() == 0) {
-			printer.writeTabs().writeSeparator(";").writeln();
+			printer.writeSeparator(";").writeln();
 		} else {
 			try (ListPrinter lp = elementPrinterHelper.createListPrinter(false, null, false, false, ",", true, false, ";")) {
 				for (CtEnumValue<?> enumValue : ctEnum.getEnumValues()) {
@@ -724,7 +724,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 
 		elementPrinterHelper.writeElementList(ctEnum.getTypeMembers());
-		printer.decTab().writeTabs().writeSeparator("}");
+		printer.decTab().writeSeparator("}");
 		context.popCurrentThis();
 	}
 
@@ -1079,7 +1079,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeSeparator("{").incTab();
 		// Content
 		elementPrinterHelper.writeElementList(intrface.getTypeMembers());
-		printer.decTab().writeTabs().writeSeparator("}");
+		printer.decTab().writeSeparator("}");
 		context.popCurrentThis();
 	}
 
@@ -1485,13 +1485,13 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		scan(switchStatement.getSelector());
 		printer.writeSeparator(")").writeSpace().writeSeparator("{").incTab();
 		for (CtCase<?> c : switchStatement.getCases()) {
-			printer.writeln().writeTabs();
+			printer.writeln();
 			scan(c);
 		}
 		if (env.isPreserveLineNumbers()) {
 			printer.decTab().writeSeparator("}");
 		} else {
-			printer.decTab().writeln().writeTabs().writeSeparator("}");
+			printer.decTab().writeln().writeSeparator("}");
 		}
 	}
 
@@ -1793,7 +1793,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(t);
 			if (!env.isPreserveLineNumbers()) {
 				// saving lines and chars
-				printer.writeln().writeln().writeTabs();
+				printer.writeln().writeln();
 			} else {
 				getPrinterHelper().adjustEndPosition(t);
 			}
@@ -1812,7 +1812,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		elementPrinterHelper = new ElementPrinterHelper(tokenWriter, this, env);
 		printer = tokenWriter;
 		return this;
-
 	}
 
 	private PrinterHelper getPrinterHelper() {

--- a/src/main/java/spoon/reflect/visitor/DefaultTokenWriter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultTokenWriter.java
@@ -78,12 +78,6 @@ public class DefaultTokenWriter implements TokenWriter {
 	}
 
 	@Override
-	public DefaultTokenWriter writeTabs() {
-		printerHelper.writeTabs();
-		return this;
-	}
-
-	@Override
 	public DefaultTokenWriter incTab() {
 		printerHelper.incTab();
 		return this;

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -76,7 +76,7 @@ public class ElementPrinterHelper {
 	public void writeAnnotations(CtElement element) {
 		for (CtAnnotation<?> annotation : element.getAnnotations()) {
 			prettyPrinter.scan(annotation);
-			printer.writeln().writeTabs();
+			printer.writeln();
 		}
 	}
 
@@ -150,7 +150,7 @@ public class ElementPrinterHelper {
 			if (element instanceof CtConstructor && element.isImplicit()) {
 				continue;
 			}
-			printer.writeln().writeTabs();
+			printer.writeln();
 			prettyPrinter.scan(element);
 			if (!env.isPreserveLineNumbers()) {
 				printer.writeln();
@@ -259,7 +259,7 @@ public class ElementPrinterHelper {
 			if (!types.get(0).getPackage().isUnnamedPackage()) {
 				writePackageLine(types.get(0).getPackage().getQualifiedName());
 			}
-			printer.writeln().writeln().writeTabs();
+			printer.writeln().writeln();
 			Set<String> setImports = new HashSet<>();
 			Set<String> setStaticImports = new HashSet<>();
 			for (CtReference ref : imports) {
@@ -286,18 +286,18 @@ public class ElementPrinterHelper {
 			Collections.sort(sortedImports);
 			for (String importLine : sortedImports) {
 				printer.writeKeyword("import").writeSpace();
-				writeQualifiedName(importLine).writeSeparator(";").writeln().writeTabs();
+				writeQualifiedName(importLine).writeSeparator(";").writeln();
 			}
 			if (setStaticImports.size() > 0) {
-				printer.writeln().writeTabs();
+				printer.writeln();
 				List<String> sortedStaticImports = new ArrayList<>(setStaticImports);
 				Collections.sort(sortedStaticImports);
 				for (String importLine : sortedStaticImports) {
 					printer.writeKeyword("import").writeSpace().writeKeyword("static").writeSpace();
-					writeQualifiedName(importLine).writeSeparator(";").writeln().writeTabs();
+					writeQualifiedName(importLine).writeSeparator(";").writeln();
 				}
 			}
-			printer.writeln().writeTabs();
+			printer.writeln();
 		}
 	}
 
@@ -315,7 +315,7 @@ public class ElementPrinterHelper {
 			return;
 		}
 		prettyPrinter.scan(comment);
-		printer.writeln().writeTabs();
+		printer.writeln();
 	}
 
 	private void writeComment(List<CtComment> comments) {
@@ -381,11 +381,11 @@ public class ElementPrinterHelper {
 			}
 			if (!(block instanceof CtBlock) && !(block instanceof CtIf)) {
 				printer.incTab();
-				printer.writeln().writeTabs();
+				printer.writeln();
 			}
 			writeStatement(block);
 			if (!(block instanceof CtBlock) && !(block instanceof CtIf)) {
-				printer.decTab().writeln().writeTabs();
+				printer.decTab().writeln();
 			}
 			if (!block.isImplicit()) {
 				if (!block.isParentInitialized() || (!(block.getParent() instanceof CtFor) && !(block.getParent() instanceof CtForEach) && !(block.getParent() instanceof CtIf))) {

--- a/src/main/java/spoon/reflect/visitor/TokenWriter.java
+++ b/src/main/java/spoon/reflect/visitor/TokenWriter.java
@@ -113,10 +113,6 @@ public interface TokenWriter {
 	 */
 	TokenWriter writeln();
 	/**
-	 * writes indentation
-	 */
-	TokenWriter writeTabs();
-	/**
 	 * increments indentation
 	 */
 	TokenWriter incTab();

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -42,7 +42,7 @@ public class EnumsTest {
 				foo.getFields().get(0).getAnnotations().get(0)));
 		assertEquals(
 				"public enum Foo {" + DefaultJavaPrettyPrinter.LINE_SEPARATOR
-						+ "@java.lang.Deprecated"
+						+ "    @java.lang.Deprecated"
 						+ DefaultJavaPrettyPrinter.LINE_SEPARATOR + "    Bar;}",
 				foo.toString());
 	}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -422,7 +422,7 @@ public class ImportTest {
 
 		CtClass<Object> aClass = factory.Class().get(A.class);
 		assertEquals("public class A {" + newLine
-				+ "    public class ArrayList extends java.util.ArrayList {    }" + newLine
+				+ "    public class ArrayList extends java.util.ArrayList {}" + newLine
 				+ "}", aClass.toString());
 	}
 	

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -213,7 +213,7 @@ public class DefaultPrettyPrinterTest {
 
 		expected =
 			"public enum ENUM {" +nl+
-			"E1(globalField,E1);" +nl+
+			"    E1(globalField,E1);" +nl+
 			"    final int NUM;" +nl+nl+
 			"    final Enum<?> e;" +nl+nl+
 			"    private ENUM(int num, Enum<?> e) {" +nl+

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -247,11 +247,11 @@ public class PrinterTest {
 		spoon.createCompiler(
 				factory,
 				SpoonResourceHelper
-						.resources(
-								"./src/test/java/spoon/test/annotation/testclasses/",
-								"./src/test/java/spoon/test/prettyprinter/"))
+				.resources(
+						"./src/test/java/spoon/test/annotation/testclasses/",
+						"./src/test/java/spoon/test/prettyprinter/"))
 //this case needs longer, but checks contract on all spoon java sources
-//						.resources("./src/main/java/"))
+//				.resources("./src/main/java/"))
 				.build();
 		
 		assertTrue(factory.Type().getAll().size() > 0);
@@ -275,6 +275,7 @@ public class PrinterTest {
 					checkTokenWhitespace(separator, false);					
 					//one of the separators
 					assertTrue("Unexpected separator: "+separator, separators.contains(separator));
+					handleTabs();
 					allTokens.append(separator);
 					return this;
 				}
@@ -284,6 +285,7 @@ public class PrinterTest {
 					checkRepeatingOfTokens("writeOperator");
 					checkTokenWhitespace(operator, false);					
 					assertTrue("Unexpected operator: "+operator, operators.contains(operator));
+					handleTabs();
 					allTokens.append(operator);
 					return this;
 				}
@@ -292,6 +294,7 @@ public class PrinterTest {
 				public TokenWriter writeLiteral(String literal) {
 					checkRepeatingOfTokens("writeLiteral");
 					assertTrue(literal.length() > 0);
+					handleTabs();
 					allTokens.append(literal);
 					return this;
 				}
@@ -301,6 +304,7 @@ public class PrinterTest {
 					checkRepeatingOfTokens("writeKeyword");
 					checkTokenWhitespace(keyword, false);					
 					assertTrue("Unexpected java keyword: "+keyword, javaKeywords.contains(keyword));
+					handleTabs();
 					allTokens.append(keyword);
 					return this;
 				}
@@ -318,6 +322,7 @@ public class PrinterTest {
 						}
 					}
 					assertTrue("Keyword found in Identifier: "+identifier, javaKeywords.contains(identifier) == false);
+					handleTabs();
 					allTokens.append(identifier);
 					return this;
 				}
@@ -330,6 +335,7 @@ public class PrinterTest {
 					ph.setLineSeparator(getPrinterHelper().getLineSeparator());
 					ph.setTabCount(getPrinterHelper().getTabCount());
 					sptw.writeComment(comment);
+					handleTabs();
 					allTokens.append(sptw.getPrinterHelper().toString());
 					return this;
 				}
@@ -338,20 +344,26 @@ public class PrinterTest {
 				public TokenWriter writeln() {
 					checkRepeatingOfTokens("writeln");
 					allTokens.append(getPrinterHelper().getLineSeparator());
+					lastTokenWasEOL = true;
 					return this;
 				}
 				
-				@Override
-				public TokenWriter writeTabs() {
-					checkRepeatingOfTokens("writeTabs");
-					for (int i = 0; i < getPrinterHelper().getTabCount(); i++) {
-						if (factory.getEnvironment().isUsingTabulations()) {
-							allTokens.append('\t');
-						} else {
-							for (int j = 0; j < factory.getEnvironment().getTabulationSize(); j++) {
-								allTokens.append(' ');
+				private boolean lastTokenWasEOL = true;
+				private int tabCount = 0;
+				
+				public TokenWriter handleTabs() {
+					if(lastTokenWasEOL) {
+						lastTokenWasEOL = false;
+						for (int i = 0; i < tabCount; i++) {
+							if (factory.getEnvironment().isUsingTabulations()) {
+								allTokens.append('\t');
+							} else {
+								for (int j = 0; j < factory.getEnvironment().getTabulationSize(); j++) {
+									allTokens.append(' ');
+								}
 							}
 						}
+						
 					}
 					return this;
 				}
@@ -360,17 +372,20 @@ public class PrinterTest {
 				public TokenWriter writeCodeSnippet(String token) {
 					checkRepeatingOfTokens("writeCodeSnippet");
 					assertTrue(token.length() > 0);
+					handleTabs();
 					allTokens.append(token);
 					return this;
 				}
 
 				@Override
 				public TokenWriter incTab() {
+					tabCount++;
 					return this;
 				}
 
 				@Override
 				public TokenWriter decTab() {
+					tabCount--;
 					return this;
 				}
 


### PR DESCRIPTION
PrinterHelper can print tabs automatically. So all TokenWriter.writeTabs and related calls are useless and can be removed - simpler code!