### PR TITLE
refactor: fix code inspection - qualified static access

### DIFF
--- a/src/main/java/spoon/reflect/meta/impl/RoleHandlerHelper.java
+++ b/src/main/java/spoon/reflect/meta/impl/RoleHandlerHelper.java
@@ -128,6 +128,6 @@ public class RoleHandlerHelper {
 		if (roleInParent == null) {
 			return null;
 		}
-		return RoleHandlerHelper.getRoleHandler(parent.getClass(), roleInParent);
+		return getRoleHandler(parent.getClass(), roleInParent);
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -222,7 +222,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public <E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
 		if (annotations == null || annotations.isEmpty()) {
-			this.annotations = CtElementImpl.emptyList();
+			this.annotations = emptyList();
 			return (E) this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
@@ -565,7 +565,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public <E extends CtElement> E setComments(List<CtComment> comments) {
 		if (comments == null || comments.isEmpty()) {
-			this.comments = CtElementImpl.emptyList();
+			this.comments = emptyList();
 			return (E) this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, COMMENT, this.comments, new ArrayList<>(this.comments));

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -235,7 +235,7 @@ public abstract class Parameters {
 	 * 		the template that holds the parameter values
 	 */
 	public static Map<String, Object> getTemplateParametersAsMap(Factory f, CtType<?> targetType, Template<?> template) {
-		Map<String, Object> params = new HashMap<>(Parameters.getNamesToValues(template, (CtClass) f.Class().get(template.getClass())));
+		Map<String, Object> params = new HashMap<>(getNamesToValues(template, (CtClass) f.Class().get(template.getClass())));
 		//detect reference to to be generated type
 		CtTypeReference<?> targetTypeRef = targetType == null ? null : targetType.getReference();
 		if (targetType == null) {

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1281,7 +1281,7 @@ public class ReplacementVisitor extends spoon.reflect.visitor.CtScanner {
 
 	private ReplacementVisitor(spoon.reflect.declaration.CtElement original, spoon.reflect.declaration.CtElement... replace) {
 		this.original = original;
-		this.replace = (replace == null) ? spoon.support.visitor.replace.ReplacementVisitor.EMPTY : replace;
+		this.replace = (replace == null) ? EMPTY : replace;
 	}
 
 	private <K, V extends spoon.reflect.declaration.CtElement> void replaceInMapIfExist(java.util.Map<K, V> mapProtected, spoon.support.visitor.replace.ReplaceMapListener listener) {


### PR DESCRIPTION
- Unqualified static access: 408 cases
- Unnecessarily qualified static access: 5 cases

There is no need to prefix static fields&methods inside its own class.
All Spoon classes use direct static acces *static_method_invocation()*,
not prefixed: *X.static_method_invocation()*.

I normalized 5 cases with not needed prefixes.

Inside BlockTemplate class:
BlockTemplate.getBlock(c) -> getBlock(c)

I am ready to merge.