### PR TITLE
refactor: use direct assertions in tests

### DIFF
--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -563,7 +563,7 @@ public class JavaReflectionTreeBuilderTest {
 		CtTypeParameter typeParameter = shadowType.getFormalCtTypeParameters().get(0);
 
 		assertEquals("T", typeParameter.getSimpleName());
-		assertTrue(typeParameter.getSuperclass() == null);
+		assertNull(typeParameter.getSuperclass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -86,6 +86,7 @@ import java.util.Set;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -227,7 +228,7 @@ public class AnnotationTest {
 		assertEquals(2, annot.classes().length);
 		assertEquals(Integer.class, annot.classes()[0]);
 		assertEquals(String.class, annot.classes()[1]);
-		assertEquals(true, annot.b());
+		assertTrue(annot.b());
 		assertEquals('c', annot.c());
 		assertEquals(42, annot.byt());
 		assertEquals((short) 42, annot.s());
@@ -251,7 +252,7 @@ public class AnnotationTest {
 		assertEquals(2, annot.strings().length);
 		assertEquals("Hello", annot.strings()[0]);
 		assertEquals("world", annot.strings()[1]);
-		assertEquals(false, annot.b());
+		assertFalse(annot.b());
 		assertEquals(42, annot.byt());
 		assertEquals((short) 42, annot.s());
 		assertEquals(42, annot.l());
@@ -276,7 +277,7 @@ public class AnnotationTest {
 		assertEquals(2, annot.strings().length);
 		assertEquals("Helloconcatenated", annot.strings()[0]);
 		assertEquals("worldconcatenated", annot.strings()[1]);
-		assertEquals(true, annot.b());
+		assertTrue(annot.b());
 		assertEquals(42 ^ 1, annot.byt());
 		assertEquals((short) 42 / 2, annot.s());
 		assertEquals(43, annot.l());

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -551,7 +551,7 @@ public class MetamodelTest {
 		assertListContracts(packages, typeRef, 1, null);
 
 		//contract: set of new value replaces existing value
-		assertEquals(null, packages.set(0, factory.Package().createReference("some.test.package")));
+		assertNull(packages.set(0, factory.Package().createReference("some.test.package")));
 		assertListContracts(packages, typeRef, 1, "some.test.package");
 
 		//contract: set of null value keeps size==1 even if value is replaced by null

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -141,7 +141,7 @@ public class NoClasspathTest {
 		CtMethod<?> method = clazz.getMethodsByName("doSomething").get(0);
 		CtReturn<?> ctReturn = method.getElements(new TypeFilter<CtReturn<?>>(CtReturn.class)).get(0);
 
-		assertEquals(true, ctReturn.getReferencedTypes().contains(expectedType));
+		assertTrue(ctReturn.getReferencedTypes().contains(expectedType));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -768,7 +768,7 @@ public class CommentTest {
 		codeElementsDocumentationPage.append("\n\n");
 		launcher.getModel().getElements(new TypeFilter<>(CtInterface.class)).stream().forEach(x -> {
 
-			assertTrue(x.getSimpleName()+ " has no documentation", x.getDocComment() != null);
+			assertNotNull(x.getSimpleName() + " has no documentation", x.getDocComment());
 			assertTrue(x.getSimpleName()+ " has no documentation", !x.getDocComment().isEmpty());
 
 			// we only consider instantiable interfaces

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -3,6 +3,7 @@ package spoon.test.compilation;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -68,9 +69,9 @@ public class CompilationTest {
 				"--level", "OFF"
 		});
 
-		assertEquals(true, launcher.getEnvironment().shouldCompile());
+		assertTrue(launcher.getEnvironment().shouldCompile());
 
-		assertEquals(true, new File(compiledFile).exists());
+		assertTrue(new File(compiledFile).exists());
 	}
 
 	@Test
@@ -352,7 +353,7 @@ public class CompilationTest {
 		Class<?> foo = launcher.getEnvironment().getInputClassLoader().loadClass("spoontest.Foo");
 
 		assertTrue(ifoo.isAssignableFrom(foo));
-		assertTrue(ifoo.getClassLoader()==foo.getClassLoader());
+		assertSame(ifoo.getClassLoader(), foo.getClassLoader());
 	}
 	
 

--- a/src/test/java/spoon/test/ctBlock/TestCtBlock.java
+++ b/src/test/java/spoon/test/ctBlock/TestCtBlock.java
@@ -15,6 +15,7 @@ import spoon.test.ctBlock.testclasses.Toto;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -43,7 +44,7 @@ public class TestCtBlock {
 
         CtStatement newLastStatement = block.getLastStatement();
 
-        assertTrue(newLastStatement != lastStatement);
+        assertNotSame(newLastStatement, lastStatement);
         assertTrue(newLastStatement instanceof CtIf);
     }
 

--- a/src/test/java/spoon/test/ctCase/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/ctCase/SwitchCaseTest.java
@@ -1,6 +1,7 @@
 package spoon.test.ctCase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
@@ -32,7 +33,7 @@ public class SwitchCaseTest {
 		statements.get(0).insertAfter(newStatement);
 		statements = firstCase.getStatements();
 		assertEquals(3, statements.size());
-		assertTrue(statements.get(1) == newStatement);
+		assertSame(statements.get(1), newStatement);
 	}
 
 	@Test
@@ -49,7 +50,7 @@ public class SwitchCaseTest {
 		statements.get(0).insertBefore(newStatement);
 		statements = firstCase.getStatements();
 		assertEquals(3, statements.size());
-		assertTrue(statements.get(0) == newStatement);
+		assertSame(statements.get(0), newStatement);
 	}
 
 	private <T extends CtElement> List<T> elementsOfType(Class<T> type, Factory factory) {

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -20,6 +20,7 @@ import spoon.testing.utils.ModelUtils;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ExecutableTest {
@@ -54,29 +55,29 @@ public class ExecutableTest {
 
 		String methodName = "getInt1";
 		CtExecutableReference<?> methodRef = aClass.getMethod(methodName).getReference();
-		assertEquals(false, methodRef.isFinal());
-		assertEquals(true, methodRef.isStatic());
+		assertFalse(methodRef.isFinal());
+		assertTrue(methodRef.isStatic());
 		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
 		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
 
 		methodName = "getInt2";
 		methodRef = aClass.getMethod(methodName).getReference();
-		assertEquals(true, methodRef.isFinal());
-		assertEquals(true, methodRef.isStatic());
+		assertTrue(methodRef.isFinal());
+		assertTrue(methodRef.isStatic());
 		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
 		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
 
 		methodName = "getInt3";
 		methodRef = aClass.getMethod(methodName).getReference();
-		assertEquals(true, methodRef.isFinal());
-		assertEquals(false, methodRef.isStatic());
+		assertTrue(methodRef.isFinal());
+		assertFalse(methodRef.isStatic());
 		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
 		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
 
 		methodName = "getInt4";
 		methodRef = aClass.getMethod(methodName).getReference();
-		assertEquals(false, methodRef.isFinal());
-		assertEquals(false, methodRef.isStatic());
+		assertFalse(methodRef.isFinal());
+		assertFalse(methodRef.isStatic());
 		assertEquals(aClass.getFactory().Type().integerPrimitiveType(), methodRef.getType());
 		assertEquals(aClass.getMethod(methodName), methodRef.getDeclaration());
 	}

--- a/src/test/java/spoon/test/factory/TypeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/TypeFactoryTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class TypeFactoryTest {
 
@@ -32,7 +33,7 @@ public class TypeFactoryTest {
 		assertEquals("java.lang.Object", ctTypeReference.getQualifiedName());
 
 		ctTypeReference = launcher.getFactory().Code().createCtTypeReference(null);
-		assertEquals(null, ctTypeReference);
+		assertNull(ctTypeReference);
 
 		ctTypeReference = launcher.getFactory().Code().createCtTypeReference(CtJavaDoc.CommentType.class);
 		assertEquals("CommentType", ctTypeReference.getSimpleName());

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -18,6 +18,8 @@
 package spoon.test.field;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -114,7 +116,7 @@ public class FieldTest {
 		assertEquals(1, fieldReads.size());
 		assertEquals("i", fieldReads.get(0).toString());
 		fieldReads.get(0).getTarget().setImplicit(false);
-		assertEquals(false, fieldReads.get(0).getTarget().isImplicit());
+		assertFalse(fieldReads.get(0).getTarget().isImplicit());
 		assertEquals("this.i", fieldReads.get(0).toString());
 	}
 
@@ -157,7 +159,7 @@ public class FieldTest {
 
 		Object retour = visitorPartial.evaluate(methods.get(0));
 
-		assertTrue(retour != null);
+		assertNotNull(retour);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -42,6 +42,7 @@ import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.Assert.assertThat;
@@ -127,7 +128,7 @@ public class FieldAccessTest {
 
 		// testing the proxy method setAssignment/getAssignment on local variables
 		var.setAssignment(null);
-		assertEquals(null, var.getAssignment());
+		assertNull(var.getAssignment());
 		assertEquals("int a", var.toString());
 
 		// testing the proxy method setAssignment/getAssignment on fields
@@ -135,7 +136,7 @@ public class FieldAccessTest {
 				new TypeFilter<CtField<?>>(CtField.class)).get(0);
 		assertNotNull(field.getAssignment());
 		field.setAssignment(null);
-		assertEquals(null, field.getAssignment());
+		assertNull(field.getAssignment());
 		assertEquals("java.lang.Object[] data;", field.toString());
 
 	}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -1134,8 +1134,8 @@ public class FilterTest {
 			context.failIfTerminated("CtFunction#apply of map after CtConsumableFunction");
 			return e;
 		}).first(CtMethod.class);
-		
-		assertTrue(firstMethod!=null);
+
+		assertNotNull(firstMethod);
 		assertTrue(context.wasTerminated);
 	}
 	@Test

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -699,145 +699,145 @@ public class GenericsTest {
 
 		// T
 		CtTypeReference<?> var1Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "var1")).first(CtVariable.class).getType();
-		assertEquals(true, var1Ref.isGenerics());
+		assertTrue(var1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Subscriber<? super T>
 		CtTypeReference<?> sRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "s")).first(CtVariable.class).getType();
-		assertEquals(true, sRef.isGenerics());
+		assertTrue(sRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>
 		CtTypeReference<?> notificationRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "notification")).first(CtVariable.class).getType();
-		assertEquals(false, notificationRef.isGenerics());
+		assertFalse(notificationRef.isGenerics());
 
 		// java.util.function.Function<? super spoon.test.generics.testclasses.rxjava.Observable<spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>, ? extends spoon.test.generics.testclasses.rxjava.Publisher<?>>
 		CtTypeReference<?> managerRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "manager")).first(CtVariable.class).getType();
-		assertEquals(false, managerRef.isGenerics());
+		assertFalse(managerRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.BehaviorSubject<spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>
 		CtTypeReference<?> subjectRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "subject")).first(CtVariable.class).getType();
-		assertEquals(false, subjectRef.isGenerics());
+		assertFalse(subjectRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.PublisherRedo.RedoSubscriber<T>
 		CtTypeReference<?> parentRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "parent")).first(CtVariable.class).getType();
-		assertEquals(true, parentRef.isGenerics());
+		assertTrue(parentRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.Publisher<?>
 		CtTypeReference<?> actionRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "action")).first(CtVariable.class).getType();
-		assertEquals(false, actionRef.isGenerics());
+		assertFalse(actionRef.isGenerics());
 
 		// spoon.test.generics.testclasses.rxjava.ToNotificationSubscriber
 		CtTypeReference<?> trucRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "truc")).first(CtVariable.class).getType();
-		assertEquals(false, trucRef.isGenerics());
+		assertFalse(trucRef.isGenerics());
 
 		// java.util.function.Consumer<? super spoon.test.generics.testclasses.rxjava.Try<java.util.Optional<java.lang.Object>>>
 		CtTypeReference<?> consumerRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "consumer")).first(CtVariable.class).getType();
-		assertEquals(false, consumerRef.isGenerics());
+		assertFalse(consumerRef.isGenerics());
 
 		// S
 		CtTypeReference<?> sectionRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "section")).first(CtVariable.class).getType();
-		assertEquals(true, sectionRef.isGenerics());
+		assertTrue(sectionRef.isGenerics());
 
 		// X
 		CtTypeReference<?> paramARef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "paramA")).first(CtVariable.class).getType();
-		assertEquals(true, paramARef.isGenerics());
+		assertTrue(paramARef.isGenerics());
 
 		// spoon.test.generics.testclasses.Tacos
 		CtTypeReference<?> paramBRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "paramB")).first(CtVariable.class).getType();
-		assertEquals(false, paramBRef.isGenerics());
+		assertFalse(paramBRef.isGenerics());
 
 		// C
 		CtTypeReference<?> paramCRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "paramC")).first(CtVariable.class).getType();
-		assertEquals(true, paramCRef.isGenerics());
+		assertTrue(paramCRef.isGenerics());
 
 		// R
 		CtTypeReference<?> cookRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "cook")).first(CtVariable.class).getType();
-		assertEquals(true, cookRef.isGenerics());
+		assertTrue(cookRef.isGenerics());
 
 		// spoon.test.generics.testclasses.CelebrationLunch<java.lang.Integer, java.lang.Long, java.lang.Double>
 		CtTypeReference<?> clRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "cl")).first(CtVariable.class).getType();
-		assertEquals(false, clRef.isGenerics());
+		assertFalse(clRef.isGenerics());
 
 		// spoon.test.generics.testclasses.CelebrationLunch<java.lang.Integer, java.lang.Long, java.lang.Double>.WeddingLunch<spoon.test.generics.testclasses.Mole>
 		CtTypeReference<?> disgustRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "disgust")).first(CtVariable.class).getType();
-		assertEquals(false, disgustRef.isGenerics());
+		assertFalse(disgustRef.isGenerics());
 
 		// L
 		CtTypeReference<?> paramRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "param")).first(CtVariable.class).getType();
-		assertEquals(true, paramRef.isGenerics());
+		assertTrue(paramRef.isGenerics());
 
 		// spoon.reflect.declaration.CtType<? extends spoon.reflect.declaration.CtNamedElement>
 		CtTypeReference<?> targetTypeRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "targetType")).first(CtVariable.class).getType();
-		assertEquals(false, targetTypeRef.isGenerics());
+		assertFalse(targetTypeRef.isGenerics());
 
 		// spoon.reflect.declaration.CtType<?>
 		CtTypeReference<?> somethingRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "something")).first(CtVariable.class).getType();
-		assertEquals(false, somethingRef.isGenerics());
+		assertFalse(somethingRef.isGenerics());
 
 		// int
 		CtTypeReference<?> iRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "i")).first(CtVariable.class).getType();
-		assertEquals(false, iRef.isGenerics());
+		assertFalse(iRef.isGenerics());
 
 		// T
 		CtTypeReference<?> biduleRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "bidule")).first(CtVariable.class).getType();
-		assertEquals(true, biduleRef.isGenerics());
+		assertTrue(biduleRef.isGenerics());
 
 		// Cook<java.lang.String>
 		CtTypeReference<?> aClassRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "aClass")).first(CtVariable.class).getType();
-		assertEquals(false, aClassRef.isGenerics());
+		assertFalse(aClassRef.isGenerics());
 
 		// java.util.List<java.util.List<M>>
 		CtTypeReference<?> list2mRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "list2m")).first(CtVariable.class).getType();
-		assertEquals(true, list2mRef.isGenerics());
+		assertTrue(list2mRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Panini.Subscriber<? extends java.lang.Long>
 		CtTypeReference<?> tRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "t")).first(CtVariable.class).getType();
-		assertEquals(false, tRef.isGenerics());
+		assertFalse(tRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.Tester
 		CtTypeReference<?> testerRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "tester")).first(CtVariable.class).getType();
-		assertEquals(false, testerRef.isGenerics());
+		assertFalse(testerRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.Tester
 		CtTypeReference<?> tester1Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "tester1")).first(CtVariable.class).getType();
-		assertEquals(false, tester1Ref.isGenerics());
+		assertFalse(tester1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<B>.That<java.lang.String, java.lang.String>
 		CtTypeReference<?> fieldRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "field")).first(CtVariable.class).getType();
-		assertEquals(false, fieldRef.isGenerics());
+		assertFalse(fieldRef.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<java.lang.String>.That<java.lang.String, java.lang.String>
 		CtTypeReference<?> field1Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "field1")).first(CtVariable.class).getType();
-		assertEquals(false, field1Ref.isGenerics());
+		assertFalse(field1Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Spaghetti<java.lang.Number>.That<java.lang.String, java.lang.String>
 		CtTypeReference<?> field2Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "field2")).first(CtVariable.class).getType();
-		assertEquals(false, field2Ref.isGenerics());
+		assertFalse(field2Ref.isGenerics());
 
 		// spoon.test.generics.testclasses.Tacos<K, java.lang.String>.Burritos<K, V>
 		CtTypeReference<?> burritosRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "burritos")).first(CtVariable.class).getType();
 		// now that the order of type members is correct
 		// this burritos is indeed "IBurritos<?, ?> burritos = new Burritos<>()" with no generics
-		assertEquals(false, burritosRef.isGenerics());
+		assertFalse(burritosRef.isGenerics());
 
 		// int
 		CtTypeReference<?> nbTacosRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "nbTacos")).first(CtVariable.class).getType();
-		assertEquals(false, nbTacosRef.isGenerics());
+		assertFalse(nbTacosRef.isGenerics());
 
 		// java.util.List<java.lang.String>
 		CtTypeReference<?> lRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "l")).first(CtVariable.class).getType();
-		assertEquals(false, lRef.isGenerics());
+		assertFalse(lRef.isGenerics());
 
 		// java.util.List
 		CtTypeReference<?> l2Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "l2")).first(CtVariable.class).getType();
-		assertEquals(false, l2Ref.isGenerics());
+		assertFalse(l2Ref.isGenerics());
 
 		// java.util.List<?>
 		CtTypeReference<?> l3Ref = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "l3")).first(CtVariable.class).getType();
-		assertEquals(false, l3Ref.isGenerics());
+		assertFalse(l3Ref.isGenerics());
 
 		// T
 		CtTypeReference<?> anObjectRef = factory.getModel().filterChildren(new NamedElementFilter(CtVariable.class, "anObject")).first(CtVariable.class).getType();
-		assertEquals(true, anObjectRef.isGenerics());
+		assertTrue(anObjectRef.isGenerics());
 
 	}
 	@Test
@@ -1085,14 +1085,14 @@ public class GenericsTest {
 		CtMethod<?> adaptedLunchEatMe = (CtMethod<?>) methodSTH.getAdaptationScope();
 
 		//contract: adapting of method declared in different scope, returns new method
-		assertTrue(adaptedLunchEatMe != trLunch_eatMe);
+		assertNotSame(adaptedLunchEatMe, trLunch_eatMe);
 
 		//check that new method is adapted correctly
 		//is declared in correct class
 		assertSame(ctClassWeddingLunch, adaptedLunchEatMe.getDeclaringType());
 		//  is not member of the same class (WeddingLunch)
 		for (CtTypeMember typeMember : ctClassWeddingLunch.getTypeMembers()) {
-			assertFalse(adaptedLunchEatMe==typeMember);
+			assertNotSame(adaptedLunchEatMe, typeMember);
 		}
 		// the name is the same
 		assertEquals("eatMe", adaptedLunchEatMe.getSimpleName());

--- a/src/test/java/spoon/test/initializers/InitializerTest.java
+++ b/src/test/java/spoon/test/initializers/InitializerTest.java
@@ -11,6 +11,7 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
@@ -46,7 +47,7 @@ public class InitializerTest {
 		assertTrue(l.getDefaultExpression() instanceof CtConstructorCall);
 
 		CtField<?> x = type.getElements(new NamedElementFilter<>(CtField.class,"x")).get(0);
-		assertTrue(x.getDefaultExpression() == null);
+		assertNull(x.getDefaultExpression());
 
 		CtField<?> y = type.getElements(new NamedElementFilter<>(CtField.class,"y")).get(0);
 		assertTrue(y.getDefaultExpression() instanceof CtLiteral);

--- a/src/test/java/spoon/test/intercession/insertBefore/InsertMethodsTest.java
+++ b/src/test/java/spoon/test/intercession/insertBefore/InsertMethodsTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -266,7 +267,7 @@ public class InsertMethodsTest {
 
 		// We make sure the parent of the while is updated
 		CtElement newParent = theWhile.getParent();
-		assertTrue(newParent != ifParent);
+		assertNotSame(newParent, ifParent);
 		assertTrue(newParent instanceof CtBlock);
 		assertFalse(newParent.isImplicit());
 	}

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -16,6 +16,7 @@ import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -100,7 +101,7 @@ public class LiteralTest {
 		assertEquals(typeFactory.STRING, literal.getType());
 
 		literal = (CtLiteral<?>) ctType.getField("h").getDefaultExpression();
-		assertEquals(null, literal.getValue());
+		assertNull(literal.getValue());
 		assertFalse(literal.getType().isPrimitive());
 		assertEquals(typeFactory.NULL_TYPE, literal.getType());
 

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -344,7 +345,7 @@ public class MainTest {
 				} else {
 					// contract: all elements have been cloned and are still equal
 					assertEquals(element, other);
-					assertFalse(element == other);
+					assertNotSame(element, other);
 				}
 				super.biScan(element, other);
 			}

--- a/src/test/java/spoon/test/model/IncrementalLauncherTest.java
+++ b/src/test/java/spoon/test/model/IncrementalLauncherTest.java
@@ -1,6 +1,8 @@
 package spoon.test.model;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -63,8 +65,8 @@ public class IncrementalLauncherTest {
 		assertTrue(originalModel.getAllTypes().equals(cachedCachedModel.getAllTypes()));
 
 		for (CtType<?> t : cachedCachedModel.getAllTypes()) {
-			assertTrue(t.getPosition() != null);
-			assertTrue(t.getPosition().getFile() != null);
+			assertNotNull(t.getPosition());
+			assertNotNull(t.getPosition().getFile());
 			assertTrue(t.getPosition().getLine() != -1);
 		}
 	}
@@ -95,7 +97,7 @@ public class IncrementalLauncherTest {
 		Collection<CtType<?>> types1 = originalModel.getAllTypes();
 		Collection<CtType<?>> types2 = newModel.getAllTypes();
 
-		assertFalse(types1.equals(types2));
+		assertNotEquals(types1, types2);
 
 		CtType<?> a1 = getTypeByName(types1, "A");
 		CtType<?> b1 = getTypeByName(types1, "B");
@@ -108,7 +110,7 @@ public class IncrementalLauncherTest {
 		assertTrue(a1.equals(a2));
 		assertTrue(b1.equals(b2));
 		assertTrue(c1.equals(c2));
-		assertFalse(d1.equals(d2));
+		assertNotEquals(d1, d2);
 
 		assertTrue(d1.getDeclaredFields().isEmpty());
 		assertTrue(d2.getDeclaredFields().size() == 2);
@@ -154,7 +156,7 @@ public class IncrementalLauncherTest {
 		CtType<?> d2 = getTypeByName(types2, "D");
 		assertTrue(a1.equals(a2));
 		assertTrue(b1.equals(b2));
-		assertFalse(c1.equals(d2));
+		assertNotEquals(c1, d2);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ParameterTest {
 
@@ -104,7 +105,7 @@ public class ParameterTest {
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = (CtTypeReference) param.getReference().getType();
 			// unknown parameters have no type
-			assertEquals(null, refType);
+			assertNull(refType);
 		}
 	}
 }

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
@@ -278,7 +279,7 @@ public class ParentTest {
 
 		// not present element
 		CtWhile ctWhile = ctStatement1.getParent(new TypeFilter<>(CtWhile.class));
-		assertEquals(null, ctWhile);
+		assertNull(ctWhile);
 
 		CtStatement statementParent = statement
 				.getParent(new AbstractFilter<CtStatement>(CtStatement.class) {

--- a/src/test/java/spoon/test/parent/SetParentTest.java
+++ b/src/test/java/spoon/test/parent/SetParentTest.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.test.parent.ContractOnSettersParametrizedTest.createCompatibleObject;
@@ -76,7 +77,7 @@ public class SetParentTest<T extends CtVisitable> {
 
 		// contract: the parent has not been changed by a call to setParent on an elemnt
 		assertTrue(argument.equals(argumentClone));
-		assertFalse(argument == argumentClone);
+		assertNotSame(argument, argumentClone);
 
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
+++ b/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
@@ -73,11 +73,11 @@ public class QualifiedThisRefTest {
 		final CtMethod<?> m2 = adobada.getMethod("methodUsingjlObjectMethods");
 
 		CtThisAccess th = (CtThisAccess) m2.getElements(new TypeFilter(CtThisAccess.class)).get(0);
-		assertEquals(true,th.isImplicit());
+		assertTrue(th.isImplicit());
 		assertEquals("notify()",th.getParent().toString());
 		CtInvocation<?> clone = m2.clone().getBody().getStatement(0);
 		// clone preserves implicitness
-		assertEquals(true, clone.getTarget().isImplicit());
+		assertTrue(clone.getTarget().isImplicit());
 		assertEquals("notify()", clone.toString()); // the original bug
 
 		// note that this behavior means that you can only keep cloned "this" in the same class,

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -81,8 +82,8 @@ public class ProcessingTest {
 		assertEquals("insert has not been done at the right position", myBeforeStatementAsString, constructor.getBody().getStatement(5).toString());
 		assertEquals("insert has not been done at the right position", myBeforeStatementAsString, constructor.getBody().getStatement(7).toString());
 
-		assertFalse("switch should not be the same", constructor.getBody().getStatement(6).equals(constructor.getBody().getStatement(8)));
-		assertFalse("switch should not be the same", constructor.getBody().getStatement(6).toString().equals(constructor.getBody().getStatement(8).toString()));
+		assertNotEquals("switch should not be the same", constructor.getBody().getStatement(6), constructor.getBody().getStatement(8));
+		assertNotEquals("switch should not be the same", constructor.getBody().getStatement(6).toString(), constructor.getBody().getStatement(8).toString());
 
 	}
 
@@ -120,8 +121,8 @@ public class ProcessingTest {
 		assertEquals("insert has not been done at the right position", myBeforeStatementAsString, constructor.getBody().getStatement(5).toString());
 		assertEquals("insert has not been done at the right position", myBeforeStatementAsString, constructor.getBody().getStatement(7).toString());
 
-		assertFalse("switch should not be the same", constructor.getBody().getStatement(6).equals(constructor.getBody().getStatement(8)));
-		assertFalse("switch should not be the same", constructor.getBody().getStatement(6).toString().equals(constructor.getBody().getStatement(8).toString()));
+		assertNotEquals("switch should not be the same", constructor.getBody().getStatement(6), constructor.getBody().getStatement(8));
+		assertNotEquals("switch should not be the same", constructor.getBody().getStatement(6).toString(), constructor.getBody().getStatement(8).toString());
 
 	}
 

--- a/src/test/java/spoon/test/reference/CloneReferenceTest.java
+++ b/src/test/java/spoon/test/reference/CloneReferenceTest.java
@@ -13,6 +13,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class CloneReferenceTest {
@@ -34,7 +36,7 @@ public class CloneReferenceTest {
         for (String name : names) {
             CtVariable var1 = findVariable(a, name);
             CtVariable var2 = findReference(a, name).getDeclaration();
-            assertTrue(var1 == var2);
+            assertSame(var1, var2);
         }
 
         CtClass b = a.clone();
@@ -44,7 +46,7 @@ public class CloneReferenceTest {
             CtVariable var1 = findVariable(b, name);
             CtVariableReference refVar1 = findReference(b, name);
             CtVariable var2 = refVar1.getDeclaration();
-            assertTrue("Var1 and var2 are not the same element", var1 == var2);
+            assertSame("Var1 and var2 are not the same element", var1, var2);
         }
     }
 
@@ -65,7 +67,7 @@ public class CloneReferenceTest {
         // test before clone
         CtField oldVar1 = (CtField)findVariable(a, name);
         CtField oldVar2 = (CtField)findReference(a, name).getDeclaration();
-        assertTrue(oldVar1 == oldVar2);
+        assertSame(oldVar1, oldVar2);
 
         CtClass b = a.clone();
 
@@ -73,9 +75,9 @@ public class CloneReferenceTest {
         CtField var1 = (CtField)findVariable(b, name);
         CtVariableReference refVar1 = findReference(b, name);
         CtField var2 = (CtField)refVar1.getDeclaration();
-        assertTrue(var1 != var2);
-        assertTrue(var2 == oldVar1);
-        assertTrue(var1.getParent(CtClass.class) == b);
+        assertNotSame(var1, var2);
+        assertSame(var2, oldVar1);
+        assertSame(var1.getParent(CtClass.class), b);
     }
 
     class Finder<T> extends CtScanner {

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -116,7 +117,7 @@ public class TypeReferenceTest {
 				break;
 			}
 		}
-		assertFalse(referencedType == null);
+		assertNotNull(referencedType);
 
 		// we can get the actual class from the reference, because it is loaded from the class path
 		Class referencedClass = referencedType.getActualClass();
@@ -619,7 +620,7 @@ public class TypeReferenceTest {
 		CtParameterReference<?> parameterRef2 = aClass.getElements((CtParameterReference<?> ref)->ref.getSimpleName().equals("param")).get(0);
 
 		// fresh reference not put in a context
-		assertEquals(null, parameterRef1.getDeclaringExecutable());
+		assertNull(parameterRef1.getDeclaringExecutable());
 		assertEquals(aClass.getReference(), parameterRef2.getDeclaringExecutable().getType());
 
 		assertEquals(parameterRef1, parameterRef2);

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -122,7 +123,7 @@ public class SignatureTest {
 		CtStatement sta2 = (factory).Code().createCodeSnippetStatement("String hello =\"t1\"; System.out.println(hello)")
 				.compile();
 
-		assertFalse(sta1.equals(sta2));// equals depends on deep equality
+		assertNotEquals(sta1, sta2);// equals depends on deep equality
 
 		String parameterWithQuotes = ((CtInvocation<?>)sta1).getArguments().get(0).toString();
 		assertEquals("\"hello\"",parameterWithQuotes);
@@ -144,7 +145,7 @@ public class SignatureTest {
 		String signature1 = ((CtInvocation)sta1).getExecutable().getSignature();
 		String signature2 = ((CtInvocation)sta2).getExecutable().getSignature();
 		assertEquals(signature1,  signature2);
-		assertFalse(sta1.equals(sta2));
+		assertNotEquals(sta1, sta2);
 
 
 		CtStatement stb1 = (factory).Code().createCodeSnippetStatement("Integer.toBinaryString(20)")
@@ -155,7 +156,7 @@ public class SignatureTest {
 		String signature1b = ((CtInvocation)sta1).getExecutable().getSignature();
 		String signature2b = ((CtInvocation)sta2).getExecutable().getSignature();
 		assertEquals(signature1b,  signature2b);
-		assertFalse(stb1.equals(stb2));
+		assertNotEquals(stb1, stb2);
 
 
 		CtStatement stc1 = (factory).Code().createCodeSnippetStatement("String.format(\"format1\",\"f2\" )")
@@ -165,7 +166,7 @@ public class SignatureTest {
 		String signaturestc1 = ((CtInvocation)sta1).getExecutable().getSignature();
 		String signaturestc2 = ((CtInvocation)sta2).getExecutable().getSignature();
 		assertEquals(signaturestc1,  signaturestc2);
-		assertFalse(stc1.equals(stc2));
+		assertNotEquals(stc1, stc2);
 	}
 
 	@Test
@@ -279,7 +280,7 @@ public class SignatureTest {
 
 		CtExpression<?> left = invoToInt1.getAssigned();
 		assertEquals("this.mfield",left.toString());
-		assertEquals(null,left.getType());// null because noclasspath
+		assertNull(left.getType());// null because noclasspath
 		assertEquals("this.mfield = p",invoToInt1.toString());
 
 

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -199,7 +199,7 @@ public class TargetedExpressionTest {
 		assertEquals(6, elements.size());
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedInnerClass).target(expectedInnerClassAccess).result("this.i"), elements.get(0));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedInnerClass).target(expectedInnerClassAccess).result("i"), elements.get(1));
-		assertEquals(true, elements.get(1).getTarget().isImplicit());
+		assertTrue(elements.get(1).getTarget().isImplicit());
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedType).target(expectedThisAccess).result("this.i"), elements.get(2));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedType).target(fooTypeAccess).result("spoon.test.targeted.testclasses.Foo.k"), elements.get(3));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedSuperClassType).target(expectedThisAccess).result("this.o"), elements.get(4));

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -1276,7 +1276,7 @@ public class PatternTest {
 
 		params = matches.get(1).getParameters();
 		// all method arguments to createListPrinter have been matched
-		assertEquals(null, params.getValue("startKeyword"));
+		assertNull(params.getValue("startKeyword"));
 		assertEquals(Boolean.FALSE, params.getValue("useStartKeyword"));
 		assertEquals("false", params.getValue("startPrefixSpace").toString());
 		assertEquals("null", params.getValue("start").toString());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -85,6 +85,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
@@ -920,7 +921,7 @@ public class TemplateTest {
 		CtMethod<?> generatedClassMethod = genClass.getMethod("genMethod");
 		assertNotNull(generatedClassMethod);
 		assertNull(genClass.getMethod("someMethod"));
-		assertTrue(generatedIfaceMethod!=generatedClassMethod);
+		assertNotSame(generatedIfaceMethod, generatedClassMethod);
 		assertTrue(generatedClassMethod.isOverriding(generatedIfaceMethod));
 
 		//contract: we can generate enum

--- a/src/test/java/spoon/test/varargs/VarArgsTest.java
+++ b/src/test/java/spoon/test/varargs/VarArgsTest.java
@@ -9,6 +9,8 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.test.trycatch.testclasses.Main;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class VarArgsTest {
@@ -20,10 +22,10 @@ public class VarArgsTest {
 		CtMethod<?> m = type.getMethodsByName("foo").get(0);
 
 		CtParameter<?> param0 = m.getParameters().get(0);
-		assertEquals(false, param0.isVarArgs());
+		assertFalse(param0.isVarArgs());
 
 		CtParameter<?> param1 = m.getParameters().get(1);
-		assertEquals(true, param1.isVarArgs());
+		assertTrue(param1.isVarArgs());
 		assertEquals("java.lang.String[]", param1.getType().toString());
 		assertEquals("String[]", param1.getType().getSimpleName());
 		assertEquals("java.lang.String[]", param1.getType().getQualifiedName());


### PR DESCRIPTION
I refactored tests to simplify assertions and made them more clear.
Now intentions are provided in straightforward way:
```
assertEquals(null, ctWhile); -> assertNull(ctWhile);
```