### PR TITLE
review test: fix line separators in test

### DIFF
--- a/src/test/java/spoon/processing/CtGenerationTest.java
+++ b/src/test/java/spoon/processing/CtGenerationTest.java
@@ -1,5 +1,7 @@
 package spoon.processing;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
 import spoon.Launcher;
@@ -24,10 +26,23 @@ import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class CtGenerationTest {
+	private String oldLineSeparator;
+
+	@Before
+	public void setup() {
+		this.oldLineSeparator = System.getProperty("line.separator", "\n");
+		//use always LINUX line separator, because generated files are committed to Spoon repository which expects that.
+		System.setProperty("line.separator", "\n");
+	}
+
+	@After
+	public void teardown() {
+		System.setProperty("line.separator", this.oldLineSeparator);
+	}
+
+
 	@Test
 	public void testGenerateReplacementVisitor() throws Exception {
-		//use always LINUX line separator, because generated files are committed to Spoon repository which expects that. 
-		System.setProperty("line.separator", "\n");
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(false);
 		launcher.getEnvironment().setNoClasspath(true);
@@ -70,8 +85,6 @@ public class CtGenerationTest {
 	@Test
 	public void testGenerateCtBiScanner() throws Exception {
 		// contract: generates the biscanner that is used for equality checking
-		//use always LINUX line separator, because generated files are committed to Spoon repository which expects that. 
-		System.setProperty("line.separator", "\n");
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);
@@ -100,8 +113,6 @@ public class CtGenerationTest {
 
 	@Test
 	public void testGenerateCloneVisitor() throws Exception {
-		//use always LINUX line separator, because generated files are committed to Spoon repository which expects that. 
-		System.setProperty("line.separator", "\n");
 		// contract: generates CloneBuilder.java and CloneBuilder.java
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
@@ -150,8 +161,6 @@ public class CtGenerationTest {
 	
 	@Test
 	public void testGenerateRoleHandler() throws Exception {
-		//use always LINUX line separator, because generated files are committed to Spoon repository which expects that. 
-		System.setProperty("line.separator", "\n");
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(true);
 		launcher.getEnvironment().setNoClasspath(true);

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -146,7 +146,6 @@ public class MetamodelTest {
 	@Test
 	public void testRoleOnField() {
 		//  contract: all non-final fields must be annotated with {@link spoon.reflect.annotations.MetamodelPropertyField}
-		System.setProperty("line.separator","\n");
 		SpoonAPI implementations = new Launcher();
 		implementations.addInputResource("src/main/java/spoon/support/reflect");
 		implementations.buildModel();

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -347,8 +347,6 @@ public class ImportTest {
 
 	@Test
 	public void testImportOfInvocationOfPrivateClass() throws Exception {
-		System.setProperty("line.separator", "\n");
-		
 		final Factory factory = getFactory(
 				"./src/test/java/spoon/test/imports/testclasses/internal2/Chimichanga.java",
 				"./src/test/java/spoon/test/imports/testclasses/Mole.java");
@@ -383,8 +381,6 @@ public class ImportTest {
 
 	@Test
 	public void testImportOfInvocationOfStaticMethod() throws Exception {
-		System.setProperty("line.separator", "\n");
-
 		final Factory factory = getFactory(
 				"./src/test/java/spoon/test/imports/testclasses/internal2/Menudo.java",
 				"./src/test/java/spoon/test/imports/testclasses/Pozole.java");

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -1152,83 +1152,83 @@ public class PatternTest {
 	@Test
 	public void testPatternToString() {
 		//contract: Pattern can be printed to String and each parameter is defined there
-		System.setProperty("line.separator", "\n");
+		String nl = System.getProperty("line.separator");
 		Factory f = ModelUtils.build(
 				new File("./src/test/java/spoon/test/template/testclasses/replace/DPPSample1.java"),
 				new File("./src/test/java/spoon/test/template/testclasses/replace")
 			);
 		Pattern p = OldPattern.createPatternFromMethodPatternModel(f);
-		assertEquals("if (/* CtInvocation\n" +
-				"    / <= ${useStartKeyword}\n" +
-				" */\n" +
-				"useStartKeyword()) {\n" +
-				"    /* CtInvocation\n" +
-				"        /argument/ <= ${startKeyword}\n" +
-				"     */\n" +
-				"    /* CtInvocation\n" +
-				"        /target/ <= ${printer}\n" +
-				"     */\n" +
-				"    /* CtInvocation\n" +
-				"        / <= ${printer}\n" +
-				"     */\n" +
-				"    printer().writeSpace().writeKeyword(/* CtInvocation\n" +
-				"        / <= ${startKeyword}\n" +
-				"     */\n" +
-				"    startKeyword()).writeSpace();\n" +
-				"}\n" +
-				"try (final spoon.reflect.visitor.ListPrinter lp = /* CtInvocation\n" +
-				"    /argument/ <= ${end}\n" +
-				"    /target/ <= ${elementPrinterHelper}\n" +
-				" */\n" +
-				"/* CtInvocation\n" +
-				"    / <= ${elementPrinterHelper}\n" +
-				" */\n" +
-				"elementPrinterHelper().createListPrinter(/* CtInvocation\n" +
-				"    / <= ${startPrefixSpace}\n" +
-				" */\n" +
-				"startPrefixSpace(), /* CtInvocation\n" +
-				"    / <= ${start}\n" +
-				" */\n" +
-				"start(), /* CtInvocation\n" +
-				"    / <= ${startSuffixSpace}\n" +
-				" */\n" +
-				"startSuffixSpace(), /* CtInvocation\n" +
-				"    / <= ${nextPrefixSpace}\n" +
-				" */\n" +
-				"nextPrefixSpace(), /* CtInvocation\n" +
-				"    / <= ${next}\n" +
-				" */\n" +
-				"next(), /* CtInvocation\n" +
-				"    / <= ${nextSuffixSpace}\n" +
-				" */\n" +
-				"nextSuffixSpace(), /* CtInvocation\n" +
-				"    / <= ${endPrefixSpace}\n" +
-				" */\n" +
-				"endPrefixSpace(), /* CtInvocation\n" +
-				"    / <= ${end}\n" +
-				" */\n" +
-				"end())) {\n" +
-				"    /* CtForEach\n" +
-				"        /expression/ <= ${getIterable}\n" +
-				"        /foreachVariable/ <= ${item}\n" +
-				"     */\n" +
-				"    for (/* CtLocalVariable\n" +
-				"        / <= ${item}\n" +
-				"     */\n" +
-				"    java.lang.Object item : /* CtInvocation\n" +
-				"        / <= ${getIterable}\n" +
-				"     */\n" +
-				"    getIterable()) /* CtBlock\n" +
-				"        /statement/ <= ${statements}\n" +
-				"     */\n" +
-				"    {\n" +
-				"        lp.printSeparatorIfAppropriate();\n" +
-				"        /* CtInvocation\n" +
-				"            / <= ${statements}\n" +
-				"         */\n" +
-				"        statements();\n" +
-				"    }\n" +
-				"}\n", p.toString());
+		assertEquals("if (/* CtInvocation"+nl+"" +
+				"    / <= ${useStartKeyword}"+nl+"" +
+				" */"+nl+"" +
+				"useStartKeyword()) {"+nl+"" +
+				"    /* CtInvocation"+nl+"" +
+				"        /argument/ <= ${startKeyword}"+nl+"" +
+				"     */"+nl+"" +
+				"    /* CtInvocation"+nl+"" +
+				"        /target/ <= ${printer}"+nl+"" +
+				"     */"+nl+"" +
+				"    /* CtInvocation"+nl+"" +
+				"        / <= ${printer}"+nl+"" +
+				"     */"+nl+"" +
+				"    printer().writeSpace().writeKeyword(/* CtInvocation"+nl+"" +
+				"        / <= ${startKeyword}"+nl+"" +
+				"     */"+nl+"" +
+				"    startKeyword()).writeSpace();"+nl+"" +
+				"}"+nl+"" +
+				"try (final spoon.reflect.visitor.ListPrinter lp = /* CtInvocation"+nl+"" +
+				"    /argument/ <= ${end}"+nl+"" +
+				"    /target/ <= ${elementPrinterHelper}"+nl+"" +
+				" */"+nl+"" +
+				"/* CtInvocation"+nl+"" +
+				"    / <= ${elementPrinterHelper}"+nl+"" +
+				" */"+nl+"" +
+				"elementPrinterHelper().createListPrinter(/* CtInvocation"+nl+"" +
+				"    / <= ${startPrefixSpace}"+nl+"" +
+				" */"+nl+"" +
+				"startPrefixSpace(), /* CtInvocation"+nl+"" +
+				"    / <= ${start}"+nl+"" +
+				" */"+nl+"" +
+				"start(), /* CtInvocation"+nl+"" +
+				"    / <= ${startSuffixSpace}"+nl+"" +
+				" */"+nl+"" +
+				"startSuffixSpace(), /* CtInvocation"+nl+"" +
+				"    / <= ${nextPrefixSpace}"+nl+"" +
+				" */"+nl+"" +
+				"nextPrefixSpace(), /* CtInvocation"+nl+"" +
+				"    / <= ${next}"+nl+"" +
+				" */"+nl+"" +
+				"next(), /* CtInvocation"+nl+"" +
+				"    / <= ${nextSuffixSpace}"+nl+"" +
+				" */"+nl+"" +
+				"nextSuffixSpace(), /* CtInvocation"+nl+"" +
+				"    / <= ${endPrefixSpace}"+nl+"" +
+				" */"+nl+"" +
+				"endPrefixSpace(), /* CtInvocation"+nl+"" +
+				"    / <= ${end}"+nl+"" +
+				" */"+nl+"" +
+				"end())) {"+nl+"" +
+				"    /* CtForEach"+nl+"" +
+				"        /expression/ <= ${getIterable}"+nl+"" +
+				"        /foreachVariable/ <= ${item}"+nl+"" +
+				"     */"+nl+"" +
+				"    for (/* CtLocalVariable"+nl+"" +
+				"        / <= ${item}"+nl+"" +
+				"     */"+nl+"" +
+				"    java.lang.Object item : /* CtInvocation"+nl+"" +
+				"        / <= ${getIterable}"+nl+"" +
+				"     */"+nl+"" +
+				"    getIterable()) /* CtBlock"+nl+"" +
+				"        /statement/ <= ${statements}"+nl+"" +
+				"     */"+nl+"" +
+				"    {"+nl+"" +
+				"        lp.printSeparatorIfAppropriate();"+nl+"" +
+				"        /* CtInvocation"+nl+"" +
+				"            / <= ${statements}"+nl+"" +
+				"         */"+nl+"" +
+				"        statements();"+nl+"" +
+				"    }"+nl+"" +
+				"}"+nl+"", p.toString());
 	}
 
 	@Test


### PR DESCRIPTION
This PR is a first one in order to fix test on windows: when we set `line.separator` we need to reset it to its old value afterwards.

This alone won't fix all tests on windows: we also need to remove all `\n` usage and to use systematically `System.getProperty("line.separator");`. This will be done in another PR.