### PR TITLE
review fix: CtExecutableReference have all the same hashcode

### DIFF
--- a/src/main/java/spoon/support/visitor/HashcodeVisitor.java
+++ b/src/main/java/spoon/support/visitor/HashcodeVisitor.java
@@ -18,6 +18,7 @@ package spoon.support.visitor;
 
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 
 /** Responsible for computing CtElement.hashCode().
@@ -29,6 +30,11 @@ public class HashcodeVisitor extends CtInheritanceScanner {
 
 	@Override
 	public void scanCtNamedElement(CtNamedElement e) {
+		hashCode += e.getSimpleName().hashCode();
+	}
+
+	@Override
+	public void scanCtReference(CtReference e) {
 		hashCode += e.getSimpleName().hashCode();
 	}
 

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -13,6 +13,7 @@ import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.reference.testclasses.Bar;
 import spoon.test.reference.testclasses.Burritos;
+import spoon.test.reference.testclasses.EnumValue;
 import spoon.test.reference.testclasses.Kuu;
 import spoon.test.reference.testclasses.SuperFoo;
 
@@ -172,5 +173,35 @@ public class ExecutableReferenceTest {
 		launcher.addInputResource("./src/test/resources/noclasspath/org/elasticsearch/action/admin/cluster/node/tasks");
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.buildModel();
+	}
+
+	@Test
+	public void testHashcodeWorksWithReference() {
+		// contract: two distinct CtExecutableReference should have different hashcodes
+
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses/EnumValue.java");
+		launcher.buildModel();
+
+		CtClass enumValue = launcher.getFactory().Class().get(EnumValue.class);
+
+		CtMethod firstMethod = (CtMethod) enumValue.getMethodsByName("asEnum").get(0);
+		CtMethod secondMethod = (CtMethod) enumValue.getMethodsByName("unwrap").get(0);
+
+		assertNotNull(firstMethod);
+		assertNotNull(secondMethod);
+
+		assertNotEquals(firstMethod, secondMethod);
+		assertNotEquals(firstMethod.getReference(), secondMethod.getReference());
+
+		int hashCode1 = firstMethod.hashCode();
+		int hashCode2 = secondMethod.hashCode();
+
+		assertNotEquals(hashCode1, hashCode2);
+
+		hashCode1 = firstMethod.getReference().hashCode();
+		hashCode2 = secondMethod.getReference().hashCode();
+
+		assertNotEquals(hashCode1, hashCode2);
 	}
 }


### PR DESCRIPTION
It seems that Spoon make no distinction between reference hashcode: they all have a value to 1.