### PR TITLE
review fix(module): Spoon is now able to build module in full classpath

### DIFF
--- a/src/main/java/spoon/reflect/factory/ModuleFactory.java
+++ b/src/main/java/spoon/reflect/factory/ModuleFactory.java
@@ -103,19 +103,6 @@ public class ModuleFactory extends SubFactory implements Serializable {
 		@Override
 		public void accept(CtVisitor visitor) {
 			visitor.visitCtModule(this);
-
-			// allModules can be null during the deserialization
-			// then java will use hashCode and go through this method
-			// which may cause a NPE (to see it: comment this condition
-			// and run SerializableTest.
-			if (allModules != null) {
-				allModules.forEach(module -> {
-					if (!module.getSimpleName().equals(CtModule.TOP_LEVEL_MODULE_NAME)) {
-						module.accept(visitor);
-					}
-				});
-			}
-
 		}
 
 		@Override

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.factory;
 
+import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtPackageReference;
@@ -98,17 +99,31 @@ public class PackageFactory extends SubFactory implements Serializable {
 	}
 
 	/**
-	 * Gets or creates a package.
+	 * Gets or creates a package for the unnamed module
 	 *
 	 * @param qualifiedName
 	 * 		the full name of the package
+	 *
 	 */
 	public CtPackage getOrCreate(String qualifiedName) {
+		return this.getOrCreate(qualifiedName, factory.getModel().getUnnamedModule());
+	}
+
+	/**
+	 * Gets or creates a package and make its parent the given module
+	 *
+	 * @param qualifiedName
+	 * 		the full name of the package
+	 *
+	 * @param rootModule
+	 * 		The parent module of the package
+	 */
+	public CtPackage getOrCreate(String qualifiedName, CtModule rootModule) {
 		if (qualifiedName.isEmpty()) {
-			return factory.getModel().getRootPackage();
+			return rootModule.getRootPackage();
 		}
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage last = factory.getModel().getRootPackage();
+		CtPackage last = rootModule.getRootPackage();
 
 		while (token.hasMoreElements()) {
 			String name = token.nextToken();

--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -65,7 +65,7 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 				String fName = f.isActualFile() ? f.getPath() : f.getName();
 				inputStream = f.getContent();
 				char[] content = IOUtils.toCharArray(inputStream, jdtCompiler.getEnvironment().getEncoding());
-				cuList.add(new CompilationUnit(content, fName, null));
+				cuList.add(new CompilationUnit(content, fName, jdtCompiler.getEnvironment().getEncoding().displayName()));
 				IOUtils.closeQuietly(inputStream);
 			}
 		} catch (Exception e) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -737,7 +737,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		ModuleBinding enclosingModule = scope.fPackage.enclosingModule;
 
 		CtModule module;
-		if (enclosingModule.shortReadableName() != null && enclosingModule.shortReadableName().length > 0) {
+		if (!enclosingModule.isUnnamed() && enclosingModule.shortReadableName() != null && enclosingModule.shortReadableName().length > 0) {
 			module = getFactory().Module().getOrCreate(String.valueOf(enclosingModule.shortReadableName()));
 		} else {
 			module = getFactory().Module().getUnnamedModule();
@@ -1573,7 +1573,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			return true;
 		} else {
 			CtModule module;
-			if (typeDeclaration.binding.module != null && typeDeclaration.binding.module.shortReadableName() != null && typeDeclaration.binding.module.shortReadableName().length > 0) {
+			if (typeDeclaration.binding.module != null && !typeDeclaration.binding.module.isUnnamed() && typeDeclaration.binding.module.shortReadableName() != null && typeDeclaration.binding.module.shortReadableName().length > 0) {
 				module = factory.Module().getOrCreate(String.valueOf(typeDeclaration.binding.module.shortReadableName()));
 			} else {
 				module = factory.Module().getUnnamedModule();

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -110,6 +110,7 @@ import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
+import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
@@ -733,7 +734,16 @@ public class JDTTreeBuilder extends ASTVisitor {
 	public boolean visit(CompilationUnitDeclaration compilationUnitDeclaration, CompilationUnitScope scope) {
 		context.compilationunitdeclaration = scope.referenceContext;
 		context.compilationUnitSpoon = getFactory().CompilationUnit().getOrCreate(new String(context.compilationunitdeclaration.getFileName()));
-		context.compilationUnitSpoon.setDeclaredPackage(getFactory().Package().getOrCreate(CharOperation.toString(scope.currentPackageName)));
+		ModuleBinding enclosingModule = scope.fPackage.enclosingModule;
+
+		CtModule module;
+		if (enclosingModule.shortReadableName() != null && enclosingModule.shortReadableName().length > 0) {
+			module = getFactory().Module().getOrCreate(String.valueOf(enclosingModule.shortReadableName()));
+		} else {
+			module = getFactory().Module().getUnnamedModule();
+		}
+
+		context.compilationUnitSpoon.setDeclaredPackage(getFactory().Package().getOrCreate(CharOperation.toString(scope.currentPackageName), module));
 		return true;
 	}
 
@@ -1562,11 +1572,18 @@ public class JDTTreeBuilder extends ASTVisitor {
 			context.enter(factory.Package().getOrCreate(new String(typeDeclaration.binding.fPackage.readableName())), typeDeclaration);
 			return true;
 		} else {
+			CtModule module;
+			if (typeDeclaration.binding.module != null && typeDeclaration.binding.module.shortReadableName() != null && typeDeclaration.binding.module.shortReadableName().length > 0) {
+				module = factory.Module().getOrCreate(String.valueOf(typeDeclaration.binding.module.shortReadableName()));
+			} else {
+				module = factory.Module().getUnnamedModule();
+			}
+
 			CtPackage pack;
 			if (typeDeclaration.binding.fPackage.shortReadableName() != null && typeDeclaration.binding.fPackage.shortReadableName().length > 0) {
-				pack = factory.Package().getOrCreate(new String(typeDeclaration.binding.fPackage.shortReadableName()));
+				pack = factory.Package().getOrCreate(new String(typeDeclaration.binding.fPackage.shortReadableName()), module);
 			} else {
-				pack = factory.Package().getRootPackage();
+				pack = module.getRootPackage();
 			}
 			context.enter(pack, typeDeclaration);
 			pack.addType(helper.createType(typeDeclaration));

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.CompilationProgress;
-import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.ICompilerRequestor;
 import org.eclipse.jdt.internal.compiler.IErrorHandlingPolicy;
 import org.eclipse.jdt.internal.compiler.IProblemFactory;
@@ -32,9 +31,6 @@ import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
-import org.eclipse.jdt.internal.compiler.util.HashtableOfObject;
-import org.eclipse.jdt.internal.compiler.util.Messages;
-import org.eclipse.jdt.internal.core.util.BindingKeyResolver;
 
 class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 
@@ -51,8 +47,9 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 			char[] fn2 = u2.getFileName();
 			boolean isMod1 = CharOperation.endsWith(fn1, TypeConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn1, TypeConstants.MODULE_INFO_CLASS_NAME);
 			boolean isMod2 = CharOperation.endsWith(fn2, TypeConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn2, TypeConstants.MODULE_INFO_CLASS_NAME);
-			if (isMod1 == isMod2)
+			if (isMod1 == isMod2) {
 				return 0;
+			}
 			return isMod1 ? -1 : 1;
 		});
 	}

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -263,7 +263,7 @@ public class TestModule {
 
 	@Ignore
 	@Test
-	public void testSimpleModuleCanBeBuiltAndCompiled() {
+	public void testSimpleModuleCanBeBuilt() {
 		// contract: Spoon is able to build and compile a model with a module
 
 		final Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -261,15 +261,12 @@ public class TestModule {
 		assertSame(module, moduleNewName);
 	}
 
-	@Ignore
 	@Test
 	public void testSimpleModuleCanBeBuilt() {
-		// contract: Spoon is able to build and compile a model with a module
+		// contract: Spoon is able to build a simple model with a module in full classpath
 
 		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setShouldCompile(true);
 		launcher.getEnvironment().setComplianceLevel(9);
-		//launcher.addModulePath("./src/test/resources/spoon/test/module/simple_module_with_code");
 		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
 		launcher.run();
 
@@ -284,8 +281,6 @@ public class TestModule {
 
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setComplianceLevel(9);
-		//launcher.addModulePath("./src/test/resources/spoon/test/module/code-multiple-modules/foo");
-		//launcher.addModulePath("./src/test/resources/spoon/test/module/code-multiple-modules/bar");
 		launcher.addInputResource(MODULE_RESOURCES_PATH+"/code-multiple-modules");
 		launcher.run();
 

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -282,6 +282,7 @@ public class TestModule {
 		// contract: Spoon is able to build a simple model with a module in full classpath
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.getEnvironment().setNoClasspath(false);
 		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
 		launcher.run();
 

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -7,7 +7,9 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtComment;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtModuleDirective;
 import spoon.reflect.declaration.CtPackage;
@@ -17,6 +19,7 @@ import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.reference.CtModuleReference;
+import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.io.File;
 import java.io.IOException;
@@ -281,8 +284,19 @@ public class TestModule {
 		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
 		launcher.run();
 
-		assertEquals(2, launcher.getModel().getAllModules().size());
-		assertEquals(1, launcher.getModel().getAllTypes().size());
+		CtModel model = launcher.getModel();
+
+		// unnamed module and module 'simple_module_with_code'
+		assertEquals(2, model.getAllModules().size());
+		assertEquals(1, model.getAllTypes().size());
+
+		CtClass simpleClass = model.getElements(new TypeFilter<>(CtClass.class)).get(0);
+		assertEquals("SimpleClass", simpleClass.getSimpleName());
+
+		CtModule module = simpleClass.getParent(CtModule.class);
+		assertNotNull(module);
+
+		assertEquals("simple_module_with_code", module.getSimpleName());
 	}
 
 	@Ignore

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -1,6 +1,8 @@
 package spoon.test.module;
 
 import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -31,6 +33,15 @@ import static org.junit.Assert.fail;
 
 public class TestModule {
 	private static final String MODULE_RESOURCES_PATH = "./src/test/resources/spoon/test/module";
+
+	private void checkJavaVersion() {
+		String property = System.getProperty("java.version");
+		if (property != null && !property.isEmpty()) {
+
+			// java 8 and less are versionning "1.X" where 9 and more are directly versioned "X"
+			Assume.assumeFalse(property.startsWith("1."));
+		}
+	}
 
 	@BeforeClass
 	public static void setUp() throws IOException {
@@ -263,8 +274,8 @@ public class TestModule {
 
 	@Test
 	public void testSimpleModuleCanBeBuilt() {
+		checkJavaVersion();
 		// contract: Spoon is able to build a simple model with a module in full classpath
-
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setComplianceLevel(9);
 		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -19,6 +19,7 @@ import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.reference.CtModuleReference;
+import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
 import java.io.File;
@@ -293,10 +294,13 @@ public class TestModule {
 		CtClass simpleClass = model.getElements(new TypeFilter<>(CtClass.class)).get(0);
 		assertEquals("SimpleClass", simpleClass.getSimpleName());
 
+		CtModule simpleModule = model.getElements(new NamedElementFilter<>(CtModule.class, "simple_module_with_code")).get(0);
+		assertNotNull(simpleModule);
+		assertEquals("simple_module_with_code", simpleModule.getSimpleName());
+
 		CtModule module = simpleClass.getParent(CtModule.class);
 		assertNotNull(module);
-
-		assertEquals("simple_module_with_code", module.getSimpleName());
+		assertSame(simpleModule, module);
 	}
 
 	@Ignore


### PR DESCRIPTION
Fix #1769 

This PR changes the internal mechanism of `JDTBatchCompiler` to process CU in order to attach the information of modules.
The process might be encapsulated in a condition to check if we are using Java 9 or more, but I want first to check that everything works with it. 

And kudos @abourdon for the valuable co-debugging with me on this one! 👏 