### PR TITLE
fix(position): CtCatch has no modifiers, they are in CatchVariable

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -445,13 +445,15 @@ public class PositionBuilder {
 		CtTry tryElement = catcher.getParent(CtTry.class);
 		//offset after last bracket before catch
 		int declarationStart = getEndOfLastTryBlock(tryElement, 1) + 1;
-		DeclarationSourcePosition oldCatcherPos = (DeclarationSourcePosition) catcher.getParameter().getPosition();
+		DeclarationSourcePosition paramPos = (DeclarationSourcePosition) catcher.getParameter().getPosition();
 		int bodyStart = catcher.getBody().getPosition().getSourceStart();
 		int bodyEnd = catcher.getBody().getPosition().getSourceEnd();
 		return catcher.getFactory().Core().createBodyHolderSourcePosition(
 				tryElement.getPosition().getCompilationUnit(),
-				oldCatcherPos.getNameStart(), oldCatcherPos.getNameEnd(),
-				oldCatcherPos.getModifierSourceStart(), oldCatcherPos.getModifierSourceEnd(),
+				//on the place of name there is catch variable
+				paramPos.getSourceStart(), paramPos.getSourceEnd(),
+				//catch has no modifiers, They are in catch variable
+				declarationStart, declarationStart - 1,
 				declarationStart, bodyEnd,
 				bodyStart, bodyEnd,
 				lineSeparatorPositions);

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -887,16 +887,28 @@ public class PositionTest {
 		CtTry tryStatement = (CtTry) foo.getMethodsByName("method").get(0).getBody().getStatement(0);
 		{
 			CtCatch catcher = tryStatement.getCatchers().get(0);
-			BodyHolderSourcePosition pos = (BodyHolderSourcePosition) catcher.getPosition();
+			CtCatchVariable<?> catchVar = catcher.getParameter();
+			
+			BodyHolderSourcePosition catcherPos = (BodyHolderSourcePosition) catcher.getPosition();
+			DeclarationSourcePosition catchVarPos = (DeclarationSourcePosition) catchVar.getPosition();
+
 			assertEquals(" catch (final IOException e) {\n" + 
 					"			throw new RuntimeException(e);\n" + 
-					"		}", contentAtPosition(classContent, pos.getSourceStart(), pos.getSourceEnd()));
-			assertEquals("final", contentAtPosition(classContent, pos.getModifierSourceStart(), pos.getModifierSourceEnd()));
-			assertEquals(" IOException ", contentAtPosition(classContent, pos.getModifierSourceEnd() + 1, pos.getNameStart() - 1));
-			assertEquals("e", contentAtPosition(classContent, pos.getNameStart(), pos.getNameEnd()));
+					"		}", contentAtPosition(classContent, catcherPos.getSourceStart(), catcherPos.getSourceEnd()));
+			assertEquals("final IOException e", contentAtPosition(classContent, catchVarPos.getSourceStart(), catchVarPos.getSourceEnd()));
+
+			assertEquals("", contentAtPosition(classContent, catcherPos.getModifierSourceStart(), catcherPos.getModifierSourceEnd()));
+			assertEquals("final", contentAtPosition(classContent, catchVarPos.getModifierSourceStart(), catchVarPos.getModifierSourceEnd()));
+			
+			assertEquals(" catch (", contentAtPosition(classContent, catcherPos.getModifierSourceEnd() + 1, catcherPos.getNameStart() - 1));
+			assertEquals(" IOException ", contentAtPosition(classContent, catchVarPos.getModifierSourceEnd() + 1, catchVarPos.getNameStart() - 1));
+
+			assertEquals("final IOException e", contentAtPosition(classContent, catcherPos.getNameStart(), catcherPos.getNameEnd()));
+			assertEquals("e", contentAtPosition(classContent, catchVarPos.getNameStart(), catchVarPos.getNameEnd()));
+
 			assertEquals("{\n" + 
 				"			throw new RuntimeException(e);\n" + 
-				"		}", contentAtPosition(classContent, pos.getBodyStart(), pos.getBodyEnd()));
+				"		}", contentAtPosition(classContent, catcherPos.getBodyStart(), catcherPos.getBodyEnd()));
 		}
 		{
 			CtCatch catcher = tryStatement.getCatchers().get(1);
@@ -904,8 +916,8 @@ public class PositionTest {
 			assertEquals(" /*1*/ catch/*2*/ ( /*3*/ final @Deprecated /*4*/ ClassCastException /*5*/ e /*6*/) /*7*/ {\n" + 
 					"			throw new RuntimeException(e);\n" + 
 					"		}", contentAtPosition(classContent, pos.getSourceStart(), pos.getSourceEnd()));
-			assertEquals("final @Deprecated", contentAtPosition(classContent, pos.getModifierSourceStart(), pos.getModifierSourceEnd()));
-			assertEquals("e", contentAtPosition(classContent, pos.getNameStart(), pos.getNameEnd()));
+			assertEquals("", contentAtPosition(classContent, pos.getModifierSourceStart(), pos.getModifierSourceEnd()));
+			assertEquals(" /*3*/ final @Deprecated /*4*/ ClassCastException /*5*/ e", contentAtPosition(classContent, pos.getNameStart(), pos.getNameEnd()));
 			assertEquals("{\n" + 
 					"			throw new RuntimeException(e);\n" + 
 					"		}", contentAtPosition(classContent, pos.getBodyStart(), pos.getBodyEnd()));
@@ -921,8 +933,9 @@ public class PositionTest {
 					"			throw new RuntimeException(e);\n" + 
 					"		}", contentAtPosition(classContent, pos.getSourceStart(), pos.getSourceEnd()));
 			assertEquals("", contentAtPosition(classContent, pos.getModifierSourceStart(), pos.getModifierSourceEnd()));
-			assertEquals("OutOfMemoryError|RuntimeException ", contentAtPosition(classContent, pos.getModifierSourceEnd() + 1, pos.getNameStart()-1));
-			assertEquals("e", contentAtPosition(classContent, pos.getNameStart(), pos.getNameEnd()));
+			assertEquals(" /**catch it ( */\n" + 
+					"				//catch (\n" + 
+					"				OutOfMemoryError|RuntimeException e", contentAtPosition(classContent, pos.getNameStart(), pos.getNameEnd()));
 			assertEquals("{\n" + 
 					"			throw new RuntimeException(e);\n" + 
 					"		}", contentAtPosition(classContent, pos.getBodyStart(), pos.getBodyEnd()));


### PR DESCRIPTION
The modifiers were on two places before
1) CtCatch - wrong
2) CtCactchVariable - OK

So this PR removes them from CtCatch

Note: CtCatch would need a bettet source position structure. I actually I used BodyHolderSourcePosition, but it is may be not fitting well here. WDYT? Can we live with that or we make new structure for that?