### PR TITLE
review feat: Enable comments by default

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -378,7 +378,14 @@ public class Launcher implements SpoonAPI {
 			sw1 = new Switch("enable-comments");
 			sw1.setShortFlag('c');
 			sw1.setLongFlag("enable-comments");
-			sw1.setHelp("Adds all code comments in the Spoon AST (Javadoc, line-based comments), rewrites them when pretty-printing.");
+			sw1.setHelp("[DEPRECATED] Adds all code comments in the Spoon AST (Javadoc, line-based comments), rewrites them when pretty-printing. (deprecated: by default, the comments are enabled.)");
+			sw1.setDefault("false");
+			jsap.registerParameter(sw1);
+
+			// Disable generation of javadoc.
+			sw1 = new Switch("disable-comments");
+			sw1.setLongFlag("disable-comments");
+			sw1.setHelp("Disable the parsing of comments in Spoon.");
 			sw1.setDefault("false");
 			jsap.registerParameter(sw1);
 
@@ -425,7 +432,19 @@ public class Launcher implements SpoonAPI {
 		environment.setTabulationSize(jsapActualArgs.getInt("tabsize"));
 		environment.useTabulations(jsapActualArgs.getBoolean("tabs"));
 		environment.setCopyResources(!jsapActualArgs.getBoolean("no-copy-resources"));
-		environment.setCommentEnabled(jsapActualArgs.getBoolean("enable-comments"));
+
+		if (jsapActualArgs.getBoolean("enable-comments")) {
+			Launcher.LOGGER.warn("The option --enable-comments (-c) is deprecated as it is now the default behaviour in Spoon.");
+		} else {
+			Launcher.LOGGER.warn("Spoon now parse by default the comments. Consider using the option --disable-comments if you want the old behaviour.");
+		}
+
+		if (jsapActualArgs.getBoolean("disable-comments")) {
+			environment.setCommentEnabled(false);
+		} else {
+			environment.setCommentEnabled(true);
+		}
+
 		environment.setShouldCompile(jsapActualArgs.getBoolean("compile"));
 		environment.setSelfChecks(jsapActualArgs.getBoolean("disable-model-self-checks"));
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -80,7 +80,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private boolean copyResources = true;
 
-	private boolean enableComments = false;
+	private boolean enableComments = true;
 
 	private Logger logger = Launcher.LOGGER;
 

--- a/src/main/java/spoon/testing/utils/ModelUtils.java
+++ b/src/main/java/spoon/testing/utils/ModelUtils.java
@@ -39,7 +39,9 @@ public final class ModelUtils {
 
 	/** Utility method for testing: creates the model of `packageName` from src/test/java and returns the CtType corresponding to `className` */
 	public static <T extends CtType<?>> T build(String packageName, String className) throws Exception {
-		SpoonModelBuilder comp = new Launcher().createCompiler();
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setCommentEnabled(false); // we don't want to parse the comments for equals
+		SpoonModelBuilder comp = launcher.createCompiler();
 		comp.addInputSources(SpoonResourceHelper.resources("./src/test/java/" + packageName.replace('.', '/') + "/" + className + ".java"));
 		comp.build();
 		return comp.getFactory().Package().get(packageName).getType(className);
@@ -61,7 +63,9 @@ public final class ModelUtils {
 
 	/** Utility method for testing: creates the model of the given `classesToBuild` from src/test/java and returns the factory */
 	public static Factory build(Class<?>... classesToBuild) throws Exception {
-		SpoonModelBuilder comp = new Launcher().createCompiler();
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setCommentEnabled(false);
+		SpoonModelBuilder comp = launcher.createCompiler();
 		for (Class<?> classToBuild : classesToBuild) {
 			comp.addInputSources(SpoonResourceHelper.resources("./src/test/java/" + classToBuild.getName().replace('.', '/') + ".java"));
 		}

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -262,9 +262,10 @@ public class CtScannerTest {
 		assertEquals(0, counter.nObject);
 		// this is a coarse-grain check to see if the scanner changes
 		// no more exec ref in paramref
-		assertEquals(3616, counter.nElement);
-		assertEquals(2396, counter.nEnter);
-		assertEquals(2396, counter.nExit);
+		// also takes into account the comments
+		assertEquals(3655, counter.nElement);
+		assertEquals(2435, counter.nEnter);
+		assertEquals(2435, counter.nExit);
 
 		// contract: all AST nodes which are part of Collection or Map are visited first by method "scan(Collection|Map)" and then by method "scan(CtElement)"
 		Counter counter2 = new Counter();

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -124,6 +124,7 @@ public class AnnotationValuesTest {
 		Launcher launcher = new Launcher();
 		launcher.addInputResource("src/test/resources/printer-test/spoon/test/AnnotationSpecTest.java");
 		launcher.getEnvironment().setNoClasspath(true);
+		launcher.getEnvironment().setCommentEnabled(false); // avoid getting the comment for the equals
 		launcher.buildModel();
 
 		assertEquals(strCtClassOracle,

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -37,6 +37,7 @@ public class NoClasspathTest {
 		Launcher spoon = new Launcher();
 		spoon.getEnvironment().setNoClasspath(true);
 		spoon.getEnvironment().setLevel("OFF");
+		spoon.getEnvironment().setCommentEnabled(false); // avoid getting the comments for the equals
 		spoon.addInputResource("./src/test/resources/spoon/test/noclasspath/fields");
 		spoon.getEnvironment().setSourceOutputDirectory(new File("target/spooned/apitest"));
 		spoon.run();

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -2,6 +2,7 @@ package spoon.test.javadoc;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.OutputType;
 import spoon.SpoonAPI;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
@@ -61,7 +62,7 @@ public class JavaDocTest {
 		Launcher launcher = new Launcher();
 		launcher.getEnvironment().setCommentEnabled(false);
 		launcher.getEnvironment().setNoClasspath(true);
-		launcher.setArgs(new String[] {"--output-type", "nooutput" });
+		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.addInputResource("./src/test/java/spoon/test/javadoc/testclasses/");
 		launcher.run();
 

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -530,6 +530,7 @@ public class MainTest {
 				"-i", "src/test/java",
 				"-o", "target/spooned",
 				"--noclasspath",
+				"--disable-comments",
 				"--compliance", "8",
 				"--level", "OFF"
 		});

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -236,6 +236,7 @@ public class PrinterTest {
 	public void testPrinterTokenListener() throws Exception {
 		Launcher spoon = new Launcher();
 		Factory factory = spoon.createFactory();
+		factory.getEnvironment().setCommentEnabled(false);
 		spoon.createCompiler(
 				factory,
 				SpoonResourceHelper


### PR DESCRIPTION
This PR is a proposal to change a default behaviour in Spoon: until now, the default was to **not** take into account the comments.
I assume this behaviour was used because the comments were not properly parsed then. But I think it's not the case anymore and we got more users using Spoon for parsing comments: very recently we got a question on Stackoverflow linked to that: https://stackoverflow.com/questions/50780598/how-to-get-comments-using-spoon/ and I know we also got issues related to that.

So in the same way we decided to use `noclasspath` mode by default, I propose that we parse comments by default. WDYT?