### PR TITLE
refactor: Code inspection: Use modern foreach loop

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -63,7 +63,6 @@ import java.lang.reflect.WildcardType;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.Iterator;
 
 /**
  * Builds Spoon model from class file using the reflection api. The Spoon model

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -332,9 +332,8 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 	@Override
 	public <T extends GenericDeclaration> void visitTypeParameter(TypeVariable<T> parameter) {
 		GenericDeclaration genericDeclaration = parameter.getGenericDeclaration();
-		Iterator<RuntimeBuilderContext> contextIterator = contexts.iterator();
-		while (contextIterator.hasNext()) {
-			CtTypeParameter typeParameter = contextIterator.next().getTypeParameter(genericDeclaration, parameter.getName());
+		for (RuntimeBuilderContext context : contexts) {
+			CtTypeParameter typeParameter = context.getTypeParameter(genericDeclaration, parameter.getName());
 			if (typeParameter != null) {
 				contexts.peek().addFormalType(typeParameter.clone());
 				return;
@@ -380,9 +379,8 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 		}
 
 		GenericDeclaration genericDeclaration = parameter.getGenericDeclaration();
-		Iterator<RuntimeBuilderContext> contextIterator = contexts.iterator();
-		while (contextIterator.hasNext()) {
-			CtTypeParameter typeParameter = contextIterator.next().getTypeParameter(genericDeclaration, parameter.getName());
+		for (RuntimeBuilderContext context : contexts) {
+			CtTypeParameter typeParameter = context.getTypeParameter(genericDeclaration, parameter.getName());
 			if (typeParameter != null) {
 				contexts.peek().addTypeReference(role, typeParameter.getReference());
 				return;


### PR DESCRIPTION
Code inspection
- Java language level migration aids | Java 5 | 'while' loop replaceable with 'foreach'

Rationale: foreach is shorter, more readable and easier understand. While with iterator should be avoided if possible.