### PR TITLE
remove "implements Serializable" from ModuleFactory, PackageFactory an…

### DIFF
--- a/src/main/java/spoon/reflect/factory/ModuleFactory.java
+++ b/src/main/java/spoon/reflect/factory/ModuleFactory.java
@@ -16,29 +16,29 @@
  */
 package spoon.reflect.factory;
 
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 import spoon.reflect.CtModelImpl;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtModuleRequirement;
+import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtProvidedService;
-import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtModuleReference;
-import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.reflect.declaration.CtModuleImpl;
 
-import java.io.Serializable;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
-public class ModuleFactory extends SubFactory implements Serializable {
+public class ModuleFactory extends SubFactory {
 
 	public static class CtUnnamedModule extends CtModuleImpl {
 		final Set<CtModule> allModules = new HashSet<>();
@@ -162,3 +162,4 @@ public class ModuleFactory extends SubFactory implements Serializable {
 		return factory.Core().createUsedService().setServiceType(typeReference);
 	}
 }
+

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -16,21 +16,21 @@
  */
 package spoon.reflect.factory;
 
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringTokenizer;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtPackageReference;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.StringTokenizer;
 
 /**
  * The {@link CtPackage} sub-factory.
  */
-public class PackageFactory extends SubFactory implements Serializable {
+public class PackageFactory extends SubFactory {
 	private static final long serialVersionUID = 1L;
 
 	/**
@@ -187,3 +187,4 @@ public class PackageFactory extends SubFactory implements Serializable {
 	}
 
 }
+

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.factory;
 
+
 /**
  * This class is the superclass for all the sub-factories of
  * {@link spoon.reflect.factory.Factory}.
@@ -53,3 +54,4 @@ public abstract class SubFactory {
 	//	}
 
 }
+

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -197,7 +197,6 @@ import spoon.support.reflect.reference.CtWildcardReferenceImpl;
 import spoon.support.reflect.reference.CtWildcardStaticTypeMemberReferenceImpl;
 import spoon.support.visitor.equals.CloneHelper;
 
-import static spoon.reflect.code.CtComment.CommentType.BLOCK;
 
 
 /**

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -16,6 +16,8 @@
  */
 package spoon.support;
 
+
+import java.lang.annotation.Annotation;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayRead;
 import spoon.reflect.code.CtArrayWrite;
@@ -79,13 +81,15 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModule;
-import spoon.reflect.declaration.CtPackageExport;
-import spoon.reflect.declaration.CtProvidedService;
+import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.factory.CoreFactory;
@@ -95,11 +99,9 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.declaration.CtImport;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtModuleReference;
-import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -167,13 +169,15 @@ import spoon.support.reflect.declaration.CtConstructorImpl;
 import spoon.support.reflect.declaration.CtEnumImpl;
 import spoon.support.reflect.declaration.CtEnumValueImpl;
 import spoon.support.reflect.declaration.CtFieldImpl;
+import spoon.support.reflect.declaration.CtImportImpl;
 import spoon.support.reflect.declaration.CtInterfaceImpl;
 import spoon.support.reflect.declaration.CtMethodImpl;
-import spoon.support.reflect.declaration.CtPackageExportImpl;
 import spoon.support.reflect.declaration.CtModuleImpl;
-import spoon.support.reflect.declaration.CtProvidedServiceImpl;
+import spoon.support.reflect.declaration.CtModuleRequirementImpl;
+import spoon.support.reflect.declaration.CtPackageExportImpl;
 import spoon.support.reflect.declaration.CtPackageImpl;
 import spoon.support.reflect.declaration.CtParameterImpl;
+import spoon.support.reflect.declaration.CtProvidedServiceImpl;
 import spoon.support.reflect.declaration.CtTypeParameterImpl;
 import spoon.support.reflect.declaration.CtUsedServiceImpl;
 import spoon.support.reflect.declaration.InvisibleArrayConstructorImpl;
@@ -181,11 +185,9 @@ import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 import spoon.support.reflect.reference.CtCatchVariableReferenceImpl;
 import spoon.support.reflect.reference.CtExecutableReferenceImpl;
 import spoon.support.reflect.reference.CtFieldReferenceImpl;
-import spoon.support.reflect.declaration.CtImportImpl;
 import spoon.support.reflect.reference.CtIntersectionTypeReferenceImpl;
 import spoon.support.reflect.reference.CtLocalVariableReferenceImpl;
 import spoon.support.reflect.reference.CtModuleReferenceImpl;
-import spoon.support.reflect.declaration.CtModuleRequirementImpl;
 import spoon.support.reflect.reference.CtPackageReferenceImpl;
 import spoon.support.reflect.reference.CtParameterReferenceImpl;
 import spoon.support.reflect.reference.CtTypeParameterReferenceImpl;
@@ -195,14 +197,14 @@ import spoon.support.reflect.reference.CtWildcardReferenceImpl;
 import spoon.support.reflect.reference.CtWildcardStaticTypeMemberReferenceImpl;
 import spoon.support.visitor.equals.CloneHelper;
 
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
+import static spoon.reflect.code.CtComment.CommentType.BLOCK;
+
 
 /**
  * This class implements a default core factory for Spoon's meta-model. This
  * implementation is done with regular Java classes (POJOs).
  */
-public class DefaultCoreFactory extends SubFactory implements CoreFactory, Serializable {
+public class DefaultCoreFactory extends SubFactory implements CoreFactory {
 
 	private static final long serialVersionUID = 1L;
 
@@ -1030,3 +1032,4 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory, Seria
 	}
 
 }
+


### PR DESCRIPTION
…d DefaultCoreFactory. This PR is alternative to https://github.com/INRIA/spoon/pull/2169. Instead of adding a constructor to SubFactory, it makes these subclasses unserializable.

Apart from these [3 bugs](https://sonarqube.ow2.org/project/issues?fileUuids=AWIvavK1RIyoeYNsnfL7%2CAWIvavLKRIyoeYNsnfUO%2CAWIvavLKRIyoeYNsnfUS&id=fr.inria.gforge.spoon%3Aspoon-core&open=AWOsMo5ERIyoeYNspj73&resolved=false&rules=squid%3AS2055&types=BUG), it also removes (DOESN'T)[two bugs](https://sonarqube.ow2.org/project/issues?fileUuids=AWIvavK1RIyoeYNsnfL7%2CAWIvavLKRIyoeYNsnfUO%2CAWIvavLKRIyoeYNsnfUS&id=fr.inria.gforge.spoon%3Aspoon-core&resolved=false&rules=squid%3AS1948&types=BUG) of [Sonar Rule 1948](https://rules.sonarsource.com/java/type/Bug/RSPEC-1948), since ModuleFactory will no longer be Serializable.

**Edit :** It won't remove those two bugs of rule 1948 because these fields are in a nested class which is also Serializable.