### PR TITLE
review fix(comment): Creating an inline comment with line separators throws an exception

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.factory;
 
+import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
@@ -676,10 +677,6 @@ public class CodeFactory extends SubFactory {
 		if (type == CtComment.CommentType.JAVADOC) {
 			return factory.Core().createJavaDoc().setContent(content);
 		}
-
-		if (content.contains(System.lineSeparator())) {
-			type = CtComment.CommentType.BLOCK;
-		}
 		return factory.Core().createComment().setContent(content).setCommentType(type);
 	}
 
@@ -690,6 +687,10 @@ public class CodeFactory extends SubFactory {
 	 * @return a new CtComment
 	 */
 	public CtComment createInlineComment(String content) {
+		if (content.contains(CtComment.LINE_SEPARATOR)) {
+			throw new SpoonException("The content of your comment contain at least one line separator. "
+					+ "Please consider using a block comment by calling createComment(\"your content\", CtComment.CommentType.BLOCK).");
+		}
 		return createComment(content, CtComment.CommentType.INLINE);
 	}
 

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -676,6 +676,10 @@ public class CodeFactory extends SubFactory {
 		if (type == CtComment.CommentType.JAVADOC) {
 			return factory.Core().createJavaDoc().setContent(content);
 		}
+
+		if (content.contains(System.lineSeparator())) {
+			type = CtComment.CommentType.BLOCK;
+		}
 		return factory.Core().createComment().setContent(content).setCommentType(type);
 	}
 

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
@@ -37,6 +38,7 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.JavaOutputProcessor;
@@ -905,5 +907,23 @@ public class CommentTest {
 			String expected = literal.getValue();
 			assertEquals(literal.getPosition().toString(), expected, comment.getContent());
 		}
+	}
+
+	@Test
+	public void testInlineCommentIfBlock() {
+		// contract: when creating an inline comment from a string with line separators, it creates a block comment
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/comment/testclasses/WithIfBlock.java");
+		launcher.getEnvironment().setCommentEnabled(true);
+
+		CtModel model = launcher.buildModel();
+
+		List<CtIf> ctIfs = model.getElements(new TypeFilter<>(CtIf.class));
+
+		assertEquals(1, ctIfs.size());
+		CtIf ctIf = ctIfs.get(0);
+		CtComment ctComment = launcher.getFactory().createInlineComment(ctIf.toString());
+
+		assertEquals(CtComment.CommentType.BLOCK, ctComment.getCommentType());
 	}
 }

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -4,6 +4,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.SpoonException;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtComment;
@@ -911,7 +912,7 @@ public class CommentTest {
 
 	@Test
 	public void testInlineCommentIfBlock() {
-		// contract: when creating an inline comment from a string with line separators, it creates a block comment
+		// contract: when creating an inline comment from a string with line separators, it throws an exception to create block comment
 		Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/comment/testclasses/WithIfBlock.java");
 		launcher.getEnvironment().setCommentEnabled(true);
@@ -922,8 +923,11 @@ public class CommentTest {
 
 		assertEquals(1, ctIfs.size());
 		CtIf ctIf = ctIfs.get(0);
-		CtComment ctComment = launcher.getFactory().createInlineComment(ctIf.toString());
-
-		assertEquals(CtComment.CommentType.BLOCK, ctComment.getCommentType());
+		try {
+			CtComment ctComment = launcher.getFactory().createInlineComment(ctIf.toString());
+			fail("Exception should have been thrown");
+		} catch (SpoonException e) {
+			assertTrue(e.getMessage().contains("consider using a block comment"));
+		}
 	}
 }

--- a/src/test/java/spoon/test/comment/testclasses/WithIfBlock.java
+++ b/src/test/java/spoon/test/comment/testclasses/WithIfBlock.java
@@ -1,0 +1,14 @@
+package spoon.test.comment.testclasses;
+
+public class WithIfBlock {
+
+    String value = "";
+
+    public String myMethod() {
+        if (value == null) {
+            value = new String("toto");
+        }
+
+        return value.substring(1);
+    }
+}


### PR DESCRIPTION
This PR is a proposal for the following problem: when trying to comment all statements of a method, I created an inline comment for a CtIf, and it produces an uncompilable source code, before it only added a `//` before the content.

I propose that we detect automatically the presence of new lines in the content of a comment when trying to create it and to apply an action. 
Here my proposed action is to change the comment type to create a block comment.

Another possibility is to throw an exception in that kind of case. WDYT?