### PR TITLE
review fix: actualTypeArguments of array type reference

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -199,12 +199,13 @@ public class ReferenceBuilder {
 				}
 			}
 			if (type.getTypeArguments() != null && type.getTypeArguments().length - 1 <= position && type.getTypeArguments()[position] != null && type.getTypeArguments()[position].length > 0) {
-				currentReference.getActualTypeArguments().clear();
+				CtTypeReference<?> componentReference = getTypeReferenceOfArrayComponent(currentReference);
+				componentReference.getActualTypeArguments().clear();
 				for (TypeReference typeArgument : type.getTypeArguments()[position]) {
 					if (typeArgument instanceof Wildcard || typeArgument.resolvedType instanceof WildcardBinding || typeArgument.resolvedType instanceof TypeVariableBinding) {
-						currentReference.addActualTypeArgument(buildTypeParameterReference(typeArgument, scope));
+						componentReference.addActualTypeArgument(buildTypeParameterReference(typeArgument, scope));
 					} else {
-						currentReference.addActualTypeArgument(buildTypeReference(typeArgument, scope));
+						componentReference.addActualTypeArgument(buildTypeReference(typeArgument, scope));
 					}
 				}
 			} else if ((type instanceof ParameterizedSingleTypeReference || type instanceof ParameterizedQualifiedTypeReference)
@@ -223,6 +224,13 @@ public class ReferenceBuilder {
 			currentReference = currentReference.getDeclaringType();
 		}
 		return typeReference;
+	}
+
+	private CtTypeReference<?> getTypeReferenceOfArrayComponent(CtTypeReference<?> currentReference) {
+		while (currentReference instanceof CtArrayTypeReference) {
+			currentReference = ((CtArrayTypeReference<?>) currentReference).getComponentType();
+		}
+		return currentReference;
 	}
 
 	private boolean isTypeArgumentExplicit(TypeReference[][] typeArguments) {

--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -6,9 +6,12 @@ import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.arrays.testclasses.VaragParam;
+import spoon.testing.utils.ModelUtils;
 
 import java.util.List;
 
@@ -90,5 +93,27 @@ public class ArraysTest {
 		} catch (Exception e) {
 			fail(e.getMessage());
 		}
+	}
+	
+	@Test
+	public void testParameterizedVarargReference() throws Exception {
+		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
+		CtParameter<?> param1 = ctClass.getMethodsByName("m1").get(0).getParameters().get(0);
+		CtArrayTypeReference<?> varArg1TypeRef = (CtArrayTypeReference<?>) param1.getType();
+		assertEquals("java.util.List<?>[]", varArg1TypeRef.toString());
+		assertEquals("java.util.List<?>", varArg1TypeRef.getComponentType().toString());
+		assertEquals(1, varArg1TypeRef.getComponentType().getActualTypeArguments().size());
+		assertEquals(0, varArg1TypeRef.getActualTypeArguments().size());
+	}
+	
+	@Test
+	public void testParameterizedArrayReference() throws Exception {
+		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
+		CtParameter<?> param1 = ctClass.getMethodsByName("m2").get(0).getParameters().get(0);
+		CtArrayTypeReference<?> varArg1TypeRef = (CtArrayTypeReference<?>) param1.getType();
+		assertEquals("java.util.List<?>[]", varArg1TypeRef.toString());
+		assertEquals("java.util.List<?>", varArg1TypeRef.getComponentType().toString());
+		assertEquals(1, varArg1TypeRef.getComponentType().getActualTypeArguments().size());
+		assertEquals(0, varArg1TypeRef.getActualTypeArguments().size());
 	}
 }

--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -9,6 +9,7 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtArrayTypeReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.arrays.testclasses.VaragParam;
 import spoon.testing.utils.ModelUtils;
@@ -97,6 +98,7 @@ public class ArraysTest {
 	
 	@Test
 	public void testParameterizedVarargReference() throws Exception {
+		//contract: check actual type arguments of parameter type: List<?>...
 		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
 		CtParameter<?> param1 = ctClass.getMethodsByName("m1").get(0).getParameters().get(0);
 		CtArrayTypeReference<?> varArg1TypeRef = (CtArrayTypeReference<?>) param1.getType();
@@ -108,6 +110,7 @@ public class ArraysTest {
 	
 	@Test
 	public void testParameterizedArrayReference() throws Exception {
+		//contract: check actual type arguments of parameter type: List<?>[]
 		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
 		CtParameter<?> param1 = ctClass.getMethodsByName("m2").get(0).getParameters().get(0);
 		CtArrayTypeReference<?> varArg1TypeRef = (CtArrayTypeReference<?>) param1.getType();
@@ -115,5 +118,29 @@ public class ArraysTest {
 		assertEquals("java.util.List<?>", varArg1TypeRef.getComponentType().toString());
 		assertEquals(1, varArg1TypeRef.getComponentType().getActualTypeArguments().size());
 		assertEquals(0, varArg1TypeRef.getActualTypeArguments().size());
+	}
+
+	@Test
+	public void testParameterizedArrayVarargReference() throws Exception {
+		//contract: check actual type arguments of parameter type: List<?>[]...
+		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
+		CtParameter<?> param1 = ctClass.getMethodsByName("m3").get(0).getParameters().get(0);
+		CtArrayTypeReference<?> varArg1TypeRef = (CtArrayTypeReference<?>) param1.getType();
+		assertEquals("java.util.List<?>[][]", varArg1TypeRef.toString());
+		assertEquals("java.util.List<?>[]", varArg1TypeRef.getComponentType().toString());
+		assertEquals("java.util.List<?>", ((CtArrayTypeReference<?>) varArg1TypeRef.getComponentType()).getComponentType().toString());
+		assertEquals(1, ((CtArrayTypeReference<?>) varArg1TypeRef.getComponentType()).getComponentType().getActualTypeArguments().size());
+		assertEquals(0, varArg1TypeRef.getComponentType().getActualTypeArguments().size());
+		assertEquals(0, varArg1TypeRef.getActualTypeArguments().size());
+	}
+
+	@Test
+	public void testParameterizedTypeReference() throws Exception {
+		//contract: check actual type arguments of parameter type: List<?>
+		CtType<?> ctClass = ModelUtils.buildClass(VaragParam.class);
+		CtParameter<?> param1 = ctClass.getMethodsByName("m4").get(0).getParameters().get(0);
+		CtTypeReference<?> typeRef = (CtTypeReference<?>) param1.getType();
+		assertEquals("java.util.List<?>", typeRef.toString());
+		assertEquals(1, typeRef.getActualTypeArguments().size());
 	}
 }

--- a/src/test/java/spoon/test/arrays/testclasses/VaragParam.java
+++ b/src/test/java/spoon/test/arrays/testclasses/VaragParam.java
@@ -1,0 +1,12 @@
+package spoon.test.arrays.testclasses;
+
+import java.util.List;
+
+public class VaragParam {
+
+	void m1(List<?>... arg) {
+	}
+
+	void m2(List<?>[] arg) {
+	}
+}

--- a/src/test/java/spoon/test/arrays/testclasses/VaragParam.java
+++ b/src/test/java/spoon/test/arrays/testclasses/VaragParam.java
@@ -9,4 +9,10 @@ public class VaragParam {
 
 	void m2(List<?>[] arg) {
 	}
+
+	void m3(List<?>[]... arg) {
+	}
+
+	void m4(List<?> arg) {
+	}
 }


### PR DESCRIPTION
I guess I have found a bug in actual type arguments of array type reference.
The problem is that array type reference like `List<?>[]` has set wildcard `<?>` actual type arguments on 2 places
1) on List type: `List<?>` - here it is OK
2) in List array type: `List[]` - here it is wrong. Or WDYT is it bug or feature?

I added two failing test, which both actually fails on last test line.