### PR TITLE
review: refactor: PrinterHelper can be extended to support direct writing

### DIFF
--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -44,7 +44,7 @@ public class PrinterHelper {
 	/**
 	 * The string buffer in which the code is generated.
 	 */
-	private final StringBuffer sbf = new StringBuffer();
+	protected final StringBuffer sbf = new StringBuffer();
 
 	/**
 	 * Number of tabs when we print the source code.
@@ -72,7 +72,7 @@ public class PrinterHelper {
 	 * each writeln() sets this to true.
 	 * if true then first call of write first writes tabs and then resets this to false
 	 */
-	private boolean shouldWriteTabs = true;
+	protected boolean shouldWriteTabs = true;
 	/*
 	 * true if last written character was \r
 	 * It helps to detect windows EOL, which is \r\n
@@ -167,7 +167,7 @@ public class PrinterHelper {
 		}
 	}
 
-	private void autoWriteTabs() {
+	protected void autoWriteTabs() {
 		if (shouldWriteTabs) {
 			writeTabsInternal();
 			shouldWriteTabs = false;

--- a/src/main/java/spoon/reflect/visitor/TokenWriter.java
+++ b/src/main/java/spoon/reflect/visitor/TokenWriter.java
@@ -133,9 +133,8 @@ public interface TokenWriter {
 	 */
 	void reset();
 
-	/** Writes a single space.
-	 *
-	 *  Note that this method is only there for low-level implementation reasons. A default implementation simply calls {@link PrinterHelper#writeSpace()} ()}. This method will be removed in a later refactoring.
-	 * */
+	/**
+	 * Writes a single space.
+	 */
 	TokenWriter writeSpace();
 }


### PR DESCRIPTION
The changes in PrinterHelper are needed for sniper mode, which needs low level access to the print buffer and some printer helper state.

The TokenWriter#writeSpace is needed for sniper mode too. The direct call of PrinterHelper (as written in old comment) would kill the concept of Sniper mode.