### PR TITLE
refactor: remove redundant null check

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -115,7 +115,7 @@ class JDTTreeBuilderQuery {
 		}
 		for (ImportReference anImport : imports) {
 			final String importType = CharOperation.charToString(anImport.getImportName()[anImport.getImportName().length - 1]);
-			if (importType != null && importType.equals(typeName)) {
+			if (typeName.equals(importType)) {
 				return CharOperation.toString(anImport.getImportName());
 			}
 		}


### PR DESCRIPTION
Let the equals() do the job (without NPE risk).