### PR TITLE
Fix Interface method handling

### DIFF
--- a/src/main/java/spoon/reflect/factory/MethodFactory.java
+++ b/src/main/java/spoon/reflect/factory/MethodFactory.java
@@ -27,16 +27,19 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.template.Substitution;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * The {@link CtMethod} sub-factory.
  */
 public class MethodFactory extends ExecutableFactory {
+
+	public final Set<CtMethod<?>> OBJECT_METHODS = Collections.unmodifiableSet(factory.Class().get(Object.class).getMethods());
 
 	/**
 	 * Creates a new method sub-factory.

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -23,11 +23,11 @@ import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
@@ -124,6 +124,9 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 			lambdaExecutableMethod = lambdaTypeMethods.iterator().next();
 		} else {
 			for (CtMethod<?> method : lambdaTypeMethods) {
+				if (getFactory().Method().OBJECT_METHODS.stream().anyMatch(method::isOverriding)) {
+					continue;
+				}
 				if (method.isDefaultMethod() || method.hasModifier(ModifierKind.PRIVATE) || method.hasModifier(ModifierKind.STATIC)) {
 					continue;
 				}

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -10,7 +10,6 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
@@ -35,7 +34,6 @@ import spoon.test.lambda.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -406,6 +404,7 @@ public class LambdaTest {
 
 	@Test
 	public void testInterfaceWithObjectMethods() throws Exception {
+		// contract Lambda expression works on interfaces with methods inherited from java.lang.Object
 		CtInterface<?> checkPersons = factory.Interface().get(Foo.CheckPersons.class);
 		List<CtLambda<?>> lambdas = foo.filterChildren(new LambdaFilter(checkPersons)).list();
 		assertEquals(2, lambdas.size());

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -405,14 +405,15 @@ public class LambdaTest {
 	}
 
 	@Test
-	public void testLambdaComparator() throws Exception {
-		CtInterface<?> comparatorInterface = factory.Interface().get(Comparator.class);
-		List<CtLambda<?>> comparators = foo.filterChildren(new LambdaFilter(comparatorInterface)).list();
-		assertEquals(1, comparators.size());
-		CtLambda<?> comparator = comparators.get(0);
-		assertEquals(2, comparator.getParameters().size());
-		CtMethod<?> method = comparator.getOverriddenMethod();
-		assertTrue(comparatorInterface.getMethods().contains(method));
+	public void testInterfaceWithObjectMethods() throws Exception {
+		CtInterface<?> checkPersons = factory.Interface().get(Foo.CheckPersons.class);
+		List<CtLambda<?>> lambdas = foo.filterChildren(new LambdaFilter(checkPersons)).list();
+		assertEquals(2, lambdas.size());
+		CtLambda<?> lambda = lambdas.get(0);
+		assertEquals(2, lambda.getParameters().size());
+		CtMethod<?> method = lambda.getOverriddenMethod();
+		assertTrue(checkPersons.getMethods().contains(method));
+		assertEquals("test", method.getSimpleName());
 	}
 
 	private void assertHasStrings(List<String> methodNames, String... strs) {

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -35,6 +35,7 @@ import spoon.test.lambda.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -401,6 +402,17 @@ public class LambdaTest {
 		//check empty constructor and addImplementingInterface with CtTypeReference
 		methodNames = foo.filterChildren(new LambdaFilter().addImplementingInterface(factory.createCtTypeReference(Predicate.class))).map((CtLambda l)->l.getParent(CtMethod.class).getSimpleName()).list();
 		assertHasStrings(methodNames, "m2", "m4", "m7", "m8");
+	}
+
+	@Test
+	public void testLambdaComparator() throws Exception {
+		CtInterface<?> comparatorInterface = factory.Interface().get(Comparator.class);
+		List<CtLambda<?>> comparators = foo.filterChildren(new LambdaFilter(comparatorInterface)).list();
+		assertEquals(1, comparators.size());
+		CtLambda<?> comparator = comparators.get(0);
+		assertEquals(2, comparator.getParameters().size());
+		CtMethod<?> method = comparator.getOverriddenMethod();
+		assertTrue(comparatorInterface.getMethods().contains(method));
 	}
 
 	private void assertHasStrings(List<String> methodNames, String... strs) {

--- a/src/test/java/spoon/test/lambda/testclasses/Foo.java
+++ b/src/test/java/spoon/test/lambda/testclasses/Foo.java
@@ -1,6 +1,7 @@
 package spoon.test.lambda.testclasses;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -55,6 +56,10 @@ public class Foo {
 		};
 	}
 
+	public void m10() {
+		sortPersonsWithComparator(persons, (p1, p2) -> p1.age - p2.age);
+	}
+
 	public static void printPersonsWithPredicate(List<Person> roster, Predicate<Person> tester) {
 		for (Person p : roster) {
 			if (tester.test(p)) {
@@ -83,6 +88,10 @@ public class Foo {
 		if (tester.test(roster.get(0), roster.get(1))) {
 			roster.get(0).printPerson();
 		}
+	}
+
+	public static void sortPersonsWithComparator(List<Person> roster, Comparator<Person> comparator) {
+		roster.sort(comparator);
 	}
 
 	public class Person {

--- a/src/test/java/spoon/test/lambda/testclasses/Foo.java
+++ b/src/test/java/spoon/test/lambda/testclasses/Foo.java
@@ -56,10 +56,6 @@ public class Foo {
 		};
 	}
 
-	public void m10() {
-		sortPersonsWithComparator(persons, (p1, p2) -> p1.age - p2.age);
-	}
-
 	public static void printPersonsWithPredicate(List<Person> roster, Predicate<Person> tester) {
 		for (Person p : roster) {
 			if (tester.test(p)) {
@@ -90,10 +86,6 @@ public class Foo {
 		}
 	}
 
-	public static void sortPersonsWithComparator(List<Person> roster, Comparator<Person> comparator) {
-		roster.sort(comparator);
-	}
-
 	public class Person {
 		public final int age;
 
@@ -119,5 +111,6 @@ public class Foo {
 
 	public interface CheckPersons {
 		boolean test(Person p1, Person p2);
+		boolean equals(Object other);
 	}
 }


### PR DESCRIPTION
## Description

From [FunctionalInterface](https://docs.oracle.com/javase/8/docs/api/java/lang/FunctionalInterface.html)'s JavaDoc:
> If an interface declares an abstract method overriding one of the public methods of java.lang.Object, that also does not count toward the interface's abstract method count since any implementation of the interface will have an implementation from java.lang.Object or elsewhere.

[CtLambdaImpl](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java#L126-L134) doesn't take this into account resulting in Exceptions whenever an Interface declaring one or more of `java.lang.Object`'s methods is used in combination with a Lambda Expression.

## Related Issues

- Fixes https://github.com/INRIA/spoon/issues/2003