### PR TITLE
fix: getDocComment() returns asterisk (*) and spaces before comment

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
@@ -87,7 +87,7 @@ public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 	}
 
 	@Override
-	public String toString ()	{
+	public String toString()	{
 		return this.getType().toString()	//Tag type, with @ sign included
 				+ " "	//Space required between tag type and parameter
 				+ this.param + System.lineSeparator()	//Tag parameter

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
@@ -85,4 +85,12 @@ public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 	public CtJavaDocTag clone() {
 		return (CtJavaDocTag) super.clone();
 	}
+
+	@Override
+	public String toString ()	{
+		return this.getType().toString()	//Tag type, with @ sign included
+				+ " "	//Space required between tag type and parameter
+				+ this.param + System.lineSeparator()	//Tag parameter
+				+ "\t\t" + this.content + System.lineSeparator();
+	}
 }

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -46,25 +46,14 @@ public class JavaDocTest {
 
 		// contract: getDocComment returns the comment content together with the tag content
 		assertEquals("Creates an annotation type." + System.lineSeparator()
-				+ "* @param owner" + System.lineSeparator()
-				+ " * \t\tthe package of the annotation type" + System.lineSeparator()
-				+ "* @param simpleName" + System.lineSeparator()
-				+ " * \t\tthe name of annotation" + System.lineSeparator()
+				+ "@param owner" + System.lineSeparator()
+				+ "\t\tthe package of the annotation type" + System.lineSeparator()
+				+ "@param simpleName" + System.lineSeparator()
+				+ "\t\tthe name of annotation" + System.lineSeparator()
 				, aClass.getMethodsByName("create").get(0).getDocComment());
+
 		assertEquals(2, aClass.getMethodsByName("create").get(0).getComments().get(0).asJavaDoc().getTags().size());
 
-		// JavaDocTest#testJavaDocReprint()
-		// good first bug to welcome new contributors
-		// uncomment the assertion and get it passing!
-		// there remains a minor problem with tags, they are printed with the "* " before the content
-		// and the spaces before the * are not consistently handled
-		// here is the correct assertion
-//		assertEquals("Creates an annotation type." + System.lineSeparator()
-//						+ "@param owner" + System.lineSeparator()
-//						+ " \t\tthe package of the annotation type" + System.lineSeparator()
-//						+ " @param simpleName" + System.lineSeparator()
-//						+ " \t\tthe name of annotation" + System.lineSeparator()
-//				, aClass.getMethodsByName("create").get(0).getDocComment());
 	}
 
 	@Test


### PR DESCRIPTION
Added toString() method to CtJavaDocImpl.java to handle getDocComment()