### PR TITLE
fix: DefaultJavaPrettyPrinter prints an ERROR comment instead of failure

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -854,14 +854,16 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 						 * Search for potential variable declaration until we found a class which declares or inherits this field
 						 */
 						final CtField<?> field = f.getVariable().getFieldDeclaration();
-						if (field == null) {
-							throw new SpoonException("The reference to field named \"" + f.getVariable().getSimpleName() + "\" is invalid, because there is no field with such name on path:" + getPath(f));
-						}
-						final String fieldName = field.getSimpleName();
-						CtVariable<?> var = f.getVariable().map(new PotentialVariableDeclarationFunction(fieldName)).first();
-						if (var != field) {
-							//another variable declaration was found which is hiding the field declaration for this field access. Make the field access expicit
-							target.setImplicit(false);
+						if (field != null) {
+							final String fieldName = field.getSimpleName();
+							CtVariable<?> var = f.getVariable().map(new PotentialVariableDeclarationFunction(fieldName)).first();
+							if (var != field) {
+								//another variable declaration was found which is hiding the field declaration for this field access. Make the field access expicit
+								target.setImplicit(false);
+							}
+						} else {
+							//There is a model inconsistency
+							printer.writeComment(f.getFactory().createComment("ERROR: Missing field:", CommentType.BLOCK)).writeSpace();
 						}
 					}
 					// the implicit drives the separator

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -863,7 +863,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 							}
 						} else {
 							//There is a model inconsistency
-							printer.writeComment(f.getFactory().createComment("ERROR: Missing field:", CommentType.BLOCK)).writeSpace();
+							printer.writeComment(f.getFactory().createComment("ERROR: Missing field \"" + f.getVariable().getSimpleName() + "\", please check your model. The code may not compile.", CommentType.BLOCK)).writeSpace();
 						}
 					}
 					// the implicit drives the separator

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -163,17 +163,7 @@ public class PrinterTest {
 		//It may happen during substitution operations and then it is helpful to display descriptive error message
 		type.getField("testedField").delete();
 		//contract: printer fails with descriptive exception and not with NPE
-		try {
-			type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString();
-			fail();
-		} catch (SpoonException e) {
-			//the name of the missing field declaration is part of exception
-			assertTrue(e.getMessage().indexOf("testedField")>=0);
-			//the name of the method where field declaration is missing is part of exception
-			assertTrue(e.getMessage().indexOf("failingMethod")>=0);
-			//the name of the class where field is missing is part of exception
-			assertTrue(e.getMessage().indexOf("MissingVariableDeclaration")>=0);
-		} //other exceptions are not OK
+		assertEquals("/* ERROR: Missing field: */ testedField = 1", type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString());
 	}
 
 	private final Set<String> separators = new HashSet<>(Arrays.asList("->","::","..."));

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -163,7 +163,7 @@ public class PrinterTest {
 		//It may happen during substitution operations and then it is helpful to display descriptive error message
 		type.getField("testedField").delete();
 		//contract: printer fails with descriptive exception and not with NPE
-		assertEquals("/* ERROR: Missing field: */ testedField = 1", type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString());
+		assertEquals("/* ERROR: Missing field \"testedField\", please check your model. The code may not compile. */ testedField = 1", type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString());
 	}
 
 	private final Set<String> separators = new HashSet<>(Arrays.asList("->","::","..."));


### PR DESCRIPTION
In case  of some model inconsistency (missing field declaration) the DJPP failed before. It is much more debugging friendly if there is no failure, but if it prints the comment with error description instead.
WDYT?