### PR TITLE
fix: VisitorPartialEvaluator

### DIFF
--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -55,6 +55,41 @@ public class EvalTest {
 	}
 
 	@Test
+	public void testDoNotSimplifyCasts() throws Exception {
+		CtClass<?> type = build("spoon.test.eval", "ToEvaluate");
+		assertEquals("ToEvaluate", type.getSimpleName());
+
+		CtBlock<?> b = type.getMethodsByName("testDoNotSimplifyCasts").get(0).getBody();
+		assertEquals(1, b.getStatements().size());
+		b = b.partiallyEvaluate();
+		assertEquals("return ((U) ((java.lang.Object) (spoon.test.eval.ToEvaluate.castTarget(element).getClass())))", b.getStatements().get(0).toString());
+	}
+
+	@Test
+	public void testTryCatchAndStatement() throws Exception {
+		CtClass<?> type = build("spoon.test.eval", "ToEvaluate");
+		assertEquals("ToEvaluate", type.getSimpleName());
+
+		CtBlock<?> b = type.getMethodsByName("tryCatchAndStatement").get(0).getBody();
+		assertEquals(2, b.getStatements().size());
+		b = b.partiallyEvaluate();
+		assertEquals(2, b.getStatements().size());
+	}
+
+	@Test
+	public void testDoNotSimplifyToExpressionWhenStatementIsExpected() throws Exception {
+		CtClass<?> type = build("spoon.test.eval", "ToEvaluate");
+		assertEquals("ToEvaluate", type.getSimpleName());
+
+		CtBlock<?> b = type.getMethodsByName("simplifyOnlyWhenPossible").get(0).getBody();
+		assertEquals(3, b.getStatements().size());
+		b = b.partiallyEvaluate();
+		assertEquals("spoon.test.eval.ToEvaluate.class.getName()", b.getStatements().get(0).toString());
+		assertEquals("java.lang.System.out.println(spoon.test.eval.ToEvaluate.getClassLoader())", b.getStatements().get(1).toString());
+		assertEquals("return \"spoon.test.eval.ToEvaluate\"", b.getStatements().get(2).toString());
+	}
+
+	@Test
 	public void testVisitorPartialEvaluator_binary() throws Exception {
 		Launcher launcher = new Launcher();
 
@@ -114,5 +149,4 @@ public class EvalTest {
 		// the if has been removed
 		assertEquals(0, foo.getElements(new TypeFilter<>(CtIf.class)).size());
 	}
-
 }

--- a/src/test/java/spoon/test/eval/ToEvaluate.java
+++ b/src/test/java/spoon/test/eval/ToEvaluate.java
@@ -1,5 +1,7 @@
 package spoon.test.eval;
 
+import spoon.reflect.declaration.CtElement;
+
 public class ToEvaluate {
 
 	static final String S1 = "S1";
@@ -42,5 +44,32 @@ public class ToEvaluate {
 	public static void testDoNotSimplify(String className, String methodName) {
 		// this code must not be simplified
 		java.lang.System.out.println(((("enter: " + className) + " - ") + methodName));
+	}
+
+	public static <U> U testDoNotSimplifyCasts(CtElement element) {
+		// this code must not be simplified
+		return ((U) ((Object) (castTarget(element).getClass())));
+	}
+
+	private static <T> T castTarget(CtElement element) {
+		return (T) element;
+	}
+
+	private static String tryCatchAndStatement(CtElement element) {
+		try {
+			element.getClass();
+		} catch (RuntimeException e) {
+			throw e;
+		}
+		return "This must not be removed";
+	}
+
+	private static String simplifyOnlyWhenPossible(CtElement element) {
+		//this must not be simplified because literal is not a statement.
+		ToEvaluate.class.getName();
+		//this must not be simplified because ClassLoader instance is not a literal
+		System.out.println(ToEvaluate.class.getClassLoader());
+		//this can be simplified because return expects expression
+		return ToEvaluate.class.getName();
 	}
 }


### PR DESCRIPTION
Several fixes are here:
* the simplification of invocation to literal can be done only when parent accepts CtExpression
* the simplification of invocation to literal can be done only when returned value is a primitive object
* the handling of try/catch control flow was fixed - it removed statements after catch(... e){throw e;}
* the type casts are kept