### PR TITLE
review1: fix: StackOverflowError in MethodTypingContext on <T, U extends T>

### DIFF
--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -46,6 +46,7 @@ import spoon.test.generics.testclasses.Banana;
 import spoon.test.generics.testclasses.CelebrationLunch;
 import spoon.test.generics.testclasses.CelebrationLunch.WeddingLunch;
 import spoon.test.generics.testclasses2.SameSignature2;
+import spoon.test.generics.testclasses2.SameSignature3;
 import spoon.test.generics.testclasses.EnumSetOf;
 import spoon.test.generics.testclasses.FakeTpl;
 import spoon.test.generics.testclasses.Lunch;
@@ -1337,5 +1338,26 @@ public class GenericsTest {
 
 		decl = invocation.getExecutable().getExecutableDeclaration();
 		assertEquals(rightOfMethod, decl);
+	}
+	
+	@Test
+	public void testIsSameSignatureWithReferencedGenerics() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/generics/testclasses2/SameSignature3.java");
+		launcher.buildModel();
+
+		CtClass ctClass = launcher.getFactory().Class().get(SameSignature3.class);
+		CtMethod classMethod = (CtMethod)ctClass.getMethodsByName("visitCtConditional").get(0);
+
+		CtType<?> iface = launcher.getFactory().Type().get("spoon.test.generics.testclasses2.ISameSignature3");
+		CtMethod ifaceMethod = (CtMethod)iface.getMethodsByName("visitCtConditional").get(0);
+
+		ClassTypingContext ctcSub = new ClassTypingContext(ctClass.getReference());
+		assertTrue(ctcSub.isOverriding(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isOverriding(ifaceMethod, classMethod));
+		assertTrue(ctcSub.isSubSignature(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isSubSignature(ifaceMethod, classMethod));
+		assertTrue(ctcSub.isSameSignature(classMethod, ifaceMethod));
+		assertTrue(ctcSub.isSameSignature(ifaceMethod, classMethod));
 	}
 }

--- a/src/test/java/spoon/test/generics/testclasses2/SameSignature3.java
+++ b/src/test/java/spoon/test/generics/testclasses2/SameSignature3.java
@@ -1,0 +1,13 @@
+package spoon.test.generics.testclasses2;
+
+import spoon.reflect.code.CtConditional;
+
+public class SameSignature3<T extends String> implements ISameSignature3<T> {
+    @Override
+	public <U, K extends U, L extends T> void visitCtConditional(final CtConditional<U> conditional, K k, L l) {
+	}
+}
+
+interface ISameSignature3<T> {
+	<V, L extends V, K extends T> void visitCtConditional(final CtConditional<V> conditional, L l, K k);
+}


### PR DESCRIPTION
The method like this caused StackOverflowError
```java
<U, K extends U void visitCtConditional(final CtConditional<U> conditional, K k)
```