### PR TITLE
refactor: fix order in assertions

### DIFF
--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -822,7 +822,7 @@ public class CommentTest {
 		);
 
 		try {
-			assertEquals("doc outdated, please commit doc/code_elements.md", codeElementsDocumentationPage.toString(), IOUtils.toString(new FileReader("doc/code_elements.md")));
+			assertEquals("doc outdated, please commit doc/code_elements.md", IOUtils.toString(new FileReader("doc/code_elements.md")), codeElementsDocumentationPage.toString());
 		} finally {
 			write(codeElementsDocumentationPage.toString(), new FileOutputStream("doc/code_elements.md"));
 		}

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -486,7 +486,7 @@ public class MainTest {
 						CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
 						Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
 						//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
-						assertEquals(returnedElements.size(), 1);
+						assertEquals(1, returnedElements.size());
 						CtElement actualElement = (CtElement) returnedElements.toArray()[0];
 						//contract: Element -> Path -> String -> Path -> Element leads to the original element
 						assertSame(element, actualElement);

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -108,15 +108,15 @@ public class PathTest {
 		// When role match a list but no index is provided, all of them must be returned
 		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 3);
+		assertEquals(3, results.size());
 		// When role match a set but no name is provided, all of them must be returned
 		results = new CtPathStringBuilder().fromString("#subPackage")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 1);
+		assertEquals(1, results.size());
 		// When role match a map but no key is provided, all of them must be returned
 		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 1);
+		assertEquals(1, results.size());
 
 	}
 
@@ -125,19 +125,19 @@ public class PathTest {
 		// match the else part of the if in Foo.bar() method which does not exist (Test non existing unique element)
 		Collection<CtElement> results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar#body#statement[index=2]#else")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 0);
+		assertEquals(0, results.size());
 		// match the third statement of Foo.foo() method which does not exist (Test non existing element of a list)
 		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=3]")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 0);
+		assertEquals(0, results.size());
 		// match an non existing package (Test non existing element of a set)
 		results = new CtPathStringBuilder().fromString("#subPackage[name=nonExistingPackage]")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 0);
+		assertEquals(0, results.size());
 		//match a non existing field of an annotation (Test non existing element of a map)
 		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value[key=misspelled]")
 				.evaluateOn(factory.getModel().getRootPackage());
-		assertEquals(results.size(), 0);
+		assertEquals(0, results.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/properties/PropertiesTest.java
+++ b/src/test/java/spoon/test/properties/PropertiesTest.java
@@ -29,7 +29,7 @@ public class PropertiesTest {
 		compiler.build();
 
 		compiler.instantiateAndProcess(Arrays.asList(SimpleProcessor.class.getName()));
-		assertEquals(factory.getEnvironment().getErrorCount(), 0);
+		assertEquals(0, factory.getEnvironment().getErrorCount());
 	}
 
 }

--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -172,7 +172,7 @@ public class ExecutableReferenceGenericTest {
 		CtExecutable execRefsMethods2 = refsMethodA.get(0).getDeclaration();
 		//T has more information in the invocation than its declaration because of the argument type
 		//	assertEquals(expectedMethod1, refsMethodA.get(0).getDeclaration());
-		assertEquals(execRefsMethods2.getSignature(), "method1(T extends java.lang.String)");
+		assertEquals("method1(T extends java.lang.String)", execRefsMethods2.getSignature());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -202,7 +202,7 @@ public class TypeReferenceTest {
 	public void unboxTest() {
 		Factory factory = new Launcher().createFactory();
 		CtTypeReference<Boolean> boxedBoolean = factory.Class().createReference(Boolean.class);
-		assertEquals(boxedBoolean.unbox().getActualClass(), boolean.class);
+		assertEquals(boolean.class, boxedBoolean.unbox().getActualClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -226,10 +226,10 @@ public class VariableAccessTest {
 					final CtLocalVariableReference<T> reference) {
 				assertNotNull(reference.getDeclaration());
 				final CtLocalVariable decl = reference.getDeclaration();
-				assertEquals(decl.getPosition().getLine(), 7);
+				assertEquals(7, decl.getPosition().getLine());
 				assertTrue(decl.getDefaultExpression() instanceof CtLiteral);
 				final CtLiteral literal = (CtLiteral) decl.getDefaultExpression();
-				assertEquals(literal.getValue(), 42);
+				assertEquals(42, literal.getValue());
 				super.visitCtLocalVariableReference(reference);
 			}
 		}


### PR DESCRIPTION
Order in JUnit assertions in counter-intutive. So mistakes happen from time to time. Fixed!

I am ready to merge.