### PR TITLE
review: fix: comment on nested else if statement

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -516,7 +516,7 @@ class JDTCommentBuilder {
 				if (element == null) {
 					return;
 				}
-				if (element.isImplicit()) {
+				if (element.isImplicit() && !(element instanceof CtBlock)) {
 					return;
 				}
 				CtElement body = getBody(element);

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -7,6 +7,7 @@ import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtConstructorCall;
@@ -49,6 +50,7 @@ import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.test.comment.testclasses.BlockComment;
 import spoon.test.comment.testclasses.Comment1;
 import spoon.test.comment.testclasses.Comment2;
+import spoon.test.comment.testclasses.CommentsOnStatements;
 import spoon.test.comment.testclasses.InlineComment;
 import spoon.test.comment.testclasses.JavaDocComment;
 import spoon.test.comment.testclasses.JavaDocEmptyCommentAndTags;
@@ -63,10 +65,12 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.write;
 import static org.junit.Assert.*;
@@ -962,5 +966,29 @@ public class CommentTest {
 		} catch (SpoonException e) {
 			assertTrue(e.getMessage().contains("consider using a block comment"));
 		}
+	}
+	@Test
+	public void testStatementComments() {
+		// contract: the statements have their comment even if they are nested in another block
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/comment/testclasses/CommentsOnStatements.java");
+		launcher.getEnvironment().setCommentEnabled(true);
+
+		CtModel model = launcher.buildModel();
+		
+		List<CtStatement> statements = launcher.getFactory().Type().get(CommentsOnStatements.class).getMethodsByName("m1").get(0).getBody().getStatements();
+		assertEquals(2, statements.size());
+		CtIf ifStatement = (CtIf) statements.get(0);
+		assertEquals(Arrays.asList("// c1"), getCommentStrings(ifStatement));
+		assertEquals(Arrays.asList("// c2 belongs to toto"), getCommentStrings(((CtBlock) ifStatement.getThenStatement()).getStatement(0)));
+		CtIf if2Statement = (CtIf) ((CtBlock) ifStatement.getElseStatement()).getStatement(0);
+		assertEquals("this.getClass()", ((CtBlock) if2Statement.getThenStatement()).getStatement(0).toString());
+		assertEquals(Arrays.asList("// c3 belongs to getClass"), getCommentStrings(((CtBlock) if2Statement.getThenStatement()).getStatement(0)));
+
+		assertEquals(Arrays.asList("// c4 comment of return"), getCommentStrings(statements.get(1)));
+	}
+	
+	private List<String> getCommentStrings(CtElement ele) {
+		return ele.getComments().stream().map(Object::toString).collect(Collectors.toList());
 	}
 }

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -982,7 +982,7 @@ public class CommentTest {
 		assertEquals(Arrays.asList("// c1"), getCommentStrings(ifStatement));
 		assertEquals(Arrays.asList("// c2 belongs to toto"), getCommentStrings(((CtBlock) ifStatement.getThenStatement()).getStatement(0)));
 		CtIf if2Statement = (CtIf) ((CtBlock) ifStatement.getElseStatement()).getStatement(0);
-		assertEquals("this.getClass()", ((CtBlock) if2Statement.getThenStatement()).getStatement(0).toString());
+		assertEquals("// c3 belongs to getClass\nthis.getClass()", ((CtBlock) if2Statement.getThenStatement()).getStatement(0).toString());
 		assertEquals(Arrays.asList("// c3 belongs to getClass"), getCommentStrings(((CtBlock) if2Statement.getThenStatement()).getStatement(0)));
 
 		assertEquals(Arrays.asList("// c4 comment of return"), getCommentStrings(statements.get(1)));

--- a/src/test/java/spoon/test/comment/testclasses/CommentsOnStatements.java
+++ b/src/test/java/spoon/test/comment/testclasses/CommentsOnStatements.java
@@ -1,0 +1,19 @@
+package spoon.test.comment.testclasses;
+
+public class CommentsOnStatements {
+
+    String value = "";
+
+    public String m1() {
+    	//c1
+        if (value == null) {
+        	//c2 belongs to toto
+            value = "toto";
+        } else if (value.equals("x")) {
+        	//c3 belongs to getClass
+        	this.getClass();
+        }
+        //c4 comment of return 
+        return value.substring(1);
+    }
+}


### PR DESCRIPTION
This PR contains a text which reproduces this problem:
```java
    	//c1
        if (value == null) {
        	//c2 belongs to toto
            value = "toto";
        } else if (value.equals("x")) {
        	//c3 belongs to getClass
        	this.getClass();
        }
```
The comment `//c3` is incorectly placed to root if statements