### PR TITLE
fix: derived properties return unmodifiable collections

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -76,7 +76,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 				anonymousExecutables.add((CtAnonymousExecutable) typeMember);
 			}
 		}
-		return anonymousExecutables;
+		return Collections.unmodifiableList(anonymousExecutables);
 	}
 
 	@Override
@@ -107,7 +107,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 				constructors.add((CtConstructor<T>) typeMember);
 			}
 		}
-		return constructors;
+		return Collections.unmodifiableSet(constructors);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -132,7 +132,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 		List<CtField<?>> result = new ArrayList<>();
 		result.addAll(getEnumValues());
 		result.addAll(super.getFields());
-		return result;
+		return Collections.unmodifiableList(result);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -285,7 +285,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				fields.add((CtField<?>) typeMember);
 			}
 		}
-		return fields;
+		return Collections.unmodifiableList(fields);
 	}
 
 	@Override
@@ -457,7 +457,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				nestedTypes.add((CtType<?>) typeMember);
 			}
 		}
-		return nestedTypes;
+		return Collections.unmodifiableSet(nestedTypes);
 	}
 
 	@Override
@@ -828,7 +828,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				methods.add((CtMethod<?>) typeMember);
 			}
 		}
-		return methods;
+		return Collections.unmodifiableSet(methods);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -509,7 +509,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	public Set<CtTypeReference<?>> getSuperInterfaces() {
 		CtType<?> t = getDeclaration();
 		if (t != null) {
-			return t.getSuperInterfaces();
+			return Collections.unmodifiableSet(t.getSuperInterfaces());
 		} else {
 			Class<?> c = getActualClass();
 			Class<?>[] sis = c.getInterfaces();
@@ -518,7 +518,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 				for (Class<?> si : sis) {
 					set.add(getFactory().Type().createReference(si));
 				}
-				return set;
+				return Collections.unmodifiableSet(set);
 			}
 		}
 		return Collections.emptySet();


### PR DESCRIPTION
As discussed in #1917 and detected by #1922, this PR fixes all main derived properties of Spoon model by way they return unmodifiable collections.

Before they were modifiable, but detached. So the modifications had no influence to the model. Now they are unmodifiable, so client is warn early that modifications makes no sense here.