### PR TITLE
review: feat: CompilationUnit extends SourcePositionHolder

### DIFF
--- a/src/main/java/spoon/reflect/cu/CompilationUnit.java
+++ b/src/main/java/spoon/reflect/cu/CompilationUnit.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * Defines a compilation unit. In Java, a compilation unit can contain only one
  * public type declaration and other secondary types declarations (not public).
  */
-public interface CompilationUnit extends FactoryAccessor, Serializable {
+public interface CompilationUnit extends FactoryAccessor, SourcePositionHolder, Serializable {
 
 	enum UNIT_TYPE {
 		TYPE_DECLARATION,

--- a/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
@@ -58,6 +58,11 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 
 	File file;
 
+	private SourcePosition sourcePosition;
+	/**
+	 * The index of line breaks, as computed by JDT.
+	 * Used to compute line numbers afterwards.
+	 */
 	private int[] lineSeparatorPositions;
 
 	@Override
@@ -203,7 +208,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 	@Override
 	public String getOriginalSourceCode() {
 
-		if (originalSourceCode == null) {
+		if (originalSourceCode == null && getFile() != null) {
 			try (FileInputStream s = new FileInputStream(getFile())) {
 				byte[] elementBytes = new byte[s.available()];
 				s.read(elementBytes);
@@ -304,5 +309,18 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 	@Override
 	public void setLineSeparatorPositions(int[] lineSeparatorPositions) {
 		this.lineSeparatorPositions = lineSeparatorPositions;
+	}
+
+	@Override
+	public SourcePosition getPosition() {
+		if (sourcePosition == null) {
+			String sourceCode = getOriginalSourceCode();
+			if (sourceCode != null) {
+				sourcePosition = getFactory().Core().createSourcePosition(this, 0, sourceCode.length() - 1, getLineSeparatorPositions());
+			} else {
+				sourcePosition = SourcePosition.NOPOSITION;
+			}
+		}
+		return sourcePosition;
 	}
 }

--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -103,6 +103,22 @@ public class TestCompilationUnit {
     }
 
     @Test
+    public void testCompilationUnitSourcePosition() throws IOException {
+        // contract: the CompilationUnit has root source position
+        File resource = new File("./src/test/java/spoon/test/model/Foo.java");
+        final Launcher launcher = new Launcher();
+        launcher.addInputResource(resource.getPath());
+        launcher.buildModel();
+
+        CompilationUnit cu = launcher.getFactory().CompilationUnit().getOrCreate(resource.getCanonicalPath());
+        SourcePosition sp = cu.getPosition();
+        assertNotNull(sp);
+        assertEquals(0, sp.getSourceStart());
+        assertEquals(cu.getOriginalSourceCode().length(), sp.getSourceEnd() + 1);
+        assertSame(cu, sp.getCompilationUnit());
+    }
+
+    @Test
     public void testAddDeclaredTypeInCU() throws IOException {
         // contract: when a type is added to a CU, it should also be pretty printed in cu mode
         File resource = new File("./src/test/java/spoon/test/model/Foo.java");


### PR DESCRIPTION
`CompilationUnit` extends `SourcePositionHolder` now, so it can act as root of source fragments - as needed for sniper mode pretty printer as discussed in #2254.