### PR TITLE
refactor: fix SonarQube: A NullPointerException could be thrown; o is…

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -132,7 +132,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o == null) {
+		if (!(o instanceof CtElementImpl)) {
 			return false;
 		}
 		if (this == o) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -132,6 +132,9 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public boolean equals(Object o) {
+		if (o == null) {
+			return false;
+		}
 		if (this == o) {
 			return true;
 		}


### PR DESCRIPTION
… nullable here.

@surli 
@monperrus 
@pvojtechovsky 

Should not it be something like below?
```
if (o instanceof CtElementImpl) {

}
```

BTW. Is it good practice to throw in equals?
```
throw new IllegalStateException("violation of equal/hashcode contract between \n" + this.toString() + "\nand\n" + o.toString() + "\n");
```

I am ready to merge.