### PR TITLE
review: fix: comments after class name and before type members

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -38,6 +38,7 @@ import spoon.reflect.code.CtStatementList;
 import spoon.reflect.code.CtSwitch;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.position.BodyHolderSourcePosition;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
@@ -325,7 +326,8 @@ class JDTCommentBuilder {
 
 			@Override
 			public <T> void visitCtClass(CtClass<T> e) {
-				if (comment.getPosition().getLine() <= e.getPosition().getLine()) {
+				//all the comments located before the body brackets belongs to class
+				if (comment.getPosition().getSourceEnd() < ((BodyHolderSourcePosition) e.getPosition()).getBodyStart()) {
 					e.addComment(comment);
 					return;
 				}

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -250,9 +250,9 @@ public class CommentTest {
 		Factory f = getSpoonFactory();
 		CtClass<?> type = (CtClass<?>) f.Type().get(InlineComment.class);
 		List<CtComment> comments = type.getComments();
-		assertEquals(3, comments.size());
+		assertEquals(5, comments.size());
 		type.removeComment(comments.get(0));
-		assertEquals(2, type.getComments().size());
+		assertEquals(4, type.getComments().size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -263,7 +263,7 @@ public class CommentTest {
 
 		List<CtComment> comments = type.getElements(new TypeFilter<CtComment>(CtComment.class));
 		// verify that the number of comment present in the AST is correct
-		assertEquals(64, comments.size());
+		assertEquals(66, comments.size());
 
 		// verify that all comments present in the AST is printed
 		for (CtComment comment : comments) {
@@ -275,7 +275,7 @@ public class CommentTest {
 			assertTrue(comment.toString() + ":" + comment.getParent() + " is not printed", strType.contains(comment.toString()));
 		}
 
-		assertEquals(3, type.getComments().size());
+		assertEquals(5, type.getComments().size());
 		assertEquals(CtComment.CommentType.FILE, type.getComments().get(0).getCommentType());
 		assertEquals(createFakeComment(f, "comment class"), type.getComments().get(1));
 

--- a/src/test/java/spoon/test/comment/testclasses/InlineComment.java
+++ b/src/test/java/spoon/test/comment/testclasses/InlineComment.java
@@ -4,8 +4,13 @@
  */
 package spoon.test.comment.testclasses;
 
+import java.util.ArrayList;
+
 // comment class
-public class InlineComment {
+public class InlineComment
+	//this comment 1 belongs to class too
+	extends ArrayList<String> //this comment 2 belongs to class too 
+	{
 	// Comment Field
 	// comment field 2
 	private int field // comment in field


### PR DESCRIPTION
This PR fixes this situation.
```java
class A
  // this comment belongs to class
   extends B /* this comment belongs to class too*/ { /* but this comment is comment of first member*/
  int firstMember;
}
```
Before all the comments from the example above were associated to the `firstMember`