### PR TITLE
refactor: move resources to testclasses

### DIFF
--- a/doc/path.md
+++ b/doc/path.md
@@ -6,7 +6,7 @@ keywords: quering, query, path, ast, elements
 
 `CtPath` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPath.html)) 
 defines the path to a `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) 
-in a model. For example, `.spoon.test.path.Foo.foo#body#statement[index=0]` represents the first statement of the body of method foo.
+in a model. For example, `.spoon.test.path.testclasses.Foo.foo#body#statement[index=0]` represents the first statement of the body of method foo.
 
 A `CtPath`is based on: names of elements (eg `foo`), and roles of elements with respect to their parent (eg `body`).
 A role is a relation between two AST nodes.
@@ -23,7 +23,7 @@ syntax inspired from XPath and CSS selectors.
 To evaluate a path, ie getting the elements represented by it, use `evaluateOn(List<CtElement>)`
 
 ```java
-path = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo#body#statement[index=0]");
+path = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
 List<CtElement> l = path.evaluateOn(root)
 ```
 
@@ -36,10 +36,10 @@ List<CtElement> l = path.evaluateOn(root)
 builds a path from a string representation.
 
 For instance, if we want the first statement in the body of method `foo`, declared 
-in the class `spoon.test.path.Foo`. 
+in the class `spoon.test.path.testclasses.Foo`. 
 
 ```java
-new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo#body#statement[index=0]");
+new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
 ```
 
 ## CtPathBuilder

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -63,6 +63,7 @@ import spoon.test.filters.testclasses.AbstractTostada;
 import spoon.test.filters.testclasses.Antojito;
 import spoon.test.filters.testclasses.FieldAccessFilterTacos;
 import spoon.test.filters.testclasses.Foo;
+import spoon.test.filters.testclasses.FooLine;
 import spoon.test.filters.testclasses.ITostada;
 import spoon.test.filters.testclasses.SubTostada;
 import spoon.test.filters.testclasses.Tacos;
@@ -884,7 +885,7 @@ public class FilterTest {
 			assertTrue(clazz instanceof CtClass);
 			assertTrue(((CtClass<?>)clazz).hasModifier(ModifierKind.PUBLIC));
 		});
-		assertEquals(7, context.count);
+		assertEquals(8, context.count);
 		context.count=0; //reset
 
 		// again second query, but now with CtConsumableFunction
@@ -896,7 +897,7 @@ public class FilterTest {
 			assertTrue(clazz instanceof CtClass);
 			assertTrue(((CtClass<?>)clazz).hasModifier(ModifierKind.PUBLIC));
 		});
-		assertEquals(7, context.count);
+		assertEquals(8, context.count);
 		context.count=0; //reset
 
 		// again second query, but with low-level circuitry thanks to cast
@@ -908,7 +909,7 @@ public class FilterTest {
 			assertTrue(clazz instanceof CtClass);
 			assertTrue(((CtClass<?>)clazz).hasModifier(ModifierKind.PUBLIC));
 		});
-		assertEquals(7, context.count);
+		assertEquals(8, context.count);
 	}
 	
 	@Test

--- a/src/test/java/spoon/test/filters/testclasses/FooLine.java
+++ b/src/test/java/spoon/test/filters/testclasses/FooLine.java
@@ -1,6 +1,6 @@
-package spoon.test.filters;
+package spoon.test.filters.testclasses;
 
-class FooLine {
+public class FooLine {
 	void simple() {
 		int x = 3;
 		int z = 0;

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -51,6 +51,7 @@ import spoon.test.generics.testclasses2.LikeCtClassImpl;
 import spoon.test.generics.testclasses2.SameSignature2;
 import spoon.test.generics.testclasses2.SameSignature3;
 import spoon.test.generics.testclasses3.Bar;
+import spoon.test.generics.testclasses3.ClassThatBindsAGenericType;
 import spoon.test.generics.testclasses3.ClassThatDefinesANewTypeArgument;
 import spoon.test.generics.testclasses3.Foo;
 import spoon.test.generics.testclasses3.GenericConstructor;

--- a/src/test/java/spoon/test/generics/testclasses3/ClassThatBindsAGenericType.java
+++ b/src/test/java/spoon/test/generics/testclasses3/ClassThatBindsAGenericType.java
@@ -1,10 +1,10 @@
-package spoon.test.generics;
+package spoon.test.generics.testclasses3;
 
 import java.io.File;
 import java.util.ArrayList;
 
 @SuppressWarnings("serial")
-class ClassThatBindsAGenericType extends ArrayList<File> {
+public class ClassThatBindsAGenericType extends ArrayList<File> {
 
 	public static void main(String[] args) throws Exception {
 	}

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -41,7 +41,7 @@ public class PathTest {
 		spoon.createCompiler(
 				factory,
 				SpoonResourceHelper
-						.resources("./src/test/java/spoon/test/path/Foo.java"))
+						.resources("./src/test/java/spoon/test/path/testclasses/Foo.java"))
 				.build();
 	}
 
@@ -60,15 +60,15 @@ public class PathTest {
 	@Test
 	public void testBuilderMethod() throws Exception {
 		equalsSet(
-				new CtPathBuilder().name("spoon").name("test").name("path").name("Foo").type(CtMethod.class).build(),
+				new CtPathBuilder().name("spoon").name("test").name("path").name("testclasses").name("Foo").type(CtMethod.class).build(),
 
-				factory.Type().get("spoon.test.path.Foo").getMethods()
+				factory.Type().get("spoon.test.path.testclasses.Foo").getMethods()
 		);
 
 		equalsSet(
-				new CtPathStringBuilder().fromString(".spoon.test.path.Foo/CtMethod"),
+				new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo/CtMethod"),
 
-				factory.Type().get("spoon.test.path.Foo").getMethods()
+				factory.Type().get("spoon.test.path.testclasses.Foo").getMethods()
 		);
 	}
 
@@ -78,7 +78,7 @@ public class PathTest {
 				new CtPathBuilder().recursiveWildcard().name("toto").role(
 						CtRole.DEFAULT_EXPRESSION).build(),
 
-				factory.Package().get("spoon.test.path").getType("Foo").getField("toto").getDefaultExpression()
+				factory.Package().get("spoon.test.path.testclasses").getType("Foo").getField("toto").getDefaultExpression()
 		);
 	}
 
@@ -86,12 +86,12 @@ public class PathTest {
 	public void testPathFromString() throws Exception {
 		// match the first statement of Foo.foo() method
 		equals(
-				new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo#body#statement[index=0]"),
-				factory.Package().get("spoon.test.path").getType("Foo").getMethod("foo").getBody()
+				new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]"),
+				factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("foo").getBody()
 						.getStatement(0));
 
-		equals(new CtPathStringBuilder().fromString(".spoon.test.path.Foo.bar/CtParameter"),
-				factory.Package().get("spoon.test.path").getType("Foo").getMethod("bar",
+		equals(new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar/CtParameter"),
+				factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("bar",
 						factory.Type().createReference(int.class),
 						factory.Type().createReference(int.class))
 						.getParameters().toArray(new CtElement[0])
@@ -100,13 +100,13 @@ public class PathTest {
 		CtLiteral<String> literal = factory.Core().createLiteral();
 		literal.setValue("salut");
 		literal.setType(literal.getFactory().Type().STRING);
-		equals(new CtPathStringBuilder().fromString(".spoon.test.path.Foo.toto#defaultExpression"), literal);
+		equals(new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.toto#defaultExpression"), literal);
 	}
 
 	@Test
 	public void testMultiPathFromString() throws Exception {
 		// When role match a list but no index is provided, all of them must be returned
-		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo#body#statement")
+		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 3);
 		// When role match a set but no name is provided, all of them must be returned
@@ -114,7 +114,7 @@ public class PathTest {
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 1);
 		// When role match a map but no key is provided, all of them must be returned
-		results = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.bar##annotation[index=0]#value")
+		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 1);
 
@@ -123,11 +123,11 @@ public class PathTest {
 	@Test
 	public void testIncorrectPathFromString() throws Exception {
 		// match the else part of the if in Foo.bar() method which does not exist (Test non existing unique element)
-		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.bar#body#statement[index=2]#else")
+		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar#body#statement[index=2]#else")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 0);
 		// match the third statement of Foo.foo() method which does not exist (Test non existing element of a list)
-		results = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo#body#statement[index=3]")
+		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=3]")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 0);
 		// match an non existing package (Test non existing element of a set)
@@ -135,20 +135,20 @@ public class PathTest {
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 0);
 		//match a non existing field of an annotation (Test non existing element of a map)
-		results = new CtPathStringBuilder().fromString(".spoon.test.path.Foo.bar##annotation[index=0]#value[key=misspelled]")
+		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value[key=misspelled]")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(results.size(), 0);
 	}
 
 	@Test
 	public void testGetPathFromNonParent() throws Exception {
-		CtMethod fooMethod = (CtMethod) new CtPathStringBuilder().fromString(".spoon.test.path.Foo.foo")
+		CtMethod fooMethod = (CtMethod) new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo")
 				.evaluateOn(factory.getModel().getRootPackage()).iterator().next();
-		CtMethod barMethod = (CtMethod) new CtPathStringBuilder().fromString(".spoon.test.path.Foo.bar")
+		CtMethod barMethod = (CtMethod) new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar")
 				.evaluateOn(factory.getModel().getRootPackage()).iterator().next();
 		try {
 			new CtElementPathBuilder().fromElement(fooMethod,barMethod);
-			fail("No path should be found to .spoon.test.path.Foo.foo from .spoon.test.path.Foo.bar");
+			fail("No path should be found to .spoon.test.path.testclasses.Foo.foo from .spoon.test.path.testclasses.Foo.bar");
 		} catch (CtPathException e) {
 
 		}
@@ -159,12 +159,12 @@ public class PathTest {
 		// get the first statements of all Foo methods
 		List<CtElement> list = new LinkedList<>();
 		list.add(factory.getModel().getRootPackage());
-		equals(new CtPathStringBuilder().fromString(".spoon.test.path.Foo.*#body#statement[index=0]"),
-				((CtClass) factory.Package().get("spoon.test.path").getType("Foo")).getConstructor().getBody()
+		equals(new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.*#body#statement[index=0]"),
+				((CtClass) factory.Package().get("spoon.test.path.testclasses").getType("Foo")).getConstructor().getBody()
 						.getStatement(0),
-				factory.Package().get("spoon.test.path").getType("Foo").getMethod("foo").getBody()
+				factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("foo").getBody()
 						.getStatement(0),
-				factory.Package().get("spoon.test.path").getType("Foo").getMethod("bar",
+				factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("bar",
 						factory.Type().createReference(int.class), factory.Type().createReference(int.class)).getBody()
 						.getStatement(0)
 		);
@@ -174,22 +174,22 @@ public class PathTest {
 	public void testRoles() throws Exception {
 		// get the then statement
 		equals(new CtPathStringBuilder().fromString(".**/CtIf#else"),
-				((CtIf) factory.Package().get("spoon.test.path").getType("Foo").getMethod("foo").getBody()
+				((CtIf) factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("foo").getBody()
 						.getStatement(2)).getElseStatement()
 		);
 		equals(new CtPathStringBuilder().fromString(".**#else"),
-				((CtIf) factory.Package().get("spoon.test.path").getType("Foo").getMethod("foo").getBody()
+				((CtIf) factory.Package().get("spoon.test.path.testclasses").getType("Foo").getMethod("foo").getBody()
 						.getStatement(2)).getElseStatement()
 		);
 	}
 
 	@Test
 	public void toStringTest() throws Exception {
-		comparePath(".spoon.test.path.Foo/CtMethod");
-		comparePath(".spoon.test.path.Foo.foo#body#statement[index=0]");
-		comparePath(".spoon.test.path.Foo.bar/CtParameter");
-		comparePath(".spoon.test.path.Foo.toto#defaultExpression");
-		comparePath(".spoon.test.path.Foo.*#body#statement[index=0]");
+		comparePath(".spoon.test.path.testclasses.Foo/CtMethod");
+		comparePath(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
+		comparePath(".spoon.test.path.testclasses.Foo.bar/CtParameter");
+		comparePath(".spoon.test.path.testclasses.Foo.toto#defaultExpression");
+		comparePath(".spoon.test.path.testclasses.Foo.*#body#statement[index=0]");
 		comparePath(".**/CtIf#else");
 		comparePath(".**#else");
 	}

--- a/src/test/java/spoon/test/path/testclasses/Foo.java
+++ b/src/test/java/spoon/test/path/testclasses/Foo.java
@@ -1,4 +1,4 @@
-package spoon.test.path;
+package spoon.test.path.testclasses;
 
 class Foo {
 	Foo() {

--- a/src/test/java/spoon/test/strings/StringTest.java
+++ b/src/test/java/spoon/test/strings/StringTest.java
@@ -15,7 +15,7 @@ public class StringTest {
 
 	@Test
 	public void testModelBuildingInitializer() throws Exception {
-		CtClass<?> type = build("spoon.test.strings", "Main");
+		CtClass<?> type = build("spoon.test.strings.testclasses", "Main");
 		assertEquals("Main", type.getSimpleName());
 
 		CtBinaryOperator<?> op = type.getElements(

--- a/src/test/java/spoon/test/strings/testclasses/Main.java
+++ b/src/test/java/spoon/test/strings/testclasses/Main.java
@@ -1,4 +1,4 @@
-package spoon.test.strings;
+package spoon.test.strings.testclasses;
 
 public class Main {
 


### PR DESCRIPTION
I moved 4 resources to test classes.

@surli 
@monperrus 
Please verify changed assertions (7 -> 8) and changed doc.
Of course I did not want to change assertions, but because of moved class, it was required.

- FooLine (test/filters) -> I was forced to modify assertions in FilterTest.java (7 -> 8) https://github.com/INRIA/spoon/commit/9aeddfda093ebf7b8e40d4050a97fb61e2bb52fc
- ClassThatBindsAGenericType (test/generics)
- Foo (test/path) -> please check if doc is ok - https://github.com/INRIA/spoon/pull/2277/commits/a6f1785c847080d88e554e4cd840cb7afb971e1f
- Main (test/strings)