### PR TITLE
review1: fix: CtTypeParameterReference#getBoundingType() Object -> null

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -155,6 +155,16 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 
 	@Override
 	public CtTypeReference<?> getBoundingType() {
+		if (superType != null) {
+			/*
+			 * Spoon expects that superType is null on many places.
+			 * But sometime  there is Object in it, which has same meaning like null in this case
+			 * But EqualsVisitor returns false that it is not equal
+			 */
+			if (Object.class.getName().equals(superType.getQualifiedName())) {
+				return null;
+			}
+		}
 		return superType;
 	}
 

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -45,6 +45,8 @@ import spoon.test.ctType.testclasses.ErasureModelA;
 import spoon.test.generics.testclasses.Banana;
 import spoon.test.generics.testclasses.CelebrationLunch;
 import spoon.test.generics.testclasses.CelebrationLunch.WeddingLunch;
+import spoon.test.generics.testclasses2.LikeCtClass;
+import spoon.test.generics.testclasses2.LikeCtClassImpl;
 import spoon.test.generics.testclasses2.SameSignature2;
 import spoon.test.generics.testclasses2.SameSignature3;
 import spoon.test.generics.testclasses.EnumSetOf;
@@ -499,7 +501,7 @@ public class GenericsTest {
 
 		final CtMethod<?> apply = panini.getMethodsByName("apply").get(0);
 		assertEquals(1, apply.getType().getActualTypeArguments().size());
-		assertEquals("? super java.lang.Object", apply.getType().getActualTypeArguments().get(0).toString());
+		assertEquals("?", apply.getType().getActualTypeArguments().get(0).toString());
 
 		assertEquals(1, apply.getParameters().get(0).getType().getActualTypeArguments().size());
 		assertEquals("? extends java.lang.Long", apply.getParameters().get(0).getType().getActualTypeArguments().get(0).toString());
@@ -1360,4 +1362,41 @@ public class GenericsTest {
 		assertTrue(ctcSub.isSameSignature(classMethod, ifaceMethod));
 		assertTrue(ctcSub.isSameSignature(ifaceMethod, classMethod));
 	}
+	
+	@Test
+	public void testIsGenericTypeEqual() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/generics/testclasses2/LikeCtClass.java");
+		launcher.addInputResource("./src/test/java/spoon/test/generics/testclasses2/LikeCtClassImpl.java");
+		launcher.buildModel();
+
+		CtType<?> ctIFace = launcher.getFactory().Interface().get(LikeCtClass.class);
+		CtMethod<?> ifaceGetter = (CtMethod)ctIFace.getMethodsByName("getConstructors").get(0);
+		CtMethod<?> ifaceSetter = (CtMethod)ctIFace.getMethodsByName("setConstructors").get(0);
+		assertEquals(ifaceGetter.getType().toString(), ifaceSetter.getParameters().get(0).getType().toString());
+		assertEquals(ifaceGetter.getType(), ifaceSetter.getParameters().get(0).getType());
+		
+		CtType<?> ctClass = launcher.getFactory().Class().get(LikeCtClassImpl.class);
+		CtMethod<?> classGetter = (CtMethod)ctClass.getMethodsByName("getConstructors").get(0);
+		CtMethod<?> classSetter = (CtMethod)ctClass.getMethodsByName("setConstructors").get(0);
+		assertEquals(classGetter.getType().toString(), classSetter.getParameters().get(0).getType().toString());
+		assertEquals(classGetter.getType(), classSetter.getParameters().get(0).getType());
+		
+		assertEquals(ifaceGetter.getType().toString(), classGetter.getType().toString());
+		assertEquals(ifaceGetter.getType(), classGetter.getType());
+		assertEquals(ifaceSetter.getParameters().get(0).getType().toString(), classSetter.getParameters().get(0).getType().toString());
+		assertEquals(ifaceSetter.getParameters().get(0).getType(), classSetter.getParameters().get(0).getType());
+		
+		assertEquals(ifaceSetter.getParameters().get(0).getType(), classGetter.getType());
+		
+		MethodTypingContext mtc = new MethodTypingContext().setClassTypingContext(new ClassTypingContext(ctClass)).setMethod(ifaceSetter);
+		CtMethod<?> adaptedMethod = (CtMethod<?>) mtc.getAdaptationScope();
+		/*
+		 * after adaptation of `Set<AnType<T>>` from scope of interface to scope of class there is Set<AnType<T extends Object>>
+		 * Which is semantically equivalent, but Equals check does not know that
+		 */
+		assertEquals(adaptedMethod.getParameters().get(0).getType(), classGetter.getType());
+		assertEquals(adaptedMethod.getParameters().get(0).getType(), classSetter.getParameters().get(0).getType());
+	}
+	
 }

--- a/src/test/java/spoon/test/generics/testclasses2/LikeCtClass.java
+++ b/src/test/java/spoon/test/generics/testclasses2/LikeCtClass.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.test.generics.testclasses2;
+
+import java.util.Set;
+
+public interface LikeCtClass<T extends Object> {
+	Set<AnType<T>> getConstructors();
+	<C extends LikeCtClass<T>> C setConstructors(Set<AnType<T>> constructors);
+}
+
+interface AnType<U> {}

--- a/src/test/java/spoon/test/generics/testclasses2/LikeCtClassImpl.java
+++ b/src/test/java/spoon/test/generics/testclasses2/LikeCtClassImpl.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.test.generics.testclasses2;
+
+import java.util.Set;
+
+public class LikeCtClassImpl<T extends Object> implements LikeCtClass<T> {
+	public Set<AnType<T>> getConstructors() {
+		return null;
+	}
+	public <C extends LikeCtClass<T>> C setConstructors(Set<AnType<T>> constructors) {
+		return (C)this;
+	}
+}


### PR DESCRIPTION
If CtTypeParameterReference#getBoundingType() returns null or Object, then it has same meaning - there is no bound = java.lang.Object is a bound.

The problem is that some type references returns Object and some returns null. I do not have test case yet, but it happened to me that 2 CtTypeReferences with exactly same printed representation were not equal because one of them had bounding type = null and second had Object.

For future I would prefer to fix it opposite way: to always return Object reference in such case (never null), but this solution needs much more changes in Spoon code, because it expects on many places null value.

So this PR is fast fix to be able to finish other PRs related to CtScanner, etc.

WDYT?