### PR TITLE
refactor: move processor classes to processors directory

### DIFF
--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -21,9 +21,9 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.test.processing.processors.RenameProcessor;
-import spoon.test.processing.testclasses.CtClassProcessor;
-import spoon.test.processing.testclasses.CtInterfaceProcessor;
-import spoon.test.processing.testclasses.CtTypeProcessor;
+import spoon.test.processing.processors.CtClassProcessor;
+import spoon.test.processing.processors.CtInterfaceProcessor;
+import spoon.test.processing.processors.CtTypeProcessor;
 import spoon.testing.utils.ProcessorUtils;
 
 import java.io.File;

--- a/src/test/java/spoon/test/processing/processors/CtClassProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/CtClassProcessor.java
@@ -1,4 +1,4 @@
-package spoon.test.processing.testclasses;
+package spoon.test.processing.processors;
 
 import spoon.reflect.declaration.CtClass;
 

--- a/src/test/java/spoon/test/processing/processors/CtInterfaceProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/CtInterfaceProcessor.java
@@ -1,4 +1,4 @@
-package spoon.test.processing.testclasses;
+package spoon.test.processing.processors;
 
 import spoon.reflect.declaration.CtInterface;
 

--- a/src/test/java/spoon/test/processing/processors/CtTypeProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/CtTypeProcessor.java
@@ -1,4 +1,4 @@
-package spoon.test.processing.testclasses;
+package spoon.test.processing.processors;
 
 import spoon.reflect.declaration.CtType;
 

--- a/src/test/java/spoon/test/processing/processors/GenericCtTypeProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/GenericCtTypeProcessor.java
@@ -1,4 +1,4 @@
-package spoon.test.processing.testclasses;
+package spoon.test.processing.processors;
 
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtType;

--- a/src/test/java/spoon/test/processing/processors/GenericCtTypeProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/GenericCtTypeProcessor.java
@@ -15,7 +15,7 @@ public abstract class GenericCtTypeProcessor<T extends CtType> extends AbstractP
         super.addProcessedElementType(zeClass);
     }
 
-    public List<T> elements = new ArrayList<T>();
+    public List<T> elements = new ArrayList<>();
 
     @Override
     public void process(T element) {


### PR DESCRIPTION
I have noticed that some processors are wrongly placed in testclasses.
Moved to *processors* directory.

I am ready to merge.