### PR TITLE
fix: test meta model - MMField value(Item)Type is not implicit

### DIFF
--- a/src/test/java/spoon/test/metamodel/MMField.java
+++ b/src/test/java/spoon/test/metamodel/MMField.java
@@ -199,7 +199,11 @@ public class MMField {
 				valueType = f.Type().OBJECT;
 			}
 		}
-
+		if (valueType.isImplicit()) {
+			valueType = valueType.clone();
+			//never return type  with implicit==true, such type is then not pretty printed
+			valueType.setImplicit(false);
+		}
 		this.valueType = valueType;
 		this.valueContainerType = MMContainerType.valueOf(valueType.getActualClass());
 		if (valueContainerType != MMContainerType.SINGLE) {

--- a/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
+++ b/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
@@ -36,7 +36,6 @@ public class MetaModelTest {
 	 */
 	//enable this test after everything is covered.
 	@Test
-	@Ignore
 	public void spoonMetaModelTest() {
 		SpoonMetaModel mm = new SpoonMetaModel(new File("./src/main/java"));
 		List<String> problems = new ArrayList<>();
@@ -57,6 +56,9 @@ public class MetaModelTest {
                 		problems.add("Missing setter for " + mmField.getOwnerType().getName() + " and CtRole." + mmField.getRole());
                 	}
 				}
+				//contract: type of field value is never implicit
+				assertFalse("Value type of Field " + mmField.toString() + " is implicit", mmField.getValueType().isImplicit());
+				assertFalse("Item value type of Field " + mmField.toString() + " is implicit", mmField.getItemValueType().isImplicit());
 				
 				mmField.forEachUnhandledMethod(ctMethod -> problems.add("Unhandled method signature: " + ctMethod.getDeclaringType().getSimpleName() + "#" + ctMethod.getSignature()));
 			});
@@ -64,7 +66,7 @@ public class MetaModelTest {
 		
 		unhandledRoles.forEach(it -> problems.add("Unused CtRole." + it.name()));
 		
-		assertTrue(String.join("\n", problems), problems.isEmpty());
+//		assertTrue(String.join("\n", problems), problems.isEmpty());
 	}
 	@Test
 	public void elementAnnotationRoleHandlerTest() {

--- a/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
+++ b/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
@@ -1,13 +1,11 @@
 package spoon.test.reflect.meta;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import spoon.Launcher;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.meta.ContainerKind;
 import spoon.reflect.meta.RoleHandler;
@@ -34,7 +32,6 @@ public class MetaModelTest {
 	 * this test reports all spoon model elements which are not yet handled by meta model
 	 * actually this is the result
 	 */
-	//enable this test after everything is covered.
 	@Test
 	public void spoonMetaModelTest() {
 		SpoonMetaModel mm = new SpoonMetaModel(new File("./src/main/java"));
@@ -65,7 +62,10 @@ public class MetaModelTest {
 		});
 		
 		unhandledRoles.forEach(it -> problems.add("Unused CtRole." + it.name()));
-		
+		/*
+		 * This assertion prints all the methods which are not covered by current implementation of SpoonMetaModel.
+		 * It is not a bug. It is useful to see how much is SpoonMetaModel covering real Spoon model.
+		 */
 //		assertTrue(String.join("\n", problems), problems.isEmpty());
 	}
 	@Test


### PR DESCRIPTION
Value type of MMField `CtLiteral#value` was Object with implicit = true, which caused problem in new template substitution and then invalid pretty printing of such type references... DJPP doesn't prints such TypeReferences, even if they are on place where they cannot be implicit.