### PR TITLE
review fix: Filter extends Predicate is now working with projects in JDK7

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -60,4 +60,9 @@ public abstract class AbstractFilter<T extends CtElement> implements Filter<T> {
 	public boolean matches(T element) {
 		return type.isAssignableFrom(element.getClass());
 	}
+
+	@Override
+	public boolean test(T element) {
+		return matches(element);
+	}
 }


### PR DESCRIPTION
This PR intends to fix the bug introduced in #1798 which make projects using JDK7 and custom filters fail. The error comes from the usage of a default method: overriding it in AbstractFilter fixes the bug. 