### PR TITLE
fix: Invalid end column

### DIFF
--- a/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
@@ -63,8 +63,14 @@ public class CompoundSourcePositionImpl extends SourcePositionImpl
 		return super.getSourceEnd();
 	}
 
+	@Override
 	public int getEndLine() {
 		return searchLineNumber(declarationSourceEnd);
+	}
+
+	@Override
+	public int getEndColumn() {
+		return searchColumnNumber(declarationSourceEnd);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -65,7 +65,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	/**
 	 * Search the column number
 	 */
-	private int searchColumnNumber(int position) {
+	protected int searchColumnNumber(int position) {
 		if (lineSeparatorPositions == null) {
 			return -1;
 		}

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1011,5 +1011,17 @@ public class PositionTest {
 			assertEquals("items", contentAtPosition(classContent, forEach.getExpression().getPosition()));
 		}
 	}
-	
+
+	@Test
+	public void testEndColumn() throws Exception {
+		//contract: check end column
+		final Factory build = build(FooStatement.class);
+		final CtType<FooStatement> foo = build.Type().get(FooStatement.class);
+		CtMethod<?> m = foo.getMethodsByName("m").get(0);
+		SourcePosition pos = m.getPosition();
+		assertEquals(7, pos.getLine());
+		assertEquals(14, pos.getColumn());
+		assertEquals(23, pos.getEndLine());
+		assertEquals(2, pos.getEndColumn());
+	}
 }


### PR DESCRIPTION
Hi! I've found out that `getEndColumn()` from `CompoundSourcePositionImpl` works incorrectly.
Here are 2 screenshots to illustrate the problem.    
Now:
![not_ok](https://user-images.githubusercontent.com/32983915/42217181-e2d869a0-7ecc-11e8-8914-7855230e52d8.png)
Expected:
![ok](https://user-images.githubusercontent.com/32983915/42217212-fae6828e-7ecc-11e8-8875-63645851cfa6.png)

The problem is that only `getEndLine()` has been overriden, but not `getEndColumn()`.
So this PR contains fix and additional test.