### PR TITLE
refactor: import of CtRole

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -20,7 +20,6 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.support.DerivedProperty;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
-import spoon.reflect.path.CtRole;
 
 import java.util.Set;
 
@@ -95,13 +94,13 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 *
 	 * @return the found type or null
 	 */
-	@PropertyGetter(role = CtRole.CONTAINED_TYPE)
+	@PropertyGetter(role = CONTAINED_TYPE)
 	<T extends CtType<?>> T getType(String simpleName);
 
 	/**
 	 * Returns the set of the top-level types in this package.
 	 */
-	@PropertyGetter(role = CtRole.CONTAINED_TYPE)
+	@PropertyGetter(role = CONTAINED_TYPE)
 	Set<CtType<?>> getTypes();
 
 	/**

--- a/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
@@ -19,14 +19,13 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 
 public abstract class CtArrayAccessImpl<T, V extends CtExpression<?>> extends CtTargetedExpressionImpl<T, V> implements CtArrayAccess<T, V> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	private CtExpression<Integer> expression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtAssert;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.CONDITION;
@@ -28,10 +27,10 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.CONDITION)
+	@MetamodelPropertyField(role = CONDITION)
 	CtExpression<Boolean> asserted;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<T> value;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtRHSReceiver;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
@@ -38,16 +37,16 @@ import static spoon.reflect.path.CtRole.TYPE;
 public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements CtAssignment<T, A> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.ASSIGNED)
+	@MetamodelPropertyField(role = ASSIGNED)
 	CtExpression<T> assigned;
 
-	@MetamodelPropertyField(role = CtRole.ASSIGNMENT)
+	@MetamodelPropertyField(role = ASSIGNMENT)
 	CtExpression<A> assignment;
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	CtTypeReference<T> type;
 
-	@MetamodelPropertyField(role = CtRole.CAST)
+	@MetamodelPropertyField(role = CAST)
 	List<CtTypeReference<?>> typeCasts = emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.LEFT_OPERAND;
@@ -30,13 +29,13 @@ import static spoon.reflect.path.CtRole.RIGHT_OPERAND;
 public class CtBinaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtBinaryOperator<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.OPERATOR_KIND)
+	@MetamodelPropertyField(role = OPERATOR_KIND)
 	BinaryOperatorKind kind;
 
-	@MetamodelPropertyField(role = CtRole.LEFT_OPERAND)
+	@MetamodelPropertyField(role = LEFT_OPERAND)
 	CtExpression<?> leftHandOperand;
 
-	@MetamodelPropertyField(role = CtRole.RIGHT_OPERAND)
+	@MetamodelPropertyField(role = RIGHT_OPERAND)
 	CtExpression<?> rightHandOperand;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.ParentFunction;
 
@@ -32,7 +31,7 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
 public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TARGET_LABEL)
+	@MetamodelPropertyField(role = TARGET_LABEL)
 	String targetLabel;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.BODY;
@@ -31,10 +30,10 @@ import static spoon.reflect.path.CtRole.PARAMETER;
 public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.BODY)
+	@MetamodelPropertyField(role = BODY)
 	CtBlock<?> body;
 
-	@MetamodelPropertyField(role = CtRole.PARAMETER)
+	@MetamodelPropertyField(role = PARAMETER)
 	CtCatchVariable<? extends Throwable> parameter;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.CONDITION;
@@ -29,13 +28,13 @@ import static spoon.reflect.path.CtRole.THEN;
 public class CtConditionalImpl<T> extends CtExpressionImpl<T> implements CtConditional<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.ELSE)
+	@MetamodelPropertyField(role = ELSE)
 	CtExpression<T> elseExpression;
 
-	@MetamodelPropertyField(role = CtRole.CONDITION)
+	@MetamodelPropertyField(role = CONDITION)
 	CtExpression<Boolean> condition;
 
-	@MetamodelPropertyField(role = CtRole.THEN)
+	@MetamodelPropertyField(role = THEN)
 	CtExpression<T> thenExpression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -23,7 +23,6 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -42,11 +41,11 @@ import static spoon.reflect.path.CtRole.LABEL;
 public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtConstructorCall<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.ARGUMENT)
+	@MetamodelPropertyField(role = ARGUMENT)
 	List<CtExpression<?>> arguments = emptyList();
-	@MetamodelPropertyField(role = CtRole.EXECUTABLE_REF)
+	@MetamodelPropertyField(role = EXECUTABLE_REF)
 	CtExecutableReference<T> executable;
-	@MetamodelPropertyField(role = CtRole.LABEL)
+	@MetamodelPropertyField(role = LABEL)
 	String label;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.CtContinue;
 import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.ParentFunction;
 
@@ -32,7 +31,7 @@ import static spoon.reflect.path.CtRole.TARGET_LABEL;
 public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TARGET_LABEL)
+	@MetamodelPropertyField(role = TARGET_LABEL)
 	String targetLabel;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtDoImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtDoImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtDo;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
@@ -27,7 +26,7 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtDoImpl extends CtLoopImpl implements CtDo {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<Boolean> expression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
@@ -19,14 +19,13 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
 
 public class CtExecutableReferenceExpressionImpl<T, E extends CtExpression<?>> extends CtTargetedExpressionImpl<T, E> implements CtExecutableReferenceExpression<T, E> {
-	@MetamodelPropertyField(role = CtRole.EXECUTABLE_REF)
+	@MetamodelPropertyField(role = EXECUTABLE_REF)
 	CtExecutableReference<T> executable;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -33,10 +32,10 @@ import static spoon.reflect.path.CtRole.TYPE;
 public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements CtExpression<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	CtTypeReference<T> type;
 
-	@MetamodelPropertyField(role = CtRole.CAST)
+	@MetamodelPropertyField(role = CAST)
 	List<CtTypeReference<?>> typeCasts = emptyList();
 
 	public CtTypeReference<T> getType() {

--- a/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtTargetedExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtFieldReference;
 
 import static spoon.reflect.path.CtRole.TARGET;
@@ -28,7 +27,7 @@ import static spoon.reflect.path.CtRole.TARGET;
 public abstract class CtFieldAccessImpl<T> extends CtVariableAccessImpl<T> implements CtFieldAccess<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TARGET)
+	@MetamodelPropertyField(role = TARGET)
 	CtExpression<?> target;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
@@ -29,7 +28,7 @@ import static spoon.reflect.path.CtRole.FOREACH_VARIABLE;
 public class CtForEachImpl extends CtLoopImpl implements CtForEach {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<?> expression;
 
 	@MetamodelPropertyField(role = FOREACH_VARIABLE)

--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -36,13 +35,13 @@ import static spoon.reflect.path.CtRole.FOR_UPDATE;
 public class CtForImpl extends CtLoopImpl implements CtFor {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<Boolean> expression;
 
-	@MetamodelPropertyField(role = CtRole.FOR_INIT)
+	@MetamodelPropertyField(role = FOR_INIT)
 	List<CtStatement> forInit = emptyList();
 
-	@MetamodelPropertyField(role = CtRole.FOR_UPDATE)
+	@MetamodelPropertyField(role = FOR_UPDATE)
 	List<CtStatement> forUpdate = emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtIfImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtIfImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.CONDITION;
@@ -32,13 +31,13 @@ import static spoon.reflect.path.CtRole.THEN;
 public class CtIfImpl extends CtStatementImpl implements CtIf {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.CONDITION)
+	@MetamodelPropertyField(role = CONDITION)
 	CtExpression<Boolean> condition;
 
-	@MetamodelPropertyField(role = CtRole.ELSE)
+	@MetamodelPropertyField(role = ELSE)
 	CtStatement elseStatement;
 
-	@MetamodelPropertyField(role = CtRole.THEN)
+	@MetamodelPropertyField(role = THEN)
 	CtStatement thenStatement;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -23,7 +23,6 @@ import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -42,13 +41,13 @@ import static spoon.reflect.path.CtRole.LABEL;
 public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtInvocation<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.LABEL)
+	@MetamodelPropertyField(role = LABEL)
 	String label;
 
-	@MetamodelPropertyField(role = CtRole.ARGUMENT)
+	@MetamodelPropertyField(role = ARGUMENT)
 	List<CtExpression<?>> arguments = emptyList();
 
-	@MetamodelPropertyField(role = CtRole.EXECUTABLE_REF)
+	@MetamodelPropertyField(role = EXECUTABLE_REF)
 	CtExecutableReference<T> executable;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -29,7 +29,6 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -50,13 +49,13 @@ import static spoon.reflect.path.CtRole.PARAMETER;
 import static spoon.reflect.path.CtRole.THROWN;
 
 public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> {
-	@MetamodelPropertyField(role = CtRole.NAME)
+	@MetamodelPropertyField(role = NAME)
 	String simpleName = "";
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<T> expression;
-	@MetamodelPropertyField(role = CtRole.BODY)
+	@MetamodelPropertyField(role = BODY)
 	CtBlock<?> body;
-	@MetamodelPropertyField(role = CtRole.PARAMETER)
+	@MetamodelPropertyField(role = PARAMETER)
 	List<CtParameter<?>> parameters = emptyList();
 	@MetamodelPropertyField(role = THROWN)
 	Set<CtTypeReference<? extends Throwable>> thrownTypes = emptySet();

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -23,14 +23,13 @@ import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.path.CtRole;
 
 import static spoon.reflect.path.CtRole.BODY;
 
 public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.BODY)
+	@MetamodelPropertyField(role = BODY)
 	CtStatement body;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtNewArray;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -33,10 +32,10 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.DIMENSION)
+	@MetamodelPropertyField(role = DIMENSION)
 	List<CtExpression<Integer>> dimensionExpressions = emptyList();
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	List<CtExpression<?>> expressions = emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtOperatorAssignment;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
@@ -27,7 +26,7 @@ import static spoon.reflect.path.CtRole.OPERATOR_KIND;
 public class CtOperatorAssignmentImpl<T, A extends T> extends CtAssignmentImpl<T, A> implements CtOperatorAssignment<T, A> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.OPERATOR_KIND)
+	@MetamodelPropertyField(role = OPERATOR_KIND)
 	BinaryOperatorKind kind;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
@@ -29,7 +28,7 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtReturnImpl<R> extends CtStatementImpl implements CtReturn<R> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<R> returnedExpression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -30,7 +30,6 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ParentNotInitializedException;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 
@@ -278,7 +277,7 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 		return (T) this;
 	}
 
-	@MetamodelPropertyField(role = CtRole.LABEL)
+	@MetamodelPropertyField(role = LABEL)
 	String label;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.code.CtStatementList;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
@@ -38,7 +37,7 @@ import static spoon.reflect.path.CtRole.STATEMENT;
 public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtStatementList {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.STATEMENT)
+	@MetamodelPropertyField(role = STATEMENT)
 	List<CtStatement> statements = emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtSuperAccess;
 import spoon.reflect.code.CtTargetedExpression;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.TARGET;
@@ -34,7 +33,7 @@ public class CtSuperAccessImpl<T> extends CtVariableReadImpl<T> implements CtSup
 		visitor.visitCtSuperAccess(this);
 	}
 
-	@MetamodelPropertyField(role = CtRole.TARGET)
+	@MetamodelPropertyField(role = TARGET)
 	CtExpression<?> target;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtSwitch;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -34,10 +33,10 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.CASE)
+	@MetamodelPropertyField(role = CASE)
 	List<CtCase<? super S>> cases = emptyList();
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<S> expression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtSynchronized;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.BODY;
@@ -29,10 +28,10 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtSynchronizedImpl extends CtStatementImpl implements CtSynchronized {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.BODY)
+	@MetamodelPropertyField(role = BODY)
 	CtBlock<?> block;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<?> expression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
@@ -19,14 +19,13 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtTargetedExpression;
-import spoon.reflect.path.CtRole;
 
 import static spoon.reflect.path.CtRole.TARGET;
 
 public abstract class CtTargetedExpressionImpl<E, T extends CtExpression<?>> extends CtExpressionImpl<E> implements CtTargetedExpression<E, T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TARGET)
+	@MetamodelPropertyField(role = TARGET)
 	T target;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -24,7 +24,6 @@ import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -39,13 +38,13 @@ import static spoon.reflect.path.CtRole.FINALIZER;
 public class CtTryImpl extends CtStatementImpl implements CtTry {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.BODY)
+	@MetamodelPropertyField(role = BODY)
 	CtBlock<?> body;
 
-	@MetamodelPropertyField(role = CtRole.CATCH)
+	@MetamodelPropertyField(role = CATCH)
 	List<CtCatch> catchers = emptyList();
 
-	@MetamodelPropertyField(role = CtRole.FINALIZER)
+	@MetamodelPropertyField(role = FINALIZER)
 	CtBlock<?> finalizer;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtTryWithResource;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
@@ -32,7 +31,7 @@ import static spoon.reflect.path.CtRole.TRY_RESOURCE;
 public class CtTryWithResourceImpl extends CtTryImpl implements CtTryWithResource {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TRY_RESOURCE)
+	@MetamodelPropertyField(role = TRY_RESOURCE)
 	List<CtLocalVariable<?>> resources = emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
@@ -22,7 +22,6 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
@@ -32,13 +31,13 @@ import static spoon.reflect.path.CtRole.OPERATOR_KIND;
 public class CtUnaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtUnaryOperator<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.OPERATOR_KIND)
+	@MetamodelPropertyField(role = OPERATOR_KIND)
 	UnaryOperatorKind kind;
 
-	@MetamodelPropertyField(role = CtRole.LABEL)
+	@MetamodelPropertyField(role = LABEL)
 	String label;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<T> operand;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.DerivedProperty;
@@ -29,7 +28,7 @@ import static spoon.reflect.path.CtRole.VARIABLE;
 public abstract class CtVariableAccessImpl<T> extends CtExpressionImpl<T> implements CtVariableAccess<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.VARIABLE)
+	@MetamodelPropertyField(role = VARIABLE)
 	CtVariableReference<T> variable;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.code;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtWhile;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
@@ -27,7 +26,7 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
 public class CtWhileImpl extends CtLoopImpl implements CtWhile {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.EXPRESSION)
+	@MetamodelPropertyField(role = EXPRESSION)
 	CtExpression<Boolean> expression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
@@ -26,7 +26,6 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
@@ -41,7 +40,7 @@ import java.util.Set;
  * The implementation for {@link spoon.reflect.declaration.CtAnnotationMethod}.
  */
 public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnnotationMethod<T> {
-	@MetamodelPropertyField(role = CtRole.DEFAULT_EXPRESSION)
+	@MetamodelPropertyField(role = DEFAULT_EXPRESSION)
 	CtExpression<T> defaultExpression;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -28,7 +28,6 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -60,7 +59,7 @@ import static spoon.reflect.path.CtRole.SUPER_TYPE;
 public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtClass<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.SUPER_TYPE)
+	@MetamodelPropertyField(role = SUPER_TYPE)
 	CtTypeReference<?> superClass;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -25,7 +25,6 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
@@ -42,10 +41,10 @@ import static spoon.reflect.path.CtRole.VALUE;
 public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtEnum<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.VALUE)
+	@MetamodelPropertyField(role = VALUE)
 	private List<CtEnumValue<?>> enumValues = CtElementImpl.emptyList();
 
-	@MetamodelPropertyField(role = CtRole.VALUE)
+	@MetamodelPropertyField(role = VALUE)
 	private CtMethod<T[]> valuesMethod;
 
 	private CtMethod<T> valueOfMethod;

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -20,7 +20,6 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
 
 import static spoon.reflect.path.CtRole.NAME;
@@ -29,7 +28,7 @@ public abstract class CtNamedElementImpl extends CtElementImpl implements CtName
 
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.NAME)
+	@MetamodelPropertyField(role = NAME)
 	String simpleName = "";
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -27,7 +27,6 @@ import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.declaration.ParentNotInitializedException;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -45,7 +44,7 @@ import java.util.Set;
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
 
 public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypeParameter {
-	@MetamodelPropertyField(role = CtRole.SUPER_TYPE)
+	@MetamodelPropertyField(role = SUPER_TYPE)
 	CtTypeReference<?> superClass;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -17,7 +17,6 @@
 package spoon.support.reflect.reference;
 
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -31,7 +30,7 @@ public class
 CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTypeReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	CtTypeReference<?> componentType;
 
 	public CtArrayTypeReferenceImpl() {

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -26,7 +26,6 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -57,16 +56,16 @@ import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
 public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtExecutableReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.IS_STATIC)
+	@MetamodelPropertyField(role = IS_STATIC)
 	boolean stat = false;
 
 	@MetamodelPropertyField(role = TYPE_ARGUMENT)
 	List<CtTypeReference<?>> actualTypeArguments = CtElementImpl.emptyList();
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	CtTypeReference<?> declaringType;
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	/**
 	 * For methods, stores the return type of the method. (not pretty-printed).
 	 * For constructors, stores the type of the target constructor (pretty-printed).

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -23,7 +23,6 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -41,13 +40,13 @@ import static spoon.reflect.path.CtRole.IS_STATIC;
 public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtFieldReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.DECLARING_TYPE)
+	@MetamodelPropertyField(role = DECLARING_TYPE)
 	CtTypeReference<?> declaringType;
 
-	@MetamodelPropertyField(role = CtRole.IS_FINAL)
+	@MetamodelPropertyField(role = IS_FINAL)
 	boolean fina = false;
 
-	@MetamodelPropertyField(role = CtRole.IS_STATIC)
+	@MetamodelPropertyField(role = IS_STATIC)
 	boolean stat = false;
 
 	public CtFieldReferenceImpl() {

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -17,7 +17,6 @@
 package spoon.support.reflect.reference;
 
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -31,7 +30,7 @@ import static spoon.reflect.path.CtRole.BOUND;
 
 
 public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtIntersectionTypeReference<T> {
-	@MetamodelPropertyField(role = CtRole.BOUND)
+	@MetamodelPropertyField(role = BOUND)
 	List<CtTypeReference<?>> bounds = CtElementImpl.emptyList();
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -21,7 +21,6 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
@@ -38,7 +37,7 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.NAME)
+	@MetamodelPropertyField(role = NAME)
 	protected String simplename = "";
 
 	public CtReferenceImpl() {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -23,7 +23,6 @@ import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtIntersectionTypeReference;
@@ -44,10 +43,10 @@ import static spoon.reflect.path.CtRole.BOUNDING_TYPE;
 public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> implements CtTypeParameterReference {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.BOUNDING_TYPE)
+	@MetamodelPropertyField(role = BOUNDING_TYPE)
 	CtTypeReference<?> superType;
 
-	@MetamodelPropertyField(role = CtRole.IS_UPPER)
+	@MetamodelPropertyField(role = IS_UPPER)
 	boolean upper = true;
 
 	public CtTypeParameterReferenceImpl() {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -29,7 +29,6 @@ import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -61,13 +60,13 @@ import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
 public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TYPE_ARGUMENT)
+	@MetamodelPropertyField(role = TYPE_ARGUMENT)
 	List<CtTypeReference<?>> actualTypeArguments = CtElementImpl.emptyList();
 
-	@MetamodelPropertyField(role = CtRole.DECLARING_TYPE)
+	@MetamodelPropertyField(role = DECLARING_TYPE)
 	CtTypeReference<?> declaringType;
 
-	@MetamodelPropertyField(role = CtRole.PACKAGE_REF)
+	@MetamodelPropertyField(role = PACKAGE_REF)
 	private CtPackageReference pack;
 
 	public CtTypeReferenceImpl() {
@@ -711,7 +710,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		}
 	}
 
-	@MetamodelPropertyField(role = CtRole.IS_SHADOW)
+	@MetamodelPropertyField(role = IS_SHADOW)
 	boolean isShadow;
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
@@ -19,7 +19,6 @@ package spoon.support.reflect.reference;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -33,7 +32,7 @@ import static spoon.reflect.path.CtRole.TYPE;
 public abstract class CtVariableReferenceImpl<T> extends CtReferenceImpl implements CtVariableReference<T> {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = CtRole.TYPE)
+	@MetamodelPropertyField(role = TYPE)
 	CtTypeReference<T> type;
 
 	public CtVariableReferenceImpl() {


### PR DESCRIPTION
This PR is related to #2100 

We used a lot this of construction in our code:

```java

import CtRole;
import static CtRole.AROLE;

@myRole(role = CtRole.AROLE);
public void method() {
  aCall(AROLE);
}
```

This is perfectly correct code, but it's a kind of redundancy to import twice CtRole where we used only the static field already imported. 
Moreover the import mechanism will align all this behaviour to only one import, which is the static one.
Then as we got now one test to check that Spoon imports and computed imports are the same, I propose to refactor to only use the import of the static field.