### PR TITLE
fix(test): CtGenerationTest#testGenerateRoleHandler egg/chicken problem

### DIFF
--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -209,6 +209,16 @@ public class Metamodel {
 	 */
 	public static Metamodel getInstance() {
 		if (instance == null) {
+			try {
+				//this is needed just for CtGenerationTest#testGenerateRoleHandler
+				//which must not use RoleHandler at time when RoleHandler is generated and Spoon model doesn't fit to old RoleHandlers
+				//to avoid egg/chicken problem
+				if ("true".equals(System.getProperty(MetamodelProperty.class.getName() + "-noRoleHandler"))) {
+					MetamodelProperty.useRuntimeMethodInvocation = true;
+				}
+			} catch (SecurityException e) {
+				//ignore that
+			}
 			instance = new Metamodel();
 		}
 		return instance;

--- a/src/test/java/spoon/processing/CtGenerationTest.java
+++ b/src/test/java/spoon/processing/CtGenerationTest.java
@@ -7,6 +7,7 @@ import spoon.generating.CloneVisitorGenerator;
 import spoon.generating.CtBiScannerGenerator;
 import spoon.generating.ReplacementVisitorGenerator;
 import spoon.generating.RoleHandlersGenerator;
+import spoon.metamodel.MetamodelProperty;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtBiScannerDefault;
@@ -173,7 +174,12 @@ public class CtGenerationTest {
 		launcher.addInputResource("./src/main/java/spoon/reflect/meta/impl/AbstractRoleHandler.java");
 		launcher.addProcessor(new RoleHandlersGenerator());
 		launcher.setOutputFilter(new RegexFilter("\\Q" + RoleHandlersGenerator.TARGET_PACKAGE + ".ModelRoleHandlers\\E.*"));
-		launcher.run();
+		try {
+			System.setProperty(MetamodelProperty.class.getName()+"-noRoleHandler", "true");
+			launcher.run();
+		} finally {
+			System.setProperty(MetamodelProperty.class.getName()+"-noRoleHandler", "false");
+		}
 
 		// cp ./target/generated/spoon/reflect/meta/impl/ModelRoleHandlers.java ./src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java
 		CtClass<Object> actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory()+"/spoon/reflect/meta/impl/ModelRoleHandlers.java")).Class().get("spoon.reflect.meta.impl.ModelRoleHandlers");


### PR DESCRIPTION
Fix of problem reported in #2085 

When the Spoon model is changed, then we have to generate RoleHandlers which fits to such modified Spoon model. But role handlers generator internally uses Pattern which uses Metamodel which uses RoleHandlers - expects that they fit to the model - ... so it fails if RoleHandlers are not fitting... and it is then not possible to generate new RoleHandlers.

Solution -> this PR: In case of generating of RoleHandlers the Metamodel is switched to special mode where RoleHandlers are not used, but it uses slow Java reflection instead to access Spoon model attributes.