### PR TITLE
fix getFile() for serialization

### DIFF
--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -107,9 +107,15 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	 */
 	int[] lineSeparatorPositions;
 
+	/** The file for this position. */
+	private File file;
+
 	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {
 		super();
 		this.compilationUnit = compilationUnit;
+		if (compilationUnit != null) {
+			this.file = compilationUnit.getFile();
+		}
 		this.sourceEnd = sourceEnd;
 		this.sourceStart = sourceStart;
 		this.lineSeparatorPositions = lineSeparatorPositions;
@@ -125,7 +131,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 
 	public File getFile() {
 		if (compilationUnit == null) {
-			return null;
+			return file;
 		}
 		return compilationUnit.getFile();
 	}

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -107,7 +107,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	 */
 	int[] lineSeparatorPositions;
 
-	/** The file for this position. */
+	/** The file for this position, same pointer as in the compilation unit, but required for serialization. */
 	private File file;
 
 	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {

--- a/src/test/java/spoon/test/serializable/SourcePositionTest.java
+++ b/src/test/java/spoon/test/serializable/SourcePositionTest.java
@@ -1,0 +1,56 @@
+package spoon.test.serializable;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Test;
+
+import spoon.Launcher;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.support.SerializationModelStreamer;
+
+public class SourcePositionTest {
+
+	private static Factory loadFactory(File file) throws IOException {
+		return new SerializationModelStreamer().load(new FileInputStream(file));
+	}
+
+	private static void saveFactory(Factory factory, File file) throws IOException {
+		ByteArrayOutputStream outstr = new ByteArrayOutputStream();
+		new SerializationModelStreamer().save(factory, outstr);
+		OutputStream fileStream = new FileOutputStream(file);
+		outstr.writeTo(fileStream);
+	}
+
+	@Test
+	public void testSourcePosition() throws IOException {
+		File modelFile = new File("./src/test/resources/serialization/model");
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/serialization/SomeClass.java");
+		launcher.buildModel();
+
+		Factory factory = launcher.getFactory();
+
+		saveFactory(factory, modelFile);
+
+		Factory factoryFromFile = loadFactory(modelFile);
+
+		CtType<?> type = factory.Type().get("SomeClass");
+		CtType<?> typeFromFile = factoryFromFile.Type().get("SomeClass");
+		assertTrue(type.getPosition().getFile().equals(typeFromFile.getPosition().getFile()));
+		assertTrue(type.getPosition().getLine() == typeFromFile.getPosition().getLine());
+		assertTrue(type.getPosition().getColumn() == typeFromFile.getPosition().getColumn());
+
+		CtField<?> elem1 = type.getField("a");
+		CtField<?> elem2 = typeFromFile.getField("a");
+		assertTrue(elem1.getPosition().getFile().equals(elem2.getPosition().getFile()));
+	}
+}

--- a/src/test/java/spoon/test/serializable/SourcePositionTest.java
+++ b/src/test/java/spoon/test/serializable/SourcePositionTest.java
@@ -45,6 +45,8 @@ public class SourcePositionTest {
 
 		CtType<?> type = factory.Type().get("SomeClass");
 		CtType<?> typeFromFile = factoryFromFile.Type().get("SomeClass");
+
+		// Serialized model should have same valid source positions as the original model
 		assertTrue(type.getPosition().getFile().equals(typeFromFile.getPosition().getFile()));
 		assertTrue(type.getPosition().getLine() == typeFromFile.getPosition().getLine());
 		assertTrue(type.getPosition().getColumn() == typeFromFile.getPosition().getColumn());

--- a/src/test/resources/serialization/SomeClass.java
+++ b/src/test/resources/serialization/SomeClass.java
@@ -1,0 +1,3 @@
+public class SomeClass {
+	public int a;
+}


### PR DESCRIPTION
Hi! I found out that filename from `SourcePosition` is lost during serialization (it's null). Although line number, column, etc. are present in deserialized model.
This happens because `getFile()` uses `compilationUnit`, which is null in deserialized model.
I fixed that by introducing field '`file`' in `SourcePosition`.
Also, I provided some tests. Particularly, without this fix the following assertions fail:
```
assertTrue(type.getPosition().getFile().equals(typeFromFile.getPosition().getFile()));
....
assertTrue(elem1.getPosition().getFile().equals(elem2.getPosition().getFile()));
```

Really want this fix, because without it we can't get any filename from SourcePosition from deserialized model.