### PR TITLE
review1: fix(role): CtTypeAccess getTypeAccess uses CtRole.TYPE_ACCESS

### DIFF
--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -23,7 +23,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
-import static spoon.reflect.path.CtRole.TYPE;
+import static spoon.reflect.path.CtRole.TYPE_ACCESS;
 
 /**
  * This code element represents a type reference usable as an expression.
@@ -59,7 +59,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 *
 	 * @return CtTypeReference.
 	 */
-	@PropertyGetter(role = TYPE)
+	@PropertyGetter(role = TYPE_ACCESS)
 	CtTypeReference<A> getAccessedType();
 
 	/**
@@ -68,7 +68,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 * @param accessedType
 	 * 		CtTypeReference.
 	 */
-	@PropertySetter(role = TYPE)
+	@PropertySetter(role = TYPE_ACCESS)
 	<C extends CtTypeAccess<A>> C setAccessedType(CtTypeReference<A> accessedType);
 
 	/**

--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -23,7 +23,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
-import static spoon.reflect.path.CtRole.TYPE_ACCESS;
+import static spoon.reflect.path.CtRole.ACCESSED_TYPE;
 
 /**
  * This code element represents a type reference usable as an expression.
@@ -59,7 +59,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 *
 	 * @return CtTypeReference.
 	 */
-	@PropertyGetter(role = TYPE_ACCESS)
+	@PropertyGetter(role = ACCESSED_TYPE)
 	CtTypeReference<A> getAccessedType();
 
 	/**
@@ -68,7 +68,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 * @param accessedType
 	 * 		CtTypeReference.
 	 */
-	@PropertySetter(role = TYPE_ACCESS)
+	@PropertySetter(role = ACCESSED_TYPE)
 	<C extends CtTypeAccess<A>> C setAccessedType(CtTypeReference<A> accessedType);
 
 	/**

--- a/src/main/java/spoon/reflect/path/CtRole.java
+++ b/src/main/java/spoon/reflect/path/CtRole.java
@@ -87,7 +87,7 @@ public enum CtRole {
 	JAVADOC_TAG_VALUE,
 	POSITION,
 	SNIPPET,
-	TYPE_ACCESS;
+	ACCESSED_TYPE;
 
 	/**
 	 * Get the {@link CtRole} associated to the field name

--- a/src/main/java/spoon/reflect/path/CtRole.java
+++ b/src/main/java/spoon/reflect/path/CtRole.java
@@ -86,7 +86,8 @@ public enum CtRole {
 	DOCUMENTATION_TYPE,
 	JAVADOC_TAG_VALUE,
 	POSITION,
-	SNIPPET;
+	SNIPPET,
+	TYPE_ACCESS;
 
 	/**
 	 * Get the {@link CtRole} associated to the field name

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -19,16 +19,15 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
 
-import static spoon.reflect.path.CtRole.TYPE;
+import static spoon.reflect.path.CtRole.TYPE_ACCESS;
 
 public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTypeAccess<A> {
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE_ACCESS)
 	private CtTypeReference<A> type;
 
 	@Override
@@ -46,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 		if (accessedType != null) {
 			accessedType.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, accessedType, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE_ACCESS, accessedType, this.type);
 		type = accessedType;
 		return (C) this;
 	}

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -23,11 +23,11 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
 
-import static spoon.reflect.path.CtRole.TYPE_ACCESS;
+import static spoon.reflect.path.CtRole.ACCESSED_TYPE;
 
 public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTypeAccess<A> {
 
-	@MetamodelPropertyField(role = TYPE_ACCESS)
+	@MetamodelPropertyField(role = ACCESSED_TYPE)
 	private CtTypeReference<A> type;
 
 	@Override
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 		if (accessedType != null) {
 			accessedType.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE_ACCESS, accessedType, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ACCESSED_TYPE, accessedType, this.type);
 		type = accessedType;
 		return (C) this;
 	}


### PR DESCRIPTION
There was conflict with CtTypeAccess#getType(), which returns different value, but had same role CtRole.TYPE