### PR TITLE
test: substitution of `return expression.S()`

### DIFF
--- a/src/test/java/spoon/test/template/TemplateReplaceReturnTest.java
+++ b/src/test/java/spoon/test/template/TemplateReplaceReturnTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.factory.Factory;
 import spoon.support.compiler.FileSystemFile;
@@ -31,6 +32,25 @@ public class TemplateReplaceReturnTest {
 		CtClass<?> resultKlass = factory.Class().create(factory.Package().getOrCreate("spoon.test.template"), "ReturnReplaceResult");
 		new ReturnReplaceTemplate(model).apply(resultKlass);
 		assertEquals("{ if (((java.lang.System.currentTimeMillis()) % 2L) == 0) { return \"Panna\"; }else { return \"Orel\"; }}", resultKlass.getMethod("method").getBody().toString().replaceAll("[\\r\\n\\t]+", "").replaceAll("\\s{2,}", " "));
+		launcher.setSourceOutputDirectory(new File("./target/spooned/"));
+		launcher.getModelBuilder().generateProcessedSourceFiles(OutputType.CLASSES);
+		ModelUtils.canBeBuilt(new File("./target/spooned/spoon/test/template/ReturnReplaceResult.java"), 8);
+	}
+
+	@Test
+	public void testNoReturnReplaceTemplate() throws Exception {
+		//contract: the template engine supports replace of return expression by `<CtExpression>`
+		Launcher launcher = new Launcher();
+		launcher.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/ReturnReplaceTemplate.java"));
+
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+
+		CtExpression<String> model = factory.createLiteral("AStringLiteral");
+		
+		CtClass<?> resultKlass = factory.Class().create(factory.Package().getOrCreate("spoon.test.template"), "ReturnReplaceResult");
+		new ReturnReplaceTemplate(model).apply(resultKlass);
+		assertEquals("{ return \"AStringLiteral\";}", resultKlass.getMethod("method").getBody().toString().replaceAll("[\\r\\n\\t]+", "").replaceAll("\\s{2,}", " "));
 		launcher.setSourceOutputDirectory(new File("./target/spooned/"));
 		launcher.getModelBuilder().generateProcessedSourceFiles(OutputType.CLASSES);
 		ModelUtils.canBeBuilt(new File("./target/spooned/spoon/test/template/ReturnReplaceResult.java"), 8);

--- a/src/test/java/spoon/test/template/testclasses/ReturnReplaceTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/ReturnReplaceTemplate.java
@@ -1,6 +1,5 @@
 package spoon.test.template.testclasses;
 
-import spoon.reflect.code.CtBlock;
 import spoon.template.ExtensionTemplate;
 import spoon.template.Local;
 import spoon.template.TemplateParameter;
@@ -14,7 +13,7 @@ public class ReturnReplaceTemplate extends ExtensionTemplate {
 	TemplateParameter<String> _statement_;
 
 	@Local
-	public ReturnReplaceTemplate(CtBlock<String> statement) {
+	public ReturnReplaceTemplate(TemplateParameter<String> statement) {
 		this._statement_ = statement;
 	}
 	


### PR DESCRIPTION
Improves a test of substitution of `return expression.S()`, which actually substitutes
A) `return expression.S()` if the parameter value is CtBlock
B) `expression.S()` if the parameter value is an expression

The case B) was not tested before, so I would like to add this test before #1686 so it visible that this contract is still working and did not changed.