### PR TITLE
refactor: fix code inspection - remove unused assignment

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -714,7 +714,6 @@ public class Launcher implements SpoonAPI {
 
 		env.reportProgressMessage("start processing...");
 
-		long t = 0;
 		long tstart = System.currentTimeMillis();
 
 		buildModel();
@@ -728,7 +727,7 @@ public class Launcher implements SpoonAPI {
 			modelBuilder.compile(InputType.CTTYPES);
 		}
 
-		t = System.currentTimeMillis();
+		long t = System.currentTimeMillis();
 
 		env.debugMessage("program spooning done in " + (t - tstart) + " ms");
 		env.reportEnd();

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -355,7 +355,6 @@ public class MetamodelProperty {
 	private int getIdxOfBestMatchByInputParameter(List<MMMethod> methods, MMMethodKind key, CtTypeReference<?> expectedValueType)  {
 		int idx = -1;
 		MatchLevel maxMatchLevel = null;
-		CtTypeReference<?> newValueType = null;
 		if (key.isMulti()) {
 			expectedValueType = getTypeofItems(expectedValueType);
 		}
@@ -368,13 +367,11 @@ public class MetamodelProperty {
 				if (idx == -1) {
 					idx = i;
 					maxMatchLevel = matchLevel;
-					newValueType = mMethod.getValueType();
 				} else {
 					//both methods have matching value type. Use the better match
 					if (maxMatchLevel.ordinal() < matchLevel.ordinal()) {
 						idx = i;
 						maxMatchLevel = matchLevel;
-						newValueType = mMethod.getValueType();
 					} else if (maxMatchLevel == matchLevel) {
 						//there is conflict
 						return -1;

--- a/src/main/java/spoon/pattern/internal/node/ForEachNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ForEachNode.java
@@ -54,7 +54,6 @@ public class ForEachNode extends AbstractRepeatableMatcher implements InlineNode
 	@Override
 	public boolean replaceNode(RootNode oldNode, RootNode newNode) {
 		if (iterableParameter == oldNode) {
-			oldNode = newNode;
 			return true;
 		}
 		if (iterableParameter.replaceNode(oldNode, newNode)) {

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -295,7 +295,7 @@ public class TypeFactory extends SubFactory {
 	 * Creates a reference to an n-dimension array of given type.
 	 */
 	public CtArrayTypeReference<?> createArrayReference(CtTypeReference<?> reference, int n) {
-		CtTypeReference<?> componentType = null;
+		CtTypeReference<?> componentType;
 		if (n == 1) {
 			return createArrayReference(reference);
 		}

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -670,7 +670,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace().writeOperator(":").writeSpace();
 
 		CtExpression<T> elseExpression = conditional.getElseExpression();
-		boolean isAssign = false;
+		boolean isAssign;
 		if ((isAssign = elseExpression instanceof CtAssignment)) {
 			printer.writeSeparator("(");
 		}

--- a/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
@@ -32,8 +32,8 @@ import java.util.Deque;
  */
 public class ModelConsistencyChecker extends CtScanner {
 
-	boolean fixInconsistencies = false;
-	boolean fixNullParents = false;
+	boolean fixInconsistencies;
+	boolean fixNullParents;
 
 	Environment environment;
 

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -682,7 +682,7 @@ public class ReferenceBuilder {
 			return null;
 		}
 
-		CtTypeReference<?> ref = null;
+		CtTypeReference<?> ref;
 
 		if (binding instanceof RawTypeBinding) {
 			ref = getTypeReference(((ParameterizedTypeBinding) binding).genericType());

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -65,15 +65,14 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 
 		this.reportProgress(Messages.compilation_beginningToCompile);
 
-		CompilationUnitDeclaration unit = null;
-		int i = 0;
-
 		this.sortModuleDeclarationsFirst(sourceUnits);
 		// build and record parsed units
 		beginToCompile(sourceUnits);
 
-		// process all units (some more could be injected in the loop by
-		// the lookup environment)
+		CompilationUnitDeclaration unit;
+		int i = 0;
+
+		// process all units (some more could be injected in the loop by the lookup environment)
 		for (; i < this.totalUnits; i++) {
 			unit = unitsToProcess[i];
 			this.reportProgress(Messages.bind(Messages.compilation_processing, new String(unit.getFileName())));

--- a/src/main/java/spoon/support/gui/SpoonModelTree.java
+++ b/src/main/java/spoon/support/gui/SpoonModelTree.java
@@ -284,7 +284,7 @@ public class SpoonModelTree extends JFrame implements KeyListener,
 
 	/** move to the next node matching the search criterion */
 	public DefaultMutableTreeNode next() {
-		DefaultMutableTreeNode current = null;
+		DefaultMutableTreeNode current;
 		while ((enume != null) && enume.hasMoreElements()) {
 			current = (DefaultMutableTreeNode) enume.nextElement();
 			if ((current.getUserObject() != null)

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -75,7 +75,7 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 		if (length == 0) {
 			return -1;
 		}
-		int i = 0;
+		int i;
 		for (i = 0; i < lineSeparatorPositions.length - 1; i++) {
 			if (lineSeparatorPositions[i] < position && (lineSeparatorPositions[i + 1] > position)) {
 				return position - lineSeparatorPositions[i];

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -225,7 +225,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 	@SuppressWarnings("unchecked")
 	private Object convertElementToRuntimeObject(CtElement value) {
 		if (value instanceof CtFieldReference) {
-			Class<?> c = null;
+			Class<?> c;
 			try {
 				c = ((CtFieldReference<?>) value).getDeclaringType().getActualClass();
 			} catch (Exception e) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -351,7 +351,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public CtElement getParent() throws ParentNotInitializedException {
 		if (parent == null) {
-			String exceptionMsg = "";
+			String exceptionMsg;
 			if (this instanceof CtReference) {
 				exceptionMsg = "parent not initialized for " + ((CtReference) this).getSimpleName() + "(" + this.getClass() + ")";
 			} else {

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -425,7 +425,7 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 				}
 			} else {
 				// try to completely evaluate
-				T r = null;
+				T r;
 				try {
 					// System.err.println("invocking "+i);
 					r = RtHelper.invoke(i);

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -138,7 +138,6 @@ public abstract class Parameters {
 	 */
 	@SuppressWarnings("null")
 	public static void setValue(Template<?> template, String parameterName, Integer index, Object value) {
-		Object tparamValue = null;
 		try {
 			Field rtField = null;
 			for (Field f : RtHelper.getAllFields(template.getClass())) {
@@ -163,9 +162,7 @@ public abstract class Parameters {
 			rtField.setAccessible(true);
 			rtField.set(template, value);
 			if (rtField.getType().isArray()) {
-				// TODO: RP: THIS IS WRONG!!!! tparamValue is never used or
-				// set!!
-				tparamValue = ((Object[]) tparamValue)[index];
+				// TODO: RP: THIS IS WRONG!!!! tparamValue is never used or set!
 			}
 		} catch (Exception e) {
 			throw new UndefinedParameterException();

--- a/src/main/java/spoon/support/util/ByteSerialization.java
+++ b/src/main/java/spoon/support/util/ByteSerialization.java
@@ -27,25 +27,20 @@ public class ByteSerialization {
 	private ByteSerialization() { }
 
 	public static byte[] serialize(Object obj) throws IOException {
-
-		byte[] serializedObject = null;
 		ByteArrayOutputStream bo = new ByteArrayOutputStream();
 		ObjectOutputStream so = new ObjectOutputStream(bo);
 		so.writeObject(obj);
 		so.flush();
-		serializedObject = bo.toByteArray();
+		byte[] serializedObject = bo.toByteArray();
 		so.close();
 		return serializedObject;
 	}
 
 	public static Object deserialize(byte[] serializedObject) throws Exception {
-
-		Object objInput = null;
 		ByteArrayInputStream bi = new ByteArrayInputStream(serializedObject);
 		ObjectInputStream si = new ObjectInputStream(bi);
-		objInput = si.readObject();
+		Object objInput = si.readObject();
 		si.close();
 		return objInput;
 	}
-
 }


### PR DESCRIPTION
Probable bugs
- Unused assignment

Unused assignment are confusing because we lost value later (it is overwritten line down or in ctr).
Example
int a = 1;
...
a = 0;

If the value is lost/overwritten, it is not needed.

The logic in src/main/java/spoon/support/template/Parameters.java is problematic. Should it be fixed?

I am ready to merge.