### PR TITLE
fix(performance): skip check in building of model CtTypeImpl#addMethod

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -624,9 +624,9 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 					removeTypeMember(m);
 				} else {
 					// checking contract signature implies equal
-					if (!factory.getEnvironment().checksAreSkipped() && m.equals(method)) {
-						throw new AssertionError("violation of core contract! different signature but same equal");
-					}
+//					if (!factory.getEnvironment().checksAreSkipped() && m.equals(method)) {
+//						throw new AssertionError("violation of core contract! different signature but same equal");
+//					}
 				}
 			}
 		}


### PR DESCRIPTION
This check takes about 25% of spoon model build time. Does it really makes sense to check it???

Or may be it should be by default disabled and we can enable it only in our tests?

WDYT?