### PR TITLE
review fix: method should never be transient 

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -227,7 +227,7 @@ public class ContextBuilder {
 									EnumSet.noneOf(ModifierKind.class),
 									referenceBuilder.getTypeReference(fieldBinding.type),
 									name);
-							return field.setExtendedModifiers(JDTTreeBuilderQuery.getModifiers(fieldBinding.modifiers, true));
+							return field.setExtendedModifiers(JDTTreeBuilderQuery.getModifiers(fieldBinding.modifiers, true, false));
 						}
 					}
 					// add super class if any

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -944,10 +944,10 @@ public class JDTTreeBuilder extends ASTVisitor {
 		m.setSimpleName(CharOperation.charToString(methodDeclaration.selector));
 
 		if (methodDeclaration.binding != null) {
-			m.setExtendedModifiers(getModifiers(methodDeclaration.binding.modifiers, true));
+			m.setExtendedModifiers(getModifiers(methodDeclaration.binding.modifiers, true, true));
 		}
 
-		for (CtExtendedModifier extendedModifier : getModifiers(methodDeclaration.modifiers, false)) {
+		for (CtExtendedModifier extendedModifier : getModifiers(methodDeclaration.modifiers, false, true)) {
 			m.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.
 		}
 		m.setDefaultMethod(methodDeclaration.isDefaultMethod());
@@ -973,9 +973,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 	public boolean visit(ConstructorDeclaration constructorDeclaration, ClassScope scope) {
 		CtConstructor<Object> c = factory.Core().createConstructor();
 		if (constructorDeclaration.binding != null) {
-			c.setExtendedModifiers(getModifiers(constructorDeclaration.binding.modifiers, true));
+			c.setExtendedModifiers(getModifiers(constructorDeclaration.binding.modifiers, true, true));
 		}
-		for (CtExtendedModifier extendedModifier : getModifiers(constructorDeclaration.modifiers, false)) {
+		for (CtExtendedModifier extendedModifier : getModifiers(constructorDeclaration.modifiers, false, true)) {
 			c.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.
 		}
 		context.enter(c, constructorDeclaration);
@@ -1073,9 +1073,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 		Set<CtExtendedModifier> modifierSet = new HashSet<>();
 		if (fieldDeclaration.binding != null) {
-			field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true));
+			field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true, false));
 		}
-		for (CtExtendedModifier extendedModifier : getModifiers(fieldDeclaration.modifiers, false)) {
+		for (CtExtendedModifier extendedModifier : getModifiers(fieldDeclaration.modifiers, false, false)) {
 			field.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.
 		}
 
@@ -1151,9 +1151,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		CtLocalVariable<Object> v = factory.Core().createLocalVariable();
 		v.setSimpleName(CharOperation.charToString(localDeclaration.name));
 		if (localDeclaration.binding != null) {
-			v.setExtendedModifiers(getModifiers(localDeclaration.binding.modifiers, true));
+			v.setExtendedModifiers(getModifiers(localDeclaration.binding.modifiers, true, false));
 		}
-		for (CtExtendedModifier extendedModifier : getModifiers(localDeclaration.modifiers, false)) {
+		for (CtExtendedModifier extendedModifier : getModifiers(localDeclaration.modifiers, false, false)) {
 			v.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.
 		}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -112,7 +112,7 @@ public class JDTTreeBuilderHelper {
 	 */
 	CtCatchVariable<Throwable> createCatchVariable(TypeReference typeReference) {
 		final Argument jdtCatch = (Argument) jdtTreeBuilder.getContextBuilder().stack.peekFirst().node;
-		final Set<CtExtendedModifier> modifiers = getModifiers(jdtCatch.modifiers, false);
+		final Set<CtExtendedModifier> modifiers = getModifiers(jdtCatch.modifiers, false, false);
 
 		CtCatchVariable<Throwable> result = jdtTreeBuilder.getFactory().Core().createCatchVariable();
 		result.<CtCatchVariable>setSimpleName(CharOperation.charToString(jdtCatch.name)).setExtendedModifiers(modifiers);
@@ -581,7 +581,7 @@ public class JDTTreeBuilderHelper {
 		CtParameter<T> p = jdtTreeBuilder.getFactory().Core().createParameter();
 		p.setSimpleName(CharOperation.charToString(argument.name));
 		p.setVarArgs(argument.isVarArgs());
-		p.setExtendedModifiers(getModifiers(argument.modifiers));
+		p.setExtendedModifiers(getModifiers(argument.modifiers, false, false));
 		if (argument.binding != null && argument.binding.type != null && argument.type == null) {
 			p.setType(jdtTreeBuilder.getReferencesBuilder().<T>getTypeReference(argument.binding.type));
 			p.getType().setImplicit(argument.type == null);
@@ -653,7 +653,7 @@ public class JDTTreeBuilderHelper {
 		}
 
 		// Setting modifiers
-		type.setExtendedModifiers(getModifiers(typeDeclaration.modifiers));
+		type.setExtendedModifiers(getModifiers(typeDeclaration.modifiers, false, false));
 
 		return type;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -293,16 +293,6 @@ class JDTTreeBuilderQuery {
 	}
 
 	/**
-	 * Converts the modifier from JDT to Spoon and consider all modifiers as explicit.
-	 *
-	 * @param modifier Identifier of the modifier.
-	 * @return Set of enum value of {@link CtExtendedModifier}.
-	 */
-	static Set<CtExtendedModifier> getModifiers(int modifier) {
-		return getModifiers(modifier, false);
-	}
-
-	/**
 	 * Converts the modifier from JDT to Spoon.
 	 *
 	 * @param modifier
@@ -310,7 +300,7 @@ class JDTTreeBuilderQuery {
 	 * @param implicit True if the modifier is not explicit in the source code (e.g. a missing 'public' in an interface)
 	 * @return Set of enum value of {@link CtExtendedModifier}.
 	 */
-	static Set<CtExtendedModifier> getModifiers(int modifier, boolean implicit) {
+	static Set<CtExtendedModifier> getModifiers(int modifier, boolean implicit, boolean isMethod) {
 		Set<CtExtendedModifier> modifiers = new HashSet<>();
 		if ((modifier & ClassFileConstants.AccPublic) != 0) {
 			modifiers.add(new CtExtendedModifier(ModifierKind.PUBLIC, implicit));
@@ -333,7 +323,9 @@ class JDTTreeBuilderQuery {
 		if ((modifier & ClassFileConstants.AccVolatile) != 0) {
 			modifiers.add(new CtExtendedModifier(ModifierKind.VOLATILE, implicit));
 		}
-		if ((modifier & ClassFileConstants.AccTransient) != 0) {
+		// a method can never be transient, but it can have the flag because of varArgs.
+		// source: https://stackoverflow.com/questions/16233910/can-transient-keywords-mark-a-method
+		if (!isMethod && (modifier & ClassFileConstants.AccTransient) != 0) {
 			modifiers.add(new CtExtendedModifier(ModifierKind.TRANSIENT, implicit));
 		}
 		if ((modifier & ClassFileConstants.AccAbstract) != 0) {

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -185,7 +185,7 @@ public class PositionBuilder {
 				modifiersSourceEnd = typeParameters[0].declarationSourceStart - 3;
 			}
 
-			if (getModifiers(methodDeclaration.modifiers, false).isEmpty()) {
+			if (getModifiers(methodDeclaration.modifiers, false, true).isEmpty()) {
 				modifiersSourceStart = modifiersSourceEnd + 1;
 			}
 

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -252,7 +252,7 @@ public class ReferenceBuilder {
 	 */
 	<T> CtTypeReference<T> getQualifiedTypeReference(char[][] tokens, TypeBinding receiverType, ReferenceBinding enclosingType, JDTTreeBuilder.OnAccessListener listener) {
 		final List<CtExtendedModifier> listPublicProtected = Arrays.asList(new CtExtendedModifier(ModifierKind.PUBLIC), new CtExtendedModifier(ModifierKind.PROTECTED));
-		if (enclosingType != null && Collections.disjoint(listPublicProtected, JDTTreeBuilderQuery.getModifiers(enclosingType.modifiers))) {
+		if (enclosingType != null && Collections.disjoint(listPublicProtected, JDTTreeBuilderQuery.getModifiers(enclosingType.modifiers, false, false))) {
 			String access = "";
 			int i = 0;
 			final CompilationUnitDeclaration[] units = ((TreeBuilderCompiler) this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.scope.environment.typeRequestor).unitsToProcess;

--- a/src/test/java/spoon/test/modifiers/TestModifiers.java
+++ b/src/test/java/spoon/test/modifiers/TestModifiers.java
@@ -1,0 +1,36 @@
+package spoon.test.modifiers;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.test.modifiers.testclasses.MethodVarArgs;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestModifiers {
+
+    @Test
+    public void testMethodWithVarargsDoesNotBecomeTransient() {
+        // contract: method with varsargs should not become transient
+        Launcher spoon = new Launcher();
+        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java");
+        spoon.buildModel();
+
+        CtType<?> myClass = spoon.getFactory().Type().get(MethodVarArgs.class);
+        CtMethod methodVarargs = myClass.getMethodsByName("getInitValues").get(0);
+
+        Set<ModifierKind> expectedModifiers = Collections.singleton(ModifierKind.PROTECTED);
+
+        assertEquals(expectedModifiers, methodVarargs.getModifiers());
+
+        spoon = new Launcher();
+        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java");
+        spoon.getEnvironment().setShouldCompile(true);
+        spoon.run();
+    }
+}

--- a/src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java
+++ b/src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java
@@ -1,0 +1,17 @@
+package spoon.test.modifiers.testclasses;
+
+import java.io.File;
+import java.io.IOException;
+
+public class MethodVarArgs {
+
+    protected Object[] getInitValues(String contentClassName, String... initNames) throws IOException {
+        for (String s : initNames) {
+            File f = new File(s);
+            if (f.getAbsolutePath().equals(contentClassName)) {
+                return f.listFiles();
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This PR fix a bug brings by @seintur : a method with varargs is currently printed out with transient modifier. 
This happens because of the recent usage of methodDeclaration.binding.modifier and the fact that varargs have the same modifier flag than varargs. See: https://stackoverflow.com/questions/16233910/can-transient-keywords-mark-a-method

The fix is an exception made when computing modifiers for methods.