### PR TITLE
fix: visibility of enum values

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1081,7 +1081,13 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 		Set<CtExtendedModifier> modifierSet = new HashSet<>();
 		if (fieldDeclaration.binding != null) {
-			field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true, false));
+			if (fieldDeclaration.binding.declaringClass != null && fieldDeclaration.binding.declaringClass.isEnum()) {
+				//enum values take over visibility from enum type
+				//JDT compiler has a bug that enum values are always public static final, even for private enum
+				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.declaringClass.modifiers, true, false));
+			} else {
+				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true, false));
+			}
 		}
 		for (CtExtendedModifier extendedModifier : getModifiers(fieldDeclaration.modifiers, false, false)) {
 			field.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -5,15 +5,22 @@ import spoon.Launcher;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.test.annotation.AnnotationTest;
 import spoon.test.enums.testclasses.Burritos;
 import spoon.test.enums.testclasses.Foo;
+import spoon.test.enums.testclasses.NestedEnums;
+import spoon.testing.utils.ModelUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public class EnumsTest {
 
@@ -70,4 +77,33 @@ public class EnumsTest {
 		assertTrue(burritos.getAllMethods().contains(name));
 	}
 
+	@Test
+	public void testNestedPrivateEnumValues() throws Exception {
+		// contract: ...
+		CtType<?> ctClass = ModelUtils.buildClass(NestedEnums.class);
+		{
+			CtEnum<?> ctEnum = ctClass.getNestedType("PrivateENUM");
+			assertEquals(asSet(ModifierKind.PRIVATE), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PRIVATE, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
+		}
+		{
+			CtEnum<?> ctEnum = ctClass.getNestedType("PublicENUM");
+			assertEquals(asSet(ModifierKind.PUBLIC), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PUBLIC, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
+		}
+		{
+			CtEnum<?> ctEnum = ctClass.getNestedType("ProtectedENUM");
+			assertEquals(asSet(ModifierKind.PROTECTED), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PROTECTED, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
+		}
+		{
+			CtEnum<?> ctEnum = ctClass.getNestedType("PackageProtectedENUM");
+			assertEquals(asSet(), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
+		}
+	}
+	
+	private <T> Set<T> asSet(T... values) {
+		return new HashSet<>(Arrays.asList(values));
+	}
 }

--- a/src/test/java/spoon/test/enums/testclasses/NestedEnums.java
+++ b/src/test/java/spoon/test/enums/testclasses/NestedEnums.java
@@ -1,0 +1,17 @@
+package spoon.test.enums.testclasses;
+
+public class NestedEnums {
+
+	private enum PrivateENUM {
+		VALUE
+	}
+	public enum PublicENUM {
+		VALUE
+	}
+	protected enum ProtectedENUM {
+		VALUE
+	}
+	enum PackageProtectedENUM {
+		VALUE
+	}
+}


### PR DESCRIPTION
by comparing of Spoon model created from sources and model created from java runtime, I found that Enum constants have wrong visibility modifiers, when created from sources. This PR fixes it.

I haven't found any Java language specification rule related to visibility of enum constants, but it looks like the visibility is inherited from visibility of enum type + they are always static and final.