### PR TITLE
WIP feat: javadoc {@link} can be made fully-qualified

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
@@ -153,7 +153,7 @@ public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 				JavadocInlineTag tag = (JavadocInlineTag) fragment;
 				if (tag.getType().equals(JavadocInlineTag.Type.LINK)) {
 					String stype;
-					String suffix= "";
+					String suffix = "";
 					if (tag.getContent().contains("#")) {
 						// link to a method
 						String[] split = tag.getContent().split("#");

--- a/src/test/java/spoon/test/comment/testclasses/JavadocLinkComment.java
+++ b/src/test/java/spoon/test/comment/testclasses/JavadocLinkComment.java
@@ -1,0 +1,19 @@
+package spoon.test.comment.testclasses;
+
+import spoon.SpoonException;
+import spoon.reflect.declaration.CtElement;
+
+/**
+ * for more information, please have a look
+ * on {@link CtTypeMemberWildcardImportReferenceImpl}
+ * and {@link CtElement#toString()}
+ */
+public class JavadocLinkComment {
+
+    /**
+     * Bla
+     *
+     * @throws SpoonException when something is wrong
+     */
+    public void method() throws SpoonException {}
+}


### PR DESCRIPTION
Requirements implemented:
* <s>R1: add support for getting the original comments</s> done in #2746 
* <s>R2: the original comment can be analyzed from the model and from the serialized model, even if the Java files don't exist anymore on disk)</s> abandoned 
* <s>R3: the @link fragments can be analyzed done</s> in #2802
* R4: javadoc {@link} can be made fully-qualified here

fix #2170 