### PR TITLE
review fix: launcher#setArgs cannot be called twice

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -99,6 +99,8 @@ public class Launcher implements SpoonAPI {
 	private List<String> processorTypes = new ArrayList<>();
 	private List<Processor<? extends CtElement>> processors = new ArrayList<>();
 
+	private boolean processed;
+
 	/**
 	 * A default program entry point (instantiates a launcher with the given
 	 * arguments and calls {@link #run()}).
@@ -123,6 +125,11 @@ public class Launcher implements SpoonAPI {
 
 	public void setArgs(String[] args2) {
 		this.commandLineArgs = args2;
+		if (processed) {
+			throw new SpoonException("You cannot process twice the same launcher instance.");
+		}
+		processed = true;
+
 		processArguments();
 	}
 

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -99,7 +99,10 @@ public class Launcher implements SpoonAPI {
 	private List<String> processorTypes = new ArrayList<>();
 	private List<Processor<? extends CtElement>> processors = new ArrayList<>();
 
-	private boolean processed;
+	/**
+	 * This field is used to ensure that {@link #setArgs(String[])} is only called once.
+ 	 */
+	private boolean processed = false;
 
 	/**
 	 * A default program entry point (instantiates a launcher with the given

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -9,6 +9,7 @@ import spoon.OutputType;
 import spoon.SpoonAPI;
 import spoon.compiler.Environment;
 import spoon.compiler.InvalidClassPathException;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtVariableAccess;
@@ -54,6 +55,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -588,6 +590,24 @@ public class APITest {
 
 		assertTrue(environment.getNoClasspath());
 		assertTrue(environment.isCommentsEnabled());
+	}
+
+	@Test
+	public void testProcessModelsTwice() {
+		// contract: when processing twice the launcher with different arguments, a new model should be created
+		Launcher launcher = new Launcher();
+		launcher.setArgs(new String[]{"-i", "./src/test/java/spoon/test/api/testclasses/Bar.java"});
+		CtModel model = launcher.buildModel();
+
+		Collection<CtType<?>> allTypes = model.getAllTypes();
+		assertEquals(1, allTypes.size());
+
+		launcher.setArgs(new String[] {"-i", "./src/test/java/spoon/test/arrays/testclasses/Foo.java"});
+		CtModel model2 = launcher.buildModel();
+
+		assertNotSame(model, model2);
+		allTypes = model2.getAllTypes();
+		assertEquals(1, allTypes.size());
 	}
 
 }

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonAPI;
+import spoon.SpoonException;
 import spoon.compiler.Environment;
 import spoon.compiler.InvalidClassPathException;
 import spoon.reflect.CtModel;
@@ -594,20 +595,16 @@ public class APITest {
 
 	@Test
 	public void testProcessModelsTwice() {
-		// contract: when processing twice the launcher with different arguments, a new model should be created
+		// contract: the launcher cannot be processed twice
 		Launcher launcher = new Launcher();
 		launcher.setArgs(new String[]{"-i", "./src/test/java/spoon/test/api/testclasses/Bar.java"});
-		CtModel model = launcher.buildModel();
 
-		Collection<CtType<?>> allTypes = model.getAllTypes();
-		assertEquals(1, allTypes.size());
-
-		launcher.setArgs(new String[] {"-i", "./src/test/java/spoon/test/arrays/testclasses/Foo.java"});
-		CtModel model2 = launcher.buildModel();
-
-		assertNotSame(model, model2);
-		allTypes = model2.getAllTypes();
-		assertEquals(1, allTypes.size());
+		try {
+			launcher.setArgs(new String[] {"-i", "./src/test/java/spoon/test/arrays/testclasses/Foo.java"});
+			fail();
+		} catch (SpoonException e) {
+			assertEquals("You cannot process twice the same launcher instance.", e.getMessage());
+		}
 	}
 
 }

--- a/src/test/java/spoon/test/refactoring/RefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/RefactoringTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.*;
 public class RefactoringTest {
 	@Test
 	public void testRefactoringClassChangeAllCtTypeReferenceAssociatedWithClassConcerned() throws Exception {
-		final Launcher launcher = new Launcher();
+		Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {
 				"-i", "src/test/java/spoon/test/refactoring/testclasses",
 				"-o", "target/spooned/refactoring"
@@ -30,6 +30,7 @@ public class RefactoringTest {
 		final CtClass<?> aClass = launcher.getFactory().Class().get(AClass.class);
 		assertNotNull(aClass);
 
+		launcher = new Launcher();
 		launcher.setArgs(new String[] {
 				"-i", "src/test/java/spoon/test/refactoring/testclasses",
 				"-o", "target/spooned/refactoring",


### PR DESCRIPTION
This PR shows that the current behaviour is to never reset the model, even if the same launcher is called twice with different arguments.

My current test shows that `model` and `model2` are the same and they contain 2 types at the end of the test.

I don't know if it's an expected behaviour or not, but it looks very dangerous to me. WDYT?