### PR TITLE
help: fix: always create new type reference for primitive type

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -93,7 +93,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -106,7 +105,6 @@ public class ReferenceBuilder {
 	// Allow to detect circular references and to avoid endless recursivity
 	// when resolving parameterizedTypes (e.g. Enum<E extends Enum<E>>)
 	private Map<TypeBinding, CtTypeReference> exploringParameterizedBindings = new HashMap<>();
-	private Map<String, CtTypeReference<?>> basestypes = new TreeMap<>();
 
 	private boolean bounds = false;
 
@@ -786,14 +784,9 @@ public class ReferenceBuilder {
 			}
 		} else if (binding instanceof BaseTypeBinding) {
 			String name = new String(binding.sourceName());
-			ref = basestypes.get(name);
-			if (ref == null) {
-				ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-				ref.setSimpleName(name);
-				basestypes.put(name, ref);
-			} else {
-				ref = ref == null ? ref : ref.clone();
-			}
+			//always create new TypeReference, because clonning from a cache clones invalid SourcePosition
+			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+			ref.setSimpleName(name);
 		} else if (binding instanceof WildcardBinding) {
 			WildcardBinding wildcardBinding = (WildcardBinding) binding;
 			ref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1,7 +1,6 @@
 package spoon.test.annotation;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Before;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -1055,11 +1054,11 @@ public class AnnotationTest {
 		//spoon2.addInputResource("./src/test/java/spoon/test/annotation/testclasses/PortRange.java");
 		spoon2.buildModel();
 
-		List<CtMethod<?>> methods = spoon2.getModel().getElements(new NamedElementFilter(CtMethod.class, "getPort"));
+		List<CtField<?>> fields = spoon2.getModel().getElements(new NamedElementFilter(CtField.class, "port"));
 
-		assertEquals("Number of method getPort should be 1", 1, methods.size());
+		assertEquals("Number of fields port should be 1", 1, fields.size());
 
-		CtMethod getport = methods.get(0);
+		CtField<?> getport = fields.get(0);
 		CtTypeReference returnType = getport.getType();
 
 		List<CtAnnotation<?>> annotations = returnType.getAnnotations();

--- a/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
+++ b/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
@@ -1,16 +1,25 @@
 package spoon.test.sourcePosition;
 
 import org.junit.Test;
+
+import spoon.reflect.code.CtInvocation;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.sourcePosition.testclasses.Brambora;
+import spoon.testing.utils.ModelUtils;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class SourcePositionTest {
@@ -40,6 +49,25 @@ public class SourcePositionTest {
 
 	private Factory factoryFor(String packageName, String className) throws Exception {
 		return build(packageName, className).getFactory();
+	}
+	
+	@Test
+	public void testSourcePositionOfSecondPrimitiveType() throws Exception {
+		/*
+		 * contract: fix bug: the other references to primitive type (e.g. void)
+		 * in return type of ExecutableRefernce "System.out.println" DOES NOT copy the source position
+		 * from the return type of owner method
+		 */
+		CtType<?> type = ModelUtils.buildClass(Brambora.class);
+		CtInvocation<?> invocation = type.getMethodsByName("sourcePositionOfMyReturnTypeMustNotBeCopied").get(0).getBody().getStatement(0);
+		CtExecutableReference<?> execRef = invocation.getExecutable();
+		CtTypeReference<?> typeOfReturnValueOfPrintln = execRef.getType();
+		assertEquals("void", typeOfReturnValueOfPrintln.getQualifiedName());
+		SourcePosition sp = typeOfReturnValueOfPrintln.getPosition();
+		if (sp != null && sp instanceof NoSourcePosition == false) {
+			//it copied source position from owner method return type
+			fail("The source position of invisible implicit reference to void is: [" + sp.getSourceStart() + "; " + sp.getSourceEnd() + "]");
+		}
 	}
 
 }

--- a/src/test/java/spoon/test/sourcePosition/testclasses/Brambora.java
+++ b/src/test/java/spoon/test/sourcePosition/testclasses/Brambora.java
@@ -1,0 +1,7 @@
+package spoon.test.sourcePosition.testclasses;
+
+public class Brambora {
+	void sourcePositionOfMyReturnTypeMustNotBeCopied() {
+		System.out.println();
+	}
+}


### PR DESCRIPTION
The type references to primitive types like `void` sometime copied the source position from another type reference. See test for details.