### PR TITLE
review: feat: Add Environment#setFactory

### DIFF
--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -295,6 +295,11 @@ public interface Environment {
 	Factory getFactory();
 
 	/**
+	 * Sets the factory of the environment
+	 */
+	void setFactory(Factory factory);
+
+	/**
 	 * Gets the level of loggers asked by the user.
 	 */
 	Level getLevel();

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -359,6 +359,7 @@ public class FactoryImpl implements Factory, Serializable {
 	 */
 	public FactoryImpl(CoreFactory coreFactory, Environment environment, Factory parentFactory) {
 		this.environment = environment;
+		this.environment.setFactory(this);
 		this.core = coreFactory;
 		this.core.setMainFactory(this);
 		this.parentFactory = parentFactory;

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -130,6 +130,11 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	@Override
+	public void setFactory(Factory factory) {
+		this.factory = factory;
+	}
+
+	@Override
 	public Level getLevel() {
 		return this.level;
 	}

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -201,4 +201,11 @@ public class FactoryTest {
 		}
 	}
 
+	@Test
+	public void testEnvGetFactoryIsNotNull() {
+		// contract: env.getFactory() should not return null
+
+		Launcher launcher = new Launcher();
+		assertNotNull(launcher.getEnvironment().getFactory());
+	}
 }


### PR DESCRIPTION
Add a setFactory method to environment and set it when calling the main factory constructor with a given environment. 
This allows to use the `getFactory()` of Environment without NPE. 