### PR TITLE
Sonarqube-repair - add no-argument constructor in SubFactory

### DIFF
--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -23,7 +23,10 @@ package spoon.reflect.factory;
  */
 public abstract class SubFactory {
 
-	protected Factory factory;
+	public SubFactory() {
+}
+
+protected Factory factory;
 
 	/**
 	 * The sub-factory constructor takes an instance of the parent factory.
@@ -32,9 +35,6 @@ public abstract class SubFactory {
 		super();
 		this.factory = factory;
 	}
-
-public SubFactory() {
-}
 
 }
 

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.factory;
 
+
 /**
  * This class is the superclass for all the sub-factories of
  * {@link spoon.reflect.factory.Factory}.
@@ -32,24 +33,8 @@ public abstract class SubFactory {
 		this.factory = factory;
 	}
 
-	/**
-	 * Generically sets the parent of a set of elements or lists of elements.
-	 *
-	 * @param parent
-	 *            the parent
-	 * @param elements
-	 *            some {@link CtElement} or lists of {@link CtElement}
-	 */
-	//	protected void setParent(CtElement parent, Object... elements) {
-	//		for (Object o : elements) {
-	//			if (o instanceof CtElement) {
-	//				((CtElement) o).setParent(parent);
-	//			} else if (o instanceof Collection) {
-	//				for (Object o2 : (Collection<?>) o) {
-	//					((CtElement) o2).setParent(parent);
-	//				}
-	//			}
-	//		}
-	//	}
+public SubFactory() {
+}
 
 }
+


### PR DESCRIPTION
This PR repairs [three sonarqube bugs](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&resolved=false&rules=squid%3AS2055&types=BUG). Classes ModuleFactory, PackageFactory, and DefaultCoreFactory extend SubFactory and are Serializable. But SubFactory is not Serializable and should contain a no-argument constructor according to [Sonar Rule 2055](https://rules.sonarsource.com/java/type/Bug/RSPEC-2055).

Even though I enabled comments, spoon did not pick up the commented out code and hence this diff. But that block is commented since 5 years and is itself marked as a [code smell](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&issues=AWIvav2IRIyoeYNsnf03&open=AWIvav2IRIyoeYNsnf03) by Sonarqube.