### PR TITLE
Convert from List to Set to speed up contains() logic.

### DIFF
--- a/src/main/java/spoon/support/compiler/VirtualFolder.java
+++ b/src/main/java/spoon/support/compiler/VirtualFolder.java
@@ -45,7 +45,7 @@ public class VirtualFolder implements SpoonFolder {
 
 	@Override
 	public List<SpoonFile> getAllFiles() {
-		List<SpoonFile> result = new ArrayList<>();
+		Set<SpoonFile> result = new HashSet<>();
 
 		for (SpoonFile f : getFiles()) {
 			// we take care not to add a file that was already found in a folder
@@ -53,7 +53,9 @@ public class VirtualFolder implements SpoonFolder {
 				result.add(f);
 			}
 		}
-		return result;
+
+		List<SpoonFile> resultAsList = new ArrayList<>(result);
+		return resultAsList;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/VirtualFolder.java
+++ b/src/main/java/spoon/support/compiler/VirtualFolder.java
@@ -45,17 +45,9 @@ public class VirtualFolder implements SpoonFolder {
 
 	@Override
 	public List<SpoonFile> getAllFiles() {
-		Set<SpoonFile> result = new HashSet<>();
-
-		for (SpoonFile f : getFiles()) {
-			// we take care not to add a file that was already found in a folder
-			if (!result.contains(f)) {
-				result.add(f);
-			}
-		}
-
-		List<SpoonFile> resultAsList = new ArrayList<>(result);
-		return resultAsList;
+		// there are never folders added to files in this class so just return a List here.
+		// The files are already deduplicated based on Set logic.
+		return new ArrayList<>(files);
 	}
 
 	@Override


### PR DESCRIPTION
Using a List here results in extremely long runtimes when the source
folder is large because the contains() call is O(n). The logic
ends up placing this List into a Set anyway so just use a Set here
and make contains() checks cheap.