### PR TITLE
review: feat(position): new interface SourcePositionHolder

### DIFF
--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -477,6 +477,7 @@ public class Metamodel {
 			"java.lang.Cloneable",
 			"java.lang.Object",
 			"spoon.processing.FactoryAccessor",
+			"spoon.reflect.cu.SourcePositionHolder",
 			"spoon.reflect.visitor.CtVisitable",
 			"spoon.reflect.visitor.chain.CtQueryable",
 			"spoon.template.TemplateParameter",

--- a/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
+++ b/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.cu;
+
+/**
+ * This interface represents an element which knows it's position in a source file.
+ */
+public interface SourcePositionHolder {
+	SourcePosition getPosition();
+}

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -19,6 +19,7 @@ package spoon.reflect.declaration;
 import spoon.processing.FactoryAccessor;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.path.CtPath;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
@@ -48,7 +49,7 @@ import static spoon.reflect.path.CtRole.POSITION;
  * element).
  */
 @Root
-public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable, Serializable {
+public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable, Serializable, SourcePositionHolder {
 
 	/**
 	 * Searches for an annotation of the given class that annotates the
@@ -134,6 +135,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * to detect whether return instance contains start/end indexes.
 	 */
 	@PropertyGetter(role = POSITION)
+	@Override
 	SourcePosition getPosition();
 
 	/**

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -17,6 +17,7 @@
 package spoon.support.reflect;
 
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.declaration.ModifierKind;
 
 import java.io.Serializable;
@@ -25,7 +26,7 @@ import java.io.Serializable;
  * When a modifier is "implicit", it does not appear in the source code (eg public for interface methods)
  * ModifierKind in kept for sake of full backward-compatibility.
  */
-public class CtExtendedModifier implements Serializable {
+public class CtExtendedModifier implements SourcePositionHolder, Serializable {
 	private boolean implicit;
 	private ModifierKind kind;
 	private SourcePosition position;
@@ -55,6 +56,7 @@ public class CtExtendedModifier implements Serializable {
 		this.kind = kind;
 	}
 
+	@Override
 	public SourcePosition getPosition() {
 		if (position == null) {
 			return SourcePosition.NOPOSITION;


### PR DESCRIPTION
CtElement and CtExtendedModifier now both implements SourcePositionHolder.

It is needed for Sniper mode which needs a generic access to Position of CtExtendedModifier.