### PR TITLE
fix EqualsChecker for assignments

### DIFF
--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.visitor.equals;
 
+import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtContinue;
@@ -106,6 +107,15 @@ public class EqualsChecker extends CtInheritanceScanner {
 			return;
 		}
 		super.scanCtModifiable(m);
+	}
+
+	@Override
+	public <T, A extends T> void visitCtAssignment(CtAssignment<T, A> assignment) {
+		if (!(assignment instanceof CtOperatorAssignment) && this.other instanceof CtOperatorAssignment) {
+			isNotEqual = true;
+			return;
+		}
+		super.visitCtAssignment(assignment);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
+++ b/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
@@ -1,0 +1,31 @@
+package spoon.test.visitor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.List;
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+public class AssignmentsEqualsTest {
+
+	@Test
+	public void testEquals() throws Exception {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/spoon/test/visitor/Assignments.java");
+		launcher.buildModel();
+
+		Factory factory = launcher.getFactory();
+		List<CtAssignment> assignments = Query.getElements(factory, new TypeFilter<>(CtAssignment.class));
+
+		assertTrue(assignments.size() == 10);
+		assertFalse(assignments.get(0).equals(assignments.get(1)));
+		assertFalse(assignments.get(2).equals(assignments.get(3)));
+		assertFalse(assignments.get(4).equals(assignments.get(5)));
+		assertFalse(assignments.get(6).equals(assignments.get(7)));
+		assertTrue(assignments.get(8).equals(assignments.get(9)));
+	}
+}

--- a/src/test/resources/spoon/test/visitor/Assignments.java
+++ b/src/test/resources/spoon/test/visitor/Assignments.java
@@ -1,0 +1,19 @@
+public class Assignments {
+
+	public void func(int x) {
+		x = 42;
+		x += 42;
+
+		x >>= 42;
+		x = 42;
+
+		x -= 42;
+		x += 42;
+
+		x = 42;
+		x = 100;
+
+		x = 42;
+		x = 42;
+	}
+}


### PR DESCRIPTION
Hi! I have found a bug, in `EqualsChecker` class, and this PR is a possible fix.
The problem is that `.equals` method called on `CtAssignment` and `CtOperatorAssignment` (which extends `CtAssignment`) returns true, once rhs and lhs statements are the same. But this is not correct.
For example, statements `x = 42` and `x += 42` are not the same thing at all.
To fix that, I implemented `visitCtAssignment` method.
Also, I provided some tests (second assert fails, without this fix).