### PR TITLE
fix: ClassTypingContext resolveTypeParameter of outer parameters

### DIFF
--- a/src/test/java/spoon/test/generics/testclasses/OuterTypeParameter.java
+++ b/src/test/java/spoon/test/generics/testclasses/OuterTypeParameter.java
@@ -1,0 +1,16 @@
+package spoon.test.generics.testclasses;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class OuterTypeParameter {
+	public <T> List<T> method() {
+		return new ArrayList<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return super.iterator();
+			}
+		};
+	}
+}


### PR DESCRIPTION
fix of #1835

The problem was caused by type parameters, which were declared out of the scope of ClassTypingContext. Such type parameters must be kept as they are. It is not model inconsistency or reason to fail.