### PR TITLE
review: fix class with comments has invalid DeclarationSourcePosition#modifier

### DIFF
--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -22,6 +22,7 @@ import spoon.test.position.testclasses.FooAbstractMethod;
 import spoon.test.position.testclasses.FooAnnotation;
 import spoon.test.position.testclasses.FooClazz;
 import spoon.test.position.testclasses.FooClazz2;
+import spoon.test.position.testclasses.FooClazzWithComments;
 import spoon.test.position.testclasses.FooField;
 import spoon.test.position.testclasses.FooGeneric;
 import spoon.test.position.testclasses.FooInterface;
@@ -31,16 +32,12 @@ import spoon.test.position.testclasses.FooStatement;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -76,6 +73,46 @@ public class PositionTest {
 		assertEquals("FooClazz", contentAtPosition(classContent, position.getNameStart(), position.getNameEnd()));
 		assertEquals("public", contentAtPosition(classContent, position.getModifierSourceStart(), position.getModifierSourceEnd()));
 	}
+	
+	
+	@Test
+	public void testPositionClassWithComments() throws Exception {
+		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/"));
+		final CtType<FooClazzWithComments> foo = build.Type().get(FooClazzWithComments.class);
+		String classContent = getClassContent(foo);
+
+		BodyHolderSourcePosition position = (BodyHolderSourcePosition) foo.getPosition();
+
+//		assertEquals(4, position.getLine());
+//		assertEquals(6, position.getEndLine());
+
+		assertEquals(42, position.getSourceStart());
+		assertEquals(132, position.getSourceEnd());
+		assertEquals("/*c1*/\n" + 
+				"//lc1\n" + 
+				"public /*c2*/\n" + 
+				"//lc2 /*\n" + 
+				"class \n" + 
+				"// */\n" + 
+				"/*c3 class // */\n" + 
+				"FooClazzWithComments {\n" + 
+				"\n" + 
+				"}", contentAtPosition(classContent, position));
+
+		assertEquals("{\n\n}", contentAtPosition(classContent, position.getBodyStart(), position.getBodyEnd()));
+
+		// this specifies that getLine starts at name (and not at Javadoc or annotation)
+		final CtType<FooClazz> foo2 = build.Type().get(FooClazz2.class);
+		assertEquals(42, foo2.getPosition().getSourceStart());
+		assertEquals(4, foo2.getPosition().getLine());
+		assertEquals(4, foo2.getPosition().getEndLine());
+
+		assertEquals("FooClazzWithComments", contentAtPosition(classContent, position.getNameStart(), position.getNameEnd()));
+		assertEquals("/*c1*/\n" + 
+				"//lc1\n" + 
+				"public", contentAtPosition(classContent, position.getModifierSourceStart(), position.getModifierSourceEnd()));
+	}
+
 	
 	@Test
 	public void testPositionInterface() throws Exception {

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -16,6 +16,7 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.position.testclasses.Foo;
 import spoon.test.position.testclasses.FooAbstractMethod;
@@ -28,6 +29,7 @@ import spoon.test.position.testclasses.FooGeneric;
 import spoon.test.position.testclasses.FooInterface;
 import spoon.test.position.testclasses.FooMethod;
 import spoon.test.position.testclasses.FooStatement;
+import spoon.test.position.testclasses.PositionParameterTypeWithReference;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -35,6 +37,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -113,6 +116,25 @@ public class PositionTest {
 				"public", contentAtPosition(classContent, position.getModifierSourceStart(), position.getModifierSourceEnd()));
 	}
 
+	@Test
+	public void testPositionParameterTypeReference() throws Exception {
+		//contract: the parameterized type refernce has a source position which includes parameter types, etc.
+		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/"));
+		final CtType<?> foo = build.Type().get(PositionParameterTypeWithReference.class);
+		String classContent = getClassContent(foo);
+
+		CtTypeReference<?> field2Type =  foo.getField("field2").getType();
+		//this already worked well
+		assertEquals("List<T>[][]", contentAtPosition(classContent, field2Type.getPosition()));
+
+		CtTypeReference<?> field1Type =  foo.getField("field1").getType();
+		//this probably points to an bug in JDT. But we have no workaround in Spoon
+		assertEquals("List<T>", contentAtPosition(classContent, field1Type.getPosition()));
+
+		CtTypeReference<?> field3Type =  foo.getField("field3").getType();
+		//this probably points to an bug in JDT. But we have no workaround in Spoon, which handles spaces and comments too
+		assertEquals("List<T // */ >\n\t/*// */>", contentAtPosition(classContent, field3Type.getPosition()));
+	}
 	
 	@Test
 	public void testPositionInterface() throws Exception {
@@ -570,7 +592,5 @@ public class PositionTest {
 		assertEquals(8, positionElse.getLine());
 
 		assertNotEquals(returnStatement, otherReturnStatement);
-
-
 	}
 }

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -80,6 +80,8 @@ public class PositionTest {
 	
 	@Test
 	public void testPositionClassWithComments() throws Exception {
+		//contract: check that comments before and after the 'class' keyword are handled well by PositionBuilder
+		//and it produces correct `modifierEnd`
 		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/"));
 		final CtType<FooClazzWithComments> foo = build.Type().get(FooClazzWithComments.class);
 		String classContent = getClassContent(foo);
@@ -118,7 +120,7 @@ public class PositionTest {
 
 	@Test
 	public void testPositionParameterTypeReference() throws Exception {
-		//contract: the parameterized type refernce has a source position which includes parameter types, etc.
+		//contract: the parameterized type reference has a source position which includes parameter types, etc.
 		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/"));
 		final CtType<?> foo = build.Type().get(PositionParameterTypeWithReference.class);
 		String classContent = getClassContent(foo);

--- a/src/test/java/spoon/test/position/testclasses/FooClazzWithComments.java
+++ b/src/test/java/spoon/test/position/testclasses/FooClazzWithComments.java
@@ -1,0 +1,12 @@
+package spoon.test.position.testclasses;
+
+/*c1*/
+//lc1
+public /*c2*/
+//lc2 /*
+class 
+// */
+/*c3 class // */
+FooClazzWithComments {
+
+}

--- a/src/test/java/spoon/test/position/testclasses/PositionParameterTypeWithReference.java
+++ b/src/test/java/spoon/test/position/testclasses/PositionParameterTypeWithReference.java
@@ -1,0 +1,12 @@
+package spoon.test.position.testclasses;
+
+import java.util.List;
+
+public class PositionParameterTypeWithReference<T> {
+	List<T> field1;
+	List<T>[][] field2;
+	List<T // */ >
+	/*// */> 
+	//>
+	field3;
+}


### PR DESCRIPTION
I am experimenting with another approach to implement Sniper mode and have found a bug:
Class with sources like this
```java
public class /*comment*/ Test {}
```
has wrong DeclarationSourcePosition#modifier end.

The problem is in code 
/spoon-core/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java (line 137)
because it doesn't count with comments. So we need some comment aware parser/tokenizer here.

I guess, I can fix it. But if anybody else would like to implement that comment parser, I would gladly do something else ;-)