### PR TITLE
feat: one could add a type member that already exists (equals but not same) and modify it afterwards

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -104,6 +104,9 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 		Set<CtConstructor<T>> constructors = new SignatureBasedSortedSet<>();
 		for (CtTypeMember typeMember : typeMembers) {
 			if (typeMember instanceof CtConstructor) {
+				if (constructors.contains(typeMember)) {
+					throw new SpoonException("ooops, impossible to have two constructors with the same signature");
+				}
 				constructors.add((CtConstructor<T>) typeMember);
 			}
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -104,9 +104,6 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 		Set<CtConstructor<T>> constructors = new SignatureBasedSortedSet<>();
 		for (CtTypeMember typeMember : typeMembers) {
 			if (typeMember instanceof CtConstructor) {
-				if (constructors.contains(typeMember)) {
-					throw new SpoonException("ooops, impossible to have two constructors with the same signature");
-				}
 				constructors.add((CtConstructor<T>) typeMember);
 			}
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -123,7 +123,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		if (this.typeMembers == CtElementImpl.<CtTypeMember>emptyList()) {
 			this.typeMembers = new SortedList<>(new CtLineElementComparator());
 		}
-		if (!this.typeMembers.contains(member)) {
+		if (!this.typeMembers.stream().anyMatch(m -> m == member)) {
 			member.setParent(this);
 			CtRole role;
 			if (member instanceof CtMethod) {

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -8,9 +8,11 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -20,10 +22,12 @@ import java.util.Set;
 import org.junit.Test;
 
 import spoon.Launcher;
+import spoon.SpoonException;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtNewClass;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
@@ -60,6 +64,25 @@ public class CtClassTest {
 		typeStringArrayArray.setComponentType(typeStringArray);
 		constructor = foo.getConstructor(typeStringArrayArray);
 		assertEquals(typeStringArrayArray, constructor.getParameters().get(0).getType());
+
+		// contract: one could add a type member that already exists (equals but not same) and modify it afterwards
+		// this adds some flexibility for client code
+		// see https://github.com/INRIA/spoon/issues/1862
+		CtConstructor cons = foo.getConstructors().toArray(new CtConstructor[0])[0].clone();
+		foo.addConstructor(cons);
+		// we must change the signature, so that the model becomes a valid Java model with different signatures for all constructors
+		try {
+			foo.getConstructors();
+			fail();
+		} catch (SpoonException expected) {
+			assertEquals("ooops, impossible to have two constructors with the same signature", expected.getMessage());
+		}
+		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().OBJECT));
+		// now that we have changed the signature we can call getConstructors safely
+		assertEquals(4, foo.getConstructors().size());
+		assertSame(cons, foo.getTypeMembers().get(3));
+		// the parent is set (the core problem described in the issue has been fixed)
+		assertSame(foo, cons.getParent());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -70,13 +70,9 @@ public class CtClassTest {
 		// see https://github.com/INRIA/spoon/issues/1862
 		CtConstructor cons = foo.getConstructors().toArray(new CtConstructor[0])[0].clone();
 		foo.addConstructor(cons);
-		// we must change the signature, so that the model becomes a valid Java model with different signatures for all constructors
-		try {
-			foo.getConstructors();
-			fail();
-		} catch (SpoonException expected) {
-			assertEquals("ooops, impossible to have two constructors with the same signature", expected.getMessage());
-		}
+		// as long as we have not changed the signature, getConstructors, which is based on signatures,
+		// thinks there is one single constructor (and that's OK)
+		assertEquals(3, foo.getConstructors().size());
 		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().OBJECT));
 		// now that we have changed the signature we can call getConstructors safely
 		assertEquals(4, foo.getConstructors().size());


### PR DESCRIPTION
fix #1862