### PR TITLE
fix: Optional maven dependencies should not be pass in SpoonMavenLauncher

### DIFF
--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -237,6 +237,8 @@ public class MavenLauncher extends Launcher {
 
 		/**
 		 * Get the list of dependencies available in the local maven repository
+		 *
+		 * @param isLib: If false take dependency of the main project; if true, take dependencies of a library of the project
 		 * @return the list of  dependencies
 		 */
 		public List<File> getDependencies(boolean isLib) {
@@ -268,6 +270,11 @@ public class MavenLauncher extends Launcher {
 				if (version.startsWith("[")) {
 					version = version.substring(1, version.indexOf(','));
 				}
+				// pass only the optional dependency if it's in a library dependency
+				if (isLib && dependency.isOptional()) {
+					continue;
+				}
+
 				// ignore test dependencies for app source code
 				if ("test".equals(dependency.getScope()) && SOURCE_TYPE.APP_SOURCE == sourceType) {
 					continue;

--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -268,9 +268,6 @@ public class MavenLauncher extends Launcher {
 				if (version.startsWith("[")) {
 					version = version.substring(1, version.indexOf(','));
 				}
-				if (dependency.isOptional()) {
-					continue;
-				}
 				// ignore test dependencies for app source code
 				if ("test".equals(dependency.getScope()) && SOURCE_TYPE.APP_SOURCE == sourceType) {
 					continue;


### PR DESCRIPTION
Optional dependencies are used to prevent exporting dependencies, but they're not optional for current project (it's a really bad keyword...). 
Then IMHO we should not pass them everytime for building the classpath in SpoonMavenLauncher. 