### PR TITLE
review: feature: SourcePosition checks validity and displays origin source code

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -108,7 +108,7 @@ public class PositionBuilder {
 			if (variableDeclaration.type != null) {
 				modifiersSourceEnd = variableDeclaration.type.sourceStart() - 2;
 			} else if (variableDeclaration instanceof Initializer) {
-				modifiersSourceEnd = ((Initializer) variableDeclaration).block.sourceStart;
+				modifiersSourceEnd = ((Initializer) variableDeclaration).block.sourceStart - 1;
 			} else {
 				// variable that has no type such as TypeParameter
 				modifiersSourceEnd = declarationSourceStart - 1;

--- a/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
@@ -45,6 +45,7 @@ public class BodyHolderSourcePositionImpl extends DeclarationSourcePositionImpl
 				modifierSourceStart, modifierSourceEnd,
 				declarationSourceStart, declarationSourceEnd,
 				lineSeparatorPositions);
+		checkArgsAreAscending(declarationSourceStart, modifierSourceStart, modifierSourceEnd + 1, sourceStart, sourceEnd + 1, bodyStart, bodyEnd + 1, declarationSourceEnd + 1);
 		this.bodyStart = bodyStart;
 		this.bodyEnd = bodyEnd;
 	}
@@ -57,5 +58,17 @@ public class BodyHolderSourcePositionImpl extends DeclarationSourcePositionImpl
 	@Override
 	public int getBodyEnd() {
 		return bodyEnd;
+	}
+
+	/**
+	 * @return origin source code of body
+	 */
+	public String getBodySourceFragment() {
+		return getFragment(getBodyStart(), getBodyEnd());
+	}
+
+	protected String getSourceInfo() {
+		return super.getSourceInfo()
+				+ "\nbody = " + getBodySourceFragment();
 	}
 }

--- a/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
@@ -60,15 +60,9 @@ public class BodyHolderSourcePositionImpl extends DeclarationSourcePositionImpl
 		return bodyEnd;
 	}
 
-	/**
-	 * @return origin source code of body
-	 */
-	public String getBodySourceFragment() {
-		return getFragment(getBodyStart(), getBodyEnd());
-	}
-
-	protected String getSourceInfo() {
-		return super.getSourceInfo()
-				+ "\nbody = " + getBodySourceFragment();
+	@Override
+	public String getSourceDetails() {
+		return super.getSourceDetails()
+				+ "\nbody = " + getFragment(getBodyStart(), getBodyEnd());
 	}
 }

--- a/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
@@ -40,6 +40,7 @@ public class DeclarationSourcePositionImpl extends SourcePositionImpl
 		super(compilationUnit,
 				sourceStart, sourceEnd,
 				lineSeparatorPositions);
+		checkArgsAreAscending(declarationSourceStart, modifierSourceStart, modifierSourceEnd + 1, sourceStart, sourceEnd + 1, declarationSourceEnd + 1);
 		this.modifierSourceStart = modifierSourceStart;
 		this.declarationSourceStart = declarationSourceStart;
 		this.declarationSourceEnd = declarationSourceEnd;
@@ -86,4 +87,25 @@ public class DeclarationSourcePositionImpl extends SourcePositionImpl
 	public int getEndLine() {
 		return searchLineNumber(declarationSourceEnd);
 	}
+
+	/**
+	 * @return origin source code of modifiers
+	 */
+	public String getModifierSourceFragment() {
+		return getFragment(getModifierSourceStart(), getModifierSourceEnd());
+	}
+
+	/**
+	 * @return origin source code of `name`
+	 */
+	public String getNameSourceFragment() {
+		return getFragment(getNameStart(), getNameEnd());
+	}
+
+	protected String getSourceInfo() {
+		return super.getSourceInfo()
+				+ "\nmodifier = " + getModifierSourceFragment()
+				+ "\nname = " + getNameSourceFragment();
+	}
+
 }

--- a/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
@@ -88,24 +88,11 @@ public class DeclarationSourcePositionImpl extends SourcePositionImpl
 		return searchLineNumber(declarationSourceEnd);
 	}
 
-	/**
-	 * @return origin source code of modifiers
-	 */
-	public String getModifierSourceFragment() {
-		return getFragment(getModifierSourceStart(), getModifierSourceEnd());
-	}
-
-	/**
-	 * @return origin source code of `name`
-	 */
-	public String getNameSourceFragment() {
-		return getFragment(getNameStart(), getNameEnd());
-	}
-
-	protected String getSourceInfo() {
-		return super.getSourceInfo()
-				+ "\nmodifier = " + getModifierSourceFragment()
-				+ "\nname = " + getNameSourceFragment();
+	@Override
+	public String getSourceDetails() {
+		return super.getSourceDetails()
+				+ "\nmodifier = " + getFragment(getModifierSourceStart(), getModifierSourceEnd())
+				+ "\nname = " + getFragment(getNameStart(), getNameEnd());
 	}
 
 }

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -19,6 +19,8 @@ package spoon.support.reflect.cu.position;
 import spoon.SpoonException;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.position.BodyHolderSourcePosition;
+import spoon.reflect.cu.position.DeclarationSourcePosition;
 
 import java.io.File;
 import java.io.Serializable;

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -195,19 +195,18 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 		return compilationUnit;
 	}
 
-	protected String getFragment(int start, int end) {
-		return "|" + start + ";" + end + "|" + getCompilationUnit().getOriginalSourceCode().substring(start, end + 1) + "|";
-	}
-
 	/**
-	 * @return source code of this {@link SourcePosition}
+	 * Helper for debugging purposes. Displays |startIndex; endIndex|sourceCode| of this {@link SourcePosition}
+	 * If this instance is {@link DeclarationSourcePosition} or {@link BodyHolderSourcePosition}
+	 * Then details about name, modifiers and body are included in resulting string too
+	 * @return details about source code of this {@link SourcePosition}
 	 */
-	public String getSourceFragment() {
+	public String getSourceDetails() {
 		return getFragment(getSourceStart(), getSourceEnd());
 	}
 
-	protected String getSourceInfo() {
-		return getSourceFragment();
+	protected String getFragment(int start, int end) {
+		return "|" + start + ";" + end + "|" + getCompilationUnit().getOriginalSourceCode().substring(start, end + 1) + "|";
 	}
 
 	/**

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.cu.position;
 
+import spoon.SpoonException;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 
@@ -112,6 +113,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 
 	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {
 		super();
+		checkArgsAreAscending(sourceStart, sourceEnd + 1);
 		this.compilationUnit = compilationUnit;
 		if (compilationUnit != null) {
 			this.file = compilationUnit.getFile();
@@ -193,4 +195,35 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 		return compilationUnit;
 	}
 
+	protected String getFragment(int start, int end) {
+		return "|" + start + ";" + end + "|" + getCompilationUnit().getOriginalSourceCode().substring(start, end + 1) + "|";
+	}
+
+	/**
+	 * @return source code of this {@link SourcePosition}
+	 */
+	public String getSourceFragment() {
+		return getFragment(getSourceStart(), getSourceEnd());
+	}
+
+	protected String getSourceInfo() {
+		return getSourceFragment();
+	}
+
+	/**
+	 * fails when `values` are not sorted ascending
+	 * It is used to check whether start/end values of SourcePosition are consistent
+	 */
+	protected static void checkArgsAreAscending(int...values) {
+		int last = -1;
+		for (int value : values) {
+			if (value < 0) {
+				throw new SpoonException("SourcePosition value must not be negative");
+			}
+			if (last > value) {
+				throw new SpoonException("SourcePosition values must be ascending or equal");
+			}
+			last = value;
+		}
+	}
 }

--- a/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
+++ b/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
@@ -3,6 +3,7 @@ package spoon.test.sourcePosition;
 import org.junit.Test;
 
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtMethod;
@@ -12,6 +13,10 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.cu.CompilationUnitImpl;
+import spoon.support.reflect.cu.position.BodyHolderSourcePositionImpl;
+import spoon.support.reflect.cu.position.DeclarationSourcePositionImpl;
+import spoon.support.reflect.cu.position.SourcePositionImpl;
 import spoon.test.sourcePosition.testclasses.Brambora;
 import spoon.testing.utils.ModelUtils;
 
@@ -70,4 +75,26 @@ public class SourcePositionTest {
 		}
 	}
 
+	@Test
+	public void testSourcePositionStringFragment() throws Exception {
+		CompilationUnit cu = new CompilationUnitImpl() {
+			@Override
+			public String getOriginalSourceCode() {
+				return "0123456789";
+			}
+		};
+		SourcePositionImpl sp = new SourcePositionImpl(cu, 1, 9, null);
+		assertEquals("|1;9|123456789|", sp.getSourceDetails());
+		
+		DeclarationSourcePositionImpl dsp = new DeclarationSourcePositionImpl(cu, 4, 7, 2, 2, 1,9, null);
+		assertEquals("|1;9|123456789|\n" + 
+				"modifier = |2;2|2|\n" + 
+				"name = |4;7|4567|", dsp.getSourceDetails());
+		
+		BodyHolderSourcePositionImpl bhsp = new BodyHolderSourcePositionImpl(cu, 4, 7, 2, 2, 1,9, 8, 9, null);
+		assertEquals("|1;9|123456789|\n" + 
+				"modifier = |2;2|2|\n" + 
+				"name = |4;7|4567|\n" + 
+				"body = |8;9|89|", bhsp.getSourceDetails());
+	}
 }


### PR DESCRIPTION
this new `checkArgsAreAscending` found many problems in PositionBuilder...

I guess it should be always activated... or do you think it should be possible to switch it off ... temporarily, so clients can use spoon until we fix all the `PositionBuilder x JDK compiler` problems?

WDYT?

Yes and there are some new helper methods in SourcePositions ... I was lazy to make new PR for them. I hope it is BS enough :-)