### PR TITLE
feature: add methods Refactoring#copyType and Refactoring#copyMethod

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -330,6 +330,10 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 
 	/**
 	 * Clone the element which calls this method in a new object.
+	 *
+	 * Note that that references are kept as is, and thus, so if you clone whole classes
+	 * or methods, some parts of the cloned element (eg executable references) may still point to the initial element.
+	 * In this case, consider using methods {@link spoon.refactoring.Refactoring#copyType(CtType)} and {@link spoon.refactoring.Refactoring#copyMethod(CtMethod)} instead which does additional work beyond cloning.
 	 */
 	CtElement clone();
 

--- a/src/main/java/spoon/reflect/declaration/CtMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtMethod.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.declaration;
 
+import spoon.refactoring.Refactoring;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
@@ -59,4 +60,15 @@ public interface CtMethod<T> extends CtExecutable<T>, CtTypeMember, CtFormalType
 	 * Returns the empty collection if defined here for the first time.
 	 */
 	Collection<CtMethod<?>> getTopDefinitions();
+
+	/**
+	 * Copy the method, where copy means cloning + porting all the references of the old method to the new method (important for recursive methods).
+	 * The copied method is added to the type, with a suffix "Copy".
+	 *
+	 * A new unique method name is given for each copy, and this method can be called several times.
+	 *
+	 * If you want to rename the new method, use {@link Refactoring#changeMethodName(CtMethod, String)} (and not {@link #setSimpleName(String)}, which does not update the references)
+	 */
+	CtMethod<?> copyMethod();
+
 }

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -345,4 +345,13 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 
 	@Override
 	CtType<T> clone();
+
+	/**
+	 * Copy the type, where copy means cloning + porting all the references in the clone from the old type to the new type.
+	 *
+	 * The copied type is added to the same package (and this to the factory as well).
+	 *
+	 * A new unique method name is given for each copy, and this method can be called several times.
+	 */
+	CtType<?> copyType();
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.declaration;
 
+import spoon.refactoring.Refactoring;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
@@ -276,4 +277,10 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	public boolean isAbstract() {
 		return this.modifierHandler.isAbstract();
 	}
+
+	@Override
+	public CtMethod<?> copyMethod() {
+		return Refactoring.copyMethod(this);
+	}
+
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -17,6 +17,7 @@
 package spoon.support.reflect.declaration;
 
 import spoon.SpoonException;
+import spoon.refactoring.Refactoring;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtAnnotation;
@@ -1052,5 +1053,10 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@Override
 	public boolean isAbstract() {
 		return this.modifierHandler.isAbstract();
+	}
+
+	@Override
+	public CtType<?> copyType() {
+		return Refactoring.copyType(this);
 	}
 }

--- a/src/test/resources/noclasspath/A2.java
+++ b/src/test/resources/noclasspath/A2.java
@@ -11,4 +11,9 @@ public class A2 {
 			throw e;
 		}
 	}
+
+	public void c(int param) {
+		c(param);
+	}
+}
 }


### PR DESCRIPTION
plus changeMethodName as useful bonus, see testCopyMethod

Advanced cloning usages requires more than only copying all metamodel fields. For instance, it also requires to update references and to set a parent (for future resolving with `getDeclaration`).

This is what is done here.