### PR TITLE
review: refactor: mutable collections of Spoon model handles parent and fire change events

### DIFF
--- a/src/main/java/spoon/support/comparator/QualifiedNameComparator.java
+++ b/src/main/java/spoon/support/comparator/QualifiedNameComparator.java
@@ -29,6 +29,8 @@ import spoon.reflect.reference.CtReference;
 public class QualifiedNameComparator implements Comparator<CtElement>, Serializable {
 	private static final long serialVersionUID = 1L;
 
+	public static final QualifiedNameComparator INSTANCE = new QualifiedNameComparator();
+
 	@Override
 	public int compare(CtElement o1, CtElement o2) {
 		try {

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -22,16 +22,15 @@ import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
-import spoon.support.reflect.declaration.CtElementImpl;
-import spoon.support.util.EmptyIterator;
+import spoon.support.util.ModelList;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -42,7 +41,27 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = CtRole.STATEMENT)
-	private List<CtStatement> statements = emptyList();
+	private final ModelList<CtStatement> statements = new ModelList<CtStatement>() {
+		private static final long serialVersionUID = 1L;
+		@Override
+		protected CtElement getOwner() {
+			return CtBlockImpl.this;
+		}
+		@Override
+		protected CtRole getRole() {
+			return STATEMENT;
+		}
+		@Override
+		protected int getDefaultCapacity() {
+			return BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
+		}
+		@Override
+		protected void onSizeChanged(int newSize) {
+			if (isImplicit() && (newSize > 1 || newSize == 0)) {
+				setImplicit(false);
+			}
+		}
+	};
 
 	public void accept(CtVisitor visitor) {
 		visitor.visitCtBlock(this);
@@ -50,7 +69,6 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 
 	@Override
 	public List<CtStatement> getStatements() {
-		ensureModifiableStatementsList();
 		return this.statements;
 	}
 
@@ -86,14 +104,9 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 			getStatements().get(0).insertAfter(statements);
 			return (T) this;
 		}
-		ensureModifiableStatementsList();
-		for (CtStatement statement : statements.getStatements()) {
-			statement.setParent(this);
-			this.addStatement(0, statement);
-		}
-		if (isImplicit() && this.statements.size() > 1) {
-			setImplicit(false);
-		}
+		List<CtStatement> copy = new ArrayList<>(statements.getStatements());
+		statements.setStatements(null);
+		this.statements.addAll(0, copy);
 		return (T) this;
 	}
 
@@ -103,28 +116,23 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 			getStatements().get(0).insertAfter(statement);
 			return (T) this;
 		}
-		ensureModifiableStatementsList();
-		statement.setParent(this);
-		this.addStatement(0, statement);
-
-		if (isImplicit() && this.statements.size() > 1) {
-			setImplicit(false);
-		}
+		this.statements.add(0, statement);
 		return (T) this;
 	}
 
 	@Override
 	public <T extends CtStatementList> T insertEnd(CtStatement statement) {
-		ensureModifiableStatementsList();
 		addStatement(statement);
 		return (T) this;
 	}
 
 	@Override
 	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
-		for (CtStatement s : statements.getStatements()) {
-			insertEnd(s);
-		}
+		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
+		//remove statements from the `statementsToBeInserted` before they are added to spoon model
+		//note: one element MUST NOT be part of two models.
+		statements.setStatements(null);
+		this.statements.addAll(this.statements.size(), tobeInserted);
 		return (T) this;
 	}
 
@@ -162,80 +170,31 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 
 	@Override
 	public <T extends CtStatementList> T setStatements(List<CtStatement> statements) {
-		if (statements == null || statements.isEmpty()) {
-			this.statements = CtElementImpl.emptyList();
-			return (T) this;
-		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, STATEMENT, this.statements, new ArrayList<>(this.statements));
-		this.statements.clear();
-		for (CtStatement s : statements) {
-			addStatement(s);
-		}
+		this.statements.set(statements);
 		return (T) this;
 	}
 
 	@Override
 	public <T extends CtStatementList> T addStatement(CtStatement statement) {
-		return this.addStatement(this.statements.size(), statement);
+		this.statements.add(statement);
+		return (T) this;
 	}
 
 	@Override
 	public <T extends CtStatementList> T addStatement(int index, CtStatement statement) {
-		if (statement == null) {
-			return (T) this;
-		}
-		ensureModifiableStatementsList();
-		statement.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, STATEMENT, this.statements, index, statement);
 		this.statements.add(index, statement);
-		if (isImplicit() && this.statements.size() > 1) {
-			setImplicit(false);
-		}
 		return (T) this;
 	}
 
-	private void ensureModifiableStatementsList() {
-		if (this.statements == CtElementImpl.<CtStatement>emptyList()) {
-			this.statements = new ArrayList<>(BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
-		}
-	}
 
 	@Override
 	public void removeStatement(CtStatement statement) {
-		if (this.statements != CtElementImpl.<CtStatement>emptyList()) {
-			boolean hasBeenRemoved = false;
-			// we cannot use a remove(statement) as it uses the equals
-			// and a block can have twice exactly the same statement.
-			for (int i = 0; i < this.statements.size(); i++) {
-				if (this.statements.get(i) == statement) {
-					getFactory().getEnvironment().getModelChangeListener().onListDelete(this, STATEMENT, statements, i, statement);
-					this.statements.remove(i);
-					hasBeenRemoved = true;
-					break;
-				}
-			}
-
-			// in case we use it with a statement manually built
-			if (!hasBeenRemoved) {
-				getFactory().getEnvironment().getModelChangeListener().onListDelete(this, STATEMENT, statements, statements.indexOf(statement), statement);
-				this.statements.remove(statement);
-			}
-
-			if (isImplicit() && statements.size() == 0) {
-				setImplicit(false);
-			}
-		}
+		this.statements.remove(statement);
 	}
 
 	@Override
 	public Iterator<CtStatement> iterator() {
-		if (getStatements().isEmpty()) {
-			return EmptyIterator.instance();
-		}
-		// we have to both create a defensive object and an unmodifiable list
-		// with only Collections.unmodifiableList you can modify the defensive object
-		// with only new ArrayList it breaks the encapsulation
-		return Collections.unmodifiableList(new ArrayList<>(getStatements())).iterator();
+		return this.statements.iterator();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
@@ -19,18 +19,30 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.util.ModelList;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import static spoon.reflect.path.CtRole.COMMENT_TAG;
 
 public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 
 	@MetamodelPropertyField(role = CtRole.COMMENT_TAG)
-	List<CtJavaDocTag> tags = new ArrayList<>();
+	private final ModelList<CtJavaDocTag> tags = new ModelList<CtJavaDocTag>() {
+		@Override
+		protected CtElement getOwner() {
+			return CtJavaDocImpl.this;
+		}
+		@Override
+		protected CtRole getRole() {
+			return CtRole.COMMENT_TAG;
+		}
+		@Override
+		protected int getDefaultCapacity() {
+			return 2;
+		}
+	};;
 
 	public CtJavaDocImpl() {
 		super(CommentType.JAVADOC);
@@ -38,51 +50,36 @@ public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 
 	@Override
 	public List<CtJavaDocTag> getTags() {
-		return new ArrayList<>(tags);
+		return tags;
 	}
 
 	@Override
 	public <E extends CtJavaDoc> E setTags(List<CtJavaDocTag> tags) {
-		if (tags == null) {
-			return (E) this;
-		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, COMMENT_TAG, this.tags, new ArrayList<>(this.tags));
-		this.tags = new ArrayList<>();
-		for (CtJavaDocTag tag : tags) {
-			this.addTag(tag);
-		}
+		this.tags.set(tags);
 		return (E) this;
 	}
 
 	@Override
 	public <E extends CtJavaDoc> E addTag(CtJavaDocTag tag) {
-		if (tag != null) {
-			tag.setParent(this);
-			getFactory().getEnvironment().getModelChangeListener().onListAdd(this, COMMENT_TAG, tags, tag);
-			tags.add(tag);
-		}
+		this.tags.add(tag);
 		return (E) this;
 	}
 
 	@Override
 	public <E extends CtJavaDoc> E addTag(int index, CtJavaDocTag tag) {
-		tag.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, COMMENT_TAG, tags, index, tag);
-		tags.add(index, tag);
+		this.tags.add(index, tag);
 		return (E) this;
 	}
 
 	@Override
 	public <E extends CtJavaDoc> E removeTag(int index) {
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, COMMENT_TAG, tags, index, tags.get(index));
-		tags.remove(index);
+		this.tags.remove(index);
 		return (E) this;
 	}
 
 	@Override
 	public <E extends CtJavaDoc> E removeTag(CtJavaDocTag tag) {
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, COMMENT_TAG, tags, tags.indexOf(tag), tag);
-		tags.remove(tag);
+		this.tags.remove(tag);
 		return (E) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -17,16 +17,18 @@
 package spoon.support.reflect.declaration;
 
 import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.visitor.CtVisitor;
-import spoon.support.util.QualifiedNameBasedSortedSet;
+import spoon.support.comparator.QualifiedNameComparator;
+import spoon.support.util.ModelSet;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import static spoon.reflect.path.CtRole.IS_SHADOW;
@@ -42,10 +44,54 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = SUB_PACKAGE)
-	protected Set<CtPackage> packs = orderedPackageSet();
+	protected ModelSet<CtPackage> packs = new ModelSet<CtPackage>(QualifiedNameComparator.INSTANCE) {
+		private static final long serialVersionUID = 1L;
+		@Override
+		protected CtElement getOwner() {
+			return CtPackageImpl.this;
+		}
+
+		@Override
+		protected CtRole getRole() {
+			return SUB_PACKAGE;
+		}
+
+		@Override
+		public boolean add(CtPackage pack) {
+			if (pack == null) {
+				return false;
+			}
+			// they are the same
+			if (CtPackageImpl.this.getQualifiedName().equals(pack.getQualifiedName())) {
+				addAllTypes(pack, CtPackageImpl.this);
+				addAllPackages(pack, CtPackageImpl.this);
+				return false;
+			}
+
+			// it already exists
+			for (CtPackage p1 : packs) {
+				if (p1.getQualifiedName().equals(pack.getQualifiedName())) {
+					addAllTypes(pack, p1);
+					addAllPackages(pack, p1);
+						return false;
+				}
+			}
+			return super.add(pack);
+		};
+	};
 
 	@MetamodelPropertyField(role = CONTAINED_TYPE)
-	private Set<CtType<?>> types = orderedTypeSet();
+	private ModelSet<CtType<?>> types = new ModelSet<CtType<?>>(QualifiedNameComparator.INSTANCE) {
+		private static final long serialVersionUID = 1L;
+		@Override
+		protected CtElement getOwner() {
+			return CtPackageImpl.this;
+		}
+		@Override
+		protected CtRole getRole() {
+			return CtRole.CONTAINED_TYPE;
+		}
+	};
 
 	public CtPackageImpl() {
 		super();
@@ -58,41 +104,8 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public <T extends CtPackage> T addPackage(CtPackage pack) {
-		if (pack == null) {
-			return (T) this;
-		}
-		if (packs == CtElementImpl.<CtPackage>emptySet()) {
-			this.packs = orderedPackageSet();
-		}
-		// they are the same
-		if (this.getQualifiedName().equals(pack.getQualifiedName())) {
-			addAllTypes(pack, this);
-			addAllPackages(pack, this);
-			return (T) this;
-		}
-
-		// it already exists
-		for (CtPackage p1 : packs) {
-			if (p1.getQualifiedName().equals(pack.getQualifiedName())) {
-				addAllTypes(pack, p1);
-				addAllPackages(pack, p1);
-				return (T) this;
-			}
-		}
-
-		pack.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, SUB_PACKAGE, this.packs, pack);
 		this.packs.add(pack);
-
 		return (T) this;
-	}
-
-	private Set<CtPackage> orderedPackageSet() {
-		return new QualifiedNameBasedSortedSet<>();
-	}
-
-	private Set<CtType<?>> orderedTypeSet() {
-		return new QualifiedNameBasedSortedSet<>();
 	}
 
 	/** add all types of "from" in "to" */
@@ -116,10 +129,6 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public boolean removePackage(CtPackage pack) {
-		if (packs == CtElementImpl.<CtPackage>emptySet()) {
-			return false;
-		}
-		getFactory().getEnvironment().getModelChangeListener().onSetDelete(this, SUB_PACKAGE, packs, pack);
 		return packs.remove(pack);
 	}
 
@@ -183,31 +192,15 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public <T extends CtPackage> T setPackages(Set<CtPackage> packs) {
-		if (packs == null || packs.isEmpty()) {
-			this.packs = CtElementImpl.emptySet();
+		this.packs.set(packs);
 			return (T) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(this, SUB_PACKAGE, this.packs, new HashSet<>(this.packs));
-		this.packs.clear();
-		for (CtPackage p : packs) {
-			addPackage(p);
-		}
-		return (T) this;
-	}
 
 	@Override
 	public <T extends CtPackage> T setTypes(Set<CtType<?>> types) {
-		if (types == null || types.isEmpty()) {
-			this.types = CtElementImpl.emptySet();
+		this.types.set(types);
 			return (T) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(this, CONTAINED_TYPE, this.types, new HashSet<>(this.types));
-		this.types.clear();
-		for (CtType<?> t : types) {
-			addType(t);
-		}
-		return (T) this;
-	}
 
 	@Override
 	public CtPackageReference getReference() {
@@ -216,24 +209,12 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public <T extends CtPackage> T addType(CtType<?> type) {
-		if (type == null) {
-			return (T) this;
-		}
-		if (types == CtElementImpl.<CtType<?>>emptySet()) {
-			this.types = orderedTypeSet();
-		}
-		type.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, CONTAINED_TYPE, this.types, type);
 		types.add(type);
 		return (T) this;
 	}
 
 	@Override
 	public void removeType(CtType<?> type) {
-		if (types == CtElementImpl.<CtType<?>>emptySet()) {
-			return;
-		}
-		getFactory().getEnvironment().getModelChangeListener().onSetDelete(this, CONTAINED_TYPE, types, type);
 		types.remove(type);
 	}
 

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -1,0 +1,238 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.util;
+
+
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+
+import spoon.experimental.modelobs.FineModelChangeListener;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
+import spoon.support.reflect.declaration.CtElementImpl;
+
+/**
+ * The implementation of the {@link List}, which is used by Spoon model objects.
+ * It assures:
+ * 1) each inserted {@link CtElement} gets assigned correct parent
+ * 2) each change is reported in {@link FineModelChangeListener}
+ */
+public abstract class ModelList<T extends CtElement> extends AbstractList<T> implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private List<T> list = CtElementImpl.emptyList();
+
+	protected ModelList() {
+	}
+
+	protected abstract CtElement getOwner();
+	protected abstract CtRole getRole();
+	protected abstract int getDefaultCapacity();
+	protected void onSizeChanged(int newSize) {
+	}
+
+	@Override
+	public T get(int index) {
+		return list.get(index);
+	}
+
+	/**
+	 * sets the new content of this List
+	 * @param elements new content of this list
+	 */
+	public void set(Collection<T> elements) {
+		//TODO the best would be to detect added/removed statements and to fire modifications only for them
+		this.clear();
+		if (elements != null && elements.isEmpty() == false) {
+			this.addAll(elements);
+		}
+	}
+
+	@Override
+	public int size() {
+		return list.size();
+	}
+
+	@Override
+	public T set(int index, T element) {
+		T oldElement = list.get(index);
+		if (oldElement == element) {
+			//no change
+			return oldElement;
+		}
+		CtElement owner = getOwner();
+		ensureModifiableList();
+		getModelChangeListener().onListDelete(owner, getRole(), list, index, oldElement);
+		linkToParent(owner, element);
+		getModelChangeListener().onListAdd(owner, getRole(), list, index, element);
+		list.set(index, element);
+		updateModCount();
+		return oldElement;
+	}
+
+	static void linkToParent(CtElement owner, CtElement element) {
+		element.setParent(owner);
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return list.contains(o);
+	}
+	@Override
+	public boolean isEmpty() {
+		return list.isEmpty();
+	}
+
+	@Override
+	public Object[] toArray() {
+		return list.toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		return list.toArray(a);
+	}
+
+	@Override
+	public boolean add(T e) {
+		if (e == null) {
+			return false;
+		}
+		CtElement owner = getOwner();
+		ensureModifiableList();
+		linkToParent(owner, e);
+		getModelChangeListener().onListAdd(owner, getRole(), list, e);
+		boolean result = list.add(e);
+		updateModCount();
+		onSizeChanged(list.size());
+		return result;
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		if (list.isEmpty()) {
+			return false;
+		}
+		int size = list.size();
+		for (int i = 0; i < size; i++) {
+			//first do not use equals, but same
+			if (list.get(i) == o) {
+				remove(i);
+				return true;
+			}
+		}
+		int idx = list.indexOf(o);
+		if (idx >= 0) {
+			remove(idx);
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return list.containsAll(c);
+	}
+
+	@Override
+	public void clear() {
+		getModelChangeListener().onListDeleteAll(getOwner(), getRole(), list, new ArrayList<>(list));
+		list = CtElementImpl.emptyList();
+		modCount++;
+		onSizeChanged(list.size());
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return list.equals(o);
+	}
+
+	@Override
+	public int hashCode() {
+		return list.hashCode();
+	}
+
+	@Override
+	public void add(int index, T element) {
+		if (element == null) {
+			return;
+		}
+		CtElement owner = getOwner();
+		ensureModifiableList();
+		linkToParent(owner, element);
+		getModelChangeListener().onListAdd(owner, getRole(), list, index, element);
+		list.add(index, element);
+		updateModCount();
+		onSizeChanged(list.size());
+	}
+
+	@Override
+	public T remove(int index) {
+		T oldElement = list.get(index);
+		getModelChangeListener().onListDelete(getOwner(), getRole(), list, index, oldElement);
+		list.remove(index);
+		updateModCount();
+		onSizeChanged(list.size());
+		return oldElement;
+	}
+
+	@Override
+	public int indexOf(Object o) {
+		return list.indexOf(o);
+	}
+
+	@Override
+	public int lastIndexOf(Object o) {
+		return list.lastIndexOf(o);
+	}
+
+	/**
+	 * This ArrayList wrapper is needed to get access to protected ArrayList#modCount
+	 * To be able to read modCount from `list` and to copy it into this.modCount
+	 * To manage the {@link ConcurrentModificationException}.
+	 * See https://docs.oracle.com/javase/7/docs/api/java/util/AbstractList.html#modCount
+	 */
+	private static class InternalList<T> extends ArrayList<T> {
+		InternalList(int initialCapacity) {
+			super(initialCapacity);
+		}
+
+		int getModCount() {
+			return modCount;
+		}
+	}
+
+	protected void updateModCount() {
+		if (list instanceof InternalList) {
+			modCount = ((InternalList) list).getModCount();
+		}
+	}
+
+	private void ensureModifiableList() {
+		if (list == CtElementImpl.<T>emptyList()) {
+			list = new InternalList<>(getDefaultCapacity());
+		}
+	}
+
+	private FineModelChangeListener getModelChangeListener() {
+		return getOwner().getFactory().getEnvironment().getModelChangeListener();
+	}
+}

--- a/src/main/java/spoon/support/util/ModelSet.java
+++ b/src/main/java/spoon/support/util/ModelSet.java
@@ -1,0 +1,167 @@
+/**
+ * Copyright (C) 2006-2017 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.support.util;
+
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.TreeSet;
+
+import spoon.SpoonException;
+import spoon.experimental.modelobs.FineModelChangeListener;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
+
+import static spoon.support.util.ModelList.linkToParent;
+
+/**
+ * The implementation of the {@link Set}, which is used by Spoon model objects.
+ * It assures:
+ * 1) each inserted {@link CtElement} gets assigned correct parent
+ * 2) each change is reported in {@link FineModelChangeListener}
+ */
+public abstract class ModelSet<T extends CtElement> extends AbstractSet<T> implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final Set<T> set;
+
+	protected ModelSet(Comparator<? super CtElement> comparator) {
+		set = new TreeSet<>(comparator);
+	}
+
+	protected abstract CtElement getOwner();
+	protected abstract CtRole getRole();
+	protected void onSizeChanged(int newSize) {
+	}
+
+	@Override
+	public int size() {
+		return set.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return set.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return set.contains(o);
+	}
+
+	@Override
+	public Object[] toArray() {
+		return set.toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		return set.toArray(a);
+	}
+
+	@Override
+	public boolean add(T e) {
+		if (e == null || set.contains(e)) {
+			return false;
+		}
+		CtElement owner = getOwner();
+		linkToParent(owner, e);
+		getModelChangeListener().onSetAdd(owner, getRole(), set, e);
+		set.add(e);
+		return true;
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		if (set.contains(o) == false) {
+			return false;
+		}
+		@SuppressWarnings("unchecked")
+		T e = (T) o;
+		getModelChangeListener().onSetDelete(getOwner(), getRole(), set, e);
+		if (set.remove(o) == false) {
+			throw new SpoonException("Element was contained in the Set, but Set#remove returned false. Not removed??");
+		}
+		return true;
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		return set.containsAll(c);
+	}
+
+	@Override
+	public void clear() {
+		if (set.isEmpty()) {
+			return;
+		}
+		getModelChangeListener().onSetDeleteAll(getOwner(), getRole(), set, new LinkedHashSet<T>(set));
+		set.clear();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		return set.equals(o);
+	}
+
+	@Override
+	public int hashCode() {
+		return set.hashCode();
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return new Itr();
+	}
+
+	private class Itr implements Iterator<T> {
+		final Iterator<T> delegate;
+		T lastReturned = null;
+		Itr() {
+			delegate = set.iterator();
+		}
+		@Override
+		public boolean hasNext() {
+			return delegate.hasNext();
+		}
+		@Override
+		public T next() {
+			lastReturned = delegate.next();
+			return lastReturned;
+		}
+		@Override
+		public void remove() {
+			ModelSet.this.remove(lastReturned);
+		}
+	}
+
+	private FineModelChangeListener getModelChangeListener() {
+		return getOwner().getFactory().getEnvironment().getModelChangeListener();
+	}
+
+	public void set(Collection<T> elements) {
+		//TODO the best would be to detect added/removed statements and to fire modifications only for them
+		this.clear();
+		if (elements != null && elements.isEmpty() == false) {
+			this.addAll(elements);
+		}
+	}
+}

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -16,7 +16,6 @@
  */
 package spoon.support.visitor.equals;
 
-import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtScanner;
@@ -27,10 +26,10 @@ import spoon.support.visitor.clone.CloneVisitor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeSet;
 
 /**
  * {@link CloneHelper} is responsible for creating clones of {@link CtElement} AST nodes including the whole subtree.
@@ -76,22 +75,6 @@ public class CloneHelper {
 		return others;
 	}
 
-	private <T extends CtElement> Set<T> createRightSet(Set<T> elements) {
-		try {
-			if (elements instanceof TreeSet) {
-				// we copy the set, incl its comparator
-				// we may also do this with reflection
-				Set s = (Set) ((TreeSet) elements).clone();
-				s.clear();
-				return s;
-			} else {
-				return elements.getClass().newInstance();
-			}
-		} catch (InstantiationException | IllegalAccessException e) {
-			throw new SpoonException(e);
-		}
-	}
-
 	public <T extends CtElement> Set<T> clone(Set<T> elements) {
 		if (elements instanceof EmptyClearableSet) {
 			return elements;
@@ -99,8 +82,7 @@ public class CloneHelper {
 		if (elements == null || elements.isEmpty()) {
 			return EmptyClearableSet.instance();
 		}
-
-		Set<T> others = createRightSet(elements);
+		Set<T> others = new HashSet<>(elements.size());
 		for (T element : elements) {
 			addClone(others, element);
 		}

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.experimental.modelobs.FineModelChangeListener;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtReturn;
@@ -19,6 +20,8 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 import spoon.support.comparator.CtLineElementComparator;
+import spoon.support.util.ModelList;
+import spoon.support.util.ModelSet;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -146,6 +149,7 @@ public class AstCheckerTest {
 					&& !isSurcharged(candidate) //
 					&& !isDelegateMethod(candidate) //
 					&& !isUnsupported(candidate.getBody()) //
+					&& !isCallModelCollection(candidate.getBody()) //
 					&& !hasPushToStackInvocation(candidate.getBody());
 		}
 
@@ -213,6 +217,28 @@ public class AstCheckerTest {
 			return body.getStatements().size() != 0 //
 					&& body.getStatements().get(0) instanceof CtThrow //
 					&& "UnsupportedOperationException".equals(((CtThrow) body.getStatements().get(0)).getThrownExpression().getType().getSimpleName());
+		}
+		
+		private boolean isCallModelCollection(CtBlock<?> body) {
+			
+			return body.filterChildren((CtInvocation inv) -> {
+				if (inv.getTarget() instanceof CtFieldRead) {
+					CtFieldRead fielRead = (CtFieldRead) inv.getTarget();
+					if (isModelCollection(fielRead.getType()) ) {
+						//it is invocation on ModelList, ModelSet or ModelMap
+						return true;
+					}
+				} 
+				return false;
+			}).first() != null;
+		}
+		
+		private boolean isModelCollection(CtTypeReference<?> typeRef) {
+			Factory f = typeRef.getFactory();
+			if (typeRef.isSubtypeOf(f.Type().createReference(ModelList.class))) return true;
+			if (typeRef.isSubtypeOf(f.Type().createReference(ModelSet.class))) return true;
+//			if (typeRef.isSubtypeOf(f.Type().createReference(ModelMap.class))) return true;
+			return false;
 		}
 
 		private boolean hasPushToStackInvocation(CtBlock<?> body) {

--- a/src/test/java/spoon/test/intercession/RemoveTest.java
+++ b/src/test/java/spoon/test/intercession/RemoveTest.java
@@ -3,6 +3,8 @@ package spoon.test.intercession;
 import static org.junit.Assert.assertEquals;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
+import java.util.ArrayList;
+
 import org.junit.Test;
 
 import spoon.reflect.code.CtBlock;
@@ -28,7 +30,8 @@ public class RemoveTest {
 
 	    assertEquals(2,body.getStatements().size());
 
-	    for (CtStatement s : body) {
+	    //iterate on copy of list of statements, otherwise it fails with concurrent modification exception
+	    for (CtStatement s : new ArrayList<>(body.getStatements())) {
 	    	body.removeStatement(s);
 	    }
 


### PR DESCRIPTION
A prototype of solution for #1916 and #1633
... at the beginning only for CtBlock#statements
... later the same solution should be applied to each List, Set and Map of Spoon model

WDYT?