### PR TITLE
review test: improve CtGenerationTest and CtScannerTest

### DIFF
--- a/src/test/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/test/java/spoon/generating/CloneVisitorGenerator.java
@@ -100,7 +100,11 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 
 				// Changes body of the cloned method.
 				for (int i = 1; i < clone.getBody().getStatements().size() - 1; i++) {
-					final CtInvocation targetInvocation = (CtInvocation) ((CtInvocation) clone.getBody().getStatement(i)).getArguments().get(1);
+					List<CtExpression> invArgs = ((CtInvocation) clone.getBody().getStatement(i)).getArguments();
+					if (invArgs.size() <= 1) {
+						throw new RuntimeException("You forget the role argument in line "+i+" of method "+element.getSimpleName()+" from "+element.getDeclaringType().getQualifiedName());
+					}
+					final CtInvocation targetInvocation = (CtInvocation) invArgs.get(1);
 					if ("getValue".equals(targetInvocation.getExecutable().getSimpleName()) && "CtLiteral".equals(targetInvocation.getExecutable().getDeclaringType().getSimpleName())) {
 						clone.getBody().getStatement(i--).delete();
 						continue;

--- a/src/test/java/spoon/generating/CtBiScannerGenerator.java
+++ b/src/test/java/spoon/generating/CtBiScannerGenerator.java
@@ -69,7 +69,11 @@ public class CtBiScannerGenerator extends AbstractManualProcessor {
 			clone.getBody().insertBegin(peek);
 
 			for (int i = 2; i < clone.getBody().getStatements().size() - 1; i++) {
-				final CtInvocation targetInvocation = (CtInvocation) ((CtInvocation) clone.getBody().getStatement(i)).getArguments().get(1);
+				List<CtExpression> invArgs = ((CtInvocation) clone.getBody().getStatement(i)).getArguments();
+				if (invArgs.size() <= 1) {
+					throw new RuntimeException("You forget the role argument in line "+i+" of method "+element.getSimpleName()+" from "+element.getDeclaringType().getQualifiedName());
+				}
+				final CtInvocation targetInvocation = (CtInvocation) invArgs.get(1);
 				if ("getValue".equals(targetInvocation.getExecutable().getSimpleName()) && "CtLiteral".equals(targetInvocation.getExecutable().getDeclaringType().getSimpleName())) {
 					clone.getBody().getStatement(i--).delete();
 					continue;

--- a/src/test/java/spoon/generating/replace/ReplaceScanner.java
+++ b/src/test/java/spoon/generating/replace/ReplaceScanner.java
@@ -83,6 +83,9 @@ public class ReplaceScanner extends CtScanner {
 		for (int i = 1; i < element.getBody().getStatements().size() - 1; i++) {
 			CtInvocation inv = element.getBody().getStatement(i);
 			List<CtExpression<?>> invArgs = new ArrayList<>(inv.getArguments());
+			if (invArgs.size() <= 1) {
+				throw new RuntimeException("You forget the role argument in line "+i+" of method "+element.getSimpleName()+" from "+element.getDeclaringType().getQualifiedName());
+			}
 			//remove role argument
 			invArgs.remove(0);
 			CtInvocation getter = (CtInvocation) invArgs.get(0);

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -180,15 +180,16 @@ public class CtScannerTest {
 				} else {
 					c.nbChecks++;
 					//System.out.println(invocation.toString());
+
+					// contract: the scan method is called with the same role as the one set on field / property
+					CtRole expectedRole = metaModel.getRoleOfMethod((CtMethod<?>)invocation.getExecutable().getDeclaration());
+					CtInvocation<?> scanInvocation = invocation.getParent(CtInvocation.class);
+					String realRoleName = ((CtFieldRead<?>) scanInvocation.getArguments().get(0)).getVariable().getSimpleName();
+					if(expectedRole.name().equals(realRoleName) == false) {
+						problems.add("Wrong role " + realRoleName + " used in " + scanInvocation.getPosition());
+					}
 				}
 
-				// contract: the scan method is called with the same role as the one set on field / property
-				CtRole expectedRole = metaModel.getRoleOfMethod((CtMethod<?>)invocation.getExecutable().getDeclaration());
-				CtInvocation<?> scanInvocation = invocation.getParent(CtInvocation.class);
-				String realRoleName = ((CtFieldRead<?>) scanInvocation.getArguments().get(0)).getVariable().getSimpleName();
-				if(expectedRole.name().equals(realRoleName) == false) {
-					problems.add("Wrong role " + realRoleName + " used in " + scanInvocation.getPosition());
-				}
 			});
 			calledMethods.removeAll(checkedMethods);
 


### PR DESCRIPTION
CtGenerationTest and CtScannerTest were buggy with the changes bring by adding roles in CtScanner: if no role were provided, the test were erroring with either a NPE (for CtScannerTest) or an OutOfBoundException (for CtGenerationTest).
This PR throws directly a RuntimeException with a proper message in CtGenerationTest and stack the problem in the list of problems in CtScannerTest.