### PR TITLE
refactor: fix code inspection - collection to array

### DIFF
--- a/src/main/java/spoon/IncrementalLauncher.java
+++ b/src/main/java/spoon/IncrementalLauncher.java
@@ -241,7 +241,7 @@ public class IncrementalLauncher extends Launcher {
 			setBinaryOutputDirectory(mClassFilesDir);
 		}
 
-		getEnvironment().setSourceClasspath(mSourceClasspath.toArray(new String[mSourceClasspath.size()]));
+		getEnvironment().setSourceClasspath(mSourceClasspath.toArray(new String[0]));
 	}
 
 	/**

--- a/src/main/java/spoon/compiler/builder/JDTBuilderImpl.java
+++ b/src/main/java/spoon/compiler/builder/JDTBuilderImpl.java
@@ -61,7 +61,7 @@ public class JDTBuilderImpl implements JDTBuilder {
 
 	@Override
 	public String[] build() {
-		return args.toArray(new String[args.size()]);
+		return args.toArray(new String[0]);
 	}
 
 	private void checkSources() {

--- a/src/main/java/spoon/compiler/builder/Options.java
+++ b/src/main/java/spoon/compiler/builder/Options.java
@@ -29,7 +29,7 @@ public abstract class Options<T extends Options<T>> {
 	}
 
 	public String[] build() {
-		return args.toArray(new String[args.size()]);
+		return args.toArray(new String[0]);
 	}
 
 	protected String join(String delimiter, String[] classpath) {

--- a/src/main/java/spoon/pattern/internal/PatternPrinter.java
+++ b/src/main/java/spoon/pattern/internal/PatternPrinter.java
@@ -93,7 +93,7 @@ public class PatternPrinter extends DefaultGenerator {
 						paramsOnElement.add(new ParamOnElement((CtElement) firstResult, mmField.getRole(), attrNode));
 					});
 				}
-				addParameterCommentTo((CtElement) firstResult, paramsOnElement.toArray(new ParamOnElement[paramsOnElement.size()]));
+				addParameterCommentTo((CtElement) firstResult, paramsOnElement.toArray(new ParamOnElement[0]));
 			} else if (node instanceof ParameterNode) {
 				addParameterCommentTo((CtElement) firstResult, new ParamOnElement((CtElement) firstResult, node));
 			}

--- a/src/main/java/spoon/pattern/internal/node/StringNode.java
+++ b/src/main/java/spoon/pattern/internal/node/StringNode.java
@@ -172,7 +172,7 @@ public class StringNode extends AbstractPrimitiveMatcher {
 				re.append(escapeRegExp(getStringValueWithMarkers().substring(start)));
 			}
 			regExpPattern = Pattern.compile(re.toString());
-			params = paramsByRegions.toArray(new ParameterInfo[paramsByRegions.size()]);
+			params = paramsByRegions.toArray(new ParameterInfo[0]);
 		}
 		return regExpPattern;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/FactoryCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FactoryCompilerConfig.java
@@ -44,6 +44,6 @@ public class FactoryCompilerConfig implements SpoonModelBuilder.InputType {
 				unitList.add(new CompilationUnitWrapper(ctType));
 			}
 		}
-		compiler.setCompilationUnits(unitList.toArray(new CompilationUnit[unitList.size()]));
+		compiler.setCompilationUnits(unitList.toArray(new CompilationUnit[0]));
 	}
 }

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -104,6 +104,6 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 				unitsToReturn.add(cud);
 			}
 		}
-		return unitsToReturn.toArray(new CompilationUnitDeclaration[unitsToReturn.size()]);
+		return unitsToReturn.toArray(new CompilationUnitDeclaration[0]);
 	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -123,7 +123,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		if (typeDecl == null) {
 			return null;
 		}
-		CtTypeReference<?>[] arrayParameters = parameters.toArray(new CtTypeReferenceImpl<?>[parameters.size()]);
+		CtTypeReference<?>[] arrayParameters = parameters.toArray(new CtTypeReferenceImpl<?>[0]);
 		CtExecutable<T> method = typeDecl.getMethod(getSimpleName(), arrayParameters);
 		if ((method == null) && (typeDecl instanceof CtClass) && this.isConstructor()) {
 			try {

--- a/src/main/java/spoon/support/util/RtHelper.java
+++ b/src/main/java/spoon/support/util/RtHelper.java
@@ -120,7 +120,7 @@ public abstract class RtHelper {
 		for (CtTypeReference<?> type : i.getExecutable().getActualTypeArguments()) {
 			argTypes.add(type.getActualClass());
 		}
-		return (T) c.getMethod(i.getExecutable().getSimpleName(), argTypes.toArray(new Class[argTypes.size()]))
+		return (T) c.getMethod(i.getExecutable().getSimpleName(), argTypes.toArray(new Class[0]))
 				.invoke(target, args.toArray());
 	}
 

--- a/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
@@ -200,7 +200,7 @@ public class RtMethod {
 				}
 			}
 		}
-		return methods.toArray(new RtMethod[methods.size()]);
+		return methods.toArray(new RtMethod[0]);
 	}
 
 	private boolean isLightEquals(RtMethod rtMethod) {

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1267,7 +1267,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	public static <E extends spoon.reflect.declaration.CtElement> void replace(spoon.reflect.declaration.CtElement original, java.util.Collection<E> replaces) {
 		try {
-			new spoon.support.visitor.replace.ReplacementVisitor(original, replaces.toArray(new spoon.reflect.declaration.CtElement[replaces.size()])).scan(original.getParent());
+			new spoon.support.visitor.replace.ReplacementVisitor(original, replaces.toArray(new CtElement[0])).scan(original.getParent());
 		} catch (spoon.support.visitor.replace.InvalidReplaceException e) {
 			throw e;
 		}

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1267,7 +1267,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	public static <E extends spoon.reflect.declaration.CtElement> void replace(spoon.reflect.declaration.CtElement original, java.util.Collection<E> replaces) {
 		try {
-			new spoon.support.visitor.replace.ReplacementVisitor(original, replaces.toArray(new CtElement[0])).scan(original.getParent());
+			new spoon.support.visitor.replace.ReplacementVisitor(original, replaces.toArray(new spoon.reflect.declaration.CtElement[replaces.size()])).scan(original.getParent());
 		} catch (spoon.support.visitor.replace.InvalidReplaceException e) {
 			throw e;
 		}


### PR DESCRIPTION
Use modern way to convert collection to array.

old: (mSourceClasspath.toArray(new String[mSourceClasspath.size()]));
new: (mSourceClasspath.toArray(new String[0]));

benefits:
- more readable
- faster to understand
- a bit faster

I am ready to merge.