### PR TITLE
refactor: remove redundant null check in AstCheckerTest.java

### DIFF
--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -182,7 +182,7 @@ public class AstCheckerTest {
 				return false;
 			}
 			CtExecutable declaration = potentialDelegate.getExecutable().getDeclaration();
-			if (declaration == null || !(declaration instanceof CtMethod)) {
+			if (!(declaration instanceof CtMethod)) {
 				return false;
 			}
 			// check if the invocation has a model change listener


### PR DESCRIPTION
Of course instanceof checks for null.
Similar to: refactor: remove redundant null check #2317
Let the Java do the job.

I am ready to merge.