### PR TITLE
fix: the query engine is broken on some JVM because it relies on stack trace elements

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -16,20 +16,19 @@
  */
 package spoon.reflect.visitor.chain;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.filter.CtScannerFunction;
 import spoon.support.util.RtHelper;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * The facade of {@link CtQuery} which represents a query bound to the {@link CtElement},

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -632,7 +632,8 @@ public class FilterTest {
 				});
 			fail();
 		} catch (SpoonException e) {
-			assertTrue(e.getMessage().indexOf("Step invalidStep2) spoon.support.reflect.declaration.CtClassImpl cannot be cast to spoon.reflect.declaration.CtMethod")>=0);
+			System.out.println(e.getMessage());
+			assertTrue(e.getMessage().indexOf("cannot be cast to")>=0);
 		}
 	}
 	@Test
@@ -897,120 +898,8 @@ public class FilterTest {
 					context.count++;
 					throw new ClassCastException("TEST");
 				});
-				fail("It must fail, because body of forEach should be called and thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the for each implementation made by local class throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).forEach(new CtConsumer<CtType>() {
-					@Override
-					public void accept(CtType t) {
-						context.count++;
-						throw new ClassCastException("TEST");
-					}
-				});
-				fail("It must fail, because body of forEach should be called and thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the select implementation made by local class throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).select(new Filter<CtType>(){
-					@Override
-					public boolean matches(CtType element) {
-						context.count++;
-						throw new ClassCastException("TEST");
-					}
-				}).list();
-				fail("It must fail, because body of select thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the select implementation made by lambda throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).select((CtType element) -> {
-					context.count++;
-					throw new ClassCastException("TEST");
-				}).list();
-				fail("It must fail, because body of select thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the map(CtFunction) implementation made by local class throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map(new CtFunction<CtType, Object>(){
-					@Override
-					public Object apply(CtType input) {
-						context.count++;
-						throw new ClassCastException("TEST");
-					}
-				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
-				fail("It must fail, because body of map thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the map(CtFunction) implementation made by lambda throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map((CtType input) -> {
-					context.count++;
-					throw new ClassCastException("TEST");
-				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
-				fail("It must fail, because body of map thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the map(CtConsumableFunction) implementation made by local class throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map(new CtConsumableFunction<CtType>(){
-					@Override
-					public void apply(CtType input, CtConsumer<Object> outputConsumer) {
-						context.count++;
-						throw new ClassCastException("TEST");
-					}
-				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
-				fail("It must fail, because body of map thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
-			}
-		}
-		{
-			Context context = new Context();
-			//contract: if the map(CtConsumableFunction) implementation made by lambda throws CCE then it is reported
-			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map((CtType input, CtConsumer<Object> outputConsumer) -> {
-					context.count++;
-					throw new ClassCastException("TEST");
-				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
-				fail("It must fail, because body of map thrown CCE");
-			} catch (SpoonException e) {
-				assertTrue(context.count>0);
-				assertEquals("TEST", e.getCause().getMessage());
+			} catch (SpoonException | ClassCastException e) {
+				fail();
 			}
 		}
 	}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -625,15 +625,12 @@ public class FilterTest {
 		
 		try {
 			launcher.getFactory().Package().getRootPackage().filterChildren((CtClass<?> c)->{return true;}).name("step1")
-				.map((CtMethod<?> m)->m).name("invalidStep2")
-				.map((o)->o).name("step3")
+				.map((CtMethod<?> m)->m).name("invalidStep2") // here it will fail
 				.forEach((CtInterface<?> c)->{
-					fail();
 				});
 			fail();
-		} catch (SpoonException e) {
-			System.out.println(e.getMessage());
-			assertTrue(e.getMessage().indexOf("cannot be cast to")>=0);
+		} catch (ClassCastException e) {
+			// CtCLass cannot be cast to CtMethod
 		}
 	}
 	@Test

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -626,8 +626,7 @@ public class FilterTest {
 		try {
 			launcher.getFactory().Package().getRootPackage().filterChildren((CtClass<?> c)->{return true;}).name("step1")
 				.map((CtMethod<?> m)->m).name("invalidStep2") // here it will fail
-				.forEach((CtInterface<?> c)->{
-				});
+				.list(); // forcing the evaluation of the query
 			fail();
 		} catch (ClassCastException e) {
 			// CtCLass cannot be cast to CtMethod


### PR DESCRIPTION
The query engine is broken on some JVM (eg Oracle 1.8.40), because it relies on stack trace elements, and the stack trace elements change on some JVM.

The problem is that `StackTraceElement stackEle = stackEles[0]` is not necessarily the right one (in Oracle 1.8.40 the stack frame from an anonymous lambda is not there).

This PR removes this brittleness and has to change a little bit the specification when queries or functions throw a ClassCastException
