### PR TITLE
fix(reference): fix npe in getTypeReference when the reference is null

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -544,6 +544,9 @@ public class ReferenceBuilder {
 	 * reference with a name that correspond to the name of the JDT type reference.
 	 */
 	<T> CtTypeReference<T> getTypeReference(TypeReference ref) {
+		if (ref == null) {
+			return null;
+		}
 		CtTypeReference<T> res = null;
 		CtTypeReference inner = null;
 		final String[] namesParameterized = CharOperation.charArrayToStringArray(ref.getParameterizedTypeName());


### PR DESCRIPTION
fix npe in #2014

No idea how to reproduce it in a failing test-case.