### PR TITLE
[wip] Refactor: fix checkstyle violations

### DIFF
--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -3,7 +3,6 @@ package spoon;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
-import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -66,7 +65,7 @@ public class MavenLauncherTest {
 		// in order to work on CI, make sure the version is the same in Spoon pom.xml
 		// else, we cannot guarantee that the dependency is present in .m2 cache and the test might fail
 
-		String lookingFor = Paths.get("junit","junit", "4.12", "junit-4.12.jar").toString();
+		String lookingFor = Paths.get("junit", "junit", "4.12", "junit-4.12.jar").toString();
 
 		boolean findIt = false;
 		for (String s : classpath) {

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -40,7 +40,7 @@ public class AstCheckerTest {
 		launcher.buildModel();
 
 		final Factory factory = launcher.getFactory();
-		final List<CtTypeReference<?>> collectionsRef = Arrays.asList( //
+		final List<CtTypeReference<?>> collectionsRef = Arrays.asList(
 				factory.Type().createReference(Collection.class), //
 				factory.Type().createReference(List.class), //
 				factory.Type().createReference(Set.class), //
@@ -113,7 +113,7 @@ public class AstCheckerTest {
 		private int count;
 
 		PushStackInIntercessionChecker() {
-			notCandidates = Arrays.asList( //
+			notCandidates = Arrays.asList(
 					"CtTypeImpl#setTypeMembers", //
 					"CtStatementListImpl#setPosition", //
 					"CtElementImpl#setFactory", //
@@ -219,25 +219,29 @@ public class AstCheckerTest {
 					&& body.getStatements().get(0) instanceof CtThrow //
 					&& "UnsupportedOperationException".equals(((CtThrow) body.getStatements().get(0)).getThrownExpression().getType().getSimpleName());
 		}
-		
+
 		private boolean isCallModelCollection(CtBlock<?> body) {
-			
+
 			return body.filterChildren((CtInvocation inv) -> {
 				if (inv.getTarget() instanceof CtFieldRead) {
 					CtFieldRead fielRead = (CtFieldRead) inv.getTarget();
-					if (isModelCollection(fielRead.getType()) ) {
+					if (isModelCollection(fielRead.getType())) {
 						//it is invocation on ModelList, ModelSet or ModelMap
 						return true;
 					}
-				} 
+				}
 				return false;
 			}).first() != null;
 		}
-		
+
 		private boolean isModelCollection(CtTypeReference<?> typeRef) {
 			Factory f = typeRef.getFactory();
-			if (typeRef.isSubtypeOf(f.Type().createReference(ModelList.class))) return true;
-			if (typeRef.isSubtypeOf(f.Type().createReference(ModelSet.class))) return true;
+			if (typeRef.isSubtypeOf(f.Type().createReference(ModelList.class))) {
+				return true;
+			}
+			if (typeRef.isSubtypeOf(f.Type().createReference(ModelSet.class))) {
+				return true;
+			}
 //			if (typeRef.isSubtypeOf(f.Type().createReference(ModelMap.class))) return true;
 			return false;
 		}

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -136,10 +136,10 @@ public class CloneTest {
 				assertNull(previousTarget);
 			}
 		}
-		
+
 		CloneListener cl = new CloneListener();
 		CtType<?> cloneTarget = cl.clone(cloneSource);
-		
+
 		cloneSource.filterChildren(null).forEach(sourceElement -> {
 			//contract: there exists cloned target for each visitable element
 			CtElement targetElement = cl.sourceToTarget.remove(sourceElement);
@@ -161,7 +161,7 @@ public class CloneTest {
 		CtMethod<?> method = klass.getMethodsByName("c").get(0);
 		List<CtExecutableReference> elements = method.getElements(new TypeFilter<>(CtExecutableReference.class));
 		CtExecutableReference methodRef = elements.get(0);
-		
+
 		// the lookup is OK in the original node
 		assertSame(method, methodRef.getDeclaration());
 

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -72,7 +72,7 @@ public class CtTypeInformationTest {
 			Assert.assertEquals(extendObject.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
 			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
-			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results
 			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
 			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
 
@@ -99,7 +99,7 @@ public class CtTypeInformationTest {
 			Assert.assertFalse(ctc.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
 			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
 			Assert.assertNull(getLastResolvedSuperclass(ctc));
-			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results
 			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
 			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
 			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
@@ -115,7 +115,7 @@ public class CtTypeInformationTest {
 			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
 			Assert.assertNull(getLastResolvedSuperclass(ctc2));
 
-			//contract: ClassTypingContext#isSubtypeOf returns always the same results 
+			//contract: ClassTypingContext#isSubtypeOf returns always the same results
 			Assert.assertTrue(ctc2.isSubtypeOf(arrayList));
 			Assert.assertTrue(ctc2.isSubtypeOf(extendObject));
 			Assert.assertTrue(ctc2.isSubtypeOf(subClass.getReference()));

--- a/src/test/java/spoon/reflect/declaration/testclasses/ExtendsArrayList.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/ExtendsArrayList.java
@@ -3,5 +3,5 @@ package spoon.reflect.declaration.testclasses;
 import java.util.ArrayList;
 
 public class ExtendsArrayList extends ArrayList {
-	void m() {}
+	void m() { }
 }

--- a/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
+++ b/src/test/java/spoon/reflect/declaration/testclasses/Subclass.java
@@ -1,10 +1,10 @@
 package spoon.reflect.declaration.testclasses;
 
 public class Subclass extends ExtendsArrayList implements Subinterface {
-    @Override
-    public int compareTo(Object o) {
-        return 0;
-    }
+	@Override
+	public int compareTo(Object o) {
+		return 0;
+	}
 
 	@Override
 	public void foo() {

--- a/src/test/java/spoon/reflect/visitor/CtInheritanceScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtInheritanceScannerTest.java
@@ -73,7 +73,7 @@ public class CtInheritanceScannerTest<T extends CtVisitable> {
 			if (!intf.getSimpleName().startsWith("Ct")) {
 				continue;
 			}
-			Method mth=null;
+			Method mth = null;
 
 			// if a method visitX exists, it must be invoked
 			try {
@@ -85,7 +85,7 @@ public class CtInheritanceScannerTest<T extends CtVisitable> {
 			} catch (NoSuchMethodException ex) {
 				// no such method, nothing
 			}
-			if (mth!=null && !toInvoke.contains(mth)) {
+			if (mth != null && !toInvoke.contains(mth)) {
 				toInvoke.add(mth);
 			}
 
@@ -99,7 +99,7 @@ public class CtInheritanceScannerTest<T extends CtVisitable> {
 			} catch (NoSuchMethodException ex) {
 				// no such method, nothing
 			}
-			if (mth!=null && !toInvoke.contains(mth)) {
+			if (mth != null && !toInvoke.contains(mth)) {
 				toInvoke.add(mth);
 			}
 
@@ -130,7 +130,7 @@ public class CtInheritanceScannerTest<T extends CtVisitable> {
 				toInvoke.get(i).invoke(verify(mocked), instance);
 			} catch (InvocationTargetException e) {
 				if (e.getTargetException() instanceof AssertionError) {
-					fail("visit"+instance.getClass().getSimpleName().replaceAll("Impl$", "")+" does not call "+toInvoke.get(i).getName());
+					fail("visit" + instance.getClass().getSimpleName().replaceAll("Impl$", "") + " does not call " + toInvoke.get(i).getName());
 				} else {
 					throw e.getTargetException();
 				}

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -84,13 +84,13 @@ public class CtScannerTest {
 		String signature = "";
 		@Override
 		public <T> void visitCtParameter(CtParameter<T> parameter) {
-			signature += parameter.getType().getQualifiedName()+", ";
+			signature += parameter.getType().getQualifiedName() + ", ";
 			super.visitCtParameter(parameter);
 		}
 
 		@Override
 		public <T> void visitCtMethod(CtMethod<T> m) {
-			signature += m.getSimpleName()+"(";
+			signature += m.getSimpleName() + "(";
 			super.visitCtMethod(m);
 			signature += ")";
 		}
@@ -116,21 +116,21 @@ public class CtScannerTest {
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/main/java/spoon/reflect/");
 		launcher.run();
-		
+
 		CtTypeReference<?> ctElementRef = launcher.getFactory().createCtTypeReference(CtElement.class);
 		CtTypeReference<?> ctRefRef = launcher.getFactory().createCtTypeReference(CtReference.class);
 
-		CtClass<?> scannerCtClass = (CtClass<?>)launcher.getFactory().Type().get(CtScanner.class);
-		
+		CtClass<?> scannerCtClass = (CtClass<?>) launcher.getFactory().Type().get(CtScanner.class);
+
 		List<String> problems = new ArrayList<>();
 		Set<String> ignoredInvocations = new HashSet(Arrays.asList("scan", "enter", "exit"));
-		
+
 		Metamodel metaModel = Metamodel.getInstance();
-		
+
 		//collect all scanner visit methods, to check if all were checked
 		Map<String, CtMethod<?>> scannerVisitMethodsByName = new HashMap<>();
 		scannerCtClass.getAllMethods().forEach(m -> {
-			if(m.getSimpleName().startsWith("visit")) {
+			if (m.getSimpleName().startsWith("visit")) {
 				scannerVisitMethodsByName.put(m.getSimpleName(), m);
 			}
 		});
@@ -144,8 +144,8 @@ public class CtScannerTest {
 				continue;
 			}
 
-			CtMethod<?> visitMethod = scannerVisitMethodsByName.remove("visit"+leafConcept.getName());
-			assertNotNull("CtScanner#" + "visit"+leafConcept.getName() + "(...) not found", visitMethod);
+			CtMethod<?> visitMethod = scannerVisitMethodsByName.remove("visit" + leafConcept.getName());
+			assertNotNull("CtScanner#" + "visit" + leafConcept.getName() + "(...) not found", visitMethod);
 			Set<String> calledMethods = new HashSet<>();
 			Set<String> checkedMethods = new HashSet<>();
 
@@ -170,7 +170,7 @@ public class CtScannerTest {
 				CtInvocation invocation = visitMethod.filterChildren(new TypeFilter<CtInvocation>(CtInvocation.class) {
 					@Override
 					public boolean matches(CtInvocation element) {
-						if(ignoredInvocations.contains(element.getExecutable().getSimpleName())) {
+						if (ignoredInvocations.contains(element.getExecutable().getSimpleName())) {
 							return false;
 						}
 						calledMethods.add(element.getExecutable().getSignature());
@@ -178,7 +178,7 @@ public class CtScannerTest {
 					}
 				}).first();
 
-				if(getter.getName().equals("getComments") && leafConcept.getMetamodelInterface().isSubtypeOf(ctRefRef)
+				if (getter.getName().equals("getComments") && leafConcept.getMetamodelInterface().isSubtypeOf(ctRefRef)
 						) {
 					//one cannot set comments on references see the @UnsettableProperty of CtReference#setComments
 					return;
@@ -186,16 +186,16 @@ public class CtScannerTest {
 
 				// contract: there ia at least one invocation to all non-derived, role-based getters in the visit method of the Scanner
 				if (invocation == null) {
-					problems.add("no "+getter.getSignature() +" in "+visitMethod);
+					problems.add("no " + getter.getSignature() + " in " + visitMethod);
 				} else {
 					c.nbChecks++;
 					//System.out.println(invocation.toString());
 
 					// contract: the scan method is called with the same role as the one set on field / property
-					CtRole expectedRole = metaModel.getRoleOfMethod((CtMethod<?>)invocation.getExecutable().getDeclaration());
+					CtRole expectedRole = metaModel.getRoleOfMethod((CtMethod<?>) invocation.getExecutable().getDeclaration());
 					CtInvocation<?> scanInvocation = invocation.getParent(CtInvocation.class);
 					String realRoleName = ((CtFieldRead<?>) scanInvocation.getArguments().get(0)).getVariable().getSimpleName();
-					if(expectedRole.name().equals(realRoleName) == false) {
+					if (expectedRole.name().equals(realRoleName) == false) {
 						problems.add("Wrong role " + realRoleName + " used in " + scanInvocation.getPosition());
 					}
 				}
@@ -205,15 +205,15 @@ public class CtScannerTest {
 
 			// contract: CtScanner only calls methods that have a role and the associated getter
 			if (calledMethods.size() > 0) {
-				problems.add("CtScanner " + visitMethod.getPosition() + " calls unexpected methods: "+calledMethods);
+				problems.add("CtScanner " + visitMethod.getPosition() + " calls unexpected methods: " + calledMethods);
 			}
 		}
 
 		// contract: all visit* methods in CtScanner have been checked
-		if(scannerVisitMethodsByName.isEmpty() == false) {
+		if (scannerVisitMethodsByName.isEmpty() == false) {
 			problems.add("These CtScanner visit methods were not checked: " + scannerVisitMethodsByName.keySet());
 		}
-		if(problems.size()>0) {
+		if (problems.size() > 0) {
 			fail(String.join("\n", problems));
 		}
 		assertTrue("not enough checks " + c.nbChecks, c.nbChecks >= 200);
@@ -221,19 +221,19 @@ public class CtScannerTest {
 
 	@Test
 	public void testScan() throws Exception {
-		// contract: all AST nodes are visisted through method "scan"
+		// contract: all AST nodes are visited through method "scan"
 		Launcher launcher;
 		launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.addInputResource("src/test/resources/noclasspath/draw2d");
 		launcher.buildModel();
 		class Counter {
-			int nEnter=0;
-			int nExit=0;
-			int nObject=0;
-			int nElement=0;
+			int nEnter = 0;
+			int nExit = 0;
+			int nObject = 0;
+			int nElement = 0;
 			Deque<CollectionContext> contexts = new ArrayDeque<>();
-		};
+		}
 		Counter counter = new Counter();
 		launcher.getModel().getRootPackage().accept(new CtScanner() {
 			@Override
@@ -279,10 +279,10 @@ public class CtScannerTest {
 				if (o == null) {
 					//there is no collection involved in scanning of this single value NULL attribute
 					assertNull(counter2.contexts.peek().col);
-					
+
 				} else {
 					RoleHandler rh = RoleHandlerHelper.getRoleHandler(o.getParent().getClass(), role);
-					if (rh.getContainerKind()==ContainerKind.SINGLE) {
+					if (rh.getContainerKind() == ContainerKind.SINGLE) {
 						//there is no collection involved in scanning of this single value attribute
 						assertNull(counter2.contexts.peek().col);
 					} else {

--- a/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
+++ b/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
@@ -15,14 +15,14 @@ import java.lang.reflect.InvocationTargetException;
 public class ComputeClasspathTest {
 
 	private static final String TEST_CLASSPATH =
-			"./src/test/java/spoon/test/annotation/" +
-					File.pathSeparator +
-					"./src/test/java/spoon/test/api/" +
-					File.pathSeparator +
-					"./src/test/java/spoon/test/arrays/" +
-					File.pathSeparator +
-					"./src/test/java/spoon/test/casts/" +
-					File.pathSeparator;
+			"./src/test/java/spoon/test/annotation/"
+					+	File.pathSeparator
+					+	"./src/test/java/spoon/test/api/"
+					+	File.pathSeparator
+					+	"./src/test/java/spoon/test/arrays/"
+					+	File.pathSeparator
+					+	"./src/test/java/spoon/test/casts/"
+					+	File.pathSeparator;
 
 	private JDTBasedSpoonCompiler compiler;
 	private Class<? extends JDTBasedSpoonCompiler> compilerClass;

--- a/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
+++ b/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
@@ -14,7 +14,7 @@ import java.lang.reflect.InvocationTargetException;
 
 public class ComputeClasspathTest {
 
-	private final static String TEST_CLASSPATH =
+	private static final String TEST_CLASSPATH =
 			"./src/test/java/spoon/test/annotation/" +
 					File.pathSeparator +
 					"./src/test/java/spoon/test/api/" +

--- a/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
@@ -55,7 +55,7 @@ public class ExtendedStringLiteralTest {
 		};
 		SpoonModelBuilder comp = launcher.createCompiler();
 		comp.addInputSources(SpoonResourceHelper.resources(
-				"./src/test/java/"+ExtendedStringLiteralTestClass.class.getCanonicalName().replace('.', '/')+".java"));
+				"./src/test/java/" + ExtendedStringLiteralTestClass.class.getCanonicalName().replace('.', '/') + ".java"));
 		comp.build();
 
 		CtClass<?> cl =

--- a/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTestClass.java
+++ b/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTestClass.java
@@ -2,6 +2,6 @@ package spoon.support.compiler.jdt;
 
 public class ExtendedStringLiteralTestClass {
 
-	final public static String extendedStringLiteral = "hello "+"world!";
+	public static final String extendedStringLiteral = "hello " + "world!";
 	
 }

--- a/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTestClass.java
+++ b/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTestClass.java
@@ -3,5 +3,4 @@ package spoon.support.compiler.jdt;
 public class ExtendedStringLiteralTestClass {
 
 	public static final String extendedStringLiteral = "hello " + "world!";
-	
 }

--- a/src/test/java/spoon/support/compiler/jdt/JDTBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBuilderTest.java
@@ -13,7 +13,7 @@ import java.io.File;
 import static org.junit.Assert.assertEquals;
 
 public class JDTBuilderTest {
-	private final static String TEST_CLASSPATH = "./src/test/java/spoon/test/";
+	private static final String TEST_CLASSPATH = "./src/test/java/spoon/test/";
 
 	@Test
 	public void testJdtBuilder() throws Exception {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -379,10 +379,7 @@ public class JavaReflectionTreeBuilderTest {
 				List<CtAnnotation<?>> fileteredElements = ((List<CtAnnotation<?>>) elements).stream().filter(a -> {
 					CtTypeReference<?> at = a.getAnnotationType();
 					Class ac = at.getActualClass();
-					if (ac == Override.class || ac == SuppressWarnings.class || ac == Root.class) {
-						return false;
-					}
-					return true;
+					return ac != Override.class && ac != SuppressWarnings.class && ac != Root.class;
 				}).collect(Collectors.toList());
 				super.biScan(role, fileteredElements, others);
 				return;

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -245,7 +245,7 @@ public class JavaReflectionTreeBuilderTest {
 						if (type.isInterface()) {
 							if (removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT)
 									.equals(removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT))) {
-								//it is OK, that type memebers of interface differs in public abstract modifiers
+								//it is OK, that type members of interface differs in public abstract modifiers
 								return;
 							}
 						} else if (type.isEnum()) {
@@ -254,7 +254,7 @@ public class JavaReflectionTreeBuilderTest {
 								if (type2.isInterface()) {
 									if (removeModifiers(elementModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/)
 											.equals(removeModifiers(elementModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/))) {
-										//it is OK, that type memebers of interface differs in public abstract modifiers
+										//it is OK, that type members of interface differs in public abstract modifiers
 										return;
 									}
 								}

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -122,7 +122,7 @@ public class JavaReflectionTreeBuilderTest {
 
 		assertNotNull(suppressWarning.getAnnotation(Retention.class));
 
-		assertEquals("SOURCE",suppressWarning.getAnnotation(Retention.class).value().toString());
+		assertEquals("SOURCE", suppressWarning.getAnnotation(Retention.class).value().toString());
 
 	}
 
@@ -179,7 +179,7 @@ public class JavaReflectionTreeBuilderTest {
 		// JDTSnippetCompiler have only 1 constructor with 2 arguments but its super class have 1 constructor with 1 argument.
 		assertEquals(1, ((CtClass<JDTSnippetCompiler>) aType).getConstructors().size());
 	}
-	
+
 	@Test
 	public void testShadowModelEqualsNormalModel() {
 		//contract: CtType made from sources is equal to CtType made by reflection
@@ -193,7 +193,7 @@ public class JavaReflectionTreeBuilderTest {
 		}
 		assertTrue("Found " + allProblems.size() + " problems:\n" + String.join("\n", allProblems), allProblems.isEmpty());
 	}
-	
+
 	private List<String> checkShadowTypeIsEqual(CtType<?> type) {
 		if (type == null) {
 			return Collections.emptyList();
@@ -201,10 +201,10 @@ public class JavaReflectionTreeBuilderTest {
 		Factory shadowFactory = createFactory();
 		CtTypeReference<?> shadowTypeRef = shadowFactory.Type().createReference(type.getActualClass());
 		CtType<?> shadowType = shadowTypeRef.getTypeDeclaration();
-		
+
 		assertFalse(type.isShadow());
 		assertTrue(shadowType.isShadow());
-		
+
 		ShadowEqualsVisitor sev = new ShadowEqualsVisitor(new HashSet<>(Arrays.asList(
 				//shadow classes has no body
 				CtRole.STATEMENT,
@@ -214,10 +214,10 @@ public class JavaReflectionTreeBuilderTest {
 
 				// shadow classes have no comments
 				CtRole.COMMENT)));
-		
+
 		return sev.checkDiffs(type, shadowType);
 	}
-	
+
 	private static class Diff {
 		CtElement element;
 		CtElement other;
@@ -228,11 +228,11 @@ public class JavaReflectionTreeBuilderTest {
 			this.other = other;
 		}
 	}
-	
+
 	private static class ShadowEqualsChecker extends EqualsChecker {
 		Diff currentDiff;
 		List<Diff> differences = new ArrayList<>();
-		
+
 		@Override
 		protected void setNotEqual(CtRole role) {
 			if (role == CtRole.MODIFIER) {
@@ -265,7 +265,7 @@ public class JavaReflectionTreeBuilderTest {
 			}
 			currentDiff.roles.add(role);
 		}
-		
+
 		private Set<ModifierKind> removeModifiers(Set<ModifierKind> elementModifiers, ModifierKind... modifiers) {
 			Set<ModifierKind> copy = new HashSet<>(elementModifiers);
 			for (ModifierKind modifierKind : modifiers) {
@@ -283,13 +283,13 @@ public class JavaReflectionTreeBuilderTest {
 			}
 		}
 	}
-	
+
 	private static class ShadowEqualsVisitor extends EqualsVisitor {
 		CtElement rootOfOther;
 		CtElementPathBuilder pathBuilder = new CtElementPathBuilder();
 		List<String> differences;
 		Set<CtRole> ignoredRoles;
-		
+
 		ShadowEqualsVisitor(Set<CtRole> ignoredRoles) {
 			super(new ShadowEqualsChecker());
 			this.ignoredRoles = ignoredRoles;
@@ -315,9 +315,9 @@ public class JavaReflectionTreeBuilderTest {
 
 			CtElement parentOfOther = stack.peek();
 			try {
-				differences.add("Difference on path: " + pathBuilder.fromElement(parentOfOther, rootOfOther).toString()+"#"+role.getCamelCaseName()
-				+"\nShadow: " + String.valueOf(other)
-				+"\nNormal: " + String.valueOf(element)+"\n");
+				differences.add("Difference on path: " + pathBuilder.fromElement(parentOfOther, rootOfOther).toString() + "#" + role.getCamelCaseName()
+				+ "\nShadow: " + String.valueOf(other)
+				+ "\nNormal: " + String.valueOf(element) + "\n");
 			} catch (CtPathException e) {
 				throw new SpoonException(e);
 			}
@@ -376,7 +376,7 @@ public class JavaReflectionTreeBuilderTest {
 			}
 			if (role == CtRole.ANNOTATION) {
 				//remove all RetentionPolicy#SOURCE level annotations from elements
-				List<CtAnnotation<?>> fileteredElements = ((List<CtAnnotation<?>>)elements).stream().filter(a->{
+				List<CtAnnotation<?>> fileteredElements = ((List<CtAnnotation<?>>) elements).stream().filter(a -> {
 					CtTypeReference<?> at = (CtTypeReference) a.getAnnotationType();
 					Class ac = at.getActualClass();
 					if (ac == Override.class || ac == SuppressWarnings.class || ac == Root.class) {
@@ -404,19 +404,19 @@ public class JavaReflectionTreeBuilderTest {
 						parentOf = diff.element.getParent();
 						rootOf = type;
 					}
-					differences.add("Diff on path: " + pathBuilder.fromElement(parentOf, rootOf).toString()+"#"
-					+diff.roles.stream().map(CtRole::getCamelCaseName).collect(Collectors.joining(", ", "[", "]"))
-					+"\nShadow: " + String.valueOf(diff.other)
-					+"\nNormal: " + String.valueOf(diff.element)+"\n");
+					differences.add("Diff on path: " + pathBuilder.fromElement(parentOf, rootOf).toString() + "#"
+					+ diff.roles.stream().map(CtRole::getCamelCaseName).collect(Collectors.joining(", ", "[", "]"))
+					+ "\nShadow: " + String.valueOf(diff.other)
+					+ "\nNormal: " + String.valueOf(diff.element) + "\n");
 				} catch (CtPathException e) {
 					throw new SpoonException(e);
 				}
-				
+
 			}
 			return differences;
 		}
 	}
-	
+
 	private static Map<String, CtTypeMember> groupTypeMembersBySignature(Collection<CtTypeMember> typeMembers) {
 		Map<String, CtTypeMember> typeMembersByName = new HashMap<>();
 		for (CtTypeMember tm : typeMembers) {
@@ -445,7 +445,7 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals("T", typeArg.getSimpleName());
 		assertTrue(typeArg instanceof CtTypeParameterReference);
 	}
-	
+
 	@Test
 	public void testSuperInterfaceActualTypeArgumentsByCtTypeReferenceImpl() {
 		TypeFactory typeFactory = createFactory().Type();
@@ -457,7 +457,7 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals("T", typeArg.getSimpleName());
 		assertTrue(typeArg instanceof CtTypeParameterReference);
 	}
-	
+
 	@Test
 	public void testSuperInterfaceCorrectActualTypeArgumentsByCtTypeReferenceImpl() {
 		TypeFactory typeFactory = createFactory().Type();
@@ -475,7 +475,7 @@ public class JavaReflectionTreeBuilderTest {
 			}
 		}
 	}
-	
+
 	@Test
 	public void testSuperInterfaceQName() {
 		//contract: the qualified names of super interfaces are correct
@@ -491,7 +491,7 @@ public class JavaReflectionTreeBuilderTest {
 			assertSame(aType, ifaceRef.getParent());
 		}
 	}
-	
+
 	@Test
 	public void testSuperClass() {
 		//contract: the super class have actual type arguments
@@ -505,10 +505,10 @@ public class JavaReflectionTreeBuilderTest {
 		CtTypeParameterReference paramRef = (CtTypeParameterReference) superClass.getActualTypeArguments().get(0);
 		assertSame(aType.getFormalCtTypeParameters().get(0), paramRef.getDeclaration());
 	}
-	
+
 	@Test
 	public void testSuperOfActualTypeArgumentsOfReturnTypeOfMethod() throws Exception {
-				
+
 		Consumer<CtType<?>> checker = type -> {
 			{
 				CtMethod method = type.getMethodsByName("setAssignment").get(0);
@@ -547,7 +547,7 @@ public class JavaReflectionTreeBuilderTest {
 		CtClass<?> classFromSources = launcher.getFactory().Class().get(CtAssignmentImpl.class.getName());
 		assertFalse(classFromSources.isShadow());
 		checker.accept(classFromSources);
-		
+
 		//try the same check using CtType build using reflection
 		CtType<?> classFromReflection = createFactory().Class().get(CtAssignmentImpl.class);
 		assertTrue(classFromReflection.isShadow());
@@ -568,8 +568,6 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals("T", typeParameter.getSimpleName());
 		assertTrue(typeParameter.getSuperclass() == null);
 	}
-
-
 
 	@Test
 	public void testPartialShadow() {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -377,7 +377,7 @@ public class JavaReflectionTreeBuilderTest {
 			if (role == CtRole.ANNOTATION) {
 				//remove all RetentionPolicy#SOURCE level annotations from elements
 				List<CtAnnotation<?>> fileteredElements = ((List<CtAnnotation<?>>) elements).stream().filter(a -> {
-					CtTypeReference<?> at = (CtTypeReference) a.getAnnotationType();
+					CtTypeReference<?> at = a.getAnnotationType();
 					Class ac = at.getActualClass();
 					if (ac == Override.class || ac == SuppressWarnings.class || ac == Root.class) {
 						return false;

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1330,7 +1330,7 @@ public class AnnotationTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(RepeatedArrays.class);
-		CtMethod firstMethod = (CtMethod)type.getMethodsByName("method").get(0);
+		CtMethod firstMethod = (CtMethod) type.getMethodsByName("method").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertEquals(2, annotations.size());

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -173,8 +173,6 @@ public class AnnotationTest {
 
 		// the good value is selected, not the default value
 		assertEquals("8", a.getAllValues().get("max").toString());
-
-
 	}
 
 	@Test
@@ -263,7 +261,7 @@ public class AnnotationTest {
 		assertEquals("dd", annot.ia().value());
 
 		// tests binary expressions
-		CtMethod<?> m3 = type.getElements(new NamedElementFilter<>(CtMethod.class,"m3")).get(0);
+		CtMethod<?> m3 = type.getElements(new NamedElementFilter<>(CtMethod.class, "m3")).get(0);
 
 		annotations = m3.getAnnotations();
 		assertEquals(1, annotations.size());
@@ -400,7 +398,7 @@ public class AnnotationTest {
 		assertEquals(Bound.class, annotationType.getActualClass());
 		assertNull(annotationType.getSuperclass());
 		assertEquals(1, annotationType.getMethods().size());
-		assertEquals(0,annotationType.getSuperInterfaces().size());
+		assertEquals(0, annotationType.getSuperInterfaces().size());
 
 		annotations = annotationType.getAnnotations();
 		assertEquals(1, annotations.size());
@@ -613,7 +611,7 @@ public class AnnotationTest {
 		Factory factory = launcher.getFactory();
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
-		final CtClass<?> innerClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class,"DummyClass")).get(0);
+		final CtClass<?> innerClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class, "DummyClass")).get(0);
 		final CtTypeReference<?> extendsActual = innerClass.getSuperclass();
 		final List<CtAnnotation<? extends Annotation>> extendsTypeAnnotations = extendsActual.getAnnotations();
 		final String superClassExpected = "spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "AnnotArrayInnerClass";
@@ -631,7 +629,7 @@ public class AnnotationTest {
 		assertEquals(CtAnnotatedElementType.TYPE_USE, implementsTypeAnnotations.get(0).getAnnotatedElementType());
 		assertEquals("Extends with an type annotation must be well printed", superInterfaceExpected, firstSuperInterface.toString());
 
-		final CtEnum<?> enumActual = ctClass.getElements(new NamedElementFilter<>(CtEnum.class,"DummyEnum")).get(0);
+		final CtEnum<?> enumActual = ctClass.getElements(new NamedElementFilter<>(CtEnum.class, "DummyEnum")).get(0);
 		final Set<CtTypeReference<?>> superInterfacesOfEnum = enumActual.getSuperInterfaces();
 		final CtTypeReference<?> firstSuperInterfaceOfEnum = superInterfacesOfEnum.toArray(new CtTypeReference<?>[0])[0];
 		final List<CtAnnotation<? extends Annotation>> enumTypeAnnotations = firstSuperInterfaceOfEnum.getAnnotations();
@@ -641,7 +639,7 @@ public class AnnotationTest {
 		assertEquals(CtAnnotatedElementType.TYPE_USE, enumTypeAnnotations.get(0).getAnnotatedElementType());
 		assertEquals("Implements in a enum with an type annotation must be well printed", enumExpected, enumActual.toString());
 
-		final CtInterface<?> interfaceActual = ctClass.getElements(new NamedElementFilter<>(CtInterface.class,"DummyInterface")).get(0);
+		final CtInterface<?> interfaceActual = ctClass.getElements(new NamedElementFilter<>(CtInterface.class, "DummyInterface")).get(0);
 		final Set<CtTypeReference<?>> superInterfacesOfInterface = interfaceActual.getSuperInterfaces();
 		final CtTypeReference<?> firstSuperInterfaceOfInterface = superInterfacesOfInterface.toArray(new CtTypeReference<?>[0])[0];
 		final List<CtAnnotation<? extends Annotation>> interfaceTypeAnnotations = firstSuperInterfaceOfInterface.getAnnotations();
@@ -660,7 +658,7 @@ public class AnnotationTest {
 		Factory factory = launcher.getFactory();
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
-		final CtClass<?> genericClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class,"DummyGenericClass")).get(0);
+		final CtClass<?> genericClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class, "DummyGenericClass")).get(0);
 
 		// New type parameter declaration.
 		final List<CtTypeParameter> typeParameters = genericClass.getFormalCtTypeParameters();
@@ -690,29 +688,29 @@ public class AnnotationTest {
 
 		final CtBlock<?> body = method.getBody();
 		final String expectedFirstStatement =
-				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" +
-						System.lineSeparator() + "T> list = new java.util.ArrayList<>()";
+				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation"
+				+ System.lineSeparator() + "T> list = new java.util.ArrayList<>()";
 		final CtStatement firstStatement = body.getStatement(0);
 		assertEquals("Type annotation on generic parameter declared in the method",
-					 expectedFirstStatement, firstStatement.toString());
+					expectedFirstStatement, firstStatement.toString());
 		final CtConstructorCall firstConstructorCall =
 				firstStatement.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
-							  .get(0);
+							.get(0);
 		final CtTypeReference<?> firstTypeReference = firstConstructorCall.getType()
-																		  .getActualTypeArguments()
-																		  .get(0);
+																		.getActualTypeArguments()
+																		.get(0);
 		assertTrue(firstTypeReference.isImplicit());
 		assertEquals("T", firstTypeReference.getSimpleName());
 
 		final String expectedSecondStatement =
-				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation" +
-						System.lineSeparator() + "?> list2 = new java.util.ArrayList<>()";
+				"java.util.List<@spoon.test.annotation.testclasses.TypeAnnotation"
+				+ System.lineSeparator() + "?> list2 = new java.util.ArrayList<>()";
 		final CtStatement secondStatement = body.getStatement(1);
 		assertEquals("Wildcard with an type annotation must be well printed",
-					 expectedSecondStatement, secondStatement.toString());
+					expectedSecondStatement, secondStatement.toString());
 		final CtConstructorCall secondConstructorCall =
 				secondStatement.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class))
-							   .get(0);
+							.get(0);
 		final CtTypeReference<?> secondTypeReference = secondConstructorCall.getType()
 																			.getActualTypeArguments()
 																			.get(0);
@@ -928,7 +926,7 @@ public class AnnotationTest {
 		final CtMethod<?> testMethod = ctClass.getMethodsByName("test").get(0);
 		Foo.OuterAnnotation annot = testMethod.getAnnotation(Foo.OuterAnnotation.class);
 		assertNotNull(annot);
-		assertEquals(2,annot.value().length);
+		assertEquals(2, annot.value().length);
 	}
 
 	@Test
@@ -1085,14 +1083,12 @@ public class AnnotationTest {
 	public void testSpoonSpoonResult() throws Exception {
 		Launcher spoon = new Launcher();
 		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/dropwizard/GraphiteReporterFactory.java");
-		String output = "target/spooned-" + this.getClass().getSimpleName()+"-firstspoon/";
+		String output = "target/spooned-" + this.getClass().getSimpleName() + "-firstspoon/";
 		spoon.setSourceOutputDirectory(output);
-		Factory factory = spoon.getFactory();
 		spoon.run();
 
 		Launcher spoon2 = new Launcher();
-		spoon2.addInputResource(output+"/spoon/test/annotation/testclasses/dropwizard/GraphiteReporterFactory.java");
-		//spoon2.addInputResource("./src/test/java/spoon/test/annotation/testclasses/PortRange.java");
+		spoon2.addInputResource(output + "/spoon/test/annotation/testclasses/dropwizard/GraphiteReporterFactory.java");
 		spoon2.buildModel();
 
 		List<CtField<?>> fields = spoon2.getModel().getElements(new NamedElementFilter(CtField.class, "port"));
@@ -1197,7 +1193,7 @@ public class AnnotationTest {
 		assertTrue(type.isAnnotationType());
 		assertSame(type, type.getReference().getDeclaration());
 	}
-	
+
 	@Test
 	public void testReplaceAnnotationValue() throws Exception {
 		final Launcher launcher = new Launcher();
@@ -1206,14 +1202,14 @@ public class AnnotationTest {
 		Factory factory = launcher.getFactory();
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.Main");
 
-		CtMethod<?> m1 = type.getElements(new NamedElementFilter<>(CtMethod.class,"m1")).get(0);
+		CtMethod<?> m1 = type.getElements(new NamedElementFilter<>(CtMethod.class, "m1")).get(0);
 
 		List<CtAnnotation<? extends Annotation>> annotations = m1.getAnnotations();
 		assertEquals(1, annotations.size());
 
 		CtAnnotation<?> a = annotations.get(0);
 		AnnotParamTypes annot = (AnnotParamTypes) a.getActualAnnotation();
-		
+
 		//contract: test replace of single value
 		CtExpression integerValue = a.getValue("integer");
 		assertEquals(42, ((CtLiteral<Integer>) integerValue).getValue().intValue());
@@ -1222,7 +1218,7 @@ public class AnnotationTest {
 		CtExpression newIntegerValue = a.getValue("integer");
 		assertEquals(17, ((CtLiteral<Integer>) newIntegerValue).getValue().intValue());
 		assertEquals(17, annot.integer());
-		
+
 		//contract: replacing of single value of map by multiple values must fail
 		//even if second value is null
 		try {
@@ -1231,7 +1227,7 @@ public class AnnotationTest {
 		} catch (SpoonException e)  {
 			//OK
 		}
-		
+
 		//contract: replacing of single value by no value
 		a.getValue("integer").delete();
 		assertNull(a.getValue("integer"));
@@ -1256,13 +1252,13 @@ public class AnnotationTest {
 		//contract: test replace of item in collection
 		assertEquals(1, annot.integers().length);
 		assertEquals(42, annot.integers()[0]);
-		CtNewArray<?> integersNewArray = (CtNewArray)a.getValue("integers");
+		CtNewArray<?> integersNewArray = (CtNewArray) a.getValue("integers");
 		integersNewArray.getElements().get(0).replace(Arrays.asList(null, factory.createLiteral(101), null, factory.createLiteral(102)));
 		assertEquals(2, annot.integers().length);
 		assertEquals(101, annot.integers()[0]);
 		assertEquals(102, annot.integers()[1]);
 	}
-	
+
 	@Test
 	public void testSpoonManageRecursivelyDefinedAnnotation() {
 		// contract: Spoon manage to process recursively defined annotation in shadow classes
@@ -1281,7 +1277,7 @@ public class AnnotationTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Repeated.class);
-		CtMethod firstMethod = (CtMethod)type.getMethodsByName("method").get(0);
+		CtMethod firstMethod = (CtMethod) type.getMethodsByName("method").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertEquals(2, annotations.size());
@@ -1291,8 +1287,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"machin\")"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"truc\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"machin\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"truc\")"));
 	}
 
 	@Test
@@ -1304,15 +1300,15 @@ public class AnnotationTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Repeated.class);
-		CtMethod firstMethod = (CtMethod)type.getMethodsByName("withoutAnnotation").get(0);
+		CtMethod firstMethod = (CtMethod) type.getMethodsByName("withoutAnnotation").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertTrue(annotations.isEmpty());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class,"value", "foo");
+		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class, "value", "foo");
 		assertEquals(1, firstMethod.getAnnotations().size());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class,"value", "bar");
+		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class, "value", "bar");
 
 		annotations = firstMethod.getAnnotations();
 		assertEquals(2, annotations.size());
@@ -1322,8 +1318,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"foo\")"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"bar\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"foo\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"bar\")"));
 	}
 
 	@Test
@@ -1344,8 +1340,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"machin\", \"truc\" })"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"truc\", \"bidule\" })"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"machin\", \"truc\" })"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"truc\", \"bidule\" })"));
 	}
 
 	@Test
@@ -1356,15 +1352,15 @@ public class AnnotationTest {
 		spoon.buildModel();
 
 		CtType type = spoon.getFactory().Type().get(Repeated.class);
-		CtMethod firstMethod = (CtMethod)type.getMethodsByName("withoutAnnotation").get(0);
+		CtMethod firstMethod = (CtMethod) type.getMethodsByName("withoutAnnotation").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertTrue(annotations.isEmpty());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class,"value", "foo");
+		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class, "value", "foo");
 		assertEquals(1, firstMethod.getAnnotations().size());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class,"value", "bar");
+		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class, "value", "bar");
 		annotations = firstMethod.getAnnotations();
 		assertEquals(2, annotations.size());
 
@@ -1373,8 +1369,8 @@ public class AnnotationTest {
 		}
 
 		String classContent = type.toString();
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"foo\")"));
-		assertTrue("Content of the file: "+classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"bar\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"foo\")"));
+		assertTrue("Content of the file: " + classContent, classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"bar\")"));
 	}
 
 	@Test
@@ -1390,12 +1386,12 @@ public class AnnotationTest {
 		assertEquals(1, aMethod.getAnnotations().size());
 
 		String methodContent = aMethod.toString();
-		assertTrue("Content: "+methodContent, methodContent.contains("@spoon.test.annotation.testclasses.notrepeatable.StringAnnot(\"foo\")"));
+		assertTrue("Content: " + methodContent, methodContent.contains("@spoon.test.annotation.testclasses.notrepeatable.StringAnnot(\"foo\")"));
 
 		try {
 			spoon.getFactory().Annotation().annotate(aMethod, StringAnnot.class, "value", "bar");
 			methodContent = aMethod.toString();
-			fail("You should not be able to add two values to StringAnnot annotation: "+methodContent);
+			fail("You should not be able to add two values to StringAnnot annotation: " + methodContent);
 		} catch (SpoonException e) {
 			assertEquals("cannot assign an array to a non-array annotation element", e.getMessage());
 		}
@@ -1431,8 +1427,8 @@ public class AnnotationTest {
 		List<String> lines = Files.readAllLines(new File("./target/spooned-typeandfield/spoon/test/annotation/testclasses/typeandfield/SimpleClass.java").toPath());
 		String fileContent = StringUtils.join(lines, "\n");
 
-		assertTrue("Content :"+fileContent, fileContent.contains("@spoon.test.annotation.testclasses.typeandfield.AnnotTypeAndField"));
-		assertTrue("Content :"+fileContent, fileContent.contains("public java.lang.String mandatoryField;"));
+		assertTrue("Content :" + fileContent, fileContent.contains("@spoon.test.annotation.testclasses.typeandfield.AnnotTypeAndField"));
+		assertTrue("Content :" + fileContent, fileContent.contains("public java.lang.String mandatoryField;"));
 	}
 
 	@Test
@@ -1486,10 +1482,10 @@ public class AnnotationTest {
 	@Test
 	public void testAnnotationArray() throws Exception {
 		// contract: getValue should return a value as close as possible from the sourcecode:
-        // i.e. even if the annotation should return an Array, it should return a single element
-        // if the value is given without the braces. The same behaviour should be used both for
-        // spooned source code and shadow classes.
-		
+		// i.e. even if the annotation should return an Array, it should return a single element
+		// if the value is given without the braces. The same behaviour should be used both for
+		// spooned source code and shadow classes.
+
 		Method barOneValueMethod = DumbKlass.class.getMethod("barOneValue");
 		Method barMultipleValueMethod = DumbKlass.class.getMethod("barMultipleValues");
 
@@ -1537,6 +1533,5 @@ public class AnnotationTest {
 		assertEquals(annotationOne.getAnnotationType(), shadowAnnotationOne.getAnnotationType());
 		assertTrue(shadowAnnotationOne.getValue("role") instanceof CtLiteral); // should be CtLiteral
 		assertEquals(annotationOne.getValue("role"), shadowAnnotationOne.getValue("role")); // should pass
-
 	}
 }

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -133,10 +133,10 @@ public class AnnotationValuesTest {
 
 	private static final String nl = System.lineSeparator();
 
-	private static final String strCtClassOracle = "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES, p = 1701, f = 11.1, m = { 9, 8, 1 }, l = java.lang.Override.class, j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA" +
-			", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(\"bar\")" +
-			", r = { java.lang.Float.class, java.lang.Double.class })" + nl +
-			"public class IsAnnotated {}";
+	private static final String strCtClassOracle = "@com.squareup.javapoet.AnnotationSpecTest.HasDefaultsAnnotation(o = com.squareup.javapoet.AnnotationSpecTest.Breakfast.PANCAKES, p = 1701, f = 11.1, m = { 9, 8, 1 }, l = java.lang.Override.class, j = @com.squareup.javapoet.AnnotationSpecTest.AnnotationA"
+			+ ", q = @com.squareup.javapoet.AnnotationSpecTest.AnnotationC(\"bar\")"
+			+ ", r = { java.lang.Float.class, java.lang.Double.class })"
+			+ nl +	"public class IsAnnotated {}";
 
 	static class Request {
 		private static Request myself = new Request();

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotArray.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotArray.java
@@ -5,5 +5,5 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(value = RetentionPolicy.RUNTIME)
 public @interface AnnotArray {
-	public Class<?>[] value() default { };
+	Class<?>[] value() default { };
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java
@@ -6,6 +6,6 @@ import java.lang.annotation.RetentionPolicy;
 public class AnnotArrayInnerClass {
 	@Retention(value = RetentionPolicy.RUNTIME)
 	public @interface Annotation {
-		public Class<?>[] value() default { };
+		Class<?>[] value() default { };
 	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotParam.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotParam.java
@@ -1,10 +1,9 @@
 package spoon.test.annotation.testclasses;
 
-
 public class AnnotParam {
 
-	@SuppressWarnings({"unused","rawtypes"})
+	@SuppressWarnings({"unused", "rawtypes"})
 	public void m(int a) {
-	} 
+	}
 
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java
@@ -1,8 +1,7 @@
 package spoon.test.annotation.testclasses;
 
 @TestAnnotation
-public enum AnnotParamTypeEnum
-{
+public enum AnnotParamTypeEnum {
 	@TestAnnotation
 	R,
 

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotParamTypes.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotParamTypes.java
@@ -10,7 +10,7 @@ public @interface AnnotParamTypes {
 
 	Class<?> clazz();
 	Class<?>[] classes();
-	
+
 	boolean b();
 	byte byt();
 	char c();
@@ -18,7 +18,7 @@ public @interface AnnotParamTypes {
 	long l();
 	float f();
 	double d();
-	
+
 	AnnotParamTypeEnum e();
 	InnerAnnot ia();
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotationIntrospection.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotationIntrospection.java
@@ -5,9 +5,9 @@ package spoon.test.annotation.testclasses;
  */
 public class AnnotationIntrospection {
 
-    @TestAnnotation
-    public void m() throws NoSuchMethodException {
-        TestAnnotation annotation = getClass().getMethod("m").getAnnotation(TestAnnotation.class);
-        annotation.equals(null);
-    }
+	@TestAnnotation
+	public void m() throws NoSuchMethodException {
+		TestAnnotation annotation = getClass().getMethod("m").getAnnotation(TestAnnotation.class);
+		annotation.equals(null);
+	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java
+++ b/src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java
@@ -24,17 +24,17 @@ public class AnnotationsAppliedOnAnyTypeInAClass {
 	}
 
 	public <T> void m5() {
-		List<@TypeAnnotation(integer=1) T> list;
-		List<@TypeAnnotation(integers={1}) T> list2;
-		List<@TypeAnnotation(string="") T> list3;
-		List<@TypeAnnotation(strings={""}) T> list4;
-		List<@TypeAnnotation(clazz=String.class) T> list5;
-		List<@TypeAnnotation(classes={String.class}) T> list6;
-		List<@TypeAnnotation(b=true) T> list7;
-		List<@TypeAnnotation(e=AnnotParamTypeEnum.R) T> list8;
-		List<@TypeAnnotation(ia=@InnerAnnot("")) T> list9;
-		List<@TypeAnnotation(ias={@InnerAnnot("")}) T> list10;
-		List<@TypeAnnotation(inceptions={@Inception(value = @InnerAnnot(""), values={@InnerAnnot("")})}) T> list11;
+		List<@TypeAnnotation(integer = 1) T> list;
+		List<@TypeAnnotation(integers = {1}) T> list2;
+		List<@TypeAnnotation(string = "") T> list3;
+		List<@TypeAnnotation(strings = {""}) T> list4;
+		List<@TypeAnnotation(clazz = String.class) T> list5;
+		List<@TypeAnnotation(classes = {String.class}) T> list6;
+		List<@TypeAnnotation(b = true) T> list7;
+		List<@TypeAnnotation(e = AnnotParamTypeEnum.R) T> list8;
+		List<@TypeAnnotation(ia = @InnerAnnot("")) T> list9;
+		List<@TypeAnnotation(ias = {@InnerAnnot("")}) T> list10;
+		List<@TypeAnnotation(inceptions = {@Inception(value = @InnerAnnot(""), values = {@InnerAnnot("")})}) T> list11;
 	}
 
 	public void m6(@TypeAnnotation String param) {

--- a/src/test/java/spoon/test/annotation/testclasses/Bar.java
+++ b/src/test/java/spoon/test/annotation/testclasses/Bar.java
@@ -4,5 +4,6 @@ package spoon.test.annotation.testclasses;
  * Created by urli on 03/05/2017.
  */
 public class Bar {
-    public void bidule() {}
+	public void bidule() {
+	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/Foo.java
+++ b/src/test/java/spoon/test/annotation/testclasses/Foo.java
@@ -6,14 +6,14 @@ public class Foo {
 	}
 
 	public @interface OuterAnnotation {
-		public MiddleAnnotation[] value();
+		MiddleAnnotation[] value();
 	}
 
 	public @interface MiddleAnnotation {
-		public InnerAnnotation value();
+		InnerAnnotation value();
 	}
 
 	public @interface InnerAnnotation {
-		public String value();
+		String value();
 	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java
+++ b/src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java
@@ -1,6 +1,5 @@
 package spoon.test.annotation.testclasses;
 
-public @interface InnerAnnot
-{
+public @interface InnerAnnot {
 	String value();
 }

--- a/src/test/java/spoon/test/annotation/testclasses/Main.java
+++ b/src/test/java/spoon/test/annotation/testclasses/Main.java
@@ -23,17 +23,17 @@ public class Main {
 	public void m1() {
 	}
 
-	final public static int INTEGER = 42;
-	final public static String STRING = "Hello World!";
-	final public static String STRING1 = "Hello";
-	final public static String STRING2 = "world";
-	final public static boolean BOOLEAN = false;
-	final public static byte BYTE = 42;
-	final public static char CHAR = 'c';
-	final public static short SHORT = 42;
-	final public static short LONG = 42;
-	final public static float FLOAT = 3.14f;
-	final public static double DOUBLE = 3.14159;
+	public static final int INTEGER = 42;
+	public static final String STRING = "Hello World!";
+	public static final String STRING1 = "Hello";
+	public static final String STRING2 = "world";
+	public static final boolean BOOLEAN = false;
+	public static final byte BYTE = 42;
+	public static final char CHAR = 'c';
+	public static final short SHORT = 42;
+	public static final short LONG = 42;
+	public static final float FLOAT = 3.14f;
+	public static final double DOUBLE = 3.14159;
 
 	@AnnotParamTypes(
 			integer = INTEGER, integers = { INTEGER },

--- a/src/test/java/spoon/test/annotation/testclasses/dropwizard/GraphiteReporterFactory.java
+++ b/src/test/java/spoon/test/annotation/testclasses/dropwizard/GraphiteReporterFactory.java
@@ -11,19 +11,17 @@
 
 package spoon.test.annotation.testclasses.dropwizard;
 
-
 import spoon.test.annotation.testclasses.PortRange;
 
 public class GraphiteReporterFactory {
-    @PortRange
-    private int port = 2003;
+	@PortRange
+	private int port = 2003;
 
-    public int getPort() {
-        return port;
-    }
+	public int getPort() {
+		return port;
+	}
 
-    public void setPort(int port) {
-        this.port = port;
-    }
-
+	public void setPort(int port) {
+		this.port = port;
+	}
 }


### PR DESCRIPTION
I fixed some checkstyle violations.

Also small additional fix - take a look on:
https://github.com/INRIA/spoon/pull/2136/commits/89e053fea0791943d2fd1b6062a3d5eaa7c6d0bb
I refactored
```
    if (ac == Override.class || ac == SuppressWarnings.class || ac == Root.class) {
        return false;
    }
    return true;
```

to
```
return ac != Override.class && ac != SuppressWarnings.class && ac != Root.class;
```

to improve its readability. Previous version is unwieldy, long and hard to read.