### PR TITLE
fix: all unsettable properties are derived too

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
+++ b/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
@@ -123,7 +123,6 @@ public class CtBiScannerDefault extends spoon.reflect.visitor.CtAbstractBiScanne
 	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
 		spoon.reflect.reference.CtArrayTypeReference other = ((spoon.reflect.reference.CtArrayTypeReference) (this.stack.peek()));
 		enter(reference);
-		biScan(spoon.reflect.path.CtRole.COMMENT, reference.getComments(), other.getComments());
 		biScan(spoon.reflect.path.CtRole.PACKAGE_REF, reference.getPackage(), other.getPackage());
 		biScan(spoon.reflect.path.CtRole.DECLARING_TYPE, reference.getDeclaringType(), other.getDeclaringType());
 		biScan(spoon.reflect.path.CtRole.TYPE, reference.getComponentType(), other.getComponentType());
@@ -471,7 +470,6 @@ public class CtBiScannerDefault extends spoon.reflect.visitor.CtAbstractBiScanne
 	public <T> void visitCtCatchVariableReference(final spoon.reflect.reference.CtCatchVariableReference<T> reference) {
 		spoon.reflect.reference.CtCatchVariableReference other = ((spoon.reflect.reference.CtCatchVariableReference) (this.stack.peek()));
 		enter(reference);
-		biScan(spoon.reflect.path.CtRole.COMMENT, reference.getComments(), other.getComments());
 		biScan(spoon.reflect.path.CtRole.TYPE, reference.getType(), other.getType());
 		biScan(spoon.reflect.path.CtRole.ANNOTATION, reference.getAnnotations(), other.getAnnotations());
 		exit(reference);
@@ -553,7 +551,6 @@ public class CtBiScannerDefault extends spoon.reflect.visitor.CtAbstractBiScanne
 		biScan(spoon.reflect.path.CtRole.TYPE, lambda.getType(), other.getType());
 		biScan(spoon.reflect.path.CtRole.CAST, lambda.getTypeCasts(), other.getTypeCasts());
 		biScan(spoon.reflect.path.CtRole.PARAMETER, lambda.getParameters(), other.getParameters());
-		biScan(spoon.reflect.path.CtRole.THROWN, lambda.getThrownTypes(), other.getThrownTypes());
 		biScan(spoon.reflect.path.CtRole.BODY, lambda.getBody(), other.getBody());
 		biScan(spoon.reflect.path.CtRole.EXPRESSION, lambda.getExpression(), other.getExpression());
 		biScan(spoon.reflect.path.CtRole.COMMENT, lambda.getComments(), other.getComments());

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -258,7 +258,6 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtArrayTypeReference(final CtArrayTypeReference<T> reference) {
 		enter(reference);
-		scan(CtRole.COMMENT, reference.getComments());
 		scan(CtRole.PACKAGE_REF, reference.getPackage());
 		scan(CtRole.DECLARING_TYPE, reference.getDeclaringType());
 		scan(CtRole.TYPE, reference.getComponentType());
@@ -546,7 +545,6 @@ public abstract class CtScanner implements CtVisitor {
 
 	public <T> void visitCtCatchVariableReference(final CtCatchVariableReference<T> reference) {
 		enter(reference);
-		scan(CtRole.COMMENT, reference.getComments());
 		scan(CtRole.TYPE, reference.getType());
 		scan(CtRole.ANNOTATION, reference.getAnnotations());
 		exit(reference);
@@ -616,7 +614,6 @@ public abstract class CtScanner implements CtVisitor {
 		scan(CtRole.TYPE, lambda.getType());
 		scan(CtRole.CAST, lambda.getTypeCasts());
 		scan(CtRole.PARAMETER, lambda.getParameters());
-		scan(CtRole.THROWN, lambda.getThrownTypes());
 		scan(CtRole.BODY, lambda.getBody());
 		scan(CtRole.EXPRESSION, lambda.getExpression());
 		scan(CtRole.COMMENT, lambda.getComments());

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -105,7 +105,6 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
 		spoon.reflect.reference.CtArrayTypeReference<T> aCtArrayTypeReference = reference.getFactory().Core().createArrayTypeReference();
-		aCtArrayTypeReference.setComments(this.cloneHelper.clone(reference.getComments()));
 		aCtArrayTypeReference.setPackage(this.cloneHelper.clone(reference.getPackage()));
 		aCtArrayTypeReference.setDeclaringType(this.cloneHelper.clone(reference.getDeclaringType()));
 		aCtArrayTypeReference.setComponentType(this.cloneHelper.clone(reference.getComponentType()));
@@ -483,7 +482,6 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.CloneVisitorGenerator
 	public <T> void visitCtCatchVariableReference(final spoon.reflect.reference.CtCatchVariableReference<T> reference) {
 		spoon.reflect.reference.CtCatchVariableReference<T> aCtCatchVariableReference = reference.getFactory().Core().createCatchVariableReference();
-		aCtCatchVariableReference.setComments(this.cloneHelper.clone(reference.getComments()));
 		aCtCatchVariableReference.setType(this.cloneHelper.clone(reference.getType()));
 		aCtCatchVariableReference.setAnnotations(this.cloneHelper.clone(reference.getAnnotations()));
 		this.builder.copy(reference, aCtCatchVariableReference);
@@ -571,7 +569,6 @@ public class CloneVisitor extends spoon.reflect.visitor.CtScanner {
 		aCtLambda.setType(this.cloneHelper.clone(lambda.getType()));
 		aCtLambda.setTypeCasts(this.cloneHelper.clone(lambda.getTypeCasts()));
 		aCtLambda.setParameters(this.cloneHelper.clone(lambda.getParameters()));
-		aCtLambda.setThrownTypes(this.cloneHelper.clone(lambda.getThrownTypes()));
 		aCtLambda.setBody(this.cloneHelper.clone(lambda.getBody()));
 		aCtLambda.setExpression(this.cloneHelper.clone(lambda.getExpression()));
 		aCtLambda.setComments(this.cloneHelper.clone(lambda.getComments()));

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1429,7 +1429,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtArrayTypeReference(final spoon.reflect.reference.CtArrayTypeReference<T> reference) {
-		replaceInListIfExist(reference.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(reference));
 		replaceElementIfExist(reference.getPackage(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeReferencePackageReplaceListener(reference));
 		replaceElementIfExist(reference.getDeclaringType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypeReferenceDeclaringTypeReplaceListener(reference));
 		replaceElementIfExist(reference.getComponentType(), new spoon.support.visitor.replace.ReplacementVisitor.CtArrayTypeReferenceComponentTypeReplaceListener(reference));
@@ -1714,7 +1713,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 	// auto-generated, see spoon.generating.ReplacementVisitorGenerator
 	@java.lang.Override
 	public <T> void visitCtCatchVariableReference(final spoon.reflect.reference.CtCatchVariableReference<T> reference) {
-		replaceInListIfExist(reference.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(reference));
 		replaceElementIfExist(reference.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtVariableReferenceTypeReplaceListener(reference));
 		replaceInListIfExist(reference.getAnnotations(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementAnnotationsReplaceListener(reference));
 	}
@@ -1781,7 +1779,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 		replaceElementIfExist(lambda.getType(), new spoon.support.visitor.replace.ReplacementVisitor.CtTypedElementTypeReplaceListener(lambda));
 		replaceInListIfExist(lambda.getTypeCasts(), new spoon.support.visitor.replace.ReplacementVisitor.CtExpressionTypeCastsReplaceListener(lambda));
 		replaceInListIfExist(lambda.getParameters(), new spoon.support.visitor.replace.ReplacementVisitor.CtExecutableParametersReplaceListener(lambda));
-		replaceInSetIfExist(lambda.getThrownTypes(), new spoon.support.visitor.replace.ReplacementVisitor.CtExecutableThrownTypesReplaceListener(lambda));
 		replaceElementIfExist(lambda.getBody(), new spoon.support.visitor.replace.ReplacementVisitor.CtExecutableBodyReplaceListener(lambda));
 		replaceElementIfExist(lambda.getExpression(), new spoon.support.visitor.replace.ReplacementVisitor.CtLambdaExpressionReplaceListener(lambda));
 		replaceInListIfExist(lambda.getComments(), new spoon.support.visitor.replace.ReplacementVisitor.CtElementCommentsReplaceListener(lambda));

--- a/src/test/java/spoon/test/metamodel/MetamodelProperty.java
+++ b/src/test/java/spoon/test/metamodel/MetamodelProperty.java
@@ -444,6 +444,11 @@ public class MetamodelProperty {
 	 */
 	public boolean isDerived() {
 		if (derived == null) {
+			if (isUnsettable()) {
+				//all unsettable properties are derived too 
+				derived = true;
+				return true;
+			}
 			//if DerivedProperty is found on any getter of this type, then this field is derived
 			MMMethod getter = getMethod(MMMethodKind.GET);
 			if (getter == null) {

--- a/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
+++ b/src/test/java/spoon/test/reflect/meta/MetaModelTest.java
@@ -52,6 +52,10 @@ public class MetaModelTest {
 
 		mm.getConcepts().forEach(mmConcept -> {
 			mmConcept.getRoleToProperty().forEach((role, mmField) -> {
+				if (mmField.isUnsettable()) {
+					//contract: all unsettable fields are derived too
+					assertTrue("Unsettable field " + mmField + " must be derived too", mmField.isDerived());
+				}
 				unhandledRoles.remove(role);
 				if (mmField.getMethod(MMMethodKind.GET) == null) {
 					problems.add("Missing getter for " + mmField.getOwnerConcept().getName() + " and CtRole." + mmField.getRole());


### PR DESCRIPTION
Examples are CtTypeReference#MODIFIER and COMMENT. Before they were derived==false unsettable==true. Now they are derived==true unsettable==true

WDYT?