### PR TITLE
refactor(role): CtCodeSnippet has CtRole.SOURCE_CODE

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
+++ b/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
@@ -19,7 +19,7 @@ package spoon.reflect.declaration;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import static spoon.reflect.path.CtRole.EXPRESSION;
+import static spoon.reflect.path.CtRole.SNIPPET;
 
 /**
  * This interface represents snippets of source code that can be used in the AST
@@ -36,13 +36,13 @@ public interface CtCodeSnippet {
 	/**
 	 * Sets the textual value of the code.
 	 */
-	@PropertySetter(role = EXPRESSION)
+	@PropertySetter(role = SNIPPET)
 	<C extends CtCodeSnippet> C setValue(String value);
 
 	/**
 	 * Gets the textual value of the code.
 	 */
-	@PropertyGetter(role = EXPRESSION)
+	@PropertyGetter(role = SNIPPET)
 	String getValue();
 
 }

--- a/src/main/java/spoon/reflect/path/CtRole.java
+++ b/src/main/java/spoon/reflect/path/CtRole.java
@@ -83,7 +83,8 @@ public enum CtRole {
 	COMMENT_TYPE,
 	DOCUMENTATION_TYPE,
 	JAVADOC_TAG_VALUE,
-	POSITION;
+	POSITION,
+	SNIPPET;
 
 	/**
 	 * Get the {@link CtRole} associated to the field name

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
@@ -20,12 +20,11 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtCodeSnippet;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.SnippetCompilationError;
 import spoon.support.compiler.SnippetCompilationHelper;
 
-import static spoon.reflect.path.CtRole.EXPRESSION;
+import static spoon.reflect.path.CtRole.SNIPPET;
 
 public class CtCodeSnippetExpressionImpl<T> extends CtExpressionImpl<T> implements CtCodeSnippetExpression<T> {
 
@@ -35,15 +34,17 @@ public class CtCodeSnippetExpressionImpl<T> extends CtExpressionImpl<T> implemen
 		visitor.visitCtCodeSnippetExpression(this);
 	}
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = SNIPPET)
 	String value;
 
+	@Override
 	public String getValue() {
 		return value;
 	}
 
+	@Override
 	public <C extends CtCodeSnippet> C setValue(String value) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, value, this.value);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SNIPPET, value, this.value);
 		this.value = value;
 		return (C) this;
 	}

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
@@ -20,12 +20,11 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtCodeSnippet;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.SnippetCompilationError;
 import spoon.support.compiler.SnippetCompilationHelper;
 
-import static spoon.reflect.path.CtRole.EXPRESSION;
+import static spoon.reflect.path.CtRole.SNIPPET;
 
 public class CtCodeSnippetStatementImpl extends CtStatementImpl implements CtCodeSnippetStatement {
 
@@ -35,15 +34,17 @@ public class CtCodeSnippetStatementImpl extends CtStatementImpl implements CtCod
 		visitor.visitCtCodeSnippetStatement(this);
 	}
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = SNIPPET)
 	String value;
 
+	@Override
 	public String getValue() {
 		return value;
 	}
 
+	@Override
 	public <C extends CtCodeSnippet> C setValue(String value) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, value, this.value);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SNIPPET, value, this.value);
 		this.value = value;
 		return (C) this;
 	}


### PR DESCRIPTION
This PR introduces new CtRole.SOURCE_CODE, which is used for value of CtCodeSnippet. Before there was CtRole.EXPRESSION, which has different meaning.