### PR TITLE
fix: ReplacementVisitor doesn't eat exceptions

### DIFF
--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1260,7 +1260,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 			new spoon.support.visitor.replace.ReplacementVisitor(original, (replace == null ? spoon.support.visitor.replace.ReplacementVisitor.EMPTY : new spoon.reflect.declaration.CtElement[]{ replace })).scan(original.getParent());
 		} catch (spoon.support.visitor.replace.InvalidReplaceException e) {
 			throw e;
-		} catch (spoon.SpoonException ignore) {
 		}
 	}
 
@@ -1269,7 +1268,6 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 			new spoon.support.visitor.replace.ReplacementVisitor(original, replaces.toArray(new spoon.reflect.declaration.CtElement[replaces.size()])).scan(original.getParent());
 		} catch (spoon.support.visitor.replace.InvalidReplaceException e) {
 			throw e;
-		} catch (spoon.SpoonException ignore) {
 		}
 	}
 

--- a/src/test/java/spoon/generating/replace/ReplacementVisitor.java
+++ b/src/test/java/spoon/generating/replace/ReplacementVisitor.java
@@ -16,7 +16,6 @@
  */
 package spoon.generating.replace;
 
-import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.CtScanner;
 import spoon.support.visitor.replace.InvalidReplaceException;
@@ -44,7 +43,6 @@ class ReplacementVisitor extends CtScanner {
 			new ReplacementVisitor(original, replace == null ? EMPTY : new CtElement[]{replace}).scan(original.getParent());
 		} catch (InvalidReplaceException e) {
 			throw e;
-		} catch (SpoonException ignore) {
 		}
 	}
 	public static <E extends CtElement> void replace(CtElement original, Collection<E> replaces) {
@@ -52,7 +50,6 @@ class ReplacementVisitor extends CtScanner {
 			new ReplacementVisitor(original, replaces.toArray(new CtElement[replaces.size()])).scan(original.getParent());
 		} catch (InvalidReplaceException e) {
 			throw e;
-		} catch (SpoonException ignore) {
 		}
 	}
 


### PR DESCRIPTION
I had hard time to found a reason for a strange problem ... until I found that ReplacementVisitor eats exceptions. 

May be before there was not much code running in scope of this exception block, but now with integrated Change collector and sniper mode, there makes sense to report exceptions, which happens here.

@monperrus, do you have any idea why it was caught and ignored?