### PR TITLE
refactor(TypeFactory#get(String qualifiedName)): Look for type in factory.Package() first, and not at the end. Workaround for #1889

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -419,6 +419,21 @@ public class TypeFactory extends SubFactory {
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtType<T> get(final String qualifiedName) {
+		int packageIndex = qualifiedName.lastIndexOf(CtPackage.PACKAGE_SEPARATOR);
+		CtPackage pack;
+		if (packageIndex > 0) {
+			pack = factory.Package().get(qualifiedName.substring(0, packageIndex));
+		} else {
+			pack = factory.Package().getRootPackage();
+		}
+
+		if (pack != null) {
+			CtType<T> type = pack.getType(qualifiedName.substring(packageIndex + 1));
+			if (type != null) {
+				return type;
+			}
+		}
+
 		int inertTypeIndex = qualifiedName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR);
 		if (inertTypeIndex > 0) {
 			String s = qualifiedName.substring(0, inertTypeIndex);
@@ -459,20 +474,7 @@ public class TypeFactory extends SubFactory {
 				return t.getNestedType(className);
 			}
 		}
-
-		int packageIndex = qualifiedName.lastIndexOf(CtPackage.PACKAGE_SEPARATOR);
-		CtPackage pack;
-		if (packageIndex > 0) {
-			pack = factory.Package().get(qualifiedName.substring(0, packageIndex));
-		} else {
-			pack = factory.Package().getRootPackage();
-		}
-
-		if (pack == null) {
-			return null;
-		}
-
-		return (CtType<T>) pack.getType(qualifiedName.substring(packageIndex + 1));
+		return null;
 	}
 
 	/**

--- a/src/test/java/spoon/test/factory/TypeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/TypeFactoryTest.java
@@ -4,11 +4,14 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.test.factory.testclasses3.Cooking;
 import spoon.test.factory.testclasses3.Prepare;
 import spoon.testing.utils.ModelUtils;
+
+import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -59,5 +62,16 @@ public class TypeFactoryTest {
 		assertNotNull(prepare.getFactory().Interface().get("spoon.test.factory.testclasses3.Prepare$Tacos"));
 		assertNotNull(prepare.getFactory().Type().get(Prepare.Pozole.class));
 		assertNotNull(prepare.getFactory().Interface().get(Prepare.Pozole.class));
+	}
+
+	@Test
+	public void testGetClassWithDollarAndNestedClass() throws Exception {
+		//Classes with name containing $ without being nested classes can contain nested classes
+		Factory factory = ModelUtils.build(new File("./src/test/resources/dollar-and-nested-classes"));
+		CtType<?> poorName = factory.Type().get("$Poor$Name");
+		CtType<?> poorNameChoice = factory.Type().get("$Poor$Name$Choice");
+		assertNotNull(poorName);
+		assertNotNull(poorNameChoice);
+		assertEquals(poorNameChoice,poorName.getMethodsByName("lookingForTroubles").get(0).getType().getTypeDeclaration());
 	}
 }

--- a/src/test/resources/dollar-and-nested-classes/$Poor$Name.java
+++ b/src/test/resources/dollar-and-nested-classes/$Poor$Name.java
@@ -1,0 +1,8 @@
+public class $Poor$Name {
+    public Choice lookingForTroubles() {
+        return new Choice();
+    }
+    class Choice {
+        public Choice() { }
+    }
+}


### PR DESCRIPTION
As mentioned in the name of the PR, this would refactor `TypeFactory.get(String qualifiedName)`. Instead of looking in existing packages for the wanted type only if it is not resolve otherwise, it starts by that.

It prevent to resolve recursively nested type from their root type as a first option. If you look for `A$B$C` it won't resolve `A` then `A$B` and then `A$B$C`. if `A$B` is already reachable, it will stop there.

This allow the resolution of class whose name contains `$`. The current behavior can't resolve a class named `A$B` if it's not a class `B` nested in `A`.


