### PR TITLE
refactor: remove commented code (SonarQube defect fix)

### DIFF
--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -630,7 +630,7 @@ public class PatternParameterConfigurator {
 						}
 						return oldAttrNode;
 					});
-			}
+				}
 			}
 		}.scan(patternBuilder.getPatternModel());
 		return this;

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -136,6 +136,7 @@ public class PatternParameterConfigurator {
 		currentParameter.setMinOccurrences(minOccurence);
 		return this;
 	}
+
 	public PatternParameterConfigurator setMaxOccurence(int maxOccurence) {
 		if (maxOccurence == ParameterInfo.UNLIMITED_OCCURRENCES || maxOccurence > 1 && currentParameter.isMultiple() == false) {
 			throw new SpoonException("Cannot set maxOccurrences > 1 for single value parameter. Call setMultiple(true) first.");
@@ -143,6 +144,7 @@ public class PatternParameterConfigurator {
 		currentParameter.setMaxOccurrences(maxOccurence);
 		return this;
 	}
+
 	public PatternParameterConfigurator setMatchingStrategy(Quantifier quantifier) {
 		currentParameter.setMatchingStrategy(quantifier);
 		return this;
@@ -185,6 +187,7 @@ public class PatternParameterConfigurator {
 	public PatternParameterConfigurator byType(Class<?> type) {
 		return byType(type.getName());
 	}
+
 	/**
 	 * type identified by `typeQualifiedName` itself and all the references (with arbitrary actual type arguments)
 	 * to that type are subject for substitution by current parameter
@@ -208,6 +211,7 @@ public class PatternParameterConfigurator {
 		}
 		return this;
 	}
+
 	/**
 	 * type referred by {@link CtTypeReference} `type` and all the references (with same actual type arguments)
 	 * to that type are subject for substitution by current parameter
@@ -243,6 +247,7 @@ public class PatternParameterConfigurator {
 		byLocalType(searchScope, localTypeSimpleName, false);
 		return this;
 	}
+
 	PatternParameterConfigurator byLocalType(CtType<?> searchScope, String localTypeSimpleName, boolean optional) {
 		String nestedType = getLocalTypeRefBySimpleName(searchScope, localTypeSimpleName);
 		if (nestedType == null) {
@@ -334,6 +339,7 @@ public class PatternParameterConfigurator {
 		}
 		return this;
 	}
+
 	/**
 	 * Add parameters for each variable reference of `variable`
 	 * @param variable to be substituted variable
@@ -371,6 +377,7 @@ public class PatternParameterConfigurator {
 	public PatternParameterConfigurator byTemplateParameter() {
 		return byTemplateParameter(null);
 	}
+
 	/**
 	 * Creates pattern parameter for each field of type {@link TemplateParameter}
 	 * @param parameterValues pattern parameter values.
@@ -808,6 +815,7 @@ public class PatternParameterConfigurator {
 	void addSubstitutionRequest(ParameterInfo parameter, CtElement element, CtRole attributeRole) {
 		patternBuilder.setNodeOfAttributeOfElement(element, attributeRole, new ParameterNode(parameter), conflictResolutionMode);
 	}
+
 	/**
 	 * Adds request to substitute substring of {@link String} value of `attributeRole` of `element`, by the value of this {@link ListOfNodes} parameter {@link ParameterInfo} value
 	 * @param element whose part of String attribute of {@link CtRole} `attributeRole` have to be replaced
@@ -894,6 +902,7 @@ public class PatternParameterConfigurator {
 		}
 		return pep;
 	}
+
 	/**
 	 * @return an invocation of {@link TemplateParameter#S()} if it is parent of `element`
 	 */

--- a/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
@@ -109,7 +109,6 @@ public class CtRolePathElement extends AbstractPathElement<CtElement, CtElement>
 									matchs.add(match);
 								}
 							} catch (CtPathException e) {
-								//System.err.println("[ERROR] Element not found for name: " + name);
 								//No element found for name.
 							}
 						} else {

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -616,7 +616,6 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			elementPrinterHelper.writeExtendsClause(ctClass);
 			elementPrinterHelper.writeImplementsClause(ctClass);
 		}
-		// lst.addAll(elementPrinterHelper.getComments(ctClass, CommentOffset.INSIDE));
 		printer.writeSpace().writeSeparator("{").incTab();
 		elementPrinterHelper.writeElementList(ctClass.getTypeMembers());
 		getPrinterHelper().adjustEndPosition(ctClass);

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -414,9 +414,6 @@ public class CtQueryImpl implements CtQuery {
 			if (indexOfCallerInStack < 0) {
 				//this is an exotic JVM, where we cannot detect type of parameter of Lambda expression
 				//Silently ignore this CCE, which was may be expected or may be problem in client's code.
-//				if (Launcher.LOGGER.isDebugEnabled()) {
-//					Launcher.LOGGER.debug("ClassCastException thrown by client's code or Query engine ...", e);
-//				}
 				return;
 			}
 			//we can detect whether CCE was thrown in client's code (unexpected - must be rethrown) or Query engine (expected - has to be ignored)

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -863,13 +863,6 @@ public class ReferenceBuilder {
 				} else {
 					ref.setPackage(getPackageReference(binding.getPackage()));
 				}
-				// if(((SourceTypeBinding) binding).typeVariables!=null &&
-				// ((SourceTypeBinding) binding).typeVariables.length>0){
-				// for (TypeBinding b : ((SourceTypeBinding)
-				// binding).typeVariables) {
-				// ref.getActualTypeArguments().add(getTypeReference(b));
-				// }
-				// }
 			}
 		} else if (binding instanceof ArrayBinding) {
 			CtArrayTypeReference<Object> arrayref;

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -77,7 +77,6 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 		for (; i < this.totalUnits; i++) {
 			unit = unitsToProcess[i];
 			this.reportProgress(Messages.bind(Messages.compilation_processing, new String(unit.getFileName())));
-			// System.err.println(unit);
 			this.parser.getMethodBodies(unit);
 
 			// fault in fields & methods

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -427,7 +427,6 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 				// try to completely evaluate
 				T r = null;
 				try {
-					// System.err.println("invocking "+i);
 					r = RtHelper.invoke(i);
 					if (isLiteralType(r)) {
 						CtLiteral<T> l = invocation.getFactory().Core().createLiteral();

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -94,66 +94,6 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		return getSimpleName().equals(CONSTRUCTOR_NAME);
 	}
 
-	//	@Override
-	//	public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
-	//		A annotation = super.getAnnotation(annotationType);
-	//		if (annotation != null) {
-	//			return annotation;
-	//		}
-	//		// use reflection
-	//		Class<?> c = getDeclaringType().getActualClass();
-	//		for (Method m : RtHelper.getAllMethods(c)) {
-	//			if (!getSimpleName().equals(m.getName())) {
-	//				continue;
-	//			}
-	//			if (getParameterTypes().size() != m.getParameterTypes().length) {
-	//				continue;
-	//			}
-	//			int i = 0;
-	//			for (Class<?> t : m.getParameterTypes()) {
-	//				if (t != getParameterTypes().get(i).getActualClass()) {
-	//					break;
-	//				}
-	//				i++;
-	//			}
-	//			if (i == getParameterTypes().size()) {
-	//				m.setAccessible(true);
-	//				return m.getAnnotation(annotationType);
-	//			}
-	//		}
-	//		return null;
-	//	}
-
-	//	@Override
-	//	public Annotation[] getAnnotations() {
-	//		Annotation[] annotations = super.getAnnotations();
-	//		if (annotations != null) {
-	//			return annotations;
-	//		}
-	//		// use reflection
-	//		Class<?> c = getDeclaringType().getActualClass();
-	//		for (Method m : RtHelper.getAllMethods(c)) {
-	//			if (!getSimpleName().equals(m.getName())) {
-	//				continue;
-	//			}
-	//			if (getParameterTypes().size() != m.getParameterTypes().length) {
-	//				continue;
-	//			}
-	//			int i = 0;
-	//			for (Class<?> t : m.getParameterTypes()) {
-	//				if (t != getParameterTypes().get(i).getActualClass()) {
-	//					break;
-	//				}
-	//				i++;
-	//			}
-	//			if (i == getParameterTypes().size()) {
-	//				m.setAccessible(true);
-	//				return m.getAnnotations();
-	//			}
-	//		}
-	//		return null;
-	//	}
-
 	@Override
 	@SuppressWarnings("unchecked")
 	public CtExecutable<T> getDeclaration() {

--- a/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
+++ b/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
@@ -102,15 +102,6 @@ public class TypeReferenceScanner extends CtScanner {
 		exit(reference);
 	}
 
-	//	public <T> boolean isImported(CtTypeReference<T> ref) {
-	//		if (imports.containsKey(ref.getSimpleName())) {
-	//			CtTypeReference<?> exist = imports.get(ref.getSimpleName());
-	//			if (exist.getQualifiedName().equals(ref.getQualifiedName()))
-	//				return true;
-	//		}
-	//		return false;
-	//	}
-
 	@Override
 	public <T> void visitCtExecutableReference(
 			CtExecutableReference<T> reference) {

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -399,14 +399,6 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 		ctTypeReference.setSimpleName(((Class) type.getRawType()).getSimpleName());
 
 		RuntimeBuilderContext context = new TypeReferenceRuntimeBuilderContext(type, ctTypeReference) {
-//			@Override
-//			public void addTypeReference(CtRole role, CtTypeReference<?> typeReference) {
-//				ctTypeReference.setSimpleName(typeReference.getSimpleName());
-//				ctTypeReference.setPackage(typeReference.getPackage());
-//				ctTypeReference.setDeclaringType(typeReference.getDeclaringType());
-//				ctTypeReference.setActualTypeArguments(typeReference.getActualTypeArguments());
-//				ctTypeReference.setAnnotations(typeReference.getAnnotations());
-//			}
 
 			@Override
 			public void addType(CtType<?> aType) {

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -384,7 +384,6 @@ public abstract class Substitution {
 		CtConstructor<T> newConstructor = targetClass.getFactory().Constructor().create(targetClass, sourceMethod);
 		newConstructor = substitute(targetClass, template, newConstructor);
 		targetClass.addConstructor(newConstructor);
-		// newConstructor.setParent(targetClass);
 		return newConstructor;
 	}
 
@@ -408,7 +407,6 @@ public abstract class Substitution {
 			newMethod.setBody(null);
 		}
 		targetType.addMethod(newMethod);
-		// newMethod.setParent(targetType);
 		return newMethod;
 	}
 
@@ -437,7 +435,6 @@ public abstract class Substitution {
 			}
 		}
 		targetClass.addConstructor(newConstrutor);
-		// newConstrutor.setParent(targetClass);
 		return newConstrutor;
 	}
 
@@ -537,35 +534,6 @@ public abstract class Substitution {
 	}
 
 	/**
-	 * Substitutes all the template parameters in the first template element
-	 * annotated with an instance of the given annotation type.
-	 *
-	 * @param targetType
-	 *            the target type
-	 * @param template
-	 *            the template instance
-	 * @param annotationType
-	 *            the annotation type
-	 * @return the element where all the template parameters has be substituted
-	 *         by their values
-	 */
-	// public static <E extends CtElement> E substitute(
-	// CtSimpleType<?> targetType, Template template,
-	// Class<? extends Annotation> annotationType) {
-	// CtClass<? extends Template> c = targetType.getFactory().Class
-	// .get(template.getClass());
-	// E element = (E) c.getAnnotatedChildren(annotationType).get(0);
-	// if (element == null)
-	// return null;
-	// if (targetType == null)
-	// throw new RuntimeException("target is null in substitution");
-	// E result = CtCloner.clone(element);
-	// new SubstitutionVisitor(targetType.getFactory(), targetType, template)
-	// .scan(result);
-	// return result;
-	// }
-
-	/**
 	 * Substitutes all the template parameters in a given template type and
 	 * returns the resulting type.
 	 *
@@ -602,7 +570,6 @@ public abstract class Substitution {
 	public static <T> CtField<T> insertField(CtType<?> targetType, Template<?> template, CtField<T> sourceField) {
 		CtField<T> field = substitute(targetType, template, sourceField);
 		targetType.addField(field);
-		// field.setParent(targetType);
 		return field;
 	}
 
@@ -673,7 +640,7 @@ public abstract class Substitution {
 				if (fieldTypeQName.equals(String.class.getName())) {
 					// contract: the name of the template parameter must correspond to the name of the field
 					// as found, by Pavel, this is not good contract because it prevents easy refactoring of templates
-					// we remove it but keep th commented code in case somebody would come up with this bad idae
+					// we remove it but keep the commented code in case somebody would come up with this bad idea
 //					if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
 //						throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
 //					}

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -54,7 +54,7 @@ public class VariableReferencesTest {
 	CtClass<?> modelClass;
 
 	@Before
-	public void setup() throws Exception {
+	public void setup() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });
 		launcher.getEnvironment().setCommentEnabled(true);
@@ -65,7 +65,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testCheckModelConsistency() throws Exception {
+	public void testCheckModelConsistency() {
 		//1) search for all variable declarations with name isTestFieldName(name)==true
 		//2) check that each of them is using different identification value
 		class Context {
@@ -99,7 +99,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testCatchVariableReferenceFunction() throws Exception {
+	public void testCatchVariableReferenceFunction() {
 		//visits all the CtCatchVariable elements whose name is isTestFieldName(name)==true and search for all their references
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
@@ -115,7 +115,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testLocalVariableReferenceFunction() throws Exception {
+	public void testLocalVariableReferenceFunction() {
 		//visits all the CtLocalVariable elements whose name is isTestFieldName(name)==true and search for all their references
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
@@ -131,7 +131,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testParameterReferenceFunction() throws Exception {
+	public void testParameterReferenceFunction() {
 		//visits all the CtParameter elements whose name is isTestFieldName(name)==true and search for all their references
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
@@ -147,7 +147,7 @@ public class VariableReferencesTest {
 	}	
 
 	@Test
-	public void testVariableReferenceFunction() throws Exception {
+	public void testVariableReferenceFunction() {
 		//visits all the CtVariable elements whose name is isTestFieldName(name)==true and search for all their references
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
@@ -167,7 +167,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testVariableScopeFunction() throws Exception {
+	public void testVariableScopeFunction() {
 		//visits all the CtVariable elements whose name is "field" and search for all elements in their scopes
 		//Comparing with the result found by basic functions
 		List list = modelClass.filterChildren((CtVariable<?> var)->{
@@ -196,7 +196,7 @@ public class VariableReferencesTest {
 	}
 
 	@Test
-	public void testLocalVariableReferenceDeclarationFunction() throws Exception {
+	public void testLocalVariableReferenceDeclarationFunction() {
 		modelClass.filterChildren((CtLocalVariableReference<?> varRef)->{
 			if(isTestFieldName(varRef.getSimpleName())) {
 				CtLocalVariable<?> var = varRef.getDeclaration();

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -52,7 +52,7 @@ import static org.junit.Assert.*;
 
 public class VariableReferencesTest {
 	CtClass<?> modelClass;
-	
+
 	@Before
 	public void setup() throws Exception {
 		final Launcher launcher = new Launcher();
@@ -66,8 +66,7 @@ public class VariableReferencesTest {
 
 	@Test
 	public void testCheckModelConsistency() throws Exception {
-		
-		//1) search for all variable declarations with name isTestFieldName(name)==true 
+		//1) search for all variable declarations with name isTestFieldName(name)==true
 		//2) check that each of them is using different identification value
 		class Context {
 			Map<Integer, CtElement> unique = new HashMap<>();
@@ -81,7 +80,7 @@ public class VariableReferencesTest {
 			}
 		}
 		Context context = new Context();
-		
+
 		modelClass.filterChildren((CtElement e)->{
 			if (e instanceof CtVariable) {
 				CtVariable<?> var = (CtVariable<?>) e;
@@ -98,7 +97,7 @@ public class VariableReferencesTest {
 		assertEquals("Only these keys were found: "+context.unique.keySet(), context.maxKey, context.unique.size());
 		assertEquals("AllLocalVars#maxValue must be equal to maximum value number ", (int)getLiteralValue((CtVariable)modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class,"maxValue")).first()), context.maxKey);
 	}
-	
+
 	@Test
 	public void testCatchVariableReferenceFunction() throws Exception {
 		//visits all the CtCatchVariable elements whose name is isTestFieldName(name)==true and search for all their references
@@ -129,7 +128,7 @@ public class VariableReferencesTest {
 			}
 			return false;
 		}).list();
-	}	
+	}
 
 	@Test
 	public void testParameterReferenceFunction() throws Exception {
@@ -162,7 +161,7 @@ public class VariableReferencesTest {
 			return false;
 		}).list();
 	}
-	
+
 	private boolean isTestFieldName(String name) {
 		return "field".equals(name);
 	}
@@ -195,7 +194,7 @@ public class VariableReferencesTest {
 		}).list();
 		assertTrue(list.size()>0);
 	}
-	
+
 	@Test
 	public void testLocalVariableReferenceDeclarationFunction() throws Exception {
 		modelClass.filterChildren((CtLocalVariableReference<?> varRef)->{
@@ -207,7 +206,6 @@ public class VariableReferencesTest {
 			return false;
 		}).list();
 	}
-	
 
 	private void checkVariableAccess(CtVariable<?> var, int value, CtConsumableFunction<?> query) {
 		class Context {
@@ -259,7 +257,7 @@ public class VariableReferencesTest {
 			return ele.getParent(CtType.class).getSimpleName()+"#annonymous block";
 		}
 	}
-	
+
 	private int getVariableReferenceValue(CtVariableReference<?> fr) {
 		CtBinaryOperator binOp = fr.getParent(CtBinaryOperator.class);
 		if(binOp==null) {
@@ -304,7 +302,7 @@ public class VariableReferencesTest {
 		}
 		return getCommentValue(var);
 	}
-	
+
 	private int getCommentValue(CtElement e) {
 		while(true) {
 			if(e==null) {
@@ -321,11 +319,11 @@ public class VariableReferencesTest {
 		}
 		return -1;
 	}
-	
+
 	private Integer getLiteralValue(CtExpression<?> exp) {
 		return ((CtLiteral<Integer>) exp).getValue();
 	}
-	
+
 	private SourcePosition getPosition(CtElement e) {
 		SourcePosition sp = e.getPosition();
 		while(sp instanceof NoSourcePosition) {
@@ -337,7 +335,7 @@ public class VariableReferencesTest {
 		}
 		return sp;
 	}
-	
+
 	@Test
 	public void testPotentialVariableAccessFromStaticMethod() throws Exception {
 		Factory factory = ModelUtils.build(VariableReferencesFromStaticMethod.class);
@@ -349,5 +347,4 @@ public class VariableReferencesTest {
 		List<CtVariable> vars = varRef.map(new PotentialVariableDeclarationFunction()).list();
 		assertEquals("Found unexpected variable declaration.", 1, vars.size());
 	}
-
 }

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -90,12 +90,10 @@ public class VariableReferencesTest {
 				}
 				//check only these variables whose name is isTestFieldName(name)==true
 				Integer val = getLiteralValue(var);
-//				System.out.println("key = "+val+" - "+var.toString());
 				context.checkKey(val, var);
 			}
 			return false;
 		}).list();
-//		System.out.println("Next available key is: "+(context.maxKey+1));
 		assertTrue(context.unique.size()>0);
 		assertEquals("Only these keys were found: "+context.unique.keySet(), context.maxKey, context.unique.size());
 		assertEquals("AllLocalVars#maxValue must be equal to maximum value number ", (int)getLiteralValue((CtVariable)modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class,"maxValue")).first()), context.maxKey);
@@ -242,7 +240,6 @@ public class VariableReferencesTest {
 			});
 			//check that both scans found same number of references
 			assertEquals("Number of references to field="+value+" does not match", context.expectedCount, context.realCount);
-//			System.out.println("field="+value+" found "+context.realCount+" referenes");
 			
 		} catch (Throwable e) {
 			e.printStackTrace();
@@ -294,7 +291,6 @@ public class VariableReferencesTest {
 			} else {
 				CtExecutableReference<?> l_execRef = l_exec.getReference();
 				List<CtAbstractInvocation<?>> list = l_exec.getFactory().Package().getRootPackage().filterChildren((CtAbstractInvocation inv)->{
-//					return inv.getExecutable().equals(l_execRef);
 					return inv.getExecutable().getExecutableDeclaration()==l_exec;
 				}).list();
 				CtAbstractInvocation inv = list.get(0);


### PR DESCRIPTION
- PR fixes some SonarQube violations: *This block of commented-out lines of code should be removed.*
- Remove not thrown exceptions in test - VariableReferencesTest.java
- Fix formatting

**Substitution.java**
I paid attention not to remove:
```
//if (!f.getSimpleName().equals("_" + f.getAnnotation(Parameter.class).value())) {
//	throw new TemplateException("the field name of a proxy template parameter must be called _" + f.getSimpleName());
//}

```

**CtRolePathElement.java** (line 112)
```//No element found for name.```
Is this commented needed?

I am ready to merge.