### PR TITLE
fix: DefaultJavaPrettyPrinter prints tokens correctly

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -429,8 +429,7 @@ public class PrinterTest {
 			assertEquals(0, withEmptyListenerResult.length());
 			
 			//contract: result built manually from tokens is same like the one made by DefaultTokenWriter
-			//temporarily disabled until problem of PrinterHelper#hasNewContent() is solved
-//			assertEquals(standardPrintedResult, allTokens.toString());
+			assertEquals(standardPrintedResult, allTokens.toString());
 		}
 	}
 


### PR DESCRIPTION
This is solution for #1567 - token-based snapshotLength and hasNewContent internal implementations of DJPP, which are independent on implementation of client's TokenWriter.