### PR TITLE
review fix: ignore a test for memory issues on the CI

### DIFF
--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -10,6 +10,7 @@ import spoon.reflect.visitor.CtScanner;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Ignore;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertTrue;
 
 public class MavenLauncherTest {
 
+	// fixme: the test consumes too much memory for now
+	// we should reduce its footprint
+	@Ignore
 	@Test
 	public void testTypeResolution() {
 		MavenLauncher launcher = new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);


### PR DESCRIPTION
One test has been added by @nharrand in #2112 to show the usage of the new dependency resolver. However this test consumes too much memory on our CI, on the job used to deploy maven artefacts: 
> [ERROR] Tests run: 7, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 68.03 s <<< FAILURE! - in spoon.MavenLauncherTest
[ERROR] testTypeResolution(spoon.MavenLauncherTest)  Time elapsed: 38.801 s  <<< ERROR!
java.lang.OutOfMemoryError: GC overhead limit exceeded
	at spoon.MavenLauncherTest.testTypeResolution(MavenLauncherTest.java:25)

https://ci.inria.fr/sos/job/Spoon-Snapshot-Deployer/1689/console

I propose to ignore the test for now.