### PR TITLE
review refactor: Deprecate import method from DJPP

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -310,7 +310,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
      *
      * @deprecated We intend to remove those method from the DJPP and to compute imports directly in CompilationUnit in the future.
 	 */
-    @Deprecated
+	@Deprecated
 	public void computeImports(CtElement element) {
 		if (env.isAutoImports()) {
 			importsContext.computeImports(element);

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -120,6 +120,7 @@ import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.PrintingContext.Writable;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 import spoon.reflect.visitor.printer.CommentOffset;
+import spoon.support.Experimental;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -295,7 +296,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	/**
 	 * Make the imports for a given type.
+     *
+     * @deprecated We intend to remove those method from the DJPP and to compute imports directly in CompilationUnit in the future.
 	 */
+	@Deprecated
 	public Collection<CtImport> computeImports(CtType<?> type) {
 		context.currentTopLevel = type;
 		importsContext.computeImports(context.currentTopLevel);
@@ -304,7 +308,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	/**
 	 * Make the imports for all elements.
+     *
+     * @deprecated We intend to remove those method from the DJPP and to compute imports directly in CompilationUnit in the future.
 	 */
+    @Deprecated
 	public void computeImports(CtElement element) {
 		if (env.isAutoImports()) {
 			importsContext.computeImports(element);

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -120,7 +120,6 @@ import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.PrintingContext.Writable;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 import spoon.reflect.visitor.printer.CommentOffset;
-import spoon.support.Experimental;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;


### PR DESCRIPTION
This PR only intends to prepare the field for #2100 
I really want to remove the import state from the DJPP and to put it in CompilationUnit, it certainly won't be properly done for release 7, so I want at least to inform that the imports method of DJPP will be removed soon. 