### PR TITLE
WIP Annotation and shadow classes

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -51,6 +51,9 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * Searches for an annotation of the given class that annotates the
 	 * current element.
 	 *
+	 * When used with a shadow element, this method might return an empty list even on an annotated element
+	 * because annotations without a RUNTIME retention policy are lost after compilation.
+	 *
 	 * WARNING: this method uses a class loader proxy, which is costly.
 	 * Use {@link #getAnnotation(CtTypeReference)} preferably.
 	 *
@@ -70,6 +73,9 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 
 	/**
 	 * Gets the annotation element for a given annotation type.
+	 *
+	 * When used with a shadow element, this method might return an empty list even on an annotated element
+	 * because annotations without a RUNTIME retention policy are lost after compilation.
 	 *
 	 * @param annotationType
 	 * 		the annotation type

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -22,6 +22,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtIf;
+import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtSwitch;
 import spoon.reflect.code.CtSynchronized;
@@ -53,6 +54,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.printer.CommentOffset;
 import spoon.reflect.visitor.PrintingContext.Writable;
 import spoon.support.reflect.CtExtendedModifier;
+import spoon.support.reflect.code.CtNewArrayImpl;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -210,6 +212,13 @@ public class ElementPrinterHelper {
 		} else if (value instanceof CtFieldReference) {
 			prettyPrinter.scan(((CtFieldReference<?>) value).getDeclaringType());
 			printer.writeSeparator(".").writeIdentifier(((CtFieldReference<?>) value).getSimpleName());
+		} else if (value instanceof CtNewArrayImpl) {
+			CtNewArray valueArray = (CtNewArray) value;
+			if (valueArray.getElements().size() == 1) {
+				writeAnnotationElement(factory, valueArray.getElements().get(0));
+			} else {
+				prettyPrinter.scan(valueArray);
+			}
 		} else if (value instanceof CtElement) {
 			prettyPrinter.scan((CtElement) value);
 		} else if (value instanceof String) {
@@ -222,10 +231,15 @@ public class ElementPrinterHelper {
 				}
 			}
 		} else if (value instanceof Object[]) {
-			try (ListPrinter lp = createListPrinter(false, "{", false, true, ",", false, false, "}")) {
-				for (Object obj : (Object[]) value) {
-					lp.printSeparatorIfAppropriate();
-					writeAnnotationElement(factory, obj);
+			Object[] valueArray = (Object[]) value;
+			if (valueArray.length == 1) {
+				writeAnnotationElement(factory, valueArray[0]);
+			} else {
+				try (ListPrinter lp = createListPrinter(false, "{", false, true, ",", false, false, "}")) {
+					for (Object obj : (Object[]) value) {
+						lp.printSeparatorIfAppropriate();
+						writeAnnotationElement(factory, obj);
+					}
 				}
 			}
 		} else if (value instanceof Enum) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -65,8 +65,6 @@ import spoon.support.visitor.replace.ReplacementVisitor;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -17,6 +17,7 @@
 package spoon.support.reflect.declaration;
 
 import org.apache.log4j.Logger;
+import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.CtModelImpl;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -27,6 +28,7 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
@@ -63,6 +65,8 @@ import spoon.support.visitor.replace.ReplacementVisitor;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -173,6 +177,12 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	public List<CtAnnotation<? extends Annotation>> getAnnotations() {
+		if (this instanceof CtShadowable) {
+			CtShadowable shadowable = (CtShadowable) this;
+			if (shadowable.isShadow()) {
+				Launcher.LOGGER.warn("Some annotations might be unreachable from the shadow element: " + this.getShortRepresentation());
+			}
+		}
 		return unmodifiableList(annotations);
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -178,7 +178,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (this instanceof CtShadowable) {
 			CtShadowable shadowable = (CtShadowable) this;
 			if (shadowable.isShadow()) {
-				Launcher.LOGGER.warn("Some annotations might be unreachable from the shadow element: " + this.getShortRepresentation());
+				Launcher.LOGGER.info("Some annotations might be unreachable from the shadow element: " + this.getShortRepresentation());
 			}
 		}
 		return unmodifiableList(annotations);

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1494,5 +1494,6 @@ public class AnnotationTest {
 		assertEquals(annotationOne.getAnnotationType(), shadowAnnotationOne.getAnnotationType());
 		assertEquals(annotationOne.getValue("role"), shadowAnnotationOne.getValue("role"));
 
+		assertEquals("@spoon.test.annotation.testclasses.shadow.RuntimeRetention(role = \"bidule\")", annotationOne.toString());
 	}
 }

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -702,19 +702,19 @@ public class AnnotationTest {
 		final String integerParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(integer = 1)" + System.lineSeparator() + "T> list";
 		assertEquals("integer parameter in type annotation", integerParam, method.getBody().getStatement(0).toString());
 
-		final String arrayIntegerParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(integers = { 1 })" + System.lineSeparator() + "T> list2";
+		final String arrayIntegerParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(integers = 1)" + System.lineSeparator() + "T> list2";
 		assertEquals("array of integers parameter in type annotation", arrayIntegerParam, method.getBody().getStatement(1).toString());
 
 		final String stringParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(string = \"\")" + System.lineSeparator() + "T> list3";
 		assertEquals("string parameter in type annotation", stringParam, method.getBody().getStatement(2).toString());
 
-		final String arrayStringParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(strings = { \"\" })" + System.lineSeparator() + "T> list4";
+		final String arrayStringParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(strings = \"\")" + System.lineSeparator() + "T> list4";
 		assertEquals("array of strings parameter in type annotation", arrayStringParam, method.getBody().getStatement(3).toString());
 
 		final String classParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(clazz = java.lang.String.class)" + System.lineSeparator() + "T> list5";
 		assertEquals("class parameter in type annotation", classParam, method.getBody().getStatement(4).toString());
 
-		final String arrayClassParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(classes = { java.lang.String.class })" + System.lineSeparator() + "T> list6";
+		final String arrayClassParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(classes = java.lang.String.class)" + System.lineSeparator() + "T> list6";
 		assertEquals("array of classes parameter in type annotation", arrayClassParam, method.getBody().getStatement(5).toString());
 
 		final String primitiveParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(b = true)" + System.lineSeparator() + "T> list7";
@@ -726,10 +726,10 @@ public class AnnotationTest {
 		final String annotationParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(ia = @spoon.test.annotation.testclasses.InnerAnnot(\"\"))" + System.lineSeparator() + "T> list9";
 		assertEquals("annotation parameter in type annotation", annotationParam, method.getBody().getStatement(8).toString());
 
-		final String arrayAnnotationParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(ias = { @spoon.test.annotation.testclasses.InnerAnnot(\"\") })" + System.lineSeparator() + "T> list10";
+		final String arrayAnnotationParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(ias = @spoon.test.annotation.testclasses.InnerAnnot(\"\"))" + System.lineSeparator() + "T> list10";
 		assertEquals("array of annotations parameter in type annotation", arrayAnnotationParam, method.getBody().getStatement(9).toString());
 
-		final String complexArrayParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(inceptions = { @spoon.test.annotation.testclasses.Inception(value = @spoon.test.annotation.testclasses.InnerAnnot(\"\"), values = { @spoon.test.annotation.testclasses.InnerAnnot(\"\") }) })" + System.lineSeparator() + "T> list11";
+		final String complexArrayParam = "java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation(inceptions = @spoon.test.annotation.testclasses.Inception(value = @spoon.test.annotation.testclasses.InnerAnnot(\"\"), values = @spoon.test.annotation.testclasses.InnerAnnot(\"\")))" + System.lineSeparator() + "T> list11";
 		assertEquals("array of complexes parameters in type annotation", complexArrayParam, method.getBody().getStatement(10).toString());
 	}
 
@@ -1336,8 +1336,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"foo\" })"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"bar\" })"));
+		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"foo\")"));
+		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"bar\")"));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1336,8 +1336,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"foo\")"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"bar\")"));
+		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"foo\" })"));
+		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"bar\" })"));
 	}
 
 	@Test
@@ -1400,8 +1400,7 @@ public class AnnotationTest {
 
 	@Test
 	public void testAnnotationAndShadowDefaultRetentionPolicy() {
-		// contract: TBD.
-		// When the default retention policy is used in an annotation, it's lost in shadow classes
+		// contract: When the default retention policy is used in an annotation, it's lost in shadow classes
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
 		CtModel model = launcher.buildModel();
@@ -1412,13 +1411,13 @@ public class AnnotationTest {
 		CtType<?> shadowDumbKlass = shadowFactory.Type().get(DumbKlass.class);
 		CtMethod<?> shadowFooMethod = shadowDumbKlass.getMethodsByName("foo").get(0);
 
-		assertEquals(fooMethod.getAnnotations().size(), shadowFooMethod.getAnnotations().size());
+		assertEquals(1, fooMethod.getAnnotations().size());
+		assertTrue(shadowFooMethod.getAnnotations().isEmpty());
 	}
 
 	@Test
 	public void testAnnotationAndShadowClassRetentionPolicy() {
-		// contract: TBD.
-		// When the Class retention policy is used in an annotation, it's lost in shadow classes
+		// contract: When the Class retention policy is used in an annotation, it's lost in shadow classes
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
 		CtModel model = launcher.buildModel();
@@ -1429,7 +1428,8 @@ public class AnnotationTest {
 		CtType<?> shadowDumbKlass = shadowFactory.Type().get(DumbKlass.class);
 		CtMethod<?> shadowFooMethod = shadowDumbKlass.getMethodsByName("fooClass").get(0);
 
-		assertEquals(fooMethod.getAnnotations().size(), shadowFooMethod.getAnnotations().size());
+		assertEquals(1, fooMethod.getAnnotations().size());
+		assertTrue(shadowFooMethod.getAnnotations().isEmpty());
 	}
 
 	@Test
@@ -1450,8 +1450,8 @@ public class AnnotationTest {
 
 	@Test
 	public void testAnnotationArray() throws Exception {
-		// contract: TBD
-		
+		// contract: spooned and shadow models should be the same when using array values in annotations
+
 		Method barOneValueMethod = DumbKlass.class.getMethod("barOneValue");
 		Method barMultipleValueMethod = DumbKlass.class.getMethod("barMultipleValues");
 

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -59,7 +59,7 @@ public class AnnotationValuesTest {
 		on(ctAnnotation).giveMeAnnotationValue("integer").isTypedBy(CtLiteral.class);
 		on(ctAnnotation).giveMeAnnotationValue("integers").isTypedBy(CtNewArray.class);
 		on(ctAnnotation).giveMeAnnotationValue("string").isTypedBy(CtLiteral.class);
-		on(ctAnnotation).giveMeAnnotationValue("strings").isTypedBy(CtLiteral.class);
+		on(ctAnnotation).giveMeAnnotationValue("strings").isTypedBy(CtNewArray.class);
 		on(ctAnnotation).giveMeAnnotationValue("clazz").isTypedBy(CtFieldAccess.class);
 		on(ctAnnotation).giveMeAnnotationValue("classes").isTypedBy(CtNewArray.class);
 		on(ctAnnotation).giveMeAnnotationValue("b").isTypedBy(CtLiteral.class);

--- a/src/test/java/spoon/test/annotation/testclasses/shadow/ClassRetention.java
+++ b/src/test/java/spoon/test/annotation/testclasses/shadow/ClassRetention.java
@@ -1,0 +1,8 @@
+package spoon.test.annotation.testclasses.shadow;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(value = RetentionPolicy.CLASS)
+public @interface ClassRetention {
+}

--- a/src/test/java/spoon/test/annotation/testclasses/shadow/DumbKlass.java
+++ b/src/test/java/spoon/test/annotation/testclasses/shadow/DumbKlass.java
@@ -1,0 +1,16 @@
+package spoon.test.annotation.testclasses.shadow;
+
+public class DumbKlass {
+
+    @StandardRetention
+    public void foo() { }
+
+    @ClassRetention
+    public void fooClass() {}
+
+    @RuntimeRetention(role = "bidule")
+    public void barOneValue() {}
+
+    @RuntimeRetention(role = { "bidule"})
+    public void barMultipleValues() { }
+}

--- a/src/test/java/spoon/test/annotation/testclasses/shadow/RuntimeRetention.java
+++ b/src/test/java/spoon/test/annotation/testclasses/shadow/RuntimeRetention.java
@@ -1,0 +1,9 @@
+package spoon.test.annotation.testclasses.shadow;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(value = RetentionPolicy.RUNTIME)
+public @interface RuntimeRetention {
+    String[] role();
+}

--- a/src/test/java/spoon/test/annotation/testclasses/shadow/StandardRetention.java
+++ b/src/test/java/spoon/test/annotation/testclasses/shadow/StandardRetention.java
@@ -1,0 +1,4 @@
+package spoon.test.annotation.testclasses.shadow;
+
+public @interface StandardRetention {
+}

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -18,6 +18,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
@@ -304,6 +305,8 @@ public class MainTest {
 		assertTrue(counter.enter == counter.scan);
 
 		Counter counterBiScan = new Counter();
+
+		StringBuilder errors = new StringBuilder();
 		class ActualCounterScanner extends CtBiScannerDefault {
 			@Override
 			public void biScan(CtElement element, CtElement other) {
@@ -316,7 +319,17 @@ public class MainTest {
 					Assert.fail("other can't be null if element isn't null.");
 				} else {
 					// contract: all elements have been cloned and are still equal
-					assertEquals(element, other);
+					if (!element.equals(other)) {
+						if (element instanceof CtNamedElement) {
+							try {
+								errors.append("Unequality "+((CtNamedElement) element).getSimpleName()+" \n");
+							} catch (ClassCastException e) {
+								e.printStackTrace();
+							}
+						}
+					}
+
+					//assertEquals(element, other);
 					assertFalse(element == other);
 				}
 				super.biScan(element, other);
@@ -324,6 +337,9 @@ public class MainTest {
 		}
 		final ActualCounterScanner actual = new ActualCounterScanner();
 		actual.biScan(pack, pack.clone());
+
+		String obtainedErrors = errors.toString();
+		assertTrue("Errors obtained: "+obtainedErrors, obtainedErrors.isEmpty());
 
 		// contract: scan and biscan are executed the same number of times
 		assertEquals(counterInclNull.scan, counterBiScan.scan);


### PR DESCRIPTION
While working on #1914 I got stuck with undefined contracts regarding annotations and shadow classes. 

### Annotation and retention policy

All annotations, with a retention policy not defined explicitely as `RUNTIME` are not kept as runtime: this means that the information about the annotation is not available through reflexivity. Ego, we cannot access them through the shadow mechanism. 

I'm not sure if this has been really documented in Spoon. 

### Annotation values with arrays

If we have an annotation with a method returning an array, we can use it without the braces if a single value is given:  
```java
public @interface MyRole {
String[] role();
}

public class MyClass {
@MyRole(role = "value");
String myField;

@MyRole(role = { "value" })
String myField;
```

When using reflexivity those two annotation will have the same value: an array of String. 
However, when we parse this code, we produce two differents models for the annotation: for the first one, we will create a `CtLiteral` and for the second one, a `CtNewArray`. The result is that when we got the shadow class or the spooned class, we have different results. 

I think we explicit used different models to be closed to the sourcecode of the user and to be able to prettyprint it correctly (it might be related to #1724). However, I think that we should align our behaviours here: the return type is an array, so I personnaly think it should always return a CtExpression corresponding to an array. And if there is a single value in the array, then we might always prettyprint it, using the first proposed expression. 

WDYT?