### PR TITLE
refactor: remove commented code from tests

### DIFF
--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -123,10 +123,5 @@ public class ExceptionTest {
 		CtCatchVariable variable2 = catches.get(1).getParameter(); // outside the lambda
 
 		assertEquals(variable1.getMultiTypes(), variable2.getMultiTypes());
-
-		// for now the type of CtCatchVariable is not the same
-		// this should be fix in the future (see: https://github.com/INRIA/spoon/issues/1420)
-		//assertEquals(variable2, variable1);
 	}
-
 }

--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -123,5 +123,6 @@ public class ExceptionTest {
 		CtCatchVariable variable2 = catches.get(1).getParameter(); // outside the lambda
 
 		assertEquals(variable1.getMultiTypes(), variable2.getMultiTypes());
+		assertEquals(variable2, variable1);
 	}
 }

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -659,7 +659,6 @@ public class GenericsTest {
 
 		CtType<Tacos> aTacos = buildNoClasspath(Tacos.class).Type().get(Tacos.class);
 		//this returns a type reference with uninitialized actual type arguments.
-//		CtTypeReference<?> genericTypeRef = aTacos.getReference();
 		CtTypeReference<?> genericTypeRef = aTacos.getFactory().Type().createReference(aTacos, true);
 		
 		assertTrue(genericTypeRef.getActualTypeArguments().size()>0);

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -666,7 +666,7 @@ public class GenericsTest {
 		for(int i=0; i<aTacos.getFormalCtTypeParameters().size(); i++) {
 			assertSame("TypeParameter reference idx="+i+" is different", aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
 
-			// contract: getTypeParameterDeclaration goes back to the declaration, eevn without context
+			// contract: getTypeParameterDeclaration goes back to the declaration, even without context
 			assertSame(aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
 
 		}

--- a/src/test/java/spoon/test/replace/ReplaceParametrizedTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceParametrizedTest.java
@@ -140,11 +140,6 @@ public class ReplaceParametrizedTest<T extends CtVisitable> {
 							found = true;
 							return;
 						}
-//						if (rh.getRole()==CtRole.TYPE && role == CtRole.MULTI_TYPE) {
-//							//CtCatchVaraible#type sets CtCatchVaraible#multiType - OK 
-//							found = true;
-//							return;
-//						}
 						problems.add("Argument was set into " + rh.getRole() + " but was found in " + role);
 					}
 				}


### PR DESCRIPTION
It looks like that is is fixed/obsolete
```
		// for now the type of CtCatchVariable is not the same
		// this should be fix in the future (see: https://github.com/INRIA/spoon/issues/1420)
		//assertEquals(variable2, variable1);
```
But if it is needed, I will restore it.

@surli 
?

I am ready to merge.