### PR TITLE
chore: fix revapi comparison against Snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,15 @@
     </site>
   </distributionManagement>
 
+  <!-- This repository is actually needed for revapi to compare against the last Spoon Snapshot -->
+  <repositories>
+    <repository>
+      <id>maven.inria.fr-snapshot</id>
+      <name>Maven Repository for Spoon Snapshots</name>
+      <url>http://maven.inria.fr/artifactory/spoon-public-snapshot</url>
+    </repository>
+  </repositories>
+
   <dependencies>
     <dependency>
       <groupId>org.eclipse.tycho</groupId>


### PR DESCRIPTION
Last revapi report are comparing Spoon against last release version instead of last snapshot version. It's because we removed the repositories section from pom.xml. So I pushed it back.