### PR TITLE
doc: clarifies contracts of @DerivedProperty

### DIFF
--- a/src/main/java/spoon/support/DerivedProperty.java
+++ b/src/main/java/spoon/support/DerivedProperty.java
@@ -23,10 +23,16 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/** Tells that a metamodel property is derived, ie computed from the value of another property.
+/**
+ * Tells that a metamodel property is derived, ie computed from the value of another property.
+ *
  * For instance {@link CtType#getFields()}  is derived from {@link CtType#getTypeMembers()}
  *
- * This annotation is used for specifying CtScanner: derived properties are never scanned.
+ * It can be put on getter ond setters.
+ *
+ * Contracts:
+ * - A setter with @DerivedProperty never triggers a model intercession event.
+ * - A getter with @DerivedProperty is never called in CtScanner and derived classes (clone, replace)
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD })

--- a/src/main/java/spoon/support/DerivedProperty.java
+++ b/src/main/java/spoon/support/DerivedProperty.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * For instance {@link CtType#getFields()}  is derived from {@link CtType#getTypeMembers()}
  *
- * It can be put on getter ond setters.
+ * It can be put on getter and setters.
  *
  * Contracts:
  * - A setter with @DerivedProperty never triggers a model intercession event.

--- a/src/main/java/spoon/support/DerivedProperty.java
+++ b/src/main/java/spoon/support/DerivedProperty.java
@@ -31,7 +31,8 @@ import java.lang.annotation.Target;
  * It can be put on getter and setters.
  *
  * Contracts:
- * - A setter with @DerivedProperty never triggers a model intercession event.
+ * - A setter with @DerivedProperty only triggers one single model intercession event,
+ *   on the element primarily responsible for handling the state from which this dervied property is computed.
  * - A getter with @DerivedProperty is never called in CtScanner and derived classes (clone, replace)
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
per our discussion on #1586,  PropertyGetter can be used for @DerivedProperty as well