### PR TITLE
review refactor: add CtModel#getRootElement and deprecates CtModel#getRootPackage

### DIFF
--- a/src/main/java/spoon/refactoring/CtParameterRemoveRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtParameterRemoveRefactoring.java
@@ -161,7 +161,7 @@ public class CtParameterRemoveRefactoring implements CtRefactoring {
 		}
 		//all the invocations, which belongs to same inheritance tree
 		final List<CtInvocation<?>> invocations = new ArrayList<>();
-		target.getFactory().getModel().getRootPackage().filterChildren(execRefFilter).forEach(new CtConsumer<CtExecutableReference<?>>() {
+		target.getFactory().getModel().getRootElement().filterChildren(execRefFilter).forEach(new CtConsumer<CtExecutableReference<?>>() {
 			@Override
 			public void accept(CtExecutableReference<?> t) {
 				CtElement parent = t.getParent();

--- a/src/main/java/spoon/reflect/CtModel.java
+++ b/src/main/java/spoon/reflect/CtModel.java
@@ -20,6 +20,7 @@ import spoon.processing.Processor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.PackageFactory;
 import spoon.reflect.visitor.Filter;
 
 import java.io.Serializable;
@@ -31,7 +32,20 @@ import java.util.List;
  */
 public interface CtModel extends Serializable {
 
-	/** returns the root package */
+	/**
+	 * Returns the root element of the model:
+	 * it can be the root package, or the root module,
+	 * depending on the compliance version.
+	 */
+	CtElement getRootElement();
+
+	/**
+	 * Returns the root package
+	 * @deprecated If you want to traverse the model,
+	 * prefer using {@link #getRootElement()}. If you really need the rootPackage,
+	 * prefer using {@link PackageFactory#getRootPackage()}
+	 */
+	@Deprecated
 	CtPackage getRootPackage();
 
 	/** returns all top-level types of the model */

--- a/src/main/java/spoon/reflect/CtModelImpl.java
+++ b/src/main/java/spoon/reflect/CtModelImpl.java
@@ -97,6 +97,11 @@ public class CtModelImpl implements CtModel {
 	}
 
 	@Override
+	public CtElement getRootElement() {
+		return getRootPackage();
+	}
+
+	@Override
 	public CtPackage getRootPackage() {
 		return rootPackage;
 	}
@@ -122,12 +127,12 @@ public class CtModelImpl implements CtModel {
 	public void processWith(Processor<?> processor) {
 		QueueProcessingManager processingManager = new QueueProcessingManager(rootPackage.getFactory());
 		processingManager.addProcessor(processor);
-		processingManager.process(getRootPackage());
+		processingManager.process(getRootElement());
 	}
 
 	@Override
 	public <E extends CtElement> List<E> getElements(Filter<E> filter) {
-		return getRootPackage().getElements(filter);
+		return getRootElement().getElements(filter);
 	}
 
 }

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -69,7 +69,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 * Returns a reference on the top level package.
 	 */
 	public CtPackageReference topLevel() {
-		return factory.getModel().getRootPackage().getReference();
+		return getRootPackage().getReference();
 	}
 
 	/**
@@ -105,10 +105,10 @@ public class PackageFactory extends SubFactory implements Serializable {
 	 */
 	public CtPackage getOrCreate(String qualifiedName) {
 		if (qualifiedName.isEmpty()) {
-			return factory.getModel().getRootPackage();
+			return getRootPackage();
 		}
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage last = factory.getModel().getRootPackage();
+		CtPackage last = getRootPackage();
 
 		while (token.hasMoreElements()) {
 			String name = token.nextToken();
@@ -136,7 +136,7 @@ public class PackageFactory extends SubFactory implements Serializable {
 			throw new RuntimeException("Invalid package name " + qualifiedName);
 		}
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage current = factory.getModel().getRootPackage();
+		CtPackage current = getRootPackage();
 		if (token.hasMoreElements()) {
 			current = current.getPackage(token.nextToken());
 			while (token.hasMoreElements() && current != null) {

--- a/src/main/java/spoon/reflect/visitor/Query.java
+++ b/src/main/java/spoon/reflect/visitor/Query.java
@@ -49,7 +49,7 @@ public abstract class Query {
 	 */
 	public static <E extends CtElement> List<E> getElements(Factory factory,
 															Filter<E> filter) {
-		return getElements(factory.Package().getRootPackage(), filter);
+		return getElements(factory.getModel().getRootElement(), filter);
 	}
 
 	/**
@@ -101,7 +101,7 @@ public abstract class Query {
 	 */
 	public static <R extends CtReference> List<R> getReferences(
 			Factory factory, Filter<R> filter) {
-		return getReferences(factory.Package().getRootPackage(), filter);
+		return getReferences(factory.getModel().getRootElement(), filter);
 	}
 
 }

--- a/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
@@ -78,7 +78,7 @@ public class AllMethodsSameSignatureFunction implements CtConsumableFunction<CtE
 	public void apply(final CtExecutable<?> targetExecutable, final CtConsumer<Object> outputConsumer) {
 		//prepare filter for lambda expression. It will be configured by the algorithm below
 		final LambdaFilter lambdaFilter = new LambdaFilter();
-		final CtQuery lambdaQuery = targetExecutable.getFactory().getModel().getRootPackage().filterChildren(lambdaFilter);
+		final CtQuery lambdaQuery = targetExecutable.getFactory().getModel().getRootElement().filterChildren(lambdaFilter);
 		//the to be searched method
 		CtMethod<?> targetMethod;
 		if (targetExecutable instanceof CtLambda) {
@@ -131,7 +131,7 @@ public class AllMethodsSameSignatureFunction implements CtConsumableFunction<CtE
 		//at the beginning we know that we have to always search for sub types too.
 		context.haveToSearchForSubtypes = true;
 		//Sub inheritance hierarchy function, which remembers visited sub types and does not returns/visits them again
-		final SubInheritanceHierarchyResolver subHierarchyFnc = new SubInheritanceHierarchyResolver(declaringType.getFactory().getModel().getRootPackage());
+		final SubInheritanceHierarchyResolver subHierarchyFnc = new SubInheritanceHierarchyResolver(declaringType.getFactory().getModel().getRootElement());
 		//add hierarchy of `targetMethod` as to be checked for sub types of declaring type
 		subHierarchyFnc.addSuperType(declaringType);
 		//unique names of all types whose super inheritance hierarchy was searched for rootType

--- a/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
@@ -57,7 +57,7 @@ public class FieldReferenceFunction implements CtConsumableFunction<CtElement> {
 			} else {
 				throw new SpoonException("The input of FieldReferenceFunction must be a CtField but is " + fieldOrScope.getClass().getSimpleName());
 			}
-			scope = field.getFactory().getModel().getRootPackage();
+			scope = field.getFactory().getModel().getRootElement();
 		} else {
 			scope = fieldOrScope;
 		}

--- a/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
@@ -63,7 +63,7 @@ public class FieldScopeFunction implements CtConsumableFunction<CtField<?>> {
 	}
 	protected void searchForProtectedField(CtField<?> field, CtConsumer<Object> outputConsumer) {
 		//protected field can be referred from the scope of current top level type only and children
-		field.getFactory().getModel().getRootPackage()
+		field.getFactory().getModel().getRootElement()
 			//search for all types which inherits from declaring type of this field
 			.filterChildren(new SubtypeFilter(field.getDeclaringType().getReference()))
 			//visit all elements in scope of these inherited types
@@ -72,7 +72,7 @@ public class FieldScopeFunction implements CtConsumableFunction<CtField<?>> {
 	}
 	protected void searchForPublicField(CtField<?> field, CtConsumer<Object> outputConsumer) {
 		//public field is visible everywhere
-		field.getFactory().getModel().getRootPackage()
+		field.getFactory().getModel().getRootElement()
 			//visit all children of root package
 			.filterChildren(null)
 			.forEach(outputConsumer);

--- a/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodQuery.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodQuery.java
@@ -16,8 +16,8 @@
  */
 package spoon.reflect.visitor.filter;
 
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 
@@ -27,7 +27,7 @@ import spoon.reflect.visitor.chain.CtConsumer;
 public class OverriddenMethodQuery implements CtConsumableFunction<CtMethod<?>> {
 	@Override
 	public void apply(CtMethod<?> input, CtConsumer<Object> outputConsumer) {
-		CtPackage searchScope = input.getFactory().Package().getRootPackage();
+		CtElement searchScope = input.getFactory().getModel().getRootElement();
 		searchScope.filterChildren(new OverriddenMethodFilter(input)).forEach(outputConsumer);
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
@@ -17,7 +17,6 @@
 package spoon.reflect.visitor.filter;
 
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.CtQuery;
@@ -54,9 +53,9 @@ public class ParentFunction implements CtConsumableFunction<CtElement>, CtQueryA
 		if (includingSelf) {
 			outputConsumer.accept(input);
 		}
-		CtPackage rootPackage = input.getFactory().getModel().getRootPackage();
+		CtElement rootElement = input.getFactory().getModel().getRootElement();
 		CtElement parent = input;
-		while (parent != null && parent != rootPackage && query.isTerminated() == false) {
+		while (parent != null && parent != rootElement && query.isTerminated() == false) {
 			parent = parent.getParent();
 			outputConsumer.accept(parent);
 		}

--- a/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
@@ -75,7 +75,7 @@ public class SubInheritanceHierarchyFunction implements CtConsumableFunction<CtT
 
 	@Override
 	public void apply(CtTypeInformation input, final CtConsumer<Object> outputConsumer) {
-		final SubInheritanceHierarchyResolver fnc = new SubInheritanceHierarchyResolver(((CtElement) input).getFactory().getModel().getRootPackage())
+		final SubInheritanceHierarchyResolver fnc = new SubInheritanceHierarchyResolver(((CtElement) input).getFactory().getModel().getRootElement())
 			.failOnClassNotFound(failOnClassNotFound)
 			.includingInterfaces(includingInterfaces);
 		if (includingSelf) {

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -208,7 +208,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	public <T extends Annotation> CtAnnotationType<T> createAnnotationType() {
 		CtAnnotationType<T> e = new CtAnnotationTypeImpl<>();
 		e.setFactory(getMainFactory());
-		e.setParent(getMainFactory().Package().getRootPackage());
+		e.setParent(getMainFactory().Package().getRootPackage()); // FIXME: why that?
 		return e;
 	}
 
@@ -283,7 +283,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	public <T> CtClass<T> createClass() {
 		CtClass<T> e = new CtClassImpl<>();
 		e.setFactory(getMainFactory());
-		e.setParent(getMainFactory().Package().getRootPackage());
+		e.setParent(getMainFactory().Package().getRootPackage()); // FIXME: why that?
 		return e;
 	}
 
@@ -321,7 +321,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	public <T extends Enum<?>> CtEnum<T> createEnum() {
 		CtEnum<T> e = new CtEnumImpl<>();
 		e.setFactory(getMainFactory());
-		e.setParent(getMainFactory().Package().getRootPackage());
+		e.setParent(getMainFactory().Package().getRootPackage()); //FIXME: why that?
 		return e;
 	}
 
@@ -398,7 +398,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	public <T> CtInterface<T> createInterface() {
 		CtInterface<T> e = new CtInterfaceImpl<>();
 		e.setFactory(getMainFactory());
-		e.setParent(getMainFactory().Package().getRootPackage());
+		e.setParent(getMainFactory().Package().getRootPackage()); //FIXME: why that?
 		return e;
 	}
 
@@ -495,7 +495,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	public CtPackage createPackage() {
 		CtPackage e = new CtPackageImpl();
 		e.setFactory(getMainFactory());
-		e.setParent(getMainFactory().Package().getRootPackage());
+		e.setParent(getMainFactory().Package().getRootPackage()); //FIXME: why that?
 		return e;
 	}
 

--- a/src/main/java/spoon/support/SerializationModelStreamer.java
+++ b/src/main/java/spoon/support/SerializationModelStreamer.java
@@ -53,7 +53,7 @@ public class SerializationModelStreamer implements ModelStreamer {
 			final Factory f = (Factory) ois.readObject();
 			//create query using factory directly
 			//because any try to call CtElement#map or CtElement#filterChildren will fail on uninitialized factory
-			f.createQuery(f.getModel().getRootPackage()).filterChildren(new Filter<CtElement>() {
+			f.createQuery(f.getModel().getRootElement()).filterChildren(new Filter<CtElement>() {
 				@Override
 				public boolean matches(CtElement e) {
 					e.setFactory(f);

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -129,7 +129,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 
 	private void checkModel() {
 		if (!factory.getEnvironment().checksAreSkipped()) {
-			factory.getModel().getRootPackage().accept(new AstParentConsistencyChecker());
+			factory.getModel().getRootElement().accept(new AstParentConsistencyChecker());
 		}
 	}
 
@@ -168,7 +168,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			factory.getEnvironment().debugMessage("Loaded processor " + processorName + ".");
 		}
 
-		processing.process(factory.Package().getRootPackage());
+		processing.process(factory.getModel().getRootElement());
 	}
 
 	@Override
@@ -180,7 +180,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			factory.getEnvironment().debugMessage("Loaded processor " + processorName + ".");
 		}
 
-		processing.process(factory.Package().getRootPackage());
+		processing.process(factory.getModel().getRootElement());
 	}
 
 	@Override
@@ -434,9 +434,9 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			ProcessingManager processing = new QueueProcessingManager(factory);
 			processing.addProcessor(factory.getEnvironment().getDefaultFileGenerator());
 			if (typeFilter != null) {
-				processing.process(Query.getElements(factory.Package().getRootPackage(), typeFilter));
+				processing.process(Query.getElements(factory.getModel().getRootElement(), typeFilter));
 			} else {
-				processing.process(factory.Package().getRootPackage());
+				processing.process(factory.getModel().getRootElement());
 			}
 		}
 	}

--- a/src/main/java/spoon/support/gui/SpoonModelTree.java
+++ b/src/main/java/spoon/support/gui/SpoonModelTree.java
@@ -75,7 +75,7 @@ public class SpoonModelTree extends JFrame implements KeyListener,
 	public SpoonModelTree(Factory factory) {
 		super();
 		SpoonTreeBuilder cst = new SpoonTreeBuilder();
-		cst.scan(factory.Package().getRootPackage());
+		cst.scan(factory.getModel().getRootElement());
 		this.factory = factory;
 		root = cst.getRoot();
 		initialize();

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -372,7 +372,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public boolean hasParent(CtElement candidate) {
 		try {
-			return this != getFactory().getModel().getRootPackage() && (getParent() == candidate || getParent().hasParent(candidate));
+			return this != getFactory().getModel().getRootElement() && (getParent() == candidate || getParent().hasParent(candidate));
 		} catch (ParentNotInitializedException e) {
 			return false;
 		}

--- a/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
+++ b/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
@@ -54,7 +54,7 @@ import static spoon.reflect.visitor.chain.ScanningMode.SKIP_ALL;
 public class SubInheritanceHierarchyResolver {
 
 	/** where the subtypes will be looked for */
-	private CtPackage inputPackage;
+	private CtElement inputRoot;
 
 	/** whether interfaces are included in the result */
 	private boolean includingInterfaces = true;
@@ -71,8 +71,8 @@ public class SubInheritanceHierarchyResolver {
 
 	private boolean failOnClassNotFound = false;
 
-	public SubInheritanceHierarchyResolver(CtPackage input) {
-		inputPackage = input;
+	public SubInheritanceHierarchyResolver(CtElement input) {
+		inputRoot = input;
 	}
 
 	/**
@@ -126,7 +126,7 @@ public class SubInheritanceHierarchyResolver {
 		final Deque<CtTypeReference<?>> currentSubTypes = new ArrayDeque<>();
 		//algorithm
 		//1) query step: scan input package for sub classes and sub interfaces
-		final CtQuery q = inputPackage.map(new CtScannerFunction());
+		final CtQuery q = inputRoot.map(new CtScannerFunction());
 		//2) query step: visit only required CtTypes
 		if (includingInterfaces) {
 			//the client is interested in sub inheritance hierarchy of interfaces too. Check interfaces, classes, enums, Annotations, but not CtTypeParameters.

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -96,7 +96,7 @@ public class AstCheckerTest {
 		launcher.buildModel();
 
 		final PushStackInIntercessionChecker checker = new PushStackInIntercessionChecker();
-		checker.scan(launcher.getModel().getRootPackage());
+		checker.scan(launcher.getModel().getRootElement());
 		if (!checker.result.isEmpty()) {
 			System.err.println(checker.count);
 			throw new AssertionError(checker.result);

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -82,7 +82,7 @@ public class CloneTest {
 			private <T> boolean isRootDeclaration(CtInterface<T> intrface) {
 				return "CtElement".equals(intrface.getSimpleName());
 			}
-		}.scan(launcher.getModel().getRootPackage());
+		}.scan(launcher.getModel().getRootElement());
 	}
 
 	@Test

--- a/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
+++ b/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
@@ -34,9 +34,9 @@ public class UnknownDeclarationTest {
         runLaunch.addInputResource("./src/test/resources/noclasspath/UnknownCalls.java");
         runLaunch.buildModel();
 
-        final CtPackage rootPackage = runLaunch.getFactory().Package().getRootPackage();
+        final CtElement rootElement = runLaunch.getModel().getRootElement();
         final ExecutableReferenceVisitor visitor = new ExecutableReferenceVisitor();
-        visitor.scan(rootPackage);
+        visitor.scan(rootElement);
         // super constructor to Object +
         // UnknownClass constructor +
         // UnknownClass method

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -224,7 +224,7 @@ public class CtScannerTest {
 			int nElement=0;
 		};
 		Counter counter = new Counter();
-		launcher.getModel().getRootPackage().accept(new CtScanner() {
+		launcher.getModel().getRootElement().accept(new CtScanner() {
 			@Override
 			public void scan(Object o) {
 				counter.nObject++;

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -42,7 +42,7 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/main/java/spoon/reflect/factory");
 		spoon.buildModel();
 
-		for (CtType t : spoon.getFactory().Package().getRootPackage().getElements(new AbstractFilter<CtType>() {
+		for (CtType t : spoon.getModel().getRootElement().getElements(new AbstractFilter<CtType>() {
 			@Override
 			public boolean matches(CtType element) {
 				return super.matches(element)
@@ -118,7 +118,7 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
 
-		List<CtConstructorCall> treeSetWithoutComparators = spoon.getFactory().Package().getRootPackage().filterChildren(new AbstractFilter<CtConstructorCall>() {
+		List<CtConstructorCall> treeSetWithoutComparators = spoon.getModel().getRootElement().filterChildren(new AbstractFilter<CtConstructorCall>() {
 			@Override
 			public boolean matches(CtConstructorCall element) {
 				return element.getType().getActualClass().equals(TreeSet.class) && element.getArguments().size() == 0;
@@ -163,7 +163,7 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/test/java/");
 		spoon.buildModel();
 
-		for (CtMethod<?> meth : spoon.getModel().getRootPackage().getElements(new TypeFilter<CtMethod>(CtMethod.class) {
+		for (CtMethod<?> meth : spoon.getModel().getRootElement().getElements(new TypeFilter<CtMethod>(CtMethod.class) {
 			@Override
 			public boolean matches(CtMethod element) {
 				return super.matches(element) && element.getAnnotation(Test.class) != null;
@@ -175,7 +175,7 @@ public class SpoonArchitectureEnforcerTest {
 		// contract: the Spoon test suite does not depend on Junit 3 classes and methods
 		// otherwise, intellij automatically selects the junit3 runner, finds nothing
 		// and crashes with a dirty exception
-		assertEquals(0, spoon.getModel().getRootPackage().getElements(new TypeFilter<CtTypeReference>(CtTypeReference.class){
+		assertEquals(0, spoon.getModel().getRootElement().getElements(new TypeFilter<CtTypeReference>(CtTypeReference.class){
 			@Override
 			public boolean matches(CtTypeReference element) {
 				CtMethod parent = element.getParent(CtMethod.class);
@@ -204,7 +204,7 @@ public class SpoonArchitectureEnforcerTest {
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
 
-		for (CtClass<?> klass : spoon.getModel().getRootPackage().getElements(new TypeFilter<CtClass>(CtClass.class) {
+		for (CtClass<?> klass : spoon.getModel().getRootElement().getElements(new TypeFilter<CtClass>(CtClass.class) {
 			@Override
 			public boolean matches(CtClass element) {
 				return element.getSuperclass() == null && super.matches(element) && element.getMethods().size()>0

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -374,7 +374,7 @@ public class CompilationTest {
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.addInputResource("src/test/resources/reference-test/Foo.java");
 		launcher.buildModel();
-		launcher.getModel().getRootPackage().accept(new CtScanner() {
+		launcher.getModel().getRootElement().accept(new CtScanner() {
 			@Override
 			public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
 				try {

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -1,6 +1,5 @@
 package spoon.test.factory;
 
-import com.sun.javafx.font.coretext.CTFactory;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonAPI;
@@ -13,7 +12,6 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.CoreFactory;
 import spoon.reflect.factory.Factory;

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -510,7 +510,7 @@ public class FilterTest {
 		}
 		Context context = new Context();
 		
-		CtQuery l_qv = launcher.getFactory().getModel().getRootPackage().filterChildren(new TypeFilter<>(CtClass.class));
+		CtQuery l_qv = launcher.getFactory().getModel().getRootElement().filterChildren(new TypeFilter<>(CtClass.class));
 		
 		assertEquals(0, context.counter);
 		l_qv.forEach(cls->{
@@ -883,7 +883,7 @@ public class FilterTest {
 		{
 			Context context = new Context();
 			//contract: if the query produces elements which cannot be cast to forEach consumer, then they are ignored
-			launcher.getFactory().Package().getRootPackage().filterChildren(null).forEach((CtType t)->{
+			launcher.getFactory().getModel().getRootElement().filterChildren(null).forEach((CtType t)->{
 				context.count++;
 			});
 			assertTrue(context.count>0);
@@ -892,7 +892,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the for each implementation made by lambda throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).forEach((CtType t)->{
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).forEach((CtType t)->{
 					context.count++;
 					throw new ClassCastException("TEST");
 				});
@@ -906,7 +906,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the for each implementation made by local class throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).forEach(new CtConsumer<CtType>() {
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).forEach(new CtConsumer<CtType>() {
 					@Override
 					public void accept(CtType t) {
 						context.count++;
@@ -923,7 +923,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the select implementation made by local class throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).select(new Filter<CtType>(){
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).select(new Filter<CtType>(){
 					@Override
 					public boolean matches(CtType element) {
 						context.count++;
@@ -940,7 +940,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the select implementation made by lambda throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).select((CtType element) -> {
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).select((CtType element) -> {
 					context.count++;
 					throw new ClassCastException("TEST");
 				}).list();
@@ -954,7 +954,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the map(CtFunction) implementation made by local class throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map(new CtFunction<CtType, Object>(){
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).map(new CtFunction<CtType, Object>(){
 					@Override
 					public Object apply(CtType input) {
 						context.count++;
@@ -971,7 +971,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the map(CtFunction) implementation made by lambda throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map((CtType input) -> {
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).map((CtType input) -> {
 					context.count++;
 					throw new ClassCastException("TEST");
 				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
@@ -985,7 +985,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the map(CtConsumableFunction) implementation made by local class throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map(new CtConsumableFunction<CtType>(){
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).map(new CtConsumableFunction<CtType>(){
 					@Override
 					public void apply(CtType input, CtConsumer<Object> outputConsumer) {
 						context.count++;
@@ -1002,7 +1002,7 @@ public class FilterTest {
 			Context context = new Context();
 			//contract: if the map(CtConsumableFunction) implementation made by lambda throws CCE then it is reported
 			try {
-				launcher.getFactory().Package().getRootPackage().filterChildren(null).map((CtType input, CtConsumer<Object> outputConsumer) -> {
+				launcher.getFactory().getModel().getRootElement().filterChildren(null).map((CtType input, CtConsumer<Object> outputConsumer) -> {
 					context.count++;
 					throw new ClassCastException("TEST");
 				}).failurePolicy(QueryFailurePolicy.IGNORE).list();
@@ -1088,7 +1088,7 @@ public class FilterTest {
 		//context.expectedParent is last visited element
 		
 		//Check that last visited element was root package
-		assertSame(launcher.getFactory().getModel().getRootPackage(), context.expectedParent);
+		assertSame(launcher.getFactory().getModel().getRootElement(), context.expectedParent);
 		
 		//contract: if includingSelf(false), then parent of input element is first element
 		assertSame(varStrings.getParent(), varStrings.map(new ParentFunction().includingSelf(false)).first());
@@ -1114,7 +1114,7 @@ public class FilterTest {
 		Context context1 = new Context();
 
 		// scan only packages until top level classes. Do not scan class internals
-		List<CtElement> result1 = launcher.getFactory().getModel().getRootPackage().map(new CtScannerFunction().setListener(new CtScannerListener() {
+		List<CtElement> result1 = launcher.getFactory().getModel().getRootElement().map(new CtScannerFunction().setListener(new CtScannerListener() {
 			@Override
 			public ScanningMode enter(CtElement element) {
 				context1.nrOfEnter++;
@@ -1141,7 +1141,7 @@ public class FilterTest {
 		Iterator iter = result1.iterator();
 		
 		//scan only from packages till top level classes. Do not scan class internals
-		launcher.getFactory().getModel().getRootPackage().map(new CtScannerFunction().setListener(new CtScannerListener() {
+		launcher.getFactory().getModel().getRootElement().map(new CtScannerFunction().setListener(new CtScannerListener() {
 			int inClass = 0;
 			@Override
 			public ScanningMode enter(CtElement element) {
@@ -1187,7 +1187,7 @@ public class FilterTest {
 		launcher.addInputResource("./src/test/java/spoon/test/filters/testclasses");
 		launcher.buildModel();
 
-		SubInheritanceHierarchyResolver resolver = new SubInheritanceHierarchyResolver(launcher.getModel().getRootPackage());
+		SubInheritanceHierarchyResolver resolver = new SubInheritanceHierarchyResolver(launcher.getModel().getRootElement());
 
 		// contract: by default, nothing is sent to the consumer
 		resolver.forEachSubTypeInPackage(new CtConsumer<CtType<?>>() {

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -691,143 +691,143 @@ public class GenericsTest {
 		 */
 
 		// T
-		CtTypeReference<?> var1Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "var1")).first(CtVariable.class).getType();
+		CtTypeReference<?> var1Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "var1")).first(CtVariable.class).getType();
 		assertEquals(true, var1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Subscriber<? super T>
-		CtTypeReference<?> sRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "s")).first(CtVariable.class).getType();
+		CtTypeReference<?> sRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "s")).first(CtVariable.class).getType();
 		assertEquals(true, sRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>
-		CtTypeReference<?> notificationRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "notification")).first(CtVariable.class).getType();
+		CtTypeReference<?> notificationRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "notification")).first(CtVariable.class).getType();
 		assertEquals(false, notificationRef.isGenerics());
 
 		// java.util.function.Function<? super spoon.test.generics.testclasses.rxjava.Observable<spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>, ? extends spoon.test.generics.testclasses.rxjava.Publisher<?>>
-		CtTypeReference<?> managerRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "manager")).first(CtVariable.class).getType();
+		CtTypeReference<?> managerRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "manager")).first(CtVariable.class).getType();
 		assertEquals(false, managerRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.BehaviorSubject<spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>
-		CtTypeReference<?> subjectRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "subject")).first(CtVariable.class).getType();
+		CtTypeReference<?> subjectRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "subject")).first(CtVariable.class).getType();
 		assertEquals(false, subjectRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.PublisherRedo.RedoSubscriber<T>
-		CtTypeReference<?> parentRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "parent")).first(CtVariable.class).getType();
+		CtTypeReference<?> parentRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "parent")).first(CtVariable.class).getType();
 		assertEquals(true, parentRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Publisher<?>
-		CtTypeReference<?> actionRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "action")).first(CtVariable.class).getType();
+		CtTypeReference<?> actionRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "action")).first(CtVariable.class).getType();
 		assertEquals(false, actionRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.ToNotificationSubscriber
-		CtTypeReference<?> trucRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "truc")).first(CtVariable.class).getType();
+		CtTypeReference<?> trucRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "truc")).first(CtVariable.class).getType();
 		assertEquals(false, trucRef.isGenerics());
 
 		// java.util.function.Consumer<? super spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>
-		CtTypeReference<?> consumerRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "consumer")).first(CtVariable.class).getType();
+		CtTypeReference<?> consumerRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "consumer")).first(CtVariable.class).getType();
 		assertEquals(false, consumerRef.isGenerics());
 
 		// S
-		CtTypeReference<?> sectionRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "section")).first(CtVariable.class).getType();
+		CtTypeReference<?> sectionRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "section")).first(CtVariable.class).getType();
 		assertEquals(true, sectionRef.isGenerics());
 
 		// X
-		CtTypeReference<?> paramARef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "paramA")).first(CtVariable.class).getType();
+		CtTypeReference<?> paramARef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "paramA")).first(CtVariable.class).getType();
 		assertEquals(true, paramARef.isGenerics());
 
 		// spoon.test.generics.testclasses.Tacos
-		CtTypeReference<?> paramBRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "paramB")).first(CtVariable.class).getType();
+		CtTypeReference<?> paramBRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "paramB")).first(CtVariable.class).getType();
 		assertEquals(false, paramBRef.isGenerics());
 
 		// C
-		CtTypeReference<?> paramCRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "paramC")).first(CtVariable.class).getType();
+		CtTypeReference<?> paramCRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "paramC")).first(CtVariable.class).getType();
 		assertEquals(true, paramCRef.isGenerics());
 
 		// R
-		CtTypeReference<?> cookRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "cook")).first(CtVariable.class).getType();
+		CtTypeReference<?> cookRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "cook")).first(CtVariable.class).getType();
 		assertEquals(true, cookRef.isGenerics());
 
 		// spoon.test.generics.testclasses.CelebrationLunch<java.lang.Integer, java.lang.Long, java.lang.Double>
-		CtTypeReference<?> clRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "cl")).first(CtVariable.class).getType();
+		CtTypeReference<?> clRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "cl")).first(CtVariable.class).getType();
 		assertEquals(false, clRef.isGenerics());
 
 		// spoon.test.generics.testclasses.CelebrationLunch<java.lang.Integer, java.lang.Long, java.lang.Double>.WeddingLunch<spoon.test.generics.testclasses.Mole>
-		CtTypeReference<?> disgustRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "disgust")).first(CtVariable.class).getType();
+		CtTypeReference<?> disgustRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "disgust")).first(CtVariable.class).getType();
 		assertEquals(false, disgustRef.isGenerics());
 
 		// L
-		CtTypeReference<?> paramRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "param")).first(CtVariable.class).getType();
+		CtTypeReference<?> paramRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "param")).first(CtVariable.class).getType();
 		assertEquals(true, paramRef.isGenerics());
 
 		// spoon.reflect.declaration.CtType<? extends spoon.reflect.declaration.CtNamedElement>
-		CtTypeReference<?> targetTypeRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "targetType")).first(CtVariable.class).getType();
+		CtTypeReference<?> targetTypeRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "targetType")).first(CtVariable.class).getType();
 		assertEquals(false, targetTypeRef.isGenerics());
 
 		// spoon.reflect.declaration.CtType<?>
-		CtTypeReference<?> somethingRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "something")).first(CtVariable.class).getType();
+		CtTypeReference<?> somethingRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "something")).first(CtVariable.class).getType();
 		assertEquals(false, somethingRef.isGenerics());
 
 		// int
-		CtTypeReference<?> iRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "i")).first(CtVariable.class).getType();
+		CtTypeReference<?> iRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "i")).first(CtVariable.class).getType();
 		assertEquals(false, iRef.isGenerics());
 
 		// T
-		CtTypeReference<?> biduleRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "bidule")).first(CtVariable.class).getType();
+		CtTypeReference<?> biduleRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "bidule")).first(CtVariable.class).getType();
 		assertEquals(true, biduleRef.isGenerics());
 
 		// Cook<java.lang.String>
-		CtTypeReference<?> aClassRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "aClass")).first(CtVariable.class).getType();
+		CtTypeReference<?> aClassRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "aClass")).first(CtVariable.class).getType();
 		assertEquals(false, aClassRef.isGenerics());
 
 		// java.util.List<java.util.List<M>>
-		CtTypeReference<?> list2mRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "list2m")).first(CtVariable.class).getType();
+		CtTypeReference<?> list2mRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "list2m")).first(CtVariable.class).getType();
 		assertEquals(true, list2mRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Panini.Subscriber<? extends java.lang.Long>
-		CtTypeReference<?> tRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "t")).first(CtVariable.class).getType();
+		CtTypeReference<?> tRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "t")).first(CtVariable.class).getType();
 		assertEquals(false, tRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.Tester
-		CtTypeReference<?> testerRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "tester")).first(CtVariable.class).getType();
+		CtTypeReference<?> testerRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "tester")).first(CtVariable.class).getType();
 		assertEquals(false, testerRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.Tester
-		CtTypeReference<?> tester1Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "tester1")).first(CtVariable.class).getType();
+		CtTypeReference<?> tester1Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "tester1")).first(CtVariable.class).getType();
 		assertEquals(false, tester1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.That<java.lang.String, java.lang.String>
-		CtTypeReference<?> fieldRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "field")).first(CtVariable.class).getType();
+		CtTypeReference<?> fieldRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "field")).first(CtVariable.class).getType();
 		assertEquals(false, fieldRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<java.lang.String>.That<java.lang.String, java.lang.String>
-		CtTypeReference<?> field1Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "field1")).first(CtVariable.class).getType();
+		CtTypeReference<?> field1Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "field1")).first(CtVariable.class).getType();
 		assertEquals(false, field1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<java.lang.Number>.That<java.lang.String, java.lang.String>
-		CtTypeReference<?> field2Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "field2")).first(CtVariable.class).getType();
+		CtTypeReference<?> field2Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "field2")).first(CtVariable.class).getType();
 		assertEquals(false, field2Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Tacos<K, java.lang.String>.Burritos<K, V>
-		CtTypeReference<?> burritosRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "burritos")).first(CtVariable.class).getType();
+		CtTypeReference<?> burritosRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "burritos")).first(CtVariable.class).getType();
 		assertEquals(true, burritosRef.isGenerics());
 
 		// int
-		CtTypeReference<?> nbTacosRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "nbTacos")).first(CtVariable.class).getType();
+		CtTypeReference<?> nbTacosRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "nbTacos")).first(CtVariable.class).getType();
 		assertEquals(false, nbTacosRef.isGenerics());
 
 		// java.util.List<java.lang.String>
-		CtTypeReference<?> lRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "l")).first(CtVariable.class).getType();
+		CtTypeReference<?> lRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "l")).first(CtVariable.class).getType();
 		assertEquals(false, lRef.isGenerics());
 
 		// java.util.List
-		CtTypeReference<?> l2Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "l2")).first(CtVariable.class).getType();
+		CtTypeReference<?> l2Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "l2")).first(CtVariable.class).getType();
 		assertEquals(false, l2Ref.isGenerics());
 
 		// java.util.List<?>
-		CtTypeReference<?> l3Ref = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "l3")).first(CtVariable.class).getType();
+		CtTypeReference<?> l3Ref = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "l3")).first(CtVariable.class).getType();
 		assertEquals(false, l3Ref.isGenerics());
 
 		// T
-		CtTypeReference<?> anObjectRef = factory.getModel().getRootPackage().filterChildren(new NamedElementFilter(CtVariable.class, "anObject")).first(CtVariable.class).getType();
+		CtTypeReference<?> anObjectRef = factory.getModel().getRootElement().filterChildren(new NamedElementFilter(CtVariable.class, "anObject")).first(CtVariable.class).getType();
 		assertEquals(true, anObjectRef.isGenerics());
 
 	}
@@ -1400,7 +1400,7 @@ public class GenericsTest {
 		assertEquals(adaptedMethod.getParameters().get(0).getType(), classGetter.getType());
 		assertEquals(adaptedMethod.getParameters().get(0).getType(), classSetter.getParameters().get(0).getType());
 		
-		MainTest.checkParentConsistency(launcher.getFactory().getModel().getRootPackage());
+		MainTest.checkParentConsistency(launcher.getFactory().getModel().getRootElement());
 		MainTest.checkParentConsistency(adaptedMethod);
 	}
 }

--- a/src/test/java/spoon/test/intercession/IntercessionContractTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionContractTest.java
@@ -47,7 +47,7 @@ public class IntercessionContractTest {
 			protected void process(CtMethod<?> element) {
 				values.add(new Object[] { createCompatibleObject(element.getDeclaringType().getReference()), element.getReference().getActualMethod() });
 			}
-		}.scan(launcher.getModel().getRootPackage());
+		}.scan(launcher.getModel().getRootElement());
 		return values;
 	}
 

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -350,6 +350,6 @@ public class IntercessionTest {
 			private String log(CtMethod<?> element, String message) {
 				return message + "\nin " + element.getSignature() + "\ndeclared in " + element.getDeclaringType().getQualifiedName();
 			}
-		}.scan(factory.getModel().getRootPackage());
+		}.scan(factory.getModel().getRootElement());
 	}
 }

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -65,6 +65,6 @@ public class JavaDocTest {
 				fail("Shouldn't have comment in the model.");
 				super.visitCtComment(comment);
 			}
-		}.scan(launcher.getModel().getRootPackage());
+		}.scan(launcher.getModel().getRootElement());
 	}
 }

--- a/src/test/java/spoon/test/metamodel/SpoonMetaModel.java
+++ b/src/test/java/spoon/test/metamodel/SpoonMetaModel.java
@@ -91,7 +91,7 @@ public class SpoonMetaModel {
 		}
 		
 		//search for all interfaces of spoon model and create MMTypes for them
-		factory.getModel().getRootPackage().filterChildren(new TypeFilter<>(CtInterface.class))
+		factory.getModel().getRootElement().filterChildren(new TypeFilter<>(CtInterface.class))
 			.forEach((CtInterface<?> iface) -> {
 				if (MODEL_IFACE_PACKAGES.contains(iface.getPackage().getQualifiedName())) {
 					getOrCreateMMType(iface);

--- a/src/test/java/spoon/test/method_overriding/MethodOverriddingTest.java
+++ b/src/test/java/spoon/test/method_overriding/MethodOverriddingTest.java
@@ -30,7 +30,7 @@ public class MethodOverriddingTest {
 	private void checkMethodOverride(BiFunction<CtMethod<?>, CtMethod<?>, Boolean> isOverriding) {
 		Factory factory = ModelUtils.build(new File("src/test/java/spoon/test/method_overriding/testclasses").listFiles());
 		Map<String, List<CtMethod>> methodsByName = new HashMap<>();
-		factory.getModel().getRootPackage().filterChildren(new TypeFilter<>(CtMethod.class)).forEach((CtMethod m)->{
+		factory.getModel().getRootElement().filterChildren(new TypeFilter<>(CtMethod.class)).forEach((CtMethod m)->{
 			List<CtMethod> methods = methodsByName.get(m.getSimpleName());
 			if(methods==null) {
 				methods = new ArrayList<>();

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -408,7 +408,7 @@ public class ParentTest {
 				});
 				return ctInvocations.size() >0 ? ctInvocations.get(0) :  null;
 			}
-		}.scan(launcher.getModel().getRootPackage());
+		}.scan(launcher.getModel().getRootElement());
 	}
 
 }

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -43,13 +43,13 @@ public class PathTest {
 	}
 
 	private void equals(CtPath path, CtElement... elements) {
-		Collection<CtElement> result = path.evaluateOn(Arrays.asList(factory.Package().getRootPackage()));
+		Collection<CtElement> result = path.evaluateOn(Arrays.asList(factory.getModel().getRootElement()));
 		assertEquals(elements.length, result.size());
 		assertArrayEquals(elements, result.toArray(new CtElement[0]));
 	}
 
 	private void equalsSet(CtPath path, Set<? extends CtElement> elements) {
-		Collection<CtElement> result = path.evaluateOn(Arrays.asList(factory.Package().getRootPackage()));
+		Collection<CtElement> result = path.evaluateOn(Arrays.asList(factory.getModel().getRootElement()));
 		assertEquals(elements.size(), result.size());
 		assertTrue(result.containsAll(elements));
 	}

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -292,7 +292,7 @@ public class VariableReferencesTest {
 				return getLiteralValue((CtExpression<?>)inv.getArguments().get(l_argIdx));
 			} else {
 				CtExecutableReference<?> l_execRef = l_exec.getReference();
-				List<CtAbstractInvocation<?>> list = l_exec.getFactory().Package().getRootPackage().filterChildren((CtAbstractInvocation inv)->{
+				List<CtAbstractInvocation<?>> list = l_exec.getFactory().getModel().getRootElement().filterChildren((CtAbstractInvocation inv)->{
 //					return inv.getExecutable().equals(l_execRef);
 					return inv.getExecutable().getExecutableDeclaration()==l_exec;
 				}).list();

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -225,7 +225,7 @@ public class MethodsRefactoringTest {
 	}
 
 	private List<CtExecutable<?>> getExecutablesOfHierarchy(Factory factory, String hierarchyName) {
-		return factory.getModel().getRootPackage().filterChildren(new TypeFilter(CtExecutable.class)).select((CtExecutable<?> exec)->{
+		return factory.getModel().getRootElement().filterChildren(new TypeFilter(CtExecutable.class)).select((CtExecutable<?> exec)->{
 			//detect if found executable belongs to hierarchy 'hierarchyName'
 			CtElement ele = exec;
 			if (exec instanceof CtLambda) {
@@ -247,7 +247,7 @@ public class MethodsRefactoringTest {
 	public void testExecutableReferenceFilter() {
 		Factory factory = ModelUtils.build(new File("./src/test/java/spoon/test/refactoring/parameter/testclasses"));
 		
-		List<CtExecutable<?>> executables = factory.getModel().getRootPackage().filterChildren((CtExecutable<?> e)->true).list();
+		List<CtExecutable<?>> executables = factory.getModel().getRootElement().filterChildren((CtExecutable<?> e)->true).list();
 		int nrExecRefsTotal = 0;
 		//contract check that ExecutableReferenceFilter found CtExecutableReferences of each executable individually 
 		for (CtExecutable<?> executable : executables) {
@@ -259,7 +259,7 @@ public class MethodsRefactoringTest {
 		assertSame(nrExecRefsTotal, nrExecRefsTotal2);
 
 		//contract check that it found lambdas too
-		CtLambda lambda = factory.getModel().getRootPackage().filterChildren((CtLambda<?> e)->true).first();
+		CtLambda lambda = factory.getModel().getRootElement().filterChildren((CtLambda<?> e)->true).first();
 		assertNotNull(lambda);
 		//this test case is quite wild, because there is normally lambda reference in spoon model. So make one lambda reference here:
 		CtExecutableReference<?> lambdaRef = lambda.getReference();
@@ -272,10 +272,10 @@ public class MethodsRefactoringTest {
 		assertTrue(executables.size()>0);
 		ExecutableReferenceFilter execRefFilter = new ExecutableReferenceFilter();
 		executables.forEach((CtExecutable<?> e)->execRefFilter.addExecutable(e));
-		final List<CtExecutableReference<?>> refs = new ArrayList<>(factory.getModel().getRootPackage().filterChildren(execRefFilter).list());
+		final List<CtExecutableReference<?>> refs = new ArrayList<>(factory.getModel().getRootElement().filterChildren(execRefFilter).list());
 		int nrExecRefs = refs.size();
 		//use different (slower, but straight forward) algorithm to search for all executable references to check if ExecutableReferenceFilter returns correct results
-		factory.getModel().getRootPackage().filterChildren((CtExecutableReference er)->{
+		factory.getModel().getRootElement().filterChildren((CtExecutableReference er)->{
 			return containsSame(executables, er.getDeclaration());
 		}).forEach((CtExecutableReference er)->{
 			//check that each expected reference was found by ExecutableReferenceFilter and remove it from that list

--- a/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
+++ b/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
@@ -40,7 +40,7 @@ public class ElasticsearchStackoverflowTest {
 
 		CtModel model = launcher.getModel();
 		Scanner scanner = new Scanner();
-		scanner.scan(model.getRootPackage());
+		scanner.scan(model.getRootElement());
 
 		List<CtExecutableReference> executables = launcher.getModel().getElements(new TypeFilter<CtExecutableReference>(CtExecutableReference.class));
 		assertFalse(executables.isEmpty());

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -215,7 +215,7 @@ public class VariableAccessTest {
 		launcher.addInputResource("src/test/resources/reference-test/ChangeScanner.java");
 		launcher.buildModel();
 
-		new CtLocalVariableReferenceScanner().scan(launcher.getModel().getRootPackage());
+		new CtLocalVariableReferenceScanner().scan(launcher.getModel().getRootElement());
 	}
 
 	@Test
@@ -239,7 +239,7 @@ public class VariableAccessTest {
 		launcher.addInputResource("src/test/resources/reference-test/MultipleDeclarationsOfLocalVariable.java");
 		launcher.buildModel();
 
-		new CtLocalVariableReferenceScanner().scan(launcher.getModel().getRootPackage());
+		new CtLocalVariableReferenceScanner().scan(launcher.getModel().getRootElement());
 	}
 
 	private CtMethod<Object> getMethod(Launcher launcher, CtClass<Object> a2) {

--- a/src/test/java/spoon/test/serializable/SerializableTest.java
+++ b/src/test/java/spoon/test/serializable/SerializableTest.java
@@ -80,6 +80,6 @@ public class SerializableTest {
 
 		assertFalse(factory.Type().getAll().isEmpty());
 		assertFalse(loadedFactory.Type().getAll().isEmpty());
-		assertEquals(factory.getModel().getRootPackage(), loadedFactory.getModel().getRootPackage());
+		assertEquals(factory.getModel().getRootElement(), loadedFactory.getModel().getRootElement());
 	}
 }

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -613,7 +613,7 @@ public class TemplateTest {
 		CtIf templateRoot = (CtIf) templateMethod.getBody().getStatement(0);
 		TemplateMatcher matcher = new TemplateMatcher(templateRoot);
 
-		List<CtElement> matches = matcher.find(factory.getModel().getRootPackage());
+		List<CtElement> matches = matcher.find(factory.getModel().getRootElement());
 
 		assertEquals(1, matches.size());
 
@@ -657,7 +657,7 @@ public class TemplateTest {
 		TemplateMatcher matcher = new TemplateMatcher(templateRoot);
 
 		//match using legacy TemplateMatcher#find method
-		List<CtElement> matches = matcher.find(factory.getModel().getRootPackage());
+		List<CtElement> matches = matcher.find(factory.getModel().getRootElement());
 
 		assertEquals(2, matches.size());
 
@@ -667,7 +667,7 @@ public class TemplateTest {
 		assertTrue(match1.equals(match2));
 		
 		//match using TemplateMatcher#matches method and query filter
-		matches = factory.getModel().getRootPackage().filterChildren(matcher).list();
+		matches = factory.getModel().getRootElement().filterChildren(matcher).list();
 
 		assertEquals(2, matches.size());
 

--- a/src/test/java/spoon/test/visitor/VisitorTest.java
+++ b/src/test/java/spoon/test/visitor/VisitorTest.java
@@ -42,7 +42,7 @@ public class VisitorTest {
         launcher.buildModel();
 
         final MyVisitor visitor = new MyVisitor(2);
-        visitor.scan(launcher.getFactory().Package().getRootPackage());
+        visitor.scan(launcher.getFactory().getModel().getRootElement());
         assertTrue(visitor.equals);
     }
 }


### PR DESCRIPTION
The purpose of this PR is to help evolving the model without losing the clients.
I propose to : 
  1. add the method `getRootElement`, which would return a CtPackage or a CtModule depending on the java compliance version
  2. Set `CtModel#getRootPackage` as deprecated, and advise clients to use `getRootModel` or `PackageFactory#getRootPackage`. 

For now, the rootPackage is still stored on `CtModel` but I don't know if it's a good design on the long term view. 