### PR TITLE
fix: sonarqube remove commented code

### DIFF
--- a/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
+++ b/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
@@ -135,7 +135,6 @@ public class InlinedStatementConfigurator {
 			throw new SpoonException("Each inline `for(x : iterable)` statement must have defined pattern parameter for `iterable` expression");
 		}
 		PrimitiveMatcher parameterOfExpression = (PrimitiveMatcher) vr;
-//		PatternBuilder localPatternBuilder = patternBuilder.create(bodyToStatements(foreach.getBody()));
 		ForEachNode mvr = new ForEachNode();
 		mvr.setIterableParameter(parameterOfExpression);
 		CtLocalVariable<?> lv = foreach.getVariable();

--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -84,7 +84,6 @@ public class PatternBuilder {
 
 	private CtTypeReference<?> templateTypeRef;
 	private final Map<String, AbstractParameterInfo> parameterInfos = new HashMap<>();
-//	ListOfNodes pattern;
 	CtQueryable patternQuery;
 	private ValueConvertor valueConvertor;
 	private boolean addGeneratedBy = false;

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -572,32 +572,6 @@ public class PatternParameterConfigurator {
 	}
 
 	/**
-	 * CodeElement element identified by `simpleName`
-	 * @param simpleName the name of the element or reference
-	 * @return {@link PatternParameterConfigurator} to support fluent API
-	 */
-//	public PatternParameterConfigurator codeElementBySimpleName(String simpleName) {
-//		ParameterInfo pi = getCurrentParameter();
-//		pattern.getModel().filterChildren((CtNamedElement named) -> simpleName.equals(named.getSimpleName()))
-//			.forEach((CtNamedElement named) -> {
-//				if (named instanceof CtCodeElement) {
-//					addSubstitutionRequest(pi, named);
-//				}
-//			});
-//		pattern.getModel().filterChildren((CtReference ref) -> simpleName.equals(ref.getSimpleName()))
-//		.forEach((CtReference ref) -> {
-//			if (ref instanceof CtTypeReference<?>) {
-//				return;
-//			}
-//			CtCodeElement codeElement = ref.getParent(CtCodeElement.class);
-//			if (codeElement != null) {
-//				addSubstitutionRequest(pi, codeElement);
-//			}
-//		});
-//		return this;
-//	}
-
-	/**
 	 * All spoon model string attributes whose value is equal to `stringMarker`
 	 * are subject for substitution by current parameter
 	 * @param stringMarker a string value which has to be substituted

--- a/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
+++ b/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
@@ -62,6 +62,7 @@ public class TobeMatched {
 	}
 
 	private TobeMatched(ImmutableMap parameters, Object target) {
+		//It is correct to put whole container as single value in cases when ParameterNode matches agains whole attribute value
 		this.parameters = parameters;
 		//make a copy of origin collection, because it might be modified during matching process (by a refactoring algorithm)
 		this.targets = Collections.singletonList(target);

--- a/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
+++ b/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
@@ -62,10 +62,6 @@ public class TobeMatched {
 	}
 
 	private TobeMatched(ImmutableMap parameters, Object target) {
-		//It is correct to put whole container as single value in cases when ParameterNode matches agains whole attribute value
-//		if (target instanceof Collection || target instanceof Map) {
-//			throw new SpoonException("Invalid argument. Use other constructors");
-//		}
 		this.parameters = parameters;
 		//make a copy of origin collection, because it might be modified during matching process (by a refactoring algorithm)
 		this.targets = Collections.singletonList(target);

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -374,33 +374,6 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 	public String toString() {
 		return elementType.getName() + ": " + super.toString();
 	}
-//	@Override
-//	public String toString() {
-//		PrinterHelper printer = new PrinterHelper(getTemplateNode().getFactory().getEnvironment());
-//		printer.write(NodeAttributeSubstitutionRequest.getElementTypeName(getTemplateNode().getParent())).writeln().incTab();
-//		appendDescription(printer);
-//		return printer.toString();
-//	}
-//
-//	public void appendDescription(PrinterHelper printer) {
-//		if (attributeSubstititionRequests == null || attributeSubstititionRequests.values().isEmpty()) {
-//			printer.write("** no attribute substitution **");
-//		} else {
-//			boolean multipleAttrs = attributeSubstititionRequests.size() > 1;
-//			if (multipleAttrs) {
-//				printer.incTab();
-//			}
-//			for (Node node : attributeSubstititionRequests.values()) {
-//				if (multipleAttrs) {
-//					printer.writeln();
-//				}
-//				printer.write(node.toString());
-//			}
-//			if (multipleAttrs) {
-//				printer.decTab();
-//			}
-//		}
-//	}
 
 	public MetamodelConcept getElementType() {
 		return elementType;

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -170,10 +170,6 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private static ListOfNodes listOfNodesToNode(List<? extends RootNode> nodes) {
-		//The attribute is matched different if there is List of one ParameterizedNode and when there is one ParameterizedNode
-//		if (nodes.size() == 1) {
-//			return nodes.get(0);
-//		}
 		return new ListOfNodes((List) nodes);
 	}
 

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -16,7 +16,6 @@
  */
 package spoon.reflect.factory;
 
-
 /**
  * This class is the superclass for all the sub-factories of
  * {@link spoon.reflect.factory.Factory}.
@@ -32,26 +31,5 @@ public abstract class SubFactory {
 		super();
 		this.factory = factory;
 	}
-
-	/**
-	 * Generically sets the parent of a set of elements or lists of elements.
-	 *
-	 * @param parent
-	 *            the parent
-	 * @param elements
-	 *            some {@link CtElement} or lists of {@link CtElement}
-	 */
-	//	protected void setParent(CtElement parent, Object... elements) {
-	//		for (Object o : elements) {
-	//			if (o instanceof CtElement) {
-	//				((CtElement) o).setParent(parent);
-	//			} else if (o instanceof Collection) {
-	//				for (Object o2 : (Collection<?>) o) {
-	//					((CtElement) o2).setParent(parent);
-	//				}
-	//			}
-	//		}
-	//	}
-
 }
 

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -605,18 +605,7 @@ public class TypeFactory extends SubFactory {
 	 * Tells if a given Java qualified name is that of an inner type.
 	 */
 	protected int hasInnerType(String qualifiedName) {
-		int ret = qualifiedName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR);
-		// if (ret < 0) {
-		// if (hasPackage(qualifiedName) > 0) {
-		// String buf = qualifiedName.substring(0,
-		// hasPackage(qualifiedName));
-		// int tmp = buf.lastIndexOf(CtPackage.PACKAGE_SEPARATOR);
-		// if (Character.isUpperCase(buf.charAt(tmp + 1))) {
-		// ret = hasPackage(qualifiedName);
-		// }
-		// }
-		// }
-		return ret;
+		return qualifiedName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR);
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/meta/impl/SingleHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/SingleHandler.java
@@ -45,7 +45,6 @@ abstract class SingleHandler<T, U> extends AbstractRoleHandler<T, U, U> {
 	}
 
 	public <W, X> java.util.List<X> asList(W e) {
-//		return Collections.<X>singletonList(getValue(element));
 		return new AbstractList<X>() {
 			T element = castTarget(e);
 			boolean hasValue = SingleHandler.this.getValue(element) != null;
@@ -73,6 +72,7 @@ abstract class SingleHandler<T, U> extends AbstractRoleHandler<T, U, U> {
 				SingleHandler.this.setValue(element, value);
 				return (X) oldValue;
 			}
+
 			@Override
 			public boolean add(X value) {
 				if (hasValue) {
@@ -96,6 +96,7 @@ abstract class SingleHandler<T, U> extends AbstractRoleHandler<T, U, U> {
 				hasValue = false;
 				return oldValue;
 			}
+
 			@Override
 			public boolean remove(Object value) {
 				if (hasValue == false) {
@@ -111,6 +112,7 @@ abstract class SingleHandler<T, U> extends AbstractRoleHandler<T, U, U> {
 				}
 				return false;
 			}
+
 			private boolean equals(Object v1, Object v2) {
 				if (v1 == v2) {
 					return true;


### PR DESCRIPTION
SonarQube rationale
> Programmers should not comment out code as it bloats programs and reduces readability.
Unused code should be deleted and can be retrieved from source control history if required.
See
MISRA C:2004, 2.4 - Sections of code should not be "commented out".
MISRA C++:2008, 2-7-2 - Sections of code shall not be "commented out" using C-style comments.
MISRA C++:2008, 2-7-3 - Sections of code should not be "commented out" using C++ comments.
MISRA C:2012, Dir. 4.4 - Sections of code should not be "commented out"

Commented code is always availabe in repository.
There is no need to keep it (*waiting for better times*).