### PR TITLE
refactor: remove unnecessary 'super' call in ctr

### DIFF
--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -73,7 +73,6 @@ public class MavenLauncher extends Launcher {
 	 * @param m2RepositoryPath the path to the m2repository
 	 */
 	public MavenLauncher(String mavenProject, String m2RepositoryPath, SOURCE_TYPE sourceType) {
-		super();
 		this.m2RepositoryPath = m2RepositoryPath;
 		this.sourceType = sourceType;
 

--- a/src/main/java/spoon/SpoonException.java
+++ b/src/main/java/spoon/SpoonException.java
@@ -20,7 +20,6 @@ package spoon;
 public class SpoonException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
 	public SpoonException() {
-		super();
 	}
 	public SpoonException(String msg) {
 		super(msg);

--- a/src/main/java/spoon/compiler/InvalidClassPathException.java
+++ b/src/main/java/spoon/compiler/InvalidClassPathException.java
@@ -21,7 +21,6 @@ import spoon.SpoonException;
 public class InvalidClassPathException extends SpoonException {
 	private static final long serialVersionUID = 1L;
 	public InvalidClassPathException() {
-		super();
 	}
 	public InvalidClassPathException(String msg) {
 		super(msg);

--- a/src/main/java/spoon/metamodel/MetamodelConcept.java
+++ b/src/main/java/spoon/metamodel/MetamodelConcept.java
@@ -79,7 +79,6 @@ public class MetamodelConcept {
 	final List<CtMethod<?>> otherMethods = new ArrayList<>();
 
 	MetamodelConcept(String name) {
-		super();
 		this.name = name;
 	}
 

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -103,7 +103,6 @@ public class MetamodelProperty {
 	private List<MMMethodKind> ambiguousMethodKinds = new ArrayList<>();
 
 	MetamodelProperty(String name, CtRole role, MetamodelConcept ownerConcept) {
-		super();
 		this.name = name;
 		this.role = role;
 		this.ownerConcept = ownerConcept;

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -830,7 +830,6 @@ public class PatternParameterConfigurator {
 		final ParameterInfo parameter;
 		final CtElement element;
 		public ParameterElementPair(ParameterInfo parameter, CtElement element) {
-			super();
 			this.parameter = parameter;
 			this.element = element;
 		}

--- a/src/main/java/spoon/pattern/internal/DefaultGenerator.java
+++ b/src/main/java/spoon/pattern/internal/DefaultGenerator.java
@@ -47,7 +47,6 @@ public class DefaultGenerator implements Generator {
 	private ListOfNodes nodes;
 
 	public DefaultGenerator(Factory factory, ListOfNodes nodes) {
-		super();
 		this.nodes = nodes;
 		this.factory = factory;
 	}

--- a/src/main/java/spoon/pattern/internal/matcher/ChainOfMatchersImpl.java
+++ b/src/main/java/spoon/pattern/internal/matcher/ChainOfMatchersImpl.java
@@ -52,7 +52,6 @@ public class ChainOfMatchersImpl implements Matchers {
 	}
 
 	private ChainOfMatchersImpl(RootNode firstMatcher, Matchers next) {
-		super();
 		if (firstMatcher == null) {
 			throw new SpoonException("The firstMatcher Node MUST NOT be null");
 		}

--- a/src/main/java/spoon/pattern/internal/node/ConstantNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ConstantNode.java
@@ -31,7 +31,6 @@ public class ConstantNode<T> extends AbstractPrimitiveMatcher {
 	protected final T template;
 
 	public ConstantNode(T template) {
-		super();
 		this.template = template;
 	}
 

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -183,7 +183,6 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 	 * 	It is used e.g. to generate generatedBy comment
 	 */
 	public ElementNode(MetamodelConcept elementType, CtElement templateElement) {
-		super();
 		this.elementType = elementType;
 		this.templateElement = templateElement;
 	}

--- a/src/main/java/spoon/pattern/internal/node/ForEachNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ForEachNode.java
@@ -48,7 +48,6 @@ public class ForEachNode extends AbstractRepeatableMatcher implements InlineNode
 	private ParameterInfo localParameter;
 
 	public ForEachNode() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/pattern/internal/node/ListOfNodes.java
+++ b/src/main/java/spoon/pattern/internal/node/ListOfNodes.java
@@ -34,7 +34,6 @@ public class ListOfNodes extends AbstractNode {
 	protected List<RootNode> nodes;
 
 	public ListOfNodes(List<RootNode> nodes) {
-		super();
 		this.nodes = nodes;
 	}
 

--- a/src/main/java/spoon/pattern/internal/node/MapEntryNode.java
+++ b/src/main/java/spoon/pattern/internal/node/MapEntryNode.java
@@ -39,7 +39,6 @@ public class MapEntryNode extends AbstractPrimitiveMatcher {
 	private RootNode value;
 
 	public MapEntryNode(RootNode key, RootNode value) {
-		super();
 		this.key = key;
 		this.value = value;
 	}
@@ -81,7 +80,6 @@ public class MapEntryNode extends AbstractPrimitiveMatcher {
 		private CtElement value;
 
 		Entry(String key, CtElement value) {
-			super();
 			this.key = key;
 			this.value = value;
 		}

--- a/src/main/java/spoon/pattern/internal/node/ParameterNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ParameterNode.java
@@ -34,7 +34,6 @@ public class ParameterNode extends AbstractPrimitiveMatcher {
 	private final ParameterInfo parameterInfo;
 
 	public ParameterNode(ParameterInfo parameterInfo) {
-		super();
 		this.parameterInfo = parameterInfo;
 	}
 

--- a/src/main/java/spoon/pattern/internal/node/StringNode.java
+++ b/src/main/java/spoon/pattern/internal/node/StringNode.java
@@ -186,7 +186,6 @@ public class StringNode extends AbstractPrimitiveMatcher {
 		int to;
 
 		Region(ParameterInfo param, int from, int to) {
-			super();
 			this.param = param;
 			this.from = from;
 			this.to = to;

--- a/src/main/java/spoon/pattern/internal/node/SwitchNode.java
+++ b/src/main/java/spoon/pattern/internal/node/SwitchNode.java
@@ -50,7 +50,6 @@ public class SwitchNode extends AbstractNode implements InlineNode {
 	private List<CaseNode> cases = new ArrayList<>();
 
 	public SwitchNode() {
-		super();
 	}
 
 	@Override
@@ -128,7 +127,6 @@ public class SwitchNode extends AbstractNode implements InlineNode {
 		private PrimitiveMatcher vrOfExpression;
 		private RootNode statement;
 		private CaseNode(PrimitiveMatcher vrOfExpression, RootNode statement) {
-			super();
 			this.vrOfExpression = vrOfExpression;
 			this.statement = statement;
 		}

--- a/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
@@ -58,7 +58,6 @@ public abstract class AbstractParameterInfo implements ParameterInfo {
 	private Class<?> parameterValueType;
 
 	protected AbstractParameterInfo(ParameterInfo containerItemAccessor) {
-		super();
 		this.containerItemAccessor = (AbstractParameterInfo) containerItemAccessor;
 	}
 

--- a/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
@@ -43,7 +43,6 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	 */
 	@SuppressWarnings("unchecked")
 	public AbstractAnnotationProcessor() {
-		super();
 		clearProcessedElementType();
 
 		for (Method m : getClass().getMethods()) {

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -42,7 +42,6 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 	 */
 	@SuppressWarnings("unchecked")
 	public AbstractProcessor() {
-		super();
 		for (Method m : getClass().getMethods()) {
 			if ("process".equals(m.getName()) && (m.getParameterTypes().length == 1)) {
 				Class<?> c = m.getParameterTypes()[0];

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -28,7 +28,6 @@ public abstract class SubFactory {
 	 * The sub-factory constructor takes an instance of the parent factory.
 	 */
 	public SubFactory(Factory factory) {
-		super();
 		this.factory = factory;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -120,7 +120,6 @@ public abstract class CtScanner implements CtVisitor {
 	 * Default constructor.
 	 */
 	public CtScanner() {
-		super();
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/ListPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/ListPrinter.java
@@ -36,7 +36,6 @@ public class ListPrinter implements Closeable {
 	private boolean isFirst = true;
 
 	public ListPrinter(TokenWriter printerHelper, boolean startPrefixSpace, String start, boolean startSuffixSpace, boolean nextPrefixSpace, String next, boolean nextSuffixSpace, boolean endPrefixSpace, String end) {
-		super();
 		this.printerTokenWriter = printerHelper;
 		this.nextPrefixSpace = nextPrefixSpace;
 		this.separator = next;

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -461,7 +461,6 @@ public class CtQueryImpl implements CtQuery {
 	 */
 	private class OutputFunctionWrapper extends AbstractStep {
 		OutputFunctionWrapper() {
-			super();
 			localFailurePolicy = QueryFailurePolicy.IGNORE;
 		}
 		@Override
@@ -492,7 +491,6 @@ public class CtQueryImpl implements CtQuery {
 
 		@SuppressWarnings("unchecked")
 		LazyFunctionWrapper(CtConsumableFunction<?> fnc) {
-			super();
 			this.fnc = (CtConsumableFunction<Object>) fnc;
 			handleListenerSetQuery(this.fnc);
 			onCallbackSet(this.getClass().getName(), "_accept", fnc.getClass(), "apply", 2, 0);
@@ -513,7 +511,6 @@ public class CtQueryImpl implements CtQuery {
 
 		@SuppressWarnings("unchecked")
 		FunctionWrapper(CtFunction<?, ?> code) {
-			super();
 			fnc = (CtFunction<Object, Object>) code;
 			handleListenerSetQuery(fnc);
 			onCallbackSet(this.getClass().getName(), "_accept", fnc.getClass(), "apply", 1, 0);

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
@@ -41,6 +41,5 @@ public abstract class AbstractReferenceFilter<T extends CtReference> extends Abs
 	 * Creates a filter with the type computed by reflection from the matches method parameter
 	 */
 	public AbstractReferenceFilter() {
-		super();
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/LocalVariableReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LocalVariableReferenceFunction.java
@@ -170,7 +170,6 @@ public class LocalVariableReferenceFunction implements CtConsumableFunction<CtEl
 		CtQuery query;
 
 		QueryCreator(CtElement scope, CtScannerListener listener) {
-			super();
 			this.scope = scope;
 			this.listener = listener;
 		}

--- a/src/main/java/spoon/support/QueueProcessingManager.java
+++ b/src/main/java/spoon/support/QueueProcessingManager.java
@@ -55,7 +55,6 @@ public class QueueProcessingManager implements ProcessingManager {
 	 * 		meta-model)
 	 */
 	public QueueProcessingManager(Factory factory) {
-		super();
 		setFactory(factory);
 	}
 

--- a/src/main/java/spoon/support/RuntimeProcessingManager.java
+++ b/src/main/java/spoon/support/RuntimeProcessingManager.java
@@ -52,7 +52,6 @@ public class RuntimeProcessingManager implements ProcessingManager {
 	 * 		meta-model)
 	 */
 	public RuntimeProcessingManager(Factory factory) {
-		super();
 		setFactory(factory);
 	}
 

--- a/src/main/java/spoon/support/SpoonClassNotFoundException.java
+++ b/src/main/java/spoon/support/SpoonClassNotFoundException.java
@@ -29,7 +29,6 @@ public class SpoonClassNotFoundException extends SpoonException {
 	private static final long serialVersionUID = 1L;
 
 	public SpoonClassNotFoundException() {
-		super();
 	}
 
 	public SpoonClassNotFoundException(String msg) {

--- a/src/main/java/spoon/support/compiler/FileSystemFile.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFile.java
@@ -38,7 +38,6 @@ public class FileSystemFile implements SpoonFile {
 	}
 
 	public FileSystemFile(File file) {
-		super();
 		try {
 			this.file = file.getCanonicalFile();
 		} catch (IOException e) {

--- a/src/main/java/spoon/support/compiler/FileSystemFolder.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFolder.java
@@ -32,7 +32,6 @@ public class FileSystemFolder implements SpoonFolder {
 	File file;
 
 	public FileSystemFolder(File file) {
-		super();
 		if (!file.isDirectory()) {
 			throw new SpoonException("Not a directory " + file);
 		}

--- a/src/main/java/spoon/support/compiler/SnippetCompilationError.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationError.java
@@ -28,7 +28,6 @@ public class SnippetCompilationError extends SpoonException {
 	public List<String> problems;
 
 	public SnippetCompilationError(List<String> problems) {
-		super();
 		this.problems = problems;
 	}
 

--- a/src/main/java/spoon/support/compiler/ZipFile.java
+++ b/src/main/java/spoon/support/compiler/ZipFile.java
@@ -32,7 +32,6 @@ public class ZipFile implements SpoonFile {
 	ZipFolder parent;
 
 	public ZipFile(ZipFolder parent, String name, byte[] buffer) {
-		super();
 		this.buffer = buffer;
 		this.name = name;
 		this.parent = parent;

--- a/src/main/java/spoon/support/compiler/ZipFolder.java
+++ b/src/main/java/spoon/support/compiler/ZipFolder.java
@@ -42,7 +42,6 @@ public class ZipFolder implements SpoonFolder {
 	List<SpoonFile> files;
 
 	public ZipFolder(File file) throws IOException {
-		super();
 		if (!file.isFile()) {
 			throw new IOException(file.getName() + " is not a valid zip file");
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ASTPair.java
+++ b/src/main/java/spoon/support/compiler/jdt/ASTPair.java
@@ -25,7 +25,6 @@ public class ASTPair {
 	public ASTNode node;
 
 	public ASTPair(CtElement element, ASTNode node) {
-		super();
 		this.element = element;
 		this.node = node;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -210,7 +210,6 @@ public class JDTTreeBuilder extends ASTVisitor {
 	}
 
 	public JDTTreeBuilder(Factory factory) {
-		super();
 		this.factory = factory;
 		this.position = new PositionBuilder(this);
 		this.context = new ContextBuilder(this);

--- a/src/main/java/spoon/support/gui/SpoonModelTree.java
+++ b/src/main/java/spoon/support/gui/SpoonModelTree.java
@@ -74,7 +74,6 @@ public class SpoonModelTree extends JFrame implements KeyListener,
 	 * This is the default constructor
 	 */
 	public SpoonModelTree(Factory factory) {
-		super();
 		SpoonTreeBuilder cst = new SpoonTreeBuilder();
 		cst.scan(factory.Package().getRootPackage());
 		this.factory = factory;
@@ -83,7 +82,6 @@ public class SpoonModelTree extends JFrame implements KeyListener,
 	}
 
 	public SpoonModelTree(CtElement rootElement) {
-		super();
 		SpoonTreeBuilder cst = new SpoonTreeBuilder();
 		cst.scan(rootElement);
 		this.factory = rootElement.getFactory();

--- a/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
+++ b/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
@@ -40,7 +40,6 @@ public class SpoonObjectFieldsTable extends JFrame {
 		transient Object o;
 
 		public SpoonObjectTableModel(Object o) {
-			super();
 
 			this.o = o;
 			field = new ArrayList<>();
@@ -119,7 +118,6 @@ public class SpoonObjectFieldsTable extends JFrame {
 	 * This is the default constructor
 	 */
 	public SpoonObjectFieldsTable(Object o) {
-		super();
 		this.o = o;
 		initialize();
 	}

--- a/src/main/java/spoon/support/gui/SpoonTreeBuilder.java
+++ b/src/main/java/spoon/support/gui/SpoonTreeBuilder.java
@@ -31,7 +31,6 @@ public class SpoonTreeBuilder extends CtScanner {
 	DefaultMutableTreeNode root;
 
 	public SpoonTreeBuilder() {
-		super();
 		root = new DefaultMutableTreeNode("Spoon Tree Root");
 		nodes = new ArrayDeque<>();
 		nodes.push(root);

--- a/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
@@ -24,7 +24,6 @@ public abstract class CtCodeElementImpl extends CtElementImpl implements CtCodeE
 	private static final long serialVersionUID = 1L;
 
 	public CtCodeElementImpl() {
-		super();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -107,7 +107,6 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 	private int sourceStartline = -1;
 
 	public SourcePositionImpl(CompilationUnit compilationUnit, int sourceStart, int sourceEnd, int[] lineSeparatorPositions) {
-		super();
 		checkArgsAreAscending(sourceStart, sourceEnd + 1);
 		if (compilationUnit == null) {
 			throw new SpoonException("Mandatory parameter compilationUnit is null");

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -97,7 +97,6 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 	};
 
 	public CtAnnotationImpl() {
-		super();
 	}
 
 	public void accept(CtVisitor visitor) {
@@ -506,7 +505,6 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 			CtAnnotation<? extends Annotation> annotation;
 
 			AnnotationInvocationHandler(CtAnnotation<? extends Annotation> annotation) {
-				super();
 				this.annotation = annotation;
 			}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -121,9 +121,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	Map<String, Object> metadata;
 
 	public CtElementImpl() {
-		super();
 	}
-
 
 	@Override
 	public String getShortRepresentation() {

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -57,7 +57,6 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 	Set<CtTypeReference<? extends Throwable>> thrownTypes = emptySet();
 
 	public CtExecutableImpl() {
-		super();
 	}
 
 	public CtType<?> getDeclaringType() {

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -58,7 +58,6 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	private CtModifierHandler modifierHandler = new CtModifierHandler(this);
 
 	public CtFieldImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
@@ -34,7 +34,6 @@ public class CtImportImpl extends CtElementImpl implements CtImport {
 	private CtReference localReference;
 
 	public CtImportImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -65,7 +65,6 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	private CtModifierHandler modifierHandler = new CtModifierHandler(this);
 
 	public CtMethodImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -47,7 +47,6 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	private CtPackage rootPackage;
 
 	public CtModuleImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
@@ -33,7 +33,6 @@ public class CtModuleRequirementImpl extends CtElementImpl implements CtModuleRe
 	private CtModuleReference moduleReference;
 
 	public CtModuleRequirementImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
@@ -38,7 +38,6 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 	private boolean isOpen;
 
 	public CtPackageExportImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -94,7 +94,6 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	};
 
 	public CtPackageImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -58,7 +58,6 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	private CtModifierHandler modifierHandler = new CtModifierHandler(this);
 
 	public CtParameterImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
@@ -34,7 +34,6 @@ public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedSe
 	private List<CtTypeReference> implementationTypes = CtElementImpl.emptyList();
 
 	public CtProvidedServiceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -100,7 +100,6 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	List<CtTypeMember> typeMembers = emptyList();
 
 	public CtTypeImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -35,7 +35,6 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	CtTypeReference<?> componentType;
 
 	public CtArrayTypeReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
@@ -27,7 +27,6 @@ public class CtCatchVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> 
 	private static final long serialVersionUID = 1L;
 
 	public CtCatchVariableReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -76,7 +76,6 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	List<CtTypeReference<?>> parameters = CtElementImpl.emptyList();
 
 	public CtExecutableReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -50,7 +50,6 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 	boolean stat = false;
 
 	public CtFieldReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -39,7 +39,6 @@ public class CtLocalVariableReferenceImpl<T>
 	 * Default constructor.
 	 */
 	public CtLocalVariableReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
@@ -25,7 +25,6 @@ import java.lang.reflect.AnnotatedElement;
 public class CtModuleReferenceImpl extends CtReferenceImpl implements CtModuleReference {
 
 	public CtModuleReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
@@ -26,7 +26,6 @@ public class CtPackageReferenceImpl extends CtReferenceImpl implements CtPackage
 	private static final long serialVersionUID = 1L;
 
 	public CtPackageReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
@@ -30,7 +30,6 @@ public class CtParameterReferenceImpl<T> extends CtVariableReferenceImpl<T> impl
 	private static final long serialVersionUID = 1L;
 
 	public CtParameterReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -41,7 +41,6 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 	protected String simplename = "";
 
 	public CtReferenceImpl() {
-		super();
 	}
 
 	protected abstract AnnotatedElement getActualAnnotatedElement();

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -50,7 +50,6 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	boolean upper = true;
 
 	public CtTypeParameterReferenceImpl() {
-		super();
 		// calling null will set the default value of boundingType
 		this.setBoundingType(null);
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -70,7 +70,6 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	private CtPackageReference pack;
 
 	public CtTypeReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
@@ -36,7 +36,6 @@ public abstract class CtVariableReferenceImpl<T> extends CtReferenceImpl impleme
 	CtTypeReference<T> type;
 
 	public CtVariableReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardStaticTypeMemberReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardStaticTypeMemberReferenceImpl.java
@@ -27,7 +27,6 @@ import spoon.reflect.reference.CtReference;
 public class CtWildcardStaticTypeMemberReferenceImpl extends CtTypeReferenceImpl {
 
 	public CtWildcardStaticTypeMemberReferenceImpl() {
-		super();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/template/UndefinedParameterException.java
+++ b/src/main/java/spoon/support/template/UndefinedParameterException.java
@@ -23,7 +23,6 @@ public class UndefinedParameterException extends SpoonException {
 	private static final long serialVersionUID = 1L;
 
 	public UndefinedParameterException() {
-		super();
 	}
 
 	public UndefinedParameterException(String message) {

--- a/src/main/java/spoon/support/util/SortedList.java
+++ b/src/main/java/spoon/support/util/SortedList.java
@@ -28,7 +28,6 @@ public class SortedList<E> extends LinkedList<E> {
 	Comparator<? super E> comparator;
 
 	public SortedList(Comparator<? super E> comparator) {
-		super();
 		this.comparator = comparator;
 	}
 

--- a/src/main/java/spoon/template/TemplateException.java
+++ b/src/main/java/spoon/template/TemplateException.java
@@ -33,7 +33,6 @@ public class TemplateException extends SpoonException {
 	 * Empty exception.
 	 */
 	public TemplateException() {
-		super();
 	}
 
 	/**


### PR DESCRIPTION
Code style issues
- Unnecessary call to 'super()'

Rationale
I have checked all constructors (we are talking about production code, test classes are excluded).
There are 346 constructors without explicit super() call.
There are 76 constructors with explicit super() call.

So for consistency and readability, these 76 useless super() calls should be removed.
There is no reason that some classes have redundant super() call and some classes have not.

I am ready to merge.

@surli 
How about this one?