### PR TITLE
review refactor: all non-leaf interfaces of the metamodel should be visited by CtInheritanceScanner

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -479,6 +479,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public <T> void visitCtClass(CtClass<T> e) {
@@ -526,6 +527,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtVisitable(e);
 		scanCtShadowable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public void visitCtContinue(CtContinue e) {
@@ -566,6 +568,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtVisitable(e);
 		scanCtRHSReceiver(e);
+		scanCtShadowable(e);
 	}
 
 	@Override
@@ -623,6 +626,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtModifiable(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public <T> void visitCtInvocation(CtInvocation<T> e) {
@@ -693,6 +697,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtModifiable(e);
 		scanCtVisitable(e);
 		scanCtShadowable(e);
+		scanCtBodyHolder(e);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -378,6 +378,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtTypedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public <A extends Annotation> void visitCtAnnotationType(CtAnnotationType<A> e) {
@@ -389,6 +390,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtModifiable(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public void visitCtAnonymousExecutable(CtAnonymousExecutable e) {
@@ -399,6 +401,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtModifiable(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	@Override
@@ -442,6 +445,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtTypedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtRHSReceiver(e);
 	}
 
 	public <T> void visitCtBinaryOperator(CtBinaryOperator<T> e) {
@@ -488,6 +492,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtModifiable(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	@Override
@@ -500,6 +505,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(typeParameter);
 		scanCtModifiable(typeParameter);
 		scanCtVisitable(typeParameter);
+		scanCtShadowable(typeParameter);
 	}
 
 	public <T> void visitCtConditional(CtConditional<T> e) {
@@ -519,6 +525,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtModifiable(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public void visitCtContinue(CtContinue e) {
@@ -536,6 +543,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public <T extends Enum<?>> void visitCtEnum(CtEnum<T> e) {
@@ -557,6 +565,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtTypedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtRHSReceiver(e);
 	}
 
 	@Override
@@ -586,6 +595,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public void visitCtForEach(CtForEach e) {
@@ -594,6 +604,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public void visitCtIf(CtIf e) {
@@ -643,6 +654,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtModifiable(e);
 		scanCtVisitable(e);
+		scanCtRHSReceiver(e);
 	}
 
 	public <T> void visitCtLocalVariableReference(
@@ -680,6 +692,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtElement(e);
 		scanCtModifiable(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	@Override
@@ -721,6 +734,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtNamedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	@Override
@@ -742,6 +756,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtNamedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public void visitCtPackageReference(CtPackageReference e) {
@@ -757,6 +772,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtTypedElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	public <T> void visitCtParameterReference(CtParameterReference<T> e) {
@@ -807,6 +823,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	@Override
@@ -834,6 +851,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtActualTypeContainer(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtShadowable(e);
 	}
 
 	@Override
@@ -905,6 +923,7 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 		scanCtCodeElement(e);
 		scanCtElement(e);
 		scanCtVisitable(e);
+		scanCtBodyHolder(e);
 	}
 
 	public <T> void visitCtUnboundVariableReference(CtUnboundVariableReference<T> reference) {

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -25,6 +25,7 @@ import spoon.reflect.code.CtAssert;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtCase;
@@ -57,6 +58,7 @@ import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.code.CtOperatorAssignment;
+import spoon.reflect.code.CtRHSReceiver;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
@@ -94,6 +96,7 @@ import spoon.reflect.declaration.CtMultiTypedElement;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeMember;
@@ -309,6 +312,24 @@ public abstract class CtInheritanceScanner implements CtVisitor {
 	 * Scans a variable access (read and write).
 	 */
 	public <T> void scanCtVariableAccess(CtVariableAccess<T> variableAccess) {
+	}
+
+	/**
+	 * Scans the right-hand side of an assignment
+	 */
+	public <T> void scanCtRHSReceiver(CtRHSReceiver<T> ctRHSReceiver) {
+	}
+
+	/**
+	 * Scans a shadowable element
+	 */
+	public void scanCtShadowable(CtShadowable ctShadowable) {
+	}
+
+	/**
+	 * Scans a body holder
+	 */
+	public void scanCtBodyHolder(CtBodyHolder ctBodyHolder) {
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -567,7 +567,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		elementPrinterHelper.writeComment(catchBlock, CommentOffset.BEFORE);
 		printer.writeSpace().writeKeyword("catch").writeSpace().writeSeparator("(");
 		CtCatchVariable<? extends Throwable> parameter = catchBlock.getParameter();
-		if (parameter.getMultiTypes().size() > 1) {
+		if (parameter != null && parameter.getMultiTypes() != null && parameter.getMultiTypes().size() > 1) {
 			try (ListPrinter lp = elementPrinterHelper.createListPrinter(false, null, false, true, "|", true, false, null)) {
 			for (int i = 0; i < parameter.getMultiTypes().size(); i++) {
 					lp.printSeparatorIfAppropriate();

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -567,7 +567,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		elementPrinterHelper.writeComment(catchBlock, CommentOffset.BEFORE);
 		printer.writeSpace().writeKeyword("catch").writeSpace().writeSeparator("(");
 		CtCatchVariable<? extends Throwable> parameter = catchBlock.getParameter();
-		if (parameter != null && parameter.getMultiTypes() != null && parameter.getMultiTypes().size() > 1) {
+		if (parameter != null && parameter.getMultiTypes().size() > 1) {
 			try (ListPrinter lp = elementPrinterHelper.createListPrinter(false, null, false, true, "|", true, false, null)) {
 			for (int i = 0; i < parameter.getMultiTypes().size(); i++) {
 					lp.printSeparatorIfAppropriate();

--- a/src/test/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/test/java/spoon/generating/CloneVisitorGenerator.java
@@ -199,7 +199,8 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 					"spoon.support.reflect.declaration.CtCodeSnippetImpl", "spoon.support.reflect.declaration.CtFormalTypeDeclarerImpl", //
 					"spoon.support.reflect.declaration.CtGenericElementImpl", "spoon.support.reflect.reference.CtGenericElementReferenceImpl", //
 					"spoon.support.reflect.declaration.CtModifiableImpl", "spoon.support.reflect.declaration.CtMultiTypedElementImpl", //
-					"spoon.support.reflect.declaration.CtTypeMemberImpl");
+					"spoon.support.reflect.declaration.CtTypeMemberImpl", "spoon.support.reflect.code.CtRHSReceiverImpl",
+					"spoon.support.reflect.declaration.CtShadowableImpl", "spoon.support.reflect.code.CtBodyHolderImpl");
 			private final List<String> excludesFields = Arrays.asList("factory", "elementValues", "target", "metadata");
 			private final CtTypeReference<List> LIST_REFERENCE = factory.Type().createReference(List.class);
 			private final CtTypeReference<Collection> COLLECTION_REFERENCE = factory.Type().createReference(Collection.class);

--- a/src/test/java/spoon/generating/RoleHandlersGenerator.java
+++ b/src/test/java/spoon/generating/RoleHandlersGenerator.java
@@ -105,10 +105,10 @@ public class RoleHandlersGenerator extends AbstractManualProcessor {
 			}
 			params.put("$Role$", getFactory().Type().createReference(CtRole.class));
 			params.put("ROLE", rim.getRole().name());
-			params.put("$TargetType$", rim.getOwnerType().getModelInteface().getReference());
+			params.put("$TargetType$", rim.getOwnerType().getModelInterface().getReference());
 //			params.put("AbstractHandler", getFactory().Type().createReference("spoon.reflect.meta.impl.AbstractRoleHandler"));
 			params.put("AbstractHandler", getRoleHandlerSuperTypeQName(rim));
-			params.put("Node", rim.getOwnerType().getModelInteface().getReference());
+			params.put("Node", rim.getOwnerType().getModelInterface().getReference());
 			params.put("ValueType", fixMainValueType(getRoleHandlerSuperTypeQName(rim).endsWith("SingleHandler") ? rim.getValueType() : rim.getItemValueType()));
 			CtClass<?> modelRoleHandlerClass = Substitution.createTypeFromTemplate(
 					getHandlerName(rim),

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -21,6 +21,7 @@ import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.metamodel.SpoonMetaModel;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import java.util.TreeSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static spoon.test.metamodel.MMTypeKind.ABSTRACT;
 
 public class SpoonArchitectureEnforcerTest {
 
@@ -223,20 +225,19 @@ public class SpoonArchitectureEnforcerTest {
 		interfaces.addInputResource("src/main/java/spoon/reflect/visitor/CtScanner.java");
 		interfaces.buildModel();
 
-		Collection<CtType<?>> allTypes = interfaces.getModel().getAllTypes();
-
 		CtClass<?> ctScanner = interfaces.getFactory().Class().get(CtInheritanceScanner.class);
-		CtType<?> ctElement = interfaces.getFactory().Type().get(CtElement.class);
 
 		List<String> missingMethods = new ArrayList<>();
-		for (CtType type : allTypes) {
-			if (type.isSubtypeOf(ctElement.getReference())) {
-				String methodName = "scan"+type.getSimpleName();
+
+		new SpoonMetaModel(interfaces.getFactory()).getMMTypes().forEach(mmType->{
+			if(mmType.getKind()==ABSTRACT && mmType.getModelInteface()!=null)  {
+				CtInterface abstractIface = mmType.getModelInteface();
+				String methodName = "scan"+abstractIface.getSimpleName();
 				if (ctScanner.getMethodsByName(methodName).isEmpty()) {
 					missingMethods.add(methodName);
 				}
 			}
-		}
+		});
 
 		assertTrue("The following methods are missing in CtScanner: \n"+ StringUtils.join(missingMethods, "\n"),missingMethods.isEmpty());
 	}

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -219,6 +219,7 @@ public class SpoonArchitectureEnforcerTest {
 	public void testInterfacesAreCtScannable() {
 		// contract: all interface inherited from CtElement should be visited in CtScanner
 		Launcher interfaces = new Launcher();
+		interfaces.addInputResource("src/main/java/spoon/support");
 		interfaces.addInputResource("src/main/java/spoon/reflect/declaration");
 		interfaces.addInputResource("src/main/java/spoon/reflect/code");
 		interfaces.addInputResource("src/main/java/spoon/reflect/reference");

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -17,6 +17,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtInheritanceScanner;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
@@ -224,13 +225,13 @@ public class SpoonArchitectureEnforcerTest {
 
 		Collection<CtType<?>> allTypes = interfaces.getModel().getAllTypes();
 
-		CtClass<?> ctScanner = interfaces.getFactory().Class().get(CtScanner.class);
+		CtClass<?> ctScanner = interfaces.getFactory().Class().get(CtInheritanceScanner.class);
 		CtType<?> ctElement = interfaces.getFactory().Type().get(CtElement.class);
 
 		List<String> missingMethods = new ArrayList<>();
 		for (CtType type : allTypes) {
 			if (type.getSuperInterfaces().contains(ctElement.getReference())) {
-				String methodName = "visit"+type.getSimpleName();
+				String methodName = "scan"+type.getSimpleName();
 				if (ctScanner.getMethodsByName(methodName).isEmpty()) {
 					missingMethods.add(methodName);
 				}

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -230,7 +230,7 @@ public class SpoonArchitectureEnforcerTest {
 
 		List<String> missingMethods = new ArrayList<>();
 		for (CtType type : allTypes) {
-			if (type.getSuperInterfaces().contains(ctElement.getReference())) {
+			if (type.isSubtypeOf(ctElement.getReference())) {
 				String methodName = "scan"+type.getSimpleName();
 				if (ctScanner.getMethodsByName(methodName).isEmpty()) {
 					missingMethods.add(methodName);

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -230,8 +230,8 @@ public class SpoonArchitectureEnforcerTest {
 		List<String> missingMethods = new ArrayList<>();
 
 		new SpoonMetaModel(interfaces.getFactory()).getMMTypes().forEach(mmType->{
-			if(mmType.getKind()==ABSTRACT && mmType.getModelInteface()!=null)  {
-				CtInterface abstractIface = mmType.getModelInteface();
+			if(mmType.getKind()==ABSTRACT && mmType.getModelInterface() != null)  {
+				CtInterface abstractIface = mmType.getModelInterface();
 				String methodName = "scan"+abstractIface.getSimpleName();
 				if (ctScanner.getMethodsByName(methodName).isEmpty()) {
 					missingMethods.add(methodName);

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -223,6 +223,9 @@ public class SpoonArchitectureEnforcerTest {
 		interfaces.addInputResource("src/main/java/spoon/reflect/declaration");
 		interfaces.addInputResource("src/main/java/spoon/reflect/code");
 		interfaces.addInputResource("src/main/java/spoon/reflect/reference");
+		interfaces.addInputResource("src/main/java/spoon/support/reflect/declaration");
+		interfaces.addInputResource("src/main/java/spoon/support/reflect/code");
+		interfaces.addInputResource("src/main/java/spoon/support/reflect/reference");
 		interfaces.addInputResource("src/main/java/spoon/reflect/visitor/CtScanner.java");
 		interfaces.buildModel();
 

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -217,7 +217,7 @@ public class SpoonArchitectureEnforcerTest {
 
 	@Test
 	public void testInterfacesAreCtScannable() {
-		// contract: all interface inherited from CtElement should be visited in CtScanner
+		// contract: all non-leaf interfaces of the metamodel should be visited by CtInheritanceScanner
 		Launcher interfaces = new Launcher();
 		interfaces.addInputResource("src/main/java/spoon/support");
 		interfaces.addInputResource("src/main/java/spoon/reflect/declaration");

--- a/src/test/java/spoon/test/metamodel/MMType.java
+++ b/src/test/java/spoon/test/metamodel/MMType.java
@@ -28,8 +28,10 @@ import spoon.SpoonException;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
+import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.visitor.ClassTypingContext;
 
 /**
@@ -99,10 +101,13 @@ public class MMType {
 	 */
 	public MMTypeKind getKind() {
 		if (kind == null) {
-			if (modelClass != null && modelClass.hasModifier(ModifierKind.ABSTRACT) == false) {
-				kind = MMTypeKind.LEAF;
+			if (modelClass == null && modelInterface == null) {
+				return null;
 			} else {
-				kind = MMTypeKind.ABSTRACT;
+				// we first consider interface
+				CtType<?> typeToConsider = (modelInterface != null) ? modelInterface : modelClass;
+				// if we get modifier from an interface it may be implicitely abstract
+				return (typeToConsider.getExtendedModifiers().contains(new CtExtendedModifier(ModifierKind.ABSTRACT, false))) ? MMTypeKind.ABSTRACT : MMTypeKind.LEAF;
 			}
 		}
 		return kind;

--- a/src/test/java/spoon/test/metamodel/MMType.java
+++ b/src/test/java/spoon/test/metamodel/MMType.java
@@ -105,9 +105,15 @@ public class MMType {
 				return null;
 			} else {
 				// we first consider interface
-				CtType<?> typeToConsider = (modelInterface != null) ? modelInterface : modelClass;
-				// if we get modifier from an interface it may be implicitely abstract
-				return (typeToConsider.getExtendedModifiers().contains(new CtExtendedModifier(ModifierKind.ABSTRACT, false))) ? MMTypeKind.ABSTRACT : MMTypeKind.LEAF;
+				if (modelClass == null) {
+					this.kind = MMTypeKind.ABSTRACT;
+				} else {
+					if (modelClass.hasModifier(ModifierKind.ABSTRACT)) {
+						this.kind = MMTypeKind.ABSTRACT;
+					} else {
+						this.kind = MMTypeKind.LEAF;
+					}
+				}
 			}
 		}
 		return kind;


### PR DESCRIPTION
Fix #1430 