### PR TITLE
fix(position): CtImport has source position now

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -26,6 +26,7 @@ import spoon.reflect.declaration.CtPackage;
 
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 
@@ -75,13 +76,13 @@ class JDTImportBuilder {
 					CtPackage ctPackage = this.factory.Package().get(packageName);
 
 					if (ctPackage != null) {
-						this.imports.add(factory.Type().createImport(ctPackage.getReference()));
+						this.imports.add(createImportWithPosition(ctPackage.getReference(), importRef));
 					}
 
 				} else {
 					CtType klass = this.getOrLoadClass(importName);
 					if (klass != null) {
-						this.imports.add(factory.Type().createImport(klass.getReference()));
+						this.imports.add(createImportWithPosition(klass.getReference(), importRef));
 					}
 				}
 			} else {
@@ -92,13 +93,13 @@ class JDTImportBuilder {
 				CtType klass = this.getOrLoadClass(className);
 				if (klass != null) {
 					if (methodOrFieldName.equals("*")) {
-						this.imports.add(factory.Type().createImport(factory.Type().createWildcardStaticTypeMemberReference(klass.getReference())));
+						this.imports.add(createImportWithPosition(factory.Type().createWildcardStaticTypeMemberReference(klass.getReference()), importRef));
 					} else {
 						List<CtNamedElement> methodOrFields = klass.getElements(new NamedElementFilter<>(CtNamedElement.class, methodOrFieldName));
 
 						if (!methodOrFields.isEmpty()) {
 							CtNamedElement methodOrField = methodOrFields.get(0);
-							this.imports.add(factory.Type().createImport(methodOrField.getReference()));
+							this.imports.add(createImportWithPosition(methodOrField.getReference(), importRef));
 						}
 					}
 				}
@@ -106,6 +107,13 @@ class JDTImportBuilder {
 		}
 
 		spoonUnit.setImports(this.imports);
+	}
+
+	private CtImport createImportWithPosition(CtReference ref, ImportReference importRef) {
+		CtImport imprt = factory.Type().createImport(ref);
+		imprt.setPosition(factory.Core().createCompoundSourcePosition(spoonUnit, importRef.sourceStart(), importRef.sourceEnd(), importRef.declarationSourceStart, importRef.declarationEnd, spoonUnit.getLineSeparatorPositions()));
+		//TODO initialize source position of ref
+		return imprt;
 	}
 
 	private CtType getOrLoadClass(String className) {

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -12,6 +12,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
@@ -26,7 +27,9 @@ import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -693,6 +696,27 @@ public class PositionTest {
 		assertEquals(start, bhsp.getNameStart());
 		assertEquals(start - 1, bhsp.getNameEnd());
 	}
+	
+	@Test
+	public void testPositionOfCtImport() throws Exception {
+		//contract: the CtImport has position
+		final CtType<?> foo = ModelUtils.buildClass(
+			launcher ->	launcher.getEnvironment().setAutoImports(true), 
+			AnnonymousClassNewIface.class);
+		String originSources = foo.getPosition().getCompilationUnit().getOriginalSourceCode();
+		Set<CtImport> imports = foo.getPosition().getCompilationUnit().getImports();
+		assertEquals(2, imports.size());
+		Iterator<CtImport> iter = imports.iterator();
+		{
+			CtImport ctImport = iter.next();
+			assertEquals("import java.util.Set;", contentAtPosition(originSources, ctImport.getPosition()));
+		}
+		{
+			CtImport ctImport = iter.next();
+			assertEquals("import java.util.function.Consumer;", contentAtPosition(originSources, ctImport.getPosition()));
+		}
+	}
+	
 
 	@Test
 	public void testEmptyModifiersOfMethod() throws Exception {


### PR DESCRIPTION
CtImport has source position now. It is needed for Sniper mode printer.

... and I improved test `ModelUtils` here too, to allow configuration of Launcher before model is built. I guess it doesn't need separate PR. Or?