### PR TITLE
feature: one can get annotation values directly

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -68,7 +68,10 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	CtTypeReference<A> getAnnotationType();
 
 	/**
-	 * Gets a value for a given key without any conversion.
+	 * Gets a value, as a CtExpression, for a given key without any conversion.
+	 *
+	 * If you need the actual value (eg an integer and not a literal, see {@link #getValueAsObject(String)} and similar methods.
+	 *
 	 * Note that this value type does not necessarily corresponds to the annotation
 	 * type member. For example, in case the annotation type expect an array of Object,
 	 * and a single value is given, Spoon will return only the object without the CtNewArray.
@@ -80,6 +83,18 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 */
 	@PropertyGetter(role = VALUE)
 	<T extends CtExpression> T getValue(String key);
+
+	/** Returns the actual value of an annotation property */
+	@DerivedProperty
+	Object getValueAsObject(String key);
+
+	/** Returns the actual value of an annotation property, as an integer (utility method) */
+	@DerivedProperty
+	int getValueAsInt(String key);
+
+	/** Returns the actual value of an annotation property, as a String (utility method) */
+	@DerivedProperty
+	String getValueAsString(String key);
 
 	/**
 	 * Gets a value for a given key and try to fix its type based on the

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -314,7 +314,11 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	public int getValueAsInt(String key) {
-		return (int) getValueAsObject(key);
+		Object val = getValueAsObject(key);
+		if (val == null) {
+			throw new IllegalStateException(key + " not in the annotation");
+		}
+		return (int) val;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -312,7 +312,18 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 		return (T) getValueAsExpression(key);
 	}
 
-	private Object getValueAsObject(String key) {
+	@Override
+	public int getValueAsInt(String key) {
+		return (int) getValueAsObject(key);
+	}
+
+	@Override
+	public String getValueAsString(String key) {
+		return (String) getValueAsObject(key);
+	}
+
+	@Override
+	public Object getValueAsObject(String key) {
 		CtExpression expr = getWrappedValue(key);
 		Object ret = convertElementToRuntimeObject(expr);
 		Class<?> type = getElementType(key);

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -199,13 +199,16 @@ public class AnnotationTest {
 
 		CtAnnotation<?> a = annotations.get(0);
 		AnnotParamTypes annot = (AnnotParamTypes) a.getActualAnnotation();
+		assertEquals(42, a.getValueAsInt("integer"));
 		assertEquals(42, annot.integer());
 		assertEquals(1, annot.integers().length);
 		assertEquals(42, annot.integers()[0]);
+		assertEquals("Hello World!", a.getValueAsString("string"));
 		assertEquals("Hello World!", annot.string());
 		assertEquals(2, annot.strings().length);
 		assertEquals("Hello", annot.strings()[0]);
 		assertEquals("World", annot.strings()[1]);
+		assertEquals(Integer.class, a.getValueAsObject("clazz"));
 		assertEquals(Integer.class, annot.clazz());
 		assertEquals(2, annot.classes().length);
 		assertEquals(Integer.class, annot.classes()[0]);


### PR DESCRIPTION
Two advantages:
* this eases the API: direct `annot.getValueAsObject("foo") ` instead of  `((CAST)annot.getActualAnnotation()).foo()`
* this enables getting the annotation value even if the annotation binary class file is not in the classpath 

 