### PR TITLE
feature: add CtAnnotation#getAllValues to reason about all annotation values

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -105,11 +105,11 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * @return this annotation's element names and their values, or an empty map
 	 * if there are none
 	 */
-	@PropertyGetter(role = VALUE)
+	@DerivedProperty
 	Map<String, CtExpression> getValues();
 
 	/** Get all values of {@link #getValues()}, plus the default ones */
-	@DerivedProperty
+	@PropertyGetter(role = VALUE)
 	Map<String, CtExpression> getAllValues();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -108,6 +108,10 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	@PropertyGetter(role = VALUE)
 	Map<String, CtExpression> getValues();
 
+	/** Get all values of {@link #getValues()}, plus the default ones */
+	@DerivedProperty
+	Map<String, CtExpression> getAllValues();
+
 	/**
 	 * Sets the annotation's type.
 	 *

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -108,7 +108,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	@PropertyGetter(role = VALUE)
 	Map<String, CtExpression> getValues();
 
-	/** Get all values of {@link #getValues()}, plus the default ones */
+	/** Get all values of {@link #getValues()}, plus the default ones defined in the annotation type. */
 	@DerivedProperty
 	Map<String, CtExpression> getAllValues();
 

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -105,11 +105,11 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * @return this annotation's element names and their values, or an empty map
 	 * if there are none
 	 */
-	@DerivedProperty
+	@PropertyGetter(role = VALUE)
 	Map<String, CtExpression> getValues();
 
 	/** Get all values of {@link #getValues()}, plus the default ones */
-	@PropertyGetter(role = VALUE)
+	@DerivedProperty
 	Map<String, CtExpression> getAllValues();
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -189,7 +189,7 @@ public abstract class CtScanner implements CtVisitor {
 		scan(CtRole.COMMENT, annotation.getComments());
 		scan(CtRole.ANNOTATION_TYPE, annotation.getAnnotationType());
 		scan(CtRole.ANNOTATION, annotation.getAnnotations());
-		scan(CtRole.VALUE, annotation.getAllValues());
+		scan(CtRole.VALUE, annotation.getValues());
 		exit(annotation);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -189,7 +189,7 @@ public abstract class CtScanner implements CtVisitor {
 		scan(CtRole.COMMENT, annotation.getComments());
 		scan(CtRole.ANNOTATION_TYPE, annotation.getAnnotationType());
 		scan(CtRole.ANNOTATION, annotation.getAnnotations());
-		scan(CtRole.VALUE, annotation.getValues());
+		scan(CtRole.VALUE, annotation.getAllValues());
 		exit(annotation);
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -419,7 +419,16 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	public Map<String, CtExpression> getAllValues() {
-		return Collections.unmodifiableMap(elementValues);
+		Map<String, CtExpression> values = new TreeMap();
+		// first, we put the default values
+		CtAnnotationType<?> annotationType = (CtAnnotationType) getAnnotationType().getTypeDeclaration();
+		for (CtAnnotationMethod m : annotationType.getAnnotationMethods()) {
+			values.put(m.getSimpleName(), m.getDefaultExpression());
+		}
+
+		// we override the values with ones of this expression
+		values.putAll(elementValues);
+		return Collections.unmodifiableMap(values);
 	}
 
 	private Object getReflectValue(String fieldname) {

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -417,6 +417,11 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 		return Collections.unmodifiableMap(elementValues);
 	}
 
+	@Override
+	public Map<String, CtExpression> getAllValues() {
+		return Collections.unmodifiableMap(elementValues);
+	}
+
 	private Object getReflectValue(String fieldname) {
 		try {
 			Class<?> c = getAnnotationType().getActualClass();

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -168,8 +168,11 @@ public class AnnotationTest {
 		assertEquals(0, annot.getValues().size());
 
 		// direct values and default ones in getValues()
-		assertEquals(1, a.getValues().size());
+		assertEquals(1, a.getAllValues().size());
 		assertEquals(1, annot.getAllValues().size());
+
+		// the good value is selected, not the default value
+		assertEquals("8", a.getAllValues().get("max").toString());
 
 
 	}

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -162,6 +162,16 @@ public class AnnotationTest {
 		Bound actualAnnotation2 = (Bound) annot.getActualAnnotation();
 		assertEquals(10, actualAnnotation2.max());
 
+		// contract: getAllvalues
+		// only direct value, no default ones in getValues()
+		assertEquals(1, a.getValues().size());
+		assertEquals(0, annot.getValues().size());
+
+		// direct values and default ones in getValues()
+		assertEquals(1, a.getValues().size());
+		assertEquals(1, annot.getAllValues().size());
+
+
 	}
 
 	@Test
@@ -198,6 +208,9 @@ public class AnnotationTest {
 		assertEquals(1, annotations.size());
 
 		CtAnnotation<?> a = annotations.get(0);
+
+		assertEquals(15, a.getAllValues().size());
+
 		AnnotParamTypes annot = (AnnotParamTypes) a.getActualAnnotation();
 		assertEquals(42, annot.integer());
 		assertEquals(1, annot.integers().length);


### PR DESCRIPTION
add CtAnnotation#getAllValues to reason about all annotation values regardless of whether they are defined in the annotation or as default value.