### PR TITLE
review: refactor: print statement's semicolon and after comment in scope of scan

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -275,9 +275,24 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		elementPrinterHelper.writeComment(s, CommentOffset.BEFORE);
 		getPrinterHelper().mapLine(s, sourceCompilationUnit);
 		elementPrinterHelper.writeAnnotations(s);
-		if (s.getLabel() != null) {
-			printer.writeIdentifier(s.getLabel()).writeSpace().writeSeparator(":").writeSpace();
+		if (!context.isFirstForVariable() && !context.isNextForVariable()) {
+			if (s.getLabel() != null) {
+				printer.writeIdentifier(s.getLabel()).writeSpace().writeSeparator(":").writeSpace();
+			}
 		}
+	}
+
+	/**
+	 * Exits a statement.
+	 */
+	protected void exitCtStatement(CtStatement statement) {
+		if (!(statement instanceof CtBlock || statement instanceof CtIf || statement instanceof CtFor || statement instanceof CtForEach || statement instanceof CtWhile || statement instanceof CtTry
+				|| statement instanceof CtSwitch || statement instanceof CtSynchronized || statement instanceof CtClass || statement instanceof CtComment)) {
+			if (context.isStatement(statement) && !context.isFirstForVariable() && !context.isNextForVariable()) {
+				printer.writeSeparator(";");
+			}
+		}
+		elementPrinterHelper.writeComment(statement, CommentOffset.AFTER);
 	}
 
 	/**
@@ -487,7 +502,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSpace().writeSeparator(":").writeSpace();
 			scan(asserted.getExpression());
 		}
-
+		exitCtStatement(asserted);
 	}
 
 	@Override
@@ -498,6 +513,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeOperator("=").writeSpace();
 		scan(assignement.getAssignment());
 		exitCtExpression(assignement);
+		exitCtStatement(assignement);
 	}
 
 	@Override
@@ -541,6 +557,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				printer.writeSeparator("}");
 			}
 		}
+		exitCtStatement(block);
 	}
 
 	@Override
@@ -550,6 +567,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (breakStatement.getTargetLabel() != null) {
 			printer.writeSpace().writeKeyword(breakStatement.getTargetLabel());
 		}
+		exitCtStatement(breakStatement);
 	}
 
 	@Override
@@ -582,6 +600,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			elementPrinterHelper.writeStatement(statement);
 		}
 		printer.decTab();
+		exitCtStatement(caseStatement);
 	}
 
 	@Override
@@ -710,6 +729,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (continueStatement.getTargetLabel() != null) {
 			printer.writeSpace().writeIdentifier(continueStatement.getTargetLabel());
 		}
+		exitCtStatement(continueStatement);
 	}
 
 	@Override
@@ -720,6 +740,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeKeyword("while").writeSpace().writeSeparator("(");
 		scan(doLoop.getLoopingExpression());
 		printer.writeSpace().writeSeparator(")");
+		exitCtStatement(doLoop);
 	}
 
 	@Override
@@ -1152,10 +1173,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeKeyword("for").writeSpace().writeSeparator("(");
 		List<CtStatement> st = forLoop.getForInit();
 		if (!st.isEmpty()) {
-			scan(st.get(0));
+			try (Writable _context = context.modify().isFirstForVariable(true)) {
+				scan(st.get(0));
+			}
 		}
 		if (st.size() > 1) {
-			try (Writable _context = context.modify().noTypeDecl(true)) {
+			try (Writable _context = context.modify().isNextForVariable(true)) {
 				for (int i = 1; i < st.size(); i++) {
 					printer.writeSeparator(",").writeSpace();
 					scan(st.get(i));
@@ -1173,6 +1196,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			s -> scan(s));
 		printer.writeSeparator(")");
 		elementPrinterHelper.writeIfOrLoopBlock(forLoop.getBody());
+		exitCtStatement(forLoop);
 	}
 
 	@Override
@@ -1184,6 +1208,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		scan(foreach.getExpression());
 		printer.writeSeparator(")");
 		elementPrinterHelper.writeIfOrLoopBlock(foreach.getBody());
+		exitCtStatement(foreach);
 	}
 
 	@Override
@@ -1205,6 +1230,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeKeyword("else");
 			elementPrinterHelper.writeIfOrLoopBlock(ifElement.getElseStatement());
 		}
+		exitCtStatement(ifElement);
 	}
 
 	@Override
@@ -1275,6 +1301,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			null, false, "(", false, false, ",", true, false, ")",
 			e -> scan(e));
 		exitCtExpression(invocation);
+		exitCtStatement(invocation);
 	}
 
 	@Override
@@ -1286,13 +1313,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public <T> void visitCtLocalVariable(CtLocalVariable<T> localVariable) {
-		if (!context.noTypeDecl()) {
-			enterCtStatement(localVariable);
-		}
+		enterCtStatement(localVariable);
 		if (env.isPreserveLineNumbers()) {
 			getPrinterHelper().adjustStartPosition(localVariable);
 		}
-		if (!context.noTypeDecl()) {
+		if (!context.isNextForVariable()) {
 			elementPrinterHelper.writeModifiers(localVariable);
 			if (localVariable.isInferred() && this.env.getComplianceLevel() >= 10) {
 				getPrinterTokenWriter().writeKeyword("var");
@@ -1306,6 +1331,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSpace().writeOperator("=").writeSpace();
 			scan(localVariable.getDefaultExpression());
 		}
+		exitCtStatement(localVariable);
 	}
 
 	@Override
@@ -1432,6 +1458,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printConstructorCall(ctConstructorCall);
 
 		exitCtExpression(ctConstructorCall);
+		exitCtStatement(ctConstructorCall);
 	}
 
 	@Override
@@ -1443,6 +1470,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 		scan(newClass.getAnonymousClass());
 		exitCtExpression(newClass);
+		exitCtStatement(newClass);
 	}
 
 	private <T> void printConstructorCall(CtConstructorCall<T> ctConstructorCall) {
@@ -1548,6 +1576,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace();
 		scan(assignment.getAssignment());
 		exitCtExpression(assignment);
+		exitCtStatement(assignment);
 	}
 
 	@Override
@@ -1595,6 +1624,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSpace();
 		}
 		scan(returnStatement.getReturnedExpression());
+		exitCtStatement(returnStatement);
 	}
 
 	private <T> void visitCtType(CtType<T> type) {
@@ -1629,6 +1659,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		} else {
 			printer.decTab().writeln().writeSeparator("}");
 		}
+		exitCtStatement(switchStatement);
 	}
 
 	@Override
@@ -1641,6 +1672,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSeparator(")").writeSpace();
 		}
 		scan(synchro.getBlock());
+		exitCtStatement(synchro);
 	}
 
 	@Override
@@ -1648,6 +1680,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		enterCtStatement(throwStatement);
 		printer.writeKeyword("throw").writeSpace();
 		scan(throwStatement.getThrownExpression());
+		exitCtStatement(throwStatement);
 	}
 
 	@Override
@@ -1663,6 +1696,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSpace().writeKeyword("finally").writeSpace();
 			scan(tryBlock.getFinalizer());
 		}
+		exitCtStatement(tryBlock);
 	}
 
 	@Override
@@ -1684,6 +1718,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeSpace().writeKeyword("finally").writeSpace();
 			scan(tryWithResource.getFinalizer());
 		}
+		exitCtStatement(tryWithResource);
 	}
 
 	@Override
@@ -1826,6 +1861,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeOperator(OperatorHelper.getOperatorText(op));
 		}
 		exitCtExpression(operator);
+		exitCtStatement(operator);
 	}
 
 	@Override
@@ -1850,6 +1886,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSeparator(")");
 
 		elementPrinterHelper.writeIfOrLoopBlock(whileLoop.getBody());
+		exitCtStatement(whileLoop);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -274,7 +274,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	protected void enterCtStatement(CtStatement s) {
 		elementPrinterHelper.writeComment(s, CommentOffset.BEFORE);
 		getPrinterHelper().mapLine(s, sourceCompilationUnit);
-		elementPrinterHelper.writeAnnotations(s);
+		if (!context.isNextForVariable()) {
+			//TODO AnnotationLoopTest#testAnnotationDeclaredInForInit expects that annotations of next for variables are not printed
+			//but may be correct is that the next variables are not annotated, because they might have different annotation then first param!
+			elementPrinterHelper.writeAnnotations(s);
+		}
 		if (!context.isFirstForVariable() && !context.isNextForVariable()) {
 			if (s.getLabel() != null) {
 				printer.writeIdentifier(s.getLabel()).writeSpace().writeSeparator(":").writeSpace();

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1897,8 +1897,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	@Override
 	public void visitCtCodeSnippetStatement(CtCodeSnippetStatement statement) {
-		elementPrinterHelper.writeComment(statement);
+		enterCtStatement(statement);
 		printer.writeCodeSnippet(statement.getValue());
+		exitCtStatement(statement);
 	}
 
 	public ElementPrinterHelper getElementPrinterHelper() {

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -23,14 +23,9 @@ import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtSwitch;
-import spoon.reflect.code.CtSynchronized;
-import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.code.CtWhile;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
@@ -178,12 +173,9 @@ public class ElementPrinterHelper {
 	 * Writes a statement.
 	 */
 	public void writeStatement(CtStatement statement) {
-		prettyPrinter.scan(statement);
-		if (!(statement instanceof CtBlock || statement instanceof CtIf || statement instanceof CtFor || statement instanceof CtForEach || statement instanceof CtWhile || statement instanceof CtTry
-				|| statement instanceof CtSwitch || statement instanceof CtSynchronized || statement instanceof CtClass || statement instanceof CtComment)) {
-			printer.writeSeparator(";");
+		try (Writable _context = prettyPrinter.context.modify().setStatement(statement)) {
+			prettyPrinter.scan(statement);
 		}
-		writeComment(statement, CommentOffset.AFTER);
 	}
 
 	public void writeElementList(List<CtTypeMember> elements) {

--- a/src/main/java/spoon/reflect/visitor/PrintingContext.java
+++ b/src/main/java/spoon/reflect/visitor/PrintingContext.java
@@ -44,6 +44,9 @@ public class PrintingContext {
 	public boolean isFirstForVariable() {
 		return (state & FIRST_FOR_VARIABLE) != 0L;
 	}
+	/**
+	 * {@link #isNextForVariable()}
+	 */
 	@Deprecated
 	public boolean noTypeDecl() {
 		return isNextForVariable();

--- a/src/main/java/spoon/reflect/visitor/PrintingContext.java
+++ b/src/main/java/spoon/reflect/visitor/PrintingContext.java
@@ -17,6 +17,7 @@
 package spoon.reflect.visitor;
 
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtTypeReference;
@@ -26,17 +27,22 @@ import java.util.Deque;
 
 public class PrintingContext {
 
-	private long NO_TYPE_DECL 			= 1 << 0;
+	private long NEXT_FOR_VARIABLE 			= 1 << 0;
 	private long IGNORE_GENERICS 		= 1 << 1;
 	private long SKIP_ARRAY 			= 1 << 2;
 	private long IGNORE_STATIC_ACCESS   = 1 << 3;
 	private long IGNORE_ENCLOSING_CLASS = 1 << 4;
 	private long FORCE_WILDCARD_GENERICS = 1 << 5;
+	private long FIRST_FOR_VARIABLE 	= 1 << 6;
 
 	private long state;
+	private CtStatement statement;
 
-	public boolean noTypeDecl() {
-		return (state & NO_TYPE_DECL) != 0L;
+	public boolean isFirstForVariable() {
+		return (state & FIRST_FOR_VARIABLE) != 0L;
+	}
+	public boolean isNextForVariable() {
+		return (state & NEXT_FOR_VARIABLE) != 0L;
 	}
 	public boolean ignoreGenerics() {
 		return (state & IGNORE_GENERICS) != 0L;
@@ -53,20 +59,30 @@ public class PrintingContext {
 	public boolean forceWildcardGenerics() {
 		return (state & FORCE_WILDCARD_GENERICS) != 0L;
 	}
+	public boolean isStatement(CtStatement stmt) {
+		return this.statement == stmt;
+	}
 
 	public class Writable implements AutoCloseable {
 		private long oldState;
+		private CtStatement oldStatement;
 
 		protected Writable() {
 			oldState = state;
+			oldStatement = statement;
 		}
 		@Override
 		public void close() {
 			state = oldState;
+			statement = oldStatement;
 		}
 
-		public <T extends Writable> T noTypeDecl(boolean v) {
-			setState(NO_TYPE_DECL, v);
+		public <T extends Writable> T isFirstForVariable(boolean v) {
+			setState(FIRST_FOR_VARIABLE, v);
+			return (T) this;
+		}
+		public <T extends Writable> T isNextForVariable(boolean v) {
+			setState(NEXT_FOR_VARIABLE, v);
 			return (T) this;
 		}
 		public <T extends Writable> T ignoreGenerics(boolean v) {
@@ -87,6 +103,10 @@ public class PrintingContext {
 		}
 		public <T extends Writable> T forceWildcardGenerics(boolean v) {
 			setState(FORCE_WILDCARD_GENERICS, v);
+			return (T) this;
+		}
+		public <T extends Writable> T setStatement(CtStatement stmt) {
+			statement = stmt;
 			return (T) this;
 		}
 		private void setState(long mask, boolean v) {

--- a/src/main/java/spoon/reflect/visitor/PrintingContext.java
+++ b/src/main/java/spoon/reflect/visitor/PrintingContext.java
@@ -27,7 +27,7 @@ import java.util.Deque;
 
 public class PrintingContext {
 
-	private long NEXT_FOR_VARIABLE 			= 1 << 0;
+	private long NEXT_FOR_VARIABLE 		= 1 << 0;
 	private long IGNORE_GENERICS 		= 1 << 1;
 	private long SKIP_ARRAY 			= 1 << 2;
 	private long IGNORE_STATIC_ACCESS   = 1 << 3;
@@ -38,9 +38,19 @@ public class PrintingContext {
 	private long state;
 	private CtStatement statement;
 
+	/**
+	 * @return true if we are printing first variable declaration of CtFor statement
+	 */
 	public boolean isFirstForVariable() {
 		return (state & FIRST_FOR_VARIABLE) != 0L;
 	}
+	@Deprecated
+	public boolean noTypeDecl() {
+		return isNextForVariable();
+	}
+	/**
+	 * @return true if we are printing second or next variable declaration of CtFor statement
+	 */
 	public boolean isNextForVariable() {
 		return (state & NEXT_FOR_VARIABLE) != 0L;
 	}
@@ -59,6 +69,9 @@ public class PrintingContext {
 	public boolean forceWildcardGenerics() {
 		return (state & FORCE_WILDCARD_GENERICS) != 0L;
 	}
+	/**
+	 * @return true if `stmt` has to be handled as statement in current printing context
+	 */
 	public boolean isStatement(CtStatement stmt) {
 		return this.statement == stmt;
 	}
@@ -77,10 +90,21 @@ public class PrintingContext {
 			statement = oldStatement;
 		}
 
+		/**
+		 * @param v use true if printing first variable declaration of CtFor statement
+		 */
 		public <T extends Writable> T isFirstForVariable(boolean v) {
 			setState(FIRST_FOR_VARIABLE, v);
 			return (T) this;
 		}
+		@Deprecated
+		public <T extends Writable> T noTypeDecl(boolean v) {
+			isFirstForVariable(v);
+			return (T) this;
+		}
+		/**
+		 * @param v use true if printing second or next variable declaration of CtFor statement
+		 */
 		public <T extends Writable> T isNextForVariable(boolean v) {
 			setState(NEXT_FOR_VARIABLE, v);
 			return (T) this;
@@ -105,6 +129,14 @@ public class PrintingContext {
 			setState(FORCE_WILDCARD_GENERICS, v);
 			return (T) this;
 		}
+		/**
+		 * There are statements (e.g. invocation), which may play role of expression too.
+		 * They have to be suffixed by semicolon depending on the printing context.
+		 * Call this method to inform printer that invocation is used as statement.
+		 *
+		 * @param stmt the instance of the actually printed statement.
+		 * Such statement will be finished by semicolon.
+		 */
 		public <T extends Writable> T setStatement(CtStatement stmt) {
 			statement = stmt;
 			return (T) this;

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -405,7 +405,7 @@ public class CommentTest {
 				+ ") ? // comment before then CtConditional" + newLine
 				+ "null// comment after then CtConditional" + newLine
 				+ " : // comment before else CtConditional" + newLine
-				+ "new java.lang.Double((j / ((double) (i - 1))))", ctLocalVariable1.toString());
+				+ "new java.lang.Double((j / ((double) (i - 1))))// comment after else CtConditional" + newLine, ctLocalVariable1.toString());
 
 		CtNewArray ctNewArray = (CtNewArray) ((CtLocalVariable) m1.getBody().getStatement(11)).getDefaultExpression();
 		assertEquals(createFakeComment(f, "last comment at the end of array"), ctNewArray.getComments().get(0));

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -94,6 +94,8 @@ import static spoon.testing.utils.ModelUtils.getOptimizedString;
 
 public class TemplateTest {
 
+	private String newLine = System.getProperty("line.separator");
+
 	@Test
 	public void testTemplateInheritance() throws Exception {
 		Launcher spoon = new Launcher();
@@ -170,13 +172,13 @@ public class TemplateTest {
 		assertEquals("{@link SuperClass#toBeOverriden()}", varMethod.getComments().get(2).getContent());
 
 		// contract: variable are renamed
-		assertEquals("java.util.List newVarName = null", methodWithTemplatedParameters.getBody().getStatement(0).toString());
+		assertEquals("java.util.List newVarName = null// will be replaced by List newVarName = null;" + newLine, methodWithTemplatedParameters.getBody().getStatement(0).toString());
 
 		// contract: types are replaced by other types
-		assertEquals("java.util.LinkedList l = null", methodWithTemplatedParameters.getBody().getStatement(1).toString());
+		assertEquals("java.util.LinkedList l = null// will be replaced by LinkedList l = null;" + newLine, methodWithTemplatedParameters.getBody().getStatement(1).toString());
 
 		// contract: casts are replaced by substitution types
-		assertEquals("java.util.List o = ((java.util.LinkedList) (new java.util.LinkedList()))", methodWithTemplatedParameters.getBody().getStatement(2).toString());
+		assertEquals("java.util.List o = ((java.util.LinkedList) (new java.util.LinkedList()))// will be replaced by List o = (LinkedList) new LinkedList();" + newLine, methodWithTemplatedParameters.getBody().getStatement(2).toString());
 
 		// contract: invocations are replaced by actual invocations
 		assertEquals("toBeOverriden()", methodWithTemplatedParameters.getBody().getStatement(3).toString());
@@ -200,10 +202,10 @@ public class TemplateTest {
 		assertTrue(methodWithTemplatedParameters.getBody().getStatement(11) instanceof CtForEach);
 
 		// contract: local variable write are replaced by local variable write with modified local variable name
-		assertEquals("newVarName = o", methodWithTemplatedParameters.getBody().getStatement(12).toString());
+		assertEquals("newVarName = o// will be replaced by newVarName = o" + newLine, methodWithTemplatedParameters.getBody().getStatement(12).toString());
 
 		// contract: local variable read are replaced by local variable read with modified local variable name
-		assertEquals("l = ((java.util.LinkedList) (newVarName))", methodWithTemplatedParameters.getBody().getStatement(13).toString());
+		assertEquals("l = ((java.util.LinkedList) (newVarName))// will be replaced by l = (LinkedList) newVarName" + newLine, methodWithTemplatedParameters.getBody().getStatement(13).toString());
 		
 		// contract; field access is handled same like local variable access
 		CtMethod<?> methodWithFieldAccess = subc.getElements(
@@ -215,7 +217,7 @@ public class TemplateTest {
 		assertEquals("newVarName = o", methodWithFieldAccess.getBody().getStatement(2).toString());
 
 		// contract: field read are replaced by field read with modified field name
-		assertEquals("l = ((java.util.LinkedList) (newVarName))", methodWithFieldAccess.getBody().getStatement(3).toString());
+		assertEquals("l = ((java.util.LinkedList) (newVarName))// will be replaced by l = (LinkedList) newVarName" + newLine, methodWithFieldAccess.getBody().getStatement(3).toString());
 		
 
 		class Context {


### PR DESCRIPTION
The sniper printing mode algorithm expects that all source code of an element is printed in scope of it's `DJPP#scan` method.
But it was not the case of CtStatement, which printed suffix semicolon and after comment later... after living the scan method.
I hope this kind of DJPP refactoring is acceptable.

Advantage: the CtStatement#toString should now print after comment too - as expected.