### PR TITLE
fix: detection of TemplateParameter in Parameters#isParameterSource

### DIFF
--- a/doc/template_definition.md
+++ b/doc/template_definition.md
@@ -174,14 +174,17 @@ public class TryCatchOutOfBoundTemplate extends BlockTemplate {
 Similarly, templated invocations require to declare a template parameter
 
 ```java
-@Parameter
 CtInvocation invocation;
 ```
 and then all `invocation.S()` will be replaced by the actual invocation.
 
+Note: All template fields whose type extends from `TemplateParameter` are automatically considered as template parameters.
+Other fields can be marked as template parameters using annotation `@Parameter`. 
+
 #### Inlining foreach expressions
 
 Foreach expressions can be inlined. They have to be declared as follows:
+
 ```java
 @Parameter
 CtExpression[] intValues;

--- a/doc/template_definition.md
+++ b/doc/template_definition.md
@@ -149,12 +149,33 @@ Template parameters
 ------------------
 
 #### AST elements
-All meta-model elements can be used as template parameter. For instance, one can
-template a try/catch block as shown in the class `TryCatchOutOfBoundTemplate`using a block as parameter.
+All meta-model elements can be used as template parameter. 
+There are two ways of defining such a template parameter.
+
+1) Using a subtype of TemplateParameter
+
+The following template uses a block as template parameter.
 This template type-checks, and can be used as input by the substitution
 engine to wrap a method body into a try/catch block. The substitution engine
 contains various methods that implement different substitution scenarios.
 
+
+```java
+public class TryCatchOutOfBoundTemplate extends BlockTemplate {
+        // CTBlock is a subtype of TemplateParameter as most metamodel elements
+	CtBlock _body_; // the body to surround
+
+	@Override
+	public void block() {
+		try {
+			_body_.S();
+		} catch (OutOfBoundException e) {
+			e.printStackTrace();
+		}
+	}
+}
+```
+One can also type the field directly with `TemplateParameter`:
 
 ```java
 public class TryCatchOutOfBoundTemplate extends BlockTemplate {
@@ -171,44 +192,18 @@ public class TryCatchOutOfBoundTemplate extends BlockTemplate {
 }
 ```
 
-Similarly, templated invocations require to declare a template parameter
+
+2) Using annotation `@Parameter`
+
+Fields annotated with `@Parameter` are template parameters. 
 
 ```java
+@Parameter
 CtInvocation invocation;
 ```
 and then all `invocation.S()` will be replaced by the actual invocation.
 
-Note: All template fields whose type extends from `TemplateParameter` are automatically considered as template parameters.
-Other fields can be marked as template parameters using annotation `@Parameter`. 
 
-#### Inlining foreach expressions
-
-Foreach expressions can be inlined. They have to be declared as follows:
-
-```java
-@Parameter
-CtExpression[] intValues;
-...
-template.intValues = new CtExpression[2];
-template.intValues[0] = factory.Code().createLiteral(0);
-template.intValues[1] = factory.Code().createLiteral(1);
-```
-
-and then,
-
-```java
-for(Object x : intValues) {
-         System.out.println(x);
-}
-```
-is transformed into:
-
-```java
-{
-    java.lang.System.out.println(0);
-    java.lang.System.out.println(1);
-}
-```
 #### Literal template Parameters
 
 For literals, Spoon provides developers with  *literal template parameters*. When the parameter is known to
@@ -267,14 +262,31 @@ String someMethod() {
 }
 ```
 
-Note that AST elements can also be given as parameter using `@Parameter` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/template/Parameter.html))
-annotation.
+#### Inlining foreach expressions
+
+Foreach expressions can be inlined. They have to be declared as follows:
 
 ```java
-class ATemplate extends BlockTemplate {
 @Parameter
-CtExpression<String> exp;
+CtExpression[] intValues;
 ...
-if ("er".equals(exp.S())) {...}
+template.intValues = new CtExpression[2];
+template.intValues[0] = factory.Code().createLiteral(0);
+template.intValues[1] = factory.Code().createLiteral(1);
+```
+
+and then,
+
+```java
+for(Object x : intValues) {
+         System.out.println(x);
+}
+```
+is transformed into:
+
+```java
+{
+    java.lang.System.out.println(0);
+    java.lang.System.out.println(1);
 }
 ```

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -268,7 +268,7 @@ public abstract class Parameters {
 			//the reference to this is not template parameter
 			return false;
 		}
-		if (TemplateParameter.class.getName().equals(ref.getType().getQualifiedName())) {
+		if (ref.getType().isSubtypeOf(getTemplateParameterType(ref.getFactory()))) {
 			//the type of template field is TemplateParameter.
 			return true;
 		}

--- a/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
+++ b/src/test/java/spoon/test/template/TemplateInvocationSubstitutionTest.java
@@ -12,6 +12,7 @@ import spoon.reflect.factory.Factory;
 import spoon.support.compiler.FileSystemFile;
 import spoon.test.template.testclasses.InvocationSubstitutionByExpressionTemplate;
 import spoon.test.template.testclasses.InvocationSubstitutionByStatementTemplate;
+import spoon.test.template.testclasses.SubstitutionByExpressionTemplate;
 
 public class TemplateInvocationSubstitutionTest {
 
@@ -44,5 +45,19 @@ public class TemplateInvocationSubstitutionTest {
 		CtBlock<?> result = new InvocationSubstitutionByExpressionTemplate(factory.createLiteral("abc")).apply(resultKlass);
 		assertEquals("java.lang.System.out.println(\"abc\".substring(1))", result.getStatement(0).toString());
 		assertEquals("java.lang.System.out.println(\"abc\".substring(1))", result.getStatement(1).toString());
+	}
+
+	@Test
+	public void testSubstitutionByExpression() throws Exception {
+		//contract: the template engine understands fields whose type extends from TemplateParameter as template parameter automatically. No need for extra annotation
+		Launcher spoon = new Launcher();
+		spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/testclasses/SubstitutionByExpressionTemplate.java"));
+
+		spoon.buildModel();
+		Factory factory = spoon.getFactory();
+
+		CtClass<?> resultKlass = factory.Class().create("Result");
+		CtBlock<?> result = new SubstitutionByExpressionTemplate(factory.createLiteral("abc")).apply(resultKlass);
+		assertEquals("java.lang.System.out.println(\"abc\".substring(1))", result.getStatement(0).toString());
 	}
 }

--- a/src/test/java/spoon/test/template/testclasses/SubstitutionByExpressionTemplate.java
+++ b/src/test/java/spoon/test/template/testclasses/SubstitutionByExpressionTemplate.java
@@ -1,0 +1,21 @@
+package spoon.test.template.testclasses;
+
+import spoon.reflect.code.CtExpression;
+import spoon.template.BlockTemplate;
+import spoon.template.Local;
+
+public class SubstitutionByExpressionTemplate extends BlockTemplate {
+
+	@Override
+	public void block() throws Throwable {
+		System.out.println(_expression_.S().substring(1));
+	}
+	
+	//note that there is no @Parameter annotation! This field is detected as template parameter, because it's type extends TemplateParameter
+	CtExpression<String> _expression_;
+
+	@Local
+	public SubstitutionByExpressionTemplate(CtExpression<String> expr) {
+		this._expression_ = expr;
+	}
+}


### PR DESCRIPTION
Each field whose type extends TemplateParameter is a template parameter now.

For example this is template parameter.
```java
CtExpression<String> _expression_;
```