### PR TITLE
review chore:Use Maven INRIA instead of Gforge to deploy snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,9 @@ Snapshot version:
 </dependencies>
 <repositories>
 	<repository>
-      <snapshots />
-      <id>maven-inria-spoon-snapshots</id>
-      <name>public-snapshot</name>
-      <url>http://maven.inria.fr/artifactory/public-snapshot</url>
+      <id>maven.inria.fr-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>http://maven.inria.fr/artifactory/repo/spoon-public-snapshot</url>
     </repository>
 </repositories>
 ```

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Snapshot version:
 </dependencies>
 <repositories>
 	<repository>
-		<id>gforge.inria.fr-snapshot</id>
-		<name>Maven Repository for Spoon Snapshot</name>
-		<url>http://spoon.gforge.inria.fr/repositories/snapshots/</url>
-		<snapshots />
-	</repository>
+      <snapshots />
+      <id>maven-inria-spoon-snapshots</id>
+      <name>public-snapshot</name>
+      <url>http://maven.inria.fr/artifactory/public-snapshot</url>
+    </repository>
 </repositories>
 ```
 

--- a/doc/doc_homepage.md
+++ b/doc/doc_homepage.md
@@ -98,11 +98,10 @@ Snapshot version:
 </dependencies>
 <repositories>
 	<repository>
-		<id>gforge.inria.fr-snapshot</id>
-		<name>Maven Repository for Spoon Snapshot</name>
-		<url>http://spoon.gforge.inria.fr/repositories/snapshots/</url>
-		<snapshots />
-	</repository>
+      <id>maven.inria.fr-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>http://maven.inria.fr/artifactory/repo/spoon-public-snapshot</url>
+    </repository>
 </repositories>
 ```
 

--- a/doc/jenkins/build.sh
+++ b/doc/jenkins/build.sh
@@ -143,9 +143,9 @@ echo " "
 # Edits pom xml to prepare project to spoon project.
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project" --type elem -n repositories -v "" pom.xml > pom.bak.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories" --type elem -n repository -v "" pom.bak.xml > pom.bak1.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n id -v "gforge.inria.fr-snapshot" pom.bak1.xml > pom.bak2.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n id -v "maven.inria.fr-snapshot" pom.bak1.xml > pom.bak2.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n name -v "Maven Repository for Spoon Snapshot" pom.bak2.xml > pom.bak3.xml
-xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n url -v "http://spoon.gforge.inria.fr/repositories/snapshots/" pom.bak3.xml > pom.bak4.xml
+xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n url -v "http://maven.inria.fr/artifactory/repo/spoon-public-snapshot/" pom.bak3.xml > pom.bak4.xml
 xmlstarlet ed -N x="http://maven.apache.org/POM/4.0.0" -s "/x:project/x:repositories/x:repository[last()]" --type elem -n snapshots -v "" pom.bak4.xml > pom.bak5.xml
 mv pom.bak5.xml pom.xml
 rm pom.bak*.xml

--- a/pom.xml
+++ b/pom.xml
@@ -169,11 +169,6 @@
       <url>http://spoon.gforge.inria.fr/repositories/releases</url>
     </repository>
     <repository>
-      <id>gforge.inria.fr-snapshot</id>
-      <name>Maven Repository for Spoon Snapshots</name>
-      <url>http://spoon.gforge.inria.fr/repositories/snapshots</url>
-    </repository>
-    <repository>
       <id>maven.inria.fr-snapshot</id>
       <name>Maven Repository for Spoon Snapshots</name>
       <url>http://maven.inria.fr/artifactory/repo/spoon-public-snapshot</url>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,11 @@
       <name>Maven Repository for Spoon Snapshots</name>
       <url>http://spoon.gforge.inria.fr/repositories/snapshots</url>
     </repository>
+    <repository>
+      <id>maven.inria.fr-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>http://maven.inria.fr/artifactory/repo/spoon-public-snapshot</url>
+    </repository>
   </repositories>
 
   <distributionManagement>
@@ -181,9 +186,9 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
     <snapshotRepository>
-      <id>gforge.inria.fr-snapshot</id>
-      <name>inria-snapshots</name>
-      <url>scp://scm.gforge.inria.fr/home/groups/spoon/htdocs/repositories/snapshots</url>
+      <id>maven.inria.fr-snapshot</id>
+      <name>http://maven.inria.fr-snapshots</name>
+      <url>http://maven.inria.fr/artifactory/spoon-public-snapshot</url>
     </snapshotRepository>
     <site>
       <id>gforge.inria.fr-site</id>

--- a/pom.xml
+++ b/pom.xml
@@ -162,19 +162,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>gforge.inria.fr-release</id>
-      <name>Maven Repository for JDT Compiler release</name>
-      <url>http://spoon.gforge.inria.fr/repositories/releases</url>
-    </repository>
-    <repository>
-      <id>maven.inria.fr-snapshot</id>
-      <name>Maven Repository for Spoon Snapshots</name>
-      <url>http://maven.inria.fr/artifactory/repo/spoon-public-snapshot</url>
-    </repository>
-  </repositories>
-
   <distributionManagement>
     <repository>
       <id>ossrh</id>
@@ -182,7 +169,7 @@
     </repository>
     <snapshotRepository>
       <id>maven.inria.fr-snapshot</id>
-      <name>http://maven.inria.fr-snapshots</name>
+      <name>Maven Repository for Spoon Snapshots</name>
       <url>http://maven.inria.fr/artifactory/spoon-public-snapshot</url>
     </snapshotRepository>
     <site>


### PR DESCRIPTION
Fix #1900 

⚠️ This PR might breaks for some time the snapshot deployment: I should have fixed it in the CI but I did not tested it, as I need this changes in the pom.xml file. Nervertheless I already deployed manually a first snapshot in order to avoid complete service discontinuity.