### PR TITLE
review: Fix test assertion with JDK8 on Travis

### DIFF
--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -133,7 +133,7 @@ public class CtTypeInformationTest {
 
 	@Test
 	public void testGetSuperclass() throws Exception {
-		int expectedNumberInJDK8 = 61;
+		int expectedNumberInJDK8 = 62; // in Java 1.8.0_151
 		int expectedNumberInJDK9 = 81;
 
 		int expectedNumber;


### PR DESCRIPTION
Travis move from Java 1.8.0_144 to Java 1.8.0_151 for their JDK8. 
Our assertion no longer pass on CtTypeInformationTest, this PR fixes it.