### PR TITLE
refactor: fix code inspection: Java language level migration aids - J…

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -189,7 +189,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	public String getDocComment() {
 		for (CtComment ctComment : comments) {
 			if (ctComment.getCommentType() == CtComment.CommentType.JAVADOC) {
-				StringBuffer result = new StringBuffer();
+				StringBuilder result = new StringBuilder();
 				result.append(ctComment.getContent() + System.lineSeparator());
 				for (CtJavaDocTag tag: ((CtJavaDoc) ctComment).getTags()) {
 					result.append(tag.toString()); // the tag already contains a new line


### PR DESCRIPTION
…ava 5: StringBuffer may be StringBuilder

Java language migration aids - Java 5
- 'StringBuffer' may be 'StringBuilder'

Rationale:
- StringBuffer is older class with synchronized methods. By default StringBuilder should be used
- [Don't Use StringBuffer!](http://jeremymanson.blogspot.com/2008/08/dont-use-stringbuffer.html)