### PR TITLE
fix(pattern): improve Pattern parameters of CtTypeReference

### DIFF
--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -419,14 +419,14 @@ public class PatternBuilder {
 		return this;
 	}
 
-	static CtTypeReference<?> getLocalTypeRefBySimpleName(CtType<?> templateType, String typeSimpleName) {
+	static String getLocalTypeRefBySimpleName(CtType<?> templateType, String typeSimpleName) {
 		CtType<?> type = templateType.getNestedType(typeSimpleName);
 		if (type != null) {
-			return type.getReference();
+			return type.getQualifiedName();
 		}
 		type = templateType.getPackage().getType(typeSimpleName);
 		if (type != null) {
-			return type.getReference();
+			return type.getQualifiedName();
 		}
 		Set<String> typeQNames = new HashSet<>();
 		templateType
@@ -436,7 +436,7 @@ public class PatternBuilder {
 			throw new SpoonException("The type parameter " + typeSimpleName + " is ambiguous. It matches multiple types: " + typeQNames);
 		}
 		if (typeQNames.size() == 1) {
-			return templateType.getFactory().Type().createReference(typeQNames.iterator().next());
+			return typeQNames.iterator().next();
 		}
 		return null;
 	}

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -513,11 +513,10 @@ public class PatternParameterConfigurator {
 			parameterValues.forEach((paramName, paramValue) -> {
 				if (isSubstituted(paramName) == false) {
 					//and only these parameters whose name isn't already handled by explicit template parameters
-					if (paramValue instanceof CtTypeReference<?>) {
-						parameter(paramName)
-							.setConflictResolutionMode(ConflictResolutionMode.KEEP_OLD_NODE)
-							.byLocalType(templateType, paramName, true);
-					}
+					//replace types whose name fits to name of parameter
+					parameter(paramName)
+						.setConflictResolutionMode(ConflictResolutionMode.KEEP_OLD_NODE)
+						.byLocalType(templateType, paramName, true);
 					parameter(paramName)
 						.setConflictResolutionMode(ConflictResolutionMode.KEEP_OLD_NODE)
 						.bySubstring(paramName);

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -185,21 +185,37 @@ public class PatternParameterConfigurator {
 		return byType(type.getName());
 	}
 	/**
-	 * type identified by `typeQualifiedName` itself and all the references to that type are subject for substitution by current parameter
+	 * type identified by `typeQualifiedName` itself and all the references (with arbitrary actual type arguments)
+	 * to that type are subject for substitution by current parameter
 	 * @param typeQualifiedName a fully qualified name of to be substituted Class
 	 * @return {@link PatternParameterConfigurator} to support fluent API
 	 */
 	public PatternParameterConfigurator byType(String typeQualifiedName) {
-		return byType(patternBuilder.getFactory().Type().createReference(typeQualifiedName));
+		ParameterInfo pi = getCurrentParameter();
+		//substitute all references with same qualified name (ignoring actual type arguments) to that type
+		queryModel().filterChildren((CtTypeReference<?> typeRef) -> typeRef.getQualifiedName().equals(typeQualifiedName))
+			.forEach((CtTypeReference<?> typeRef) -> {
+				addSubstitutionRequest(pi, typeRef);
+			});
+		/**
+		 * If Type itself is found part of model, then substitute it's simple name too
+		 */
+		CtType<?> type2 = queryModel().filterChildren((CtType<?> t) -> t.getQualifiedName().equals(typeQualifiedName)).first();
+		if (type2 != null) {
+			//Substitute name of template too
+			addSubstitutionRequest(pi, type2, CtRole.NAME);
+		}
+		return this;
 	}
 	/**
-	 * type referred by {@link CtTypeReference} `type` and all the references to that type are subject for substitution by current parameter
+	 * type referred by {@link CtTypeReference} `type` and all the references (with same actual type arguments)
+	 * to that type are subject for substitution by current parameter
 	 * @param type a fully qualified name of to be substituted Class
 	 * @return {@link PatternParameterConfigurator} to support fluent API
 	 */
 	public PatternParameterConfigurator byType(CtTypeReference<?> type) {
 		ParameterInfo pi = getCurrentParameter();
-		//substitute all references to that type
+		//substitute all references (with same actual type arguments too) to that type
 		queryModel().filterChildren((CtTypeReference<?> typeRef) -> typeRef.equals(type))
 			.forEach((CtTypeReference<?> typeRef) -> {
 				addSubstitutionRequest(pi, typeRef);
@@ -227,7 +243,7 @@ public class PatternParameterConfigurator {
 		return this;
 	}
 	PatternParameterConfigurator byLocalType(CtType<?> searchScope, String localTypeSimpleName, boolean optional) {
-		CtTypeReference<?> nestedType = getLocalTypeRefBySimpleName(searchScope, localTypeSimpleName);
+		String nestedType = getLocalTypeRefBySimpleName(searchScope, localTypeSimpleName);
 		if (nestedType == null) {
 			//such type doesn't exist
 			if (optional) {
@@ -398,7 +414,7 @@ public class PatternParameterConfigurator {
 					/*
 					 * parameter with value type TypeReference or Class, identifies replacement of local type whose name is equal to parameter name
 					 */
-					CtTypeReference<?> nestedType = getLocalTypeRefBySimpleName(templateType, stringMarker);
+					String nestedType = getLocalTypeRefBySimpleName(templateType, stringMarker);
 					if (nestedType != null) {
 						//all references to nestedType has to be replaced
 						parameter(parameterName).byType(nestedType);
@@ -406,7 +422,7 @@ public class PatternParameterConfigurator {
 					//and replace the variable references by class access
 					parameter(parameterName).byVariable(paramField);
 				} else if (paramType.getQualifiedName().equals(String.class.getName())) {
-					CtTypeReference<?> nestedType = getLocalTypeRefBySimpleName(templateType, stringMarker);
+					String nestedType = getLocalTypeRefBySimpleName(templateType, stringMarker);
 					if (nestedType != null) {
 						//There is a local type with such name. Replace it
 						parameter(parameterName).byType(nestedType);

--- a/src/test/java/spoon/generating/RoleHandlersGenerator.java
+++ b/src/test/java/spoon/generating/RoleHandlersGenerator.java
@@ -107,9 +107,15 @@ public class RoleHandlersGenerator extends AbstractManualProcessor {
 			params.put("ROLE", rim.getRole().name());
 			params.put("$TargetType$", rim.getOwner().getMetamodelInterface().getReference());
 //			params.put("AbstractHandler", getFactory().Type().createReference("spoon.reflect.meta.impl.AbstractRoleHandler"));
-			params.put("AbstractHandler", getRoleHandlerSuperTypeQName(rim));
-			params.put("Node", rim.getOwner().getMetamodelInterface().getReference());
-			params.put("ValueType", fixMainValueType(getRoleHandlerSuperTypeQName(rim).endsWith("SingleHandler") ? rim.getTypeOfField() : rim.getTypeofItems()));
+//			params.put("AbstractHandler", getRoleHandlerSuperTypeQName(rim));
+			CtTypeReference<?> nodeRef = rim.getOwner().getMetamodelInterface().getReference();
+			CtTypeReference<?> valueTypeRef = fixMainValueType(getRoleHandlerSuperTypeQName(rim).endsWith("SingleHandler") ? rim.getTypeOfField() : rim.getTypeofItems());
+			CtTypeReference<?> handlerSuperClassRef = getFactory().Type().createReference(getRoleHandlerSuperTypeQName(rim));
+			handlerSuperClassRef.addActualTypeArgument(nodeRef);
+			handlerSuperClassRef.addActualTypeArgument(valueTypeRef);
+			params.put("AbstractHandler", handlerSuperClassRef);
+			params.put("Node", nodeRef);
+			params.put("ValueType", valueTypeRef);
 			CtClass<?> modelRoleHandlerClass = Substitution.createTypeFromTemplate(
 					getHandlerName(rim),
 					getTemplate("spoon.generating.meta.RoleHandlerTemplate"),


### PR DESCRIPTION
It is temporary/dirty solution for #2076 until the discussion in #2077 brings some concept.

`PatternParameterConfiguration#byType(String)` now marks as Pattern parameters all CtTypeReferences with same qualified name (ignoring actual type arguments) - before it marked only CtTypeReferences without actual type arguments.

The change in RoleHandlersGenerator was needed too. 