### PR TITLE
review: refactor: store line separator positions in CompilationUnit

### DIFF
--- a/src/main/java/spoon/reflect/cu/CompilationUnit.java
+++ b/src/main/java/spoon/reflect/cu/CompilationUnit.java
@@ -58,6 +58,16 @@ public interface CompilationUnit extends FactoryAccessor, Serializable {
 	void setFile(File file);
 
 	/**
+	 * @return array of offsets in the origin source file, where occurs line separator
+	 */
+	int[] getLineSeparatorPositions();
+
+	/**
+	 * @param lineSeparatorPositions array of offsets in the origin source file, where occurs line separator
+	 */
+	void setLineSeparatorPositions(int[] lineSeparatorPositions);
+
+	/**
 	 * Gets all binary (.class) files that corresponds to this compilation unit
 	 * and have been created by calling
 	 * {@link spoon.SpoonModelBuilder#compile(spoon.SpoonModelBuilder.InputType...)}.

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -89,6 +89,7 @@ public class PositionBuilder {
 		CompilationUnit cu = this.jdtTreeBuilder.getFactory().CompilationUnit().getOrCreate(new String(this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.getFileName()));
 		CompilationResult cr = this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.compilationResult;
 		int[] lineSeparatorPositions = cr.lineSeparatorPositions;
+		cu.setLineSeparatorPositions(lineSeparatorPositions);
 		char[] contents = cr.compilationUnit.getContents();
 
 		int sourceStart = node.sourceStart;

--- a/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
@@ -39,6 +39,10 @@ import java.util.Set;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.COMPILATION_UNIT_DECLARED_TYPES_CONTAINER_DEFAULT_CAPACITY;
 
+/**
+ * Implements a compilation unit. In Java, a compilation unit can contain only one
+ * public type declaration and other secondary types declarations (not public).
+ */
 public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 	private static final long serialVersionUID = 1L;
 
@@ -53,6 +57,8 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 	CtModule ctModule;
 
 	File file;
+
+	private int[] lineSeparatorPositions;
 
 	@Override
 	public UNIT_TYPE getUnitType() {
@@ -141,6 +147,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		this.ctPackage = ctPackage;
 	}
 
+	@Override
 	public void setFile(File file) {
 		this.file = file;
 	}
@@ -193,6 +200,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 
 	String originalSourceCode;
 
+	@Override
 	public String getOriginalSourceCode() {
 
 		if (originalSourceCode == null) {
@@ -207,6 +215,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		return originalSourceCode;
 	}
 
+	@Override
 	public int beginOfLineIndex(int index) {
 		int cur = index;
 		while (cur >= 0 && getOriginalSourceCode().charAt(cur) != '\n') {
@@ -215,6 +224,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		return cur + 1;
 	}
 
+	@Override
 	public int nextLineIndex(int index) {
 		int cur = index;
 		while (cur < getOriginalSourceCode().length()
@@ -224,6 +234,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		return cur + 1;
 	}
 
+	@Override
 	public int getTabCount(int index) {
 		int cur = index;
 		int tabCount = 0;
@@ -254,10 +265,12 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		this.imports = imports;
 	}
 
+	@Override
 	public Factory getFactory() {
 		return factory;
 	}
 
+	@Override
 	public void setFactory(Factory factory) {
 		this.factory = factory;
 	}
@@ -283,5 +296,13 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		return myPartialSourcePosition;
 	}
 
+	@Override
+	public int[] getLineSeparatorPositions() {
+		return lineSeparatorPositions;
+	}
 
+	@Override
+	public void setLineSeparatorPositions(int[] lineSeparatorPositions) {
+		this.lineSeparatorPositions = lineSeparatorPositions;
+	}
 }

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -37,6 +37,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	 * Search the line number corresponding to a specific position
 	 */
 	protected int searchLineNumber(int position) {
+		int[] lineSeparatorPositions = getLineSeparatorPositions();
 		if (lineSeparatorPositions == null) {
 			return 1;
 		}
@@ -66,6 +67,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	 * Search the column number
 	 */
 	protected int searchColumnNumber(int position) {
+		int[] lineSeparatorPositions = getLineSeparatorPositions();
 		if (lineSeparatorPositions == null) {
 			return -1;
 		}
@@ -104,19 +106,19 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	 */
 	private int sourceStartline = -1;
 
-	/**
-	 * The index of line breaks, as computed by JDT.
-	 * Used to compute line numbers afterwards.
-	 */
-	private final int[] lineSeparatorPositions;
-
 	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {
 		super();
 		checkArgsAreAscending(sourceStart, sourceEnd + 1);
+		if (compilationUnit == null) {
+			throw new SpoonException("Mandatory parameter compilationUnit is null");
+		}
 		this.compilationUnit = compilationUnit;
+		//TODD: this check will be removed after we remove lineSeparatorPositions from the Constructor
+		if (compilationUnit.getLineSeparatorPositions() != lineSeparatorPositions) {
+			throw new SpoonException("Unexpected lineSeparatorPositions");
+		}
 		this.sourceEnd = sourceEnd;
 		this.sourceStart = sourceStart;
-		this.lineSeparatorPositions = lineSeparatorPositions;
 	}
 
 	@Override
@@ -222,5 +224,9 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 			}
 			last = value;
 		}
+	}
+
+	private int[] getLineSeparatorPositions() {
+		return compilationUnit == null ? null : compilationUnit.getLineSeparatorPositions();
 	}
 }


### PR DESCRIPTION
Why?
* line separator positions (array of offsets of EOLs) are conceptually related to CompilationUnit
* SourcePositionImpl needs less storage now, because it takes line separator positions from it's compilation unit
