### PR TITLE
Repair of sonarqube bug, made CtElement Serializable

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -30,6 +30,7 @@ import spoon.support.DerivedProperty;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Collection;
 import java.util.Iterator;
@@ -47,7 +48,7 @@ import static spoon.reflect.path.CtRole.POSITION;
  * element).
  */
 @Root
-public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable {
+public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQueryable, Serializable {
 
 	/**
 	 * Searches for an annotation of the given class that annotates the


### PR DESCRIPTION
By making CtElement serializable, a total of 83 sonarqube bugs will be removed from spoon because every part of the Spoon model inherits from the CtElement. As recommended by @surli in https://github.com/INRIA/spoon/pull/2117 .