### PR TITLE
review: feature: fail when element is added twice

### DIFF
--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -92,6 +92,9 @@ public class SnippetCompilationHelper {
 		// Clean up
 		c.getPackage().removeType(c);
 
+		//disconnect element from the parent, so it can be added to another model
+		ret.delete();
+
 		if (ret instanceof CtClass) {
 			CtClass klass = (CtClass) ret;
 			ret.getFactory().Package().getRootPackage().addType(klass);

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -140,7 +140,11 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 
 	@Override
 	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
-		for (CtStatement s : statements.getStatements()) {
+		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
+		//remove statements from the `statementsToBeInserted` before they are added to spoon model
+		//note: one element MUST NOT be part of two models.
+		statements.setStatements(null);
+		for (CtStatement s : tobeInserted) {
 			insertEnd(s);
 		}
 		return (T) this;

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -186,6 +186,9 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 				for (CtStatement ctStatement : statementsToBeInserted) {
 					copy.add(indexOfTargetElement++, ctStatement);
 				}
+				//remove statements from the `statementsToBeInserted` before they are added to spoon model
+				//note: one element MUST NOT be part of two models.
+				statementsToBeInserted.setStatements(null);
 				block.setStatements(copy);
 			}
 
@@ -196,6 +199,9 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 				for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
 					copy.add(indexOfTargetElement, (T) statementsToBeInserted.getStatements().get(j));
 				}
+				//remove statements from the `statementsToBeInserted` before they are added to spoon model
+				//note: one element MUST NOT be part of two models.
+				statementsToBeInserted.setStatements(null);
 				return copy;
 			}
 		},
@@ -212,6 +218,9 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 				for (CtStatement s : statementsToBeInserted) {
 					copy.add(++indexOfTargetElement, s);
 				}
+				//remove statements from the `statementsToBeInserted` before they are added to spoon model
+				//note: one element MUST NOT be part of two models.
+				statementsToBeInserted.setStatements(null);
 				block.setStatements(copy);
 			}
 
@@ -222,6 +231,9 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 				for (int j = statementsToBeInserted.getStatements().size() - 1; j >= 0; j--) {
 					copy.add(indexOfTargetElement, (T) statementsToBeInserted.getStatements().get(j));
 				}
+				//remove statements from the `statementsToBeInserted` before they are added to spoon model
+				//note: one element MUST NOT be part of two models.
+				statementsToBeInserted.setStatements(null);
 				return copy;
 			}
 		};

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -124,7 +124,11 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 
 	@Override
 	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
-		for (CtStatement s : statements.getStatements()) {
+		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
+		//remove statements from the `statementsToBeInserted` before they are added to spoon model
+		//note: one element MUST NOT be part of two models.
+		statements.setStatements(null);
+		for (CtStatement s : tobeInserted) {
 			insertEnd(s);
 		}
 		return (T) this;

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -256,8 +256,8 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 				if (res instanceof CtStatement) {
 					b.addStatement((CtStatement) res);
 				} else {
-					//the context expectes statement. We cannot simplify in this case
-					b.addStatement(s);
+					//the context expects statement. We cannot simplify in this case
+					b.addStatement(s.clone());
 				}
 			}
 			// do not copy unreachable statements

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -93,7 +93,12 @@ public abstract class ModelList<T extends CtElement> extends AbstractList<T> imp
 		if (owner.getFactory().getEnvironment().checksAreSkipped() == false && element.isParentInitialized() && element.getParent() != owner) {
 			//the `e` already has an different parent. Check if it is still linked to that parent
 			if (element.getRoleInParent() != null) {
-				throw new SpoonException("The element " + element + " is already used by another part of SpoonModel. Remove it from previous model or clone it before.");
+				throw new SpoonException("The default behavior has changed, a new check has been added! Don't worry, you can disable this check\n"
+							 + "with one of the following options:\n"
+							 + " - by configuring Spoon with getEnvironment().setSelfChecks(true)\n"
+							 + " - by removing the node from its previous parent (element.delete())\n"
+							 + " - by cloning the node before adding it here (element.clone())\n"
+							);
 			}
 		}
 		element.setParent(owner);

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -94,10 +94,9 @@ public abstract class ModelList<T extends CtElement> extends AbstractList<T> imp
 			//the `e` already has an different parent. Check if it is still linked to that parent
 			if (element.getRoleInParent() != null) {
 				throw new SpoonException("The default behavior has changed, a new check has been added! Don't worry, you can disable this check\n"
-							 + "with one of the following options:\n"
-							 + " - by configuring Spoon with getEnvironment().setSelfChecks(true)\n"
-							 + " - by removing the node from its previous parent (element.delete())\n"
-							 + " - by cloning the node before adding it here (element.clone())\n"
+							+ "with one of the following options:\n"
+							+ " - by configuring Spoon with getEnvironment().setSelfChecks(true)\n"							+ " - by removing the node from its previous parent (element.delete())\n"
+							+ " - by cloning the node before adding it here (element.clone())\n"
 							);
 			}
 		}

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 
+import spoon.SpoonException;
 import spoon.experimental.modelobs.FineModelChangeListener;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
@@ -89,6 +90,12 @@ public abstract class ModelList<T extends CtElement> extends AbstractList<T> imp
 	}
 
 	static void linkToParent(CtElement owner, CtElement element) {
+		if (owner.getFactory().getEnvironment().checksAreSkipped() == false && element.isParentInitialized() && element.getParent() != owner) {
+			//the `e` already has an different parent. Check if it is still linked to that parent
+			if (element.getRoleInParent() != null) {
+				throw new SpoonException("The element " + element + " is already used by another part of SpoonModel. Remove it from previous model or clone it before.");
+			}
+		}
 		element.setParent(owner);
 	}
 

--- a/src/test/java/spoon/generating/CtBiScannerGenerator.java
+++ b/src/test/java/spoon/generating/CtBiScannerGenerator.java
@@ -104,6 +104,8 @@ public class CtBiScannerGenerator extends AbstractManualProcessor {
 	private CtClass<Object> createBiScanner() {
 		final CtPackage aPackage = getFactory().Package().getOrCreate(TARGET_BISCANNER_PACKAGE);
 		final CtClass<Object> target = getFactory().Class().get(GENERATING_BISCANNER);
+		//remove class from the old package so it can be added into new package
+		target.delete();
 		target.setSimpleName("CtBiScannerDefault");
 		target.addModifier(ModifierKind.PUBLIC);
 		aPackage.addType(target);

--- a/src/test/java/spoon/generating/ReplacementVisitorGenerator.java
+++ b/src/test/java/spoon/generating/ReplacementVisitorGenerator.java
@@ -45,6 +45,8 @@ public class ReplacementVisitorGenerator extends AbstractProcessor<CtType<?>> {
 	private CtClass<Object> createReplacementVisitor() {
 		final CtPackage aPackage = getFactory().Package().getOrCreate(TARGET_REPLACE_PACKAGE);
 		final CtClass<Object> target = getFactory().Class().get(GENERATING_REPLACE_VISITOR);
+		//remove type from old package so it can be added into new package
+		target.delete();
 		target.addModifier(ModifierKind.PUBLIC);
 		aPackage.addType(target);
 		final List<CtTypeReference> references = target.getElements(new TypeFilter<CtTypeReference>(CtTypeReference.class) {

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -123,9 +123,7 @@ public class SignatureTest {
 		CtStatement sta2 = (factory).Code().createCodeSnippetStatement("String hello =\"t1\"; System.out.println(hello)")
 				.compile();
 
-		CtStatement sta2bis = ((CtBlock<?>)sta2.getParent()).getStatement(1);
-
-		assertFalse(sta1.equals(sta2bis));// equals depends on deep equality
+		assertFalse(sta1.equals(sta2));// equals depends on deep equality
 
 		String parameterWithQuotes = ((CtInvocation<?>)sta1).getArguments().get(0).toString();
 		assertEquals("\"hello\"",parameterWithQuotes);

--- a/src/test/java/spoon/test/staticFieldAccess/InsertBlockProcessor.java
+++ b/src/test/java/spoon/test/staticFieldAccess/InsertBlockProcessor.java
@@ -18,8 +18,8 @@ public class InsertBlockProcessor extends AbstractProcessor<CtMethod<?>> {
 	@Override
 	public void process(CtMethod<?> element) {
 		CtBlock block = new CtBlockImpl();
-
-		block.getStatements().add(element.getBody());
+		// we clone the body so that there is no two elements with the same parent 
+		block.addStatement(element.getBody().clone());
 		element.setBody(block);
 	}
 }

--- a/src/test/java/spoon/testing/CtPackageAssertTest.java
+++ b/src/test/java/spoon/testing/CtPackageAssertTest.java
@@ -1,12 +1,22 @@
 package spoon.testing;
 
 import org.junit.Test;
+
+import spoon.SpoonException;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.io.File;
+import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -14,11 +24,19 @@ import static spoon.testing.utils.ModelUtils.createFactory;
 public class CtPackageAssertTest {
 	@Test
 	public void testEqualityBetweenTwoCtPackage() throws Exception {
+		//contract: two packages, one made by test code, second made by compilation from sources are equal
 		final Factory factory = createFactory();
 		final CtPackage aRootPackage = factory.Package().getOrCreate("");
-		aRootPackage.addType(factory.Class().create("spoon.testing.testclasses.Foo").addModifier(ModifierKind.PUBLIC));
-		aRootPackage.addType(factory.Class().create("spoon.testing.testclasses.Bar").addModifier(ModifierKind.PUBLIC));
-		assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(aRootPackage);
+		List<CtType<?>> types1 = aRootPackage.filterChildren(new TypeFilter<>(CtClass.class)).list();
+		assertEquals(0, types1.size());
+		factory.Class().create("spoon.testing.testclasses.Foo").addModifier(ModifierKind.PUBLIC);
+		factory.Class().create("spoon.testing.testclasses.Bar").addModifier(ModifierKind.PUBLIC);
+		List<CtType<?>> types2 = aRootPackage.filterChildren(new TypeFilter<>(CtClass.class)).list();
+		assertEquals(2, types2.size());
+		final CtPackage aRootPackage2 = build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage();
+		assertNotSame(aRootPackage, aRootPackage2);
+		assertThat(aRootPackage2).isEqualTo(aRootPackage);
+
 	}
 
 	@Test(expected = AssertionError.class)
@@ -30,7 +48,38 @@ public class CtPackageAssertTest {
 	public void testEqualityBetweenTwoCtPackageWithDifferentTypes() throws Exception {
 		final Factory factory = createFactory();
 		final CtPackage aRootPackage = factory.Package().getOrCreate("");
-		aRootPackage.addType(factory.Class().create("spoon.testing.testclasses.Foo").addModifier(ModifierKind.PUBLIC));
+		factory.Class().create("spoon.testing.testclasses.Foo").addModifier(ModifierKind.PUBLIC);
 		assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(aRootPackage);
+	}
+	
+	
+	@Test
+	public void testAddTypeToPackage() throws Exception {
+		final Factory factory = createFactory();
+		final CtType<?> type = factory.Core().createClass();
+		type.setSimpleName("X");
+		//contract: type is created in the root package
+		assertSame(factory.getModel().getRootPackage(), type.getPackage());
+		assertEquals("X", type.getQualifiedName());
+		final CtPackage aPackage1= factory.Package().getOrCreate("some.package");
+		//contract: type can be moved from root package to any other package
+		aPackage1.addType(type);
+		assertEquals("some.package.X", type.getQualifiedName());
+		//contract: second add of type into same package does nothing
+		aPackage1.addType(type);
+		assertEquals("some.package.X", type.getQualifiedName());
+		final CtPackage aPackage2= factory.Package().getOrCreate("another.package");
+		try {
+			//contract: type cannot be moved to another package as long as it belongs to some not root package
+			aPackage2.addType(type);
+			fail();
+		} catch (SpoonException e) {
+			//OK
+		}
+		assertEquals("some.package.X", type.getQualifiedName());
+		//contract: type can be moved to another package after it is removed from current package
+		type.getPackage().removeType(type);
+		aPackage2.addType(type);
+		assertEquals("another.package.X", type.getQualifiedName());
 	}
 }


### PR DESCRIPTION
There is basic spoon concept: each element of AST has 0 or 1 parent and is in children collection of exactly one parent.

When some element which is already part of AST is added into another part of AST, then this rule concept is not true and Spoon can behave unpredictable.

This PR assures that element add will fail in such situation.