### PR TITLE
refactor: remove unnecessary 'return' statement

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -197,7 +197,6 @@ public class ParentExiter extends CtInheritanceScanner {
 		if (childJDT instanceof TypeParameter && child instanceof CtTypeParameter) {
 			e.addFormalCtTypeParameter((CtTypeParameter) child);
 		}
-		return;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -206,7 +206,6 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 				throw new RuntimeException("unsupported operator " + operator.getKind());
 			}
 			setResult(res);
-			return;
 		} else if ((left instanceof CtLiteral) || (right instanceof CtLiteral)) {
 			CtLiteral<?> literal;
 			CtExpression<?> expr;

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -352,7 +352,6 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		if (getFactory().getEnvironment().getNoClasspath()) {
 			// should not be thrown in 'noClasspath' environment (#775)
 			Launcher.LOGGER.warn(msg);
-			return;
 		} else {
 			throw cnfe;
 		}

--- a/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
@@ -114,8 +114,6 @@ public class EqualsVisitor extends CtBiScannerDefault {
 		} finally {
 			lastRole = null;
 		}
-
-		return;
 	}
 
 	protected boolean fail(CtRole role, Object element, Object other) {


### PR DESCRIPTION
Verbose or redundant code constructs
- Unnecessary return statement

Rationale
Simpler, more readable code. Less clutter.