### PR TITLE
fix: ClassTypingContext#isSameSignature for generic methods

### DIFF
--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -35,7 +35,6 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
@@ -251,53 +250,6 @@ public class ClassTypingContext extends AbstractTypingContext {
 			lastResolvedSuperclass = null;
 		}
 		return listener.foundArguments;
-	}
-
-	/**
-	 * @param method to be adapted to this context
-	 * @return new method whose parameters are adapted to `this context` or the same`method` if there is no need to adapt it
-	 */
-	public <T> CtMethod<T> adaptMethod(CtMethod<T> method) {
-		CtType<?> declType = method.getDeclaringType();
-		if (declType == null) {
-			throw new SpoonException("Cannot adapt method, which has no declaringType");
-		}
-		if (getAdaptationScope() == declType) {
-			return method;
-		}
-		//the scope method is declared in different type then scope of assigned classTypingContext
-		if (isSubtypeOf(declType.getReference()) == false) {
-			throw new SpoonException("Cannot create MethodTypingContext for method declared in different ClassTypingContext");
-		}
-		/*
-		 * The method is declared in an supertype of classTypingContext.
-		 * Create virtual scope method by adapting generic types of supertype method to required scope
-		 */
-		Factory factory = method.getFactory();
-		//create new method
-		CtMethod<T> adaptedMethod = factory.Core().createMethod();
-		adaptedMethod.setParent(getAdaptationScope());
-		adaptedMethod.setModifiers(method.getModifiers());
-		adaptedMethod.setSimpleName(method.getSimpleName());
-		for (CtTypeReference<? extends Throwable> thrownType : method.getThrownTypes()) {
-			adaptedMethod.addThrownType(thrownType.clone());
-		}
-		for (CtTypeParameter typeParam : method.getFormalCtTypeParameters()) {
-			CtTypeParameter newTypeParam = typeParam.clone();
-			newTypeParam.setSuperclass(adaptTypeForNewMethod(typeParam.getSuperclass()));
-			adaptedMethod.addFormalCtTypeParameter(newTypeParam);
-		}
-		//adapt return type
-		adaptedMethod.setType((CtTypeReference) adaptTypeForNewMethod(method.getType()));
-		//adapt parameters
-		List<CtParameter<?>> adaptedParams = new ArrayList<>(method.getParameters().size());
-		for (CtParameter<?> parameter : method.getParameters()) {
-			adaptedParams.add(factory.Executable().createParameter(null,
-					adaptTypeForNewMethod(parameter.getType()),
-					parameter.getSimpleName()));
-		}
-		adaptedMethod.setParameters(adaptedParams);
-		return adaptedMethod;
 	}
 
 	/**
@@ -650,25 +602,6 @@ public class ClassTypingContext extends AbstractTypingContext {
 		}
 		//superArg is not a wildcard. Only same type is matching
 		return subArg.equals(superArg);
-	}
-
-	private CtTypeReference<?> adaptTypeForNewMethod(CtTypeReference<?> typeRef) {
-		if (typeRef == null) {
-			return null;
-		}
-		if (typeRef instanceof CtTypeParameterReference) {
-			CtTypeParameterReference typeParamRef = (CtTypeParameterReference) typeRef;
-			CtTypeParameter typeParam = typeParamRef.getDeclaration();
-			if (typeParam == null) {
-				throw new SpoonException("Declaration of the CtTypeParameter should not be null.");
-			}
-
-			if (typeParam.getTypeParameterDeclarer() instanceof CtExecutable) {
-				//the parameter is declared in scope of Method or Constructor
-				return typeRef.clone();
-			}
-		}
-		return adaptType(typeRef);
 	}
 
 	private boolean isSameSignature(CtExecutable<?> thisMethod, CtExecutable<?> thatMethod, boolean canTypeErasure) {

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -45,6 +45,7 @@ import spoon.test.ctType.testclasses.ErasureModelA;
 import spoon.test.generics.testclasses.Banana;
 import spoon.test.generics.testclasses.CelebrationLunch;
 import spoon.test.generics.testclasses.CelebrationLunch.WeddingLunch;
+import spoon.test.generics.testclasses2.SameSignature2;
 import spoon.test.generics.testclasses.EnumSetOf;
 import spoon.test.generics.testclasses.FakeTpl;
 import spoon.test.generics.testclasses.Lunch;
@@ -60,9 +61,7 @@ import spoon.testing.utils.ModelUtils;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1067,7 +1066,9 @@ public class GenericsTest {
 		ClassTypingContext ctcWeddingLunch = new ClassTypingContext(ctClassWeddingLunch);
 		// we all analyze new methods
 		final MethodTypingContext methodSTH = new MethodTypingContext().setClassTypingContext(ctcWeddingLunch);
-		CtMethod<?> adaptedLunchEatMe = ctcWeddingLunch.adaptMethod(trLunch_eatMe);
+		//contract: method can be adapted only using MethodTypingContext
+		methodSTH.setMethod(trLunch_eatMe);
+		CtMethod<?> adaptedLunchEatMe = (CtMethod<?>) methodSTH.getAdaptationScope();
 
 		//contract: adapting of method declared in different scope, returns new method
 		assertTrue(adaptedLunchEatMe != trLunch_eatMe);
@@ -1096,13 +1097,8 @@ public class GenericsTest {
 		assertEquals("C", adaptedLunchEatMe.getParameters().get(2).getType().getQualifiedName());
 
 		//contract: adapting of adapted method returns input method
-		assertSame(adaptedLunchEatMe, ctcWeddingLunch.adaptMethod(adaptedLunchEatMe));
-
-		//contract: method typing context creates adapted method automatically
-		methodSTH.setMethod(trLunch_eatMe);
-		//contract: method typing context creates adapted method automatically, which is equal to manually adapted one
-		assertEquals(adaptedLunchEatMe, methodSTH.getAdaptationScope());
-		
+		methodSTH.setMethod(adaptedLunchEatMe);
+		assertSame(adaptedLunchEatMe, methodSTH.getAdaptationScope());
 	}
 	
 	@Test
@@ -1293,6 +1289,28 @@ public class GenericsTest {
 		assertTrue(ctc.isSubSignature(methods.get(0), methodsItf.get(0)));
 		assertTrue(ctc.isSameSignature(methods.get(0), methodsItf.get(0)));
 	}
+
+	@Test
+	public void testIsSameSignatureWithMethodGenerics() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/generics/testclasses2/SameSignature2.java");
+		launcher.buildModel();
+
+		CtClass ctClass = launcher.getFactory().Class().get(SameSignature2.class);
+		CtMethod classMethod = (CtMethod)ctClass.getMethodsByName("visitCtConditional").get(0);
+
+		CtType<?> iface = launcher.getFactory().Type().get("spoon.test.generics.testclasses2.ISameSignature");
+		CtMethod ifaceMethod = (CtMethod)iface.getMethodsByName("visitCtConditional").get(0);
+
+		ClassTypingContext ctcSub = new ClassTypingContext(ctClass.getReference());
+		assertTrue(ctcSub.isOverriding(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isOverriding(ifaceMethod, classMethod));
+		assertTrue(ctcSub.isSubSignature(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isSubSignature(ifaceMethod, classMethod));
+		assertTrue(ctcSub.isSameSignature(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isSameSignature(ifaceMethod, classMethod));
+	}
+	
 	@Test
 	public void testGetExecDeclarationOfEnumSetOf() {
 		Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/generics/testclasses2/SameSignature2.java
+++ b/src/test/java/spoon/test/generics/testclasses2/SameSignature2.java
@@ -1,0 +1,13 @@
+package spoon.test.generics.testclasses2;
+
+import spoon.reflect.code.CtConditional;
+
+public class SameSignature2 implements ISameSignature {
+    @Override
+	public <U> void visitCtConditional(final CtConditional<U> conditional) {
+	}
+}
+
+interface ISameSignature {
+	<V> void visitCtConditional(final CtConditional<V> conditional);
+}


### PR DESCRIPTION
The method with this declaration
```java
<U> void visitCtConditional(final CtConditional<U> conditional)
```
defined in class and inteface returned false for ClassTypingContext#isSameSignature(methodFromIface, methodFromClass).