### PR TITLE
fix IndexOutOfBoundsException in getType()

### DIFF
--- a/src/main/java/spoon/reflect/code/CtCatchVariable.java
+++ b/src/main/java/spoon/reflect/code/CtCatchVariable.java
@@ -48,5 +48,9 @@ public interface CtCatchVariable<T> extends CtVariable<T>, CtMultiTypedElement, 
 
 	@Override
 	@DerivedProperty
+	/**
+	 * Returns type reference of the exception variable in a catch.
+	 * If type is unknown, or any of the types in a multi-catch is unknown, returns null.
+	 */
 	CtTypeReference<T> getType();
 }

--- a/src/main/java/spoon/reflect/code/CtCatchVariable.java
+++ b/src/main/java/spoon/reflect/code/CtCatchVariable.java
@@ -46,11 +46,11 @@ public interface CtCatchVariable<T> extends CtVariable<T>, CtMultiTypedElement, 
 	@UnsettableProperty
 	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
 
-	@Override
-	@DerivedProperty
 	/**
 	 * Returns type reference of the exception variable in a catch.
 	 * If type is unknown, or any of the types in a multi-catch is unknown, returns null.
 	 */
+	@Override
+	@DerivedProperty
 	CtTypeReference<T> getType();
 }

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -92,6 +92,9 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 				.includingInterfaces(false)
 				.includingSelf(true)
 				.returnTypeReferences(true)).list();
+		if (superTypesOfFirst.isEmpty()) {
+			return null;
+		}
 		int commonSuperTypeIdx = 0;
 		//index of Throwable. Last is Object
 		int throwableIdx = superTypesOfFirst.size() - 2;

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -218,7 +218,7 @@ public class TryCatchTest {
 		CtTry tryStmt = (CtTry) clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
 		List<CtCatch> catchers = tryStmt.getCatchers();
 		assertEquals(1, catchers.size());
-		
+
 		CtCatchVariable<?> catchVariable = catchers.get(0).getParameter();
 
 		assertEquals(
@@ -230,20 +230,20 @@ public class TryCatchTest {
 		assertEquals(
 				RuntimeException.class,
 				catchVariable.getMultiTypes().get(0).getActualClass());
-		
+
 		//contract: the manipulation with catch variable type is possible
 		catchVariable.setType((CtTypeReference)factory.Type().createReference(IllegalArgumentException.class));
 		assertEquals(IllegalArgumentException.class,catchVariable.getType().getActualClass());
 		//contract setType influences multitypes
 		assertEquals(1, catchVariable.getMultiTypes().size());
 		assertEquals(IllegalArgumentException.class, catchVariable.getMultiTypes().get(0).getActualClass());
-		
+
 		catchVariable.setMultiTypes(Collections.singletonList((CtTypeReference)factory.Type().createReference(UnsupportedOperationException.class)));
 		assertEquals(UnsupportedOperationException.class,catchVariable.getType().getActualClass());
 		//contract setType influences multitypes
 		assertEquals(1, catchVariable.getMultiTypes().size());
 		assertEquals(UnsupportedOperationException.class, catchVariable.getMultiTypes().get(0).getActualClass());
-		
+
 		catchVariable.setMultiTypes(Arrays.asList(
 				factory.Type().createReference(UnsupportedOperationException.class),
 				factory.Type().createReference(IllegalArgumentException.class)
@@ -251,7 +251,7 @@ public class TryCatchTest {
 		assertEquals(2, catchVariable.getMultiTypes().size());
 		assertEquals(UnsupportedOperationException.class, catchVariable.getMultiTypes().get(0).getActualClass());
 		assertEquals(IllegalArgumentException.class, catchVariable.getMultiTypes().get(1).getActualClass());
-		
+
 		//contract setMultiTypes influences types, which contains common super class of all multi types
 		assertEquals(RuntimeException.class,catchVariable.getType().getActualClass());
 	}
@@ -288,5 +288,19 @@ public class TryCatchTest {
 		String content = StringUtils.join(Files.readAllLines(f.toPath()),"\n");
 
 		assertTrue(content.contains("catch (final java.lang.Exception e)"));
+	}
+
+	@Test
+	public void testCatchWithUnknownExceptions() {
+		// contract: unknown exception type in multicatch should not cause IndexOutOfBoundsException
+		String inputResource = "./src/test/resources/spoon/test/noclasspath/exceptions/Foo.java";
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(inputResource);
+		launcher.getEnvironment().setNoClasspath(true);
+		CtModel model = launcher.buildModel();
+
+		List<CtCatch> catches = model.getElements(new TypeFilter<CtCatch>(CtCatch.class));
+		catches.get(0).getParameter().getType(); // catch with single UnknownException
+		catches.get(1).getParameter().getType(); // multicatch with UnknownException
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
@@ -300,7 +301,8 @@ public class TryCatchTest {
 		CtModel model = launcher.buildModel();
 
 		List<CtCatch> catches = model.getElements(new TypeFilter<CtCatch>(CtCatch.class));
-		catches.get(0).getParameter().getType(); // catch with single UnknownException
-		catches.get(1).getParameter().getType(); // multicatch with UnknownException
+		assertNotNull(catches.get(0).getParameter().getType()); // catch with single UnknownException
+		assertNull(catches.get(1).getParameter().getType()); // multicatch with UnknownException
+		assertNull(catches.get(2).getParameter().getType()); // multicatch with UnknownException
 	}
 }

--- a/src/test/resources/spoon/test/noclasspath/exceptions/Foo.java
+++ b/src/test/resources/spoon/test/noclasspath/exceptions/Foo.java
@@ -10,11 +10,20 @@ public class Foo {
 		}
 	}
 
-	void testMultiCatchWithUnknownException(File file) {
+	void testMultiCatchWithUnknownException1(File file) {
 		try {
 			new FileReader(file);
 		}
 		catch (UnknownException | FileNotFoundException e) {
+			System.out.println(e);
+		}
+	}
+
+	void testMultiCatchWithUnknownException2(File file) {
+		try {
+			new FileReader(file);
+		}
+		catch (FileNotFoundException | UnknownException e) {
 			System.out.println(e);
 		}
 	}

--- a/src/test/resources/spoon/test/noclasspath/exceptions/Foo.java
+++ b/src/test/resources/spoon/test/noclasspath/exceptions/Foo.java
@@ -1,0 +1,21 @@
+
+public class Foo {
+
+	void testCatchWithUnknownException(File file) {
+		try {
+			new FileReader(file);
+		}
+		catch (UnknownException e) {
+			System.out.println(e);
+		}
+	}
+
+	void testMultiCatchWithUnknownException(File file) {
+		try {
+			new FileReader(file);
+		}
+		catch (UnknownException | FileNotFoundException e) {
+			System.out.println(e);
+		}
+	}
+}


### PR DESCRIPTION
Hi! I found out that `IndexOutOfBoundsException` is occurred in cases when `getType()` is called on parameter of a catch with multiple exception types, some of which is unknown (noclasspath mode):
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at spoon.support.reflect.code.CtCatchVariableImpl.getType(CtCatchVariableImpl.java:109)
        ....
```

I think it would be better to return null from getType() in such cases instead, so I provided this PR.