### PR TITLE
review refactor(api): OutputType available in Environment

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -445,7 +445,7 @@ public class Launcher implements SpoonAPI {
 		String outputString = jsapActualArgs.getString("output-type");
 		OutputType outputType = OutputType.fromString(outputString);
 		if (outputType == null) {
-			throw  new SpoonException("Unknown output type: "+outputString);
+			throw  new SpoonException("Unknown output type: " + outputString);
 		} else {
 			environment.setOutputType(outputType);
 		}

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -442,6 +442,14 @@ public class Launcher implements SpoonAPI {
 		environment.setShouldCompile(jsapActualArgs.getBoolean("compile"));
 		environment.setSelfChecks(jsapActualArgs.getBoolean("disable-model-self-checks"));
 
+		String outputString = jsapActualArgs.getString("output-type");
+		OutputType outputType = OutputType.fromString(outputString);
+		if (outputType == null) {
+			throw  new SpoonException("Unknown output type: "+outputString);
+		} else {
+			environment.setOutputType(outputType);
+		}
+
 		try {
 			Charset charset = Charset.forName(jsapActualArgs.getString("encoding"));
 			environment.setEncoding(charset);
@@ -728,15 +736,14 @@ public class Launcher implements SpoonAPI {
 
 	@Override
 	public void prettyprint() {
-		OutputType outputType = OutputType.fromString(jsapActualArgs.getString("output-type"));
 		long tstart = System.currentTimeMillis();
 		try {
-			modelBuilder.generateProcessedSourceFiles(outputType, typeFilter);
+			modelBuilder.generateProcessedSourceFiles(getEnvironment().getOutputType(), typeFilter);
 		} catch (Exception e) {
 			throw new SpoonException(e);
 		}
 
-		if (!outputType.equals(OutputType.NO_OUTPUT) && getEnvironment().isCopyResources()) {
+		if (!getEnvironment().getOutputType().equals(OutputType.NO_OUTPUT) && getEnvironment().isCopyResources()) {
 			for (File dirInputSource : modelBuilder.getInputSources()) {
 				if (dirInputSource.isDirectory()) {
 					final Collection<?> resources = FileUtils.listFiles(dirInputSource, RESOURCES_FILE_FILTER, ALL_DIR_FILTER);

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -17,6 +17,7 @@
 package spoon.compiler;
 
 import org.apache.log4j.Level;
+import spoon.OutputType;
 import spoon.processing.FileGenerator;
 import spoon.processing.ProblemFixer;
 import spoon.processing.ProcessingManager;
@@ -362,4 +363,14 @@ public interface Environment {
 	 * Set the encoding to use for parsing source code
 	 */
 	void setEncoding(Charset encoding);
+
+	/**
+	 * Set the output type used for processing files
+	 */
+	void setOutputType(OutputType outputType);
+
+	/**
+	 * Get the output type
+	 */
+	OutputType getOutputType();
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -19,6 +19,7 @@ package spoon.support;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import spoon.Launcher;
+import spoon.OutputType;
 import spoon.SpoonException;
 import spoon.compiler.Environment;
 import spoon.compiler.InvalidClassPathException;
@@ -95,6 +96,8 @@ public class StandardEnvironment implements Serializable, Environment {
 	private int complianceLevel = DEFAULT_CODE_COMPLIANCE_LEVEL;
 
 	private File sourceOutputDirectory = new File(Launcher.OUTPUTDIR);
+
+	private OutputType outputType = OutputType.CLASSES;
 
 	/**
 	 * Creates a new environment with a <code>null</code> default file
@@ -539,5 +542,15 @@ public class StandardEnvironment implements Serializable, Environment {
 	@Override
 	public void setEncoding(Charset encoding) {
 		this.encoding = encoding;
+	}
+
+	@Override
+	public void setOutputType(OutputType outputType) {
+		this.outputType = outputType;
+	}
+
+	@Override
+	public OutputType getOutputType() {
+		return this.outputType;
 	}
 }


### PR DESCRIPTION
This PR aims at simplifying the usage of API for defining output type: until now the only way to specify the output type was using the argument "output-type" or using its own call of `JDTSpoonCompiler#generateProcessedSourceFiles`. Now it can be done simply by setting `Environment#setOutputType`