### PR TITLE
feature: IterableCtElement wrapper class, fixes #1077 (?)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/IterableCtElementWrapper.java
+++ b/src/main/java/spoon/reflect/visitor/IterableCtElementWrapper.java
@@ -1,0 +1,63 @@
+package spoon.reflect.visitor;
+
+import spoon.reflect.declaration.CtElement;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+/**
+ * Wrapper for CtElement instances, to be able to iterate through them using
+ * range-based for loops, in depth-first search order.
+ */
+public class IterableCtElementWrapper implements Iterable<CtElement> {
+
+
+    /**
+     * The CtElement this class wraps around.
+     */
+    private CtElement ctElement;
+
+    /**
+     * The CtIterator used to iterate through the wrapped CtElement.
+     */
+    private CtIterator ctIterator;
+
+    /**
+     * Constructor from a CtElement.
+     * @param ctElement
+     */
+    public IterableCtElementWrapper(CtElement ctElement) {
+        this.ctElement = ctElement;
+        this.ctIterator = new CtIterator(ctElement);
+    }
+
+    /**
+     * @return Returns an iterator over elements of type CtElement.
+     */
+    @Override
+    public Iterator<CtElement> iterator() {
+        return ctIterator;
+    }
+
+    /**
+     * Performs the given action over this iterable's range, in order of iteration.
+     * @param action The action to be performed element-wise.
+     */
+    @Override
+    public void forEach(Consumer<? super CtElement> action) {
+        for (CtElement elem : this) {
+            action.accept(elem);
+        }
+    }
+
+    /**
+     * Creates a Spliterator over the elements described by this Iterable.
+     * @return a Spliterator over the elements described by this Iterable.
+     */
+    @Override
+    public Spliterator<CtElement> spliterator() {
+        return Spliterators.spliteratorUnknownSize(ctIterator, Spliterator.ORDERED);
+    }
+}

--- a/src/test/java/spoon/reflect/visitor/IterableCtElementWrapperTest.java
+++ b/src/test/java/spoon/reflect/visitor/IterableCtElementWrapperTest.java
@@ -1,0 +1,47 @@
+package spoon.reflect.visitor;
+
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtElement;
+
+import java.util.ArrayDeque;
+
+import static org.junit.Assert.assertEquals;
+
+public class IterableCtElementWrapperTest {
+    @Test
+    public void testIterableOrder() throws Exception {
+        // contract: CtIterator must go over all nodes in dfs order
+        final Launcher launcher = new Launcher();
+        launcher.setArgs(new String[] {"--output-type", "nooutput"});
+        launcher.getEnvironment().setNoClasspath(true);
+        // resources to iterate
+        launcher.addInputResource("./src/main/java/spoon/reflect/visitor/CtScanner.java");
+        launcher.buildModel();
+
+        // get the first Type
+        CtElement root = launcher.getFactory().getModel().getAllTypes().iterator().next();
+
+        // use custom CtScanner to assert the proper ordering
+        CtScannerList counter = new CtScannerList();
+        root.accept(counter);
+
+        IterableCtElementWrapper iterable = new IterableCtElementWrapper(root);
+        for (CtElement elem : iterable) {
+            assertEquals(counter.nodes.pollFirst(), elem);
+        }
+    }
+
+    /**
+     * Class that saves a deque with all the nodes the {@link CtScanner} visits,
+     * in DFS order, for the {@link CtIterator} test
+     */
+    class CtScannerList extends CtScanner {
+        public ArrayDeque<CtElement> nodes = new ArrayDeque<>();
+
+        @Override
+        protected void enter(CtElement e) {
+            nodes.addLast(e);
+        }
+    }
+}


### PR DESCRIPTION
Implements an iterable wrapper class for CtElement, making it possible to iterate in for-each loops:
```java
IterableCtElementWrapper iterable = new IterableCtElementWrapper(rootElement);
for (CtElement elem : iterable) { // iterates in dfs, as CtIterator
         doSomething(elem);
}
```

This possibly fixes #1077 (in discussion).

Other alternatives would be implementing an ```iterator()``` method in CtElement, or making ```CtElement extend Iterable<CtElement>```, but this would lead to code repetition among subclasses.
