### PR TITLE
refactor: use assertSame in rest of tests

### DIFF
--- a/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
@@ -9,6 +9,7 @@ import spoon.test.annotation.testclasses.Pozole;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 
 public class AnnotationLoopTest {
 
@@ -18,9 +19,9 @@ public class AnnotationLoopTest {
 
 		final CtFor aLoop = aPozole.getMethod("cook").getElements(new TypeFilter<>(CtFor.class)).get(0);
 		assertEquals(3, aLoop.getForInit().size());
-		assertEquals(SuppressWarnings.class, aLoop.getForInit().get(0).getAnnotations().get(0).getAnnotationType().getActualClass());
-		assertEquals(SuppressWarnings.class, aLoop.getForInit().get(1).getAnnotations().get(0).getAnnotationType().getActualClass());
-		assertEquals(SuppressWarnings.class, aLoop.getForInit().get(2).getAnnotations().get(0).getAnnotationType().getActualClass());
+		assertSame(SuppressWarnings.class, aLoop.getForInit().get(0).getAnnotations().get(0).getAnnotationType().getActualClass());
+		assertSame(SuppressWarnings.class, aLoop.getForInit().get(1).getAnnotations().get(0).getAnnotationType().getActualClass());
+		assertSame(SuppressWarnings.class, aLoop.getForInit().get(2).getAnnotations().get(0).getAnnotationType().getActualClass());
 
 		assertEquals("u", ((CtLocalVariable) aLoop.getForInit().get(0)).getSimpleName());
 		assertEquals("p", ((CtLocalVariable) aLoop.getForInit().get(1)).getSimpleName());

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -250,9 +250,9 @@ public class MetamodelTest {
 			assertNull(runtimeConcept.getImplementationClass());
 		} else {
 			assertNotNull(runtimeConcept.getImplementationClass());
-			assertEquals(expectedConcept.getImplementationClass().getActualClass(), runtimeConcept.getImplementationClass().getActualClass());
+			assertSame(expectedConcept.getImplementationClass().getActualClass(), runtimeConcept.getImplementationClass().getActualClass());
 		}
-		assertEquals(expectedConcept.getMetamodelInterface().getActualClass(), runtimeConcept.getMetamodelInterface().getActualClass());
+		assertSame(expectedConcept.getMetamodelInterface().getActualClass(), runtimeConcept.getMetamodelInterface().getActualClass());
 		assertEquals(expectedConcept.getKind(), runtimeConcept.getKind());
 		assertEquals(expectedConcept.getSuperConcepts().size(), runtimeConcept.getSuperConcepts().size());
 		for (int i = 0; i < expectedConcept.getSuperConcepts().size(); i++) {
@@ -270,7 +270,7 @@ public class MetamodelTest {
 	private void assertPropertiesEqual(MetamodelProperty expectedProperty, MetamodelProperty runtimeProperty) {
 		assertSame(expectedProperty.getRole(), runtimeProperty.getRole());
 		assertEquals(expectedProperty.getName(), runtimeProperty.getName());
-		assertEquals(expectedProperty.getTypeofItems().getActualClass(), runtimeProperty.getTypeofItems().getActualClass());
+		assertSame(expectedProperty.getTypeofItems().getActualClass(), runtimeProperty.getTypeofItems().getActualClass());
 		assertEquals(expectedProperty.getOwner().getName(), runtimeProperty.getOwner().getName());
 		assertSame(expectedProperty.getContainerKind(), runtimeProperty.getContainerKind());
 		assertEquals(expectedProperty.getTypeOfField(), runtimeProperty.getTypeOfField());
@@ -385,10 +385,10 @@ public class MetamodelTest {
 		//check contract of low level RoleHandler
 		RoleHandler roleHandler = RoleHandlerHelper.getRoleHandler(type.getClass(), CtRole.ANNOTATION);
 		assertNotNull(roleHandler);
-		assertEquals(CtElement.class, roleHandler.getTargetType());
+		assertSame(CtElement.class, roleHandler.getTargetType());
 		assertSame(CtRole.ANNOTATION, roleHandler.getRole());
 		assertSame(ContainerKind.LIST, roleHandler.getContainerKind());
-		assertEquals(CtAnnotation.class, roleHandler.getValueClass());
+		assertSame(CtAnnotation.class, roleHandler.getValueClass());
 
 		//check getting value using role handler
 		List<CtAnnotation<?>> value = roleHandler.getValue(type);

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -383,7 +383,7 @@ public class CompilationTest {
 
 		assertEquals(3, l.size());
 		assertTrue(l.contains("KJHKY"));
-		assertEquals(MyClassLoader.class, launcher.getEnvironment().getInputClassLoader().getClass());
+		assertSame(MyClassLoader.class, launcher.getEnvironment().getInputClassLoader().getClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class ConstructorCallTest {
@@ -107,7 +108,7 @@ public class ConstructorCallTest {
 	}
 
 	private void assertConstructorCallWithType(Class<?> typeExpected, CtConstructorCall<?> constructorCall) {
-		assertEquals("Constructor call is typed by the class of the constructor", typeExpected, constructorCall.getType().getActualClass());
+		assertSame("Constructor call is typed by the class of the constructor", typeExpected, constructorCall.getType().getActualClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
@@ -69,7 +70,7 @@ public class NewClassTest {
 		assertIsAnonymous(newClass.getAnonymousClass());
 		assertSuperInterface(Foo.Tacos.class, newClass.getAnonymousClass());
 		CtTypeReference[] ctTypeReferences = newClass.getAnonymousClass().getSuperInterfaces().toArray(new CtTypeReference[0]);
-		assertEquals("Super interface is typed by the class of the constructor", String.class,
+		assertSame("Super interface is typed by the class of the constructor", String.class,
 				ctTypeReferences[0].getActualTypeArguments().get(0).getActualClass());
 	}
 
@@ -102,12 +103,12 @@ public class NewClassTest {
 
 	private void assertSuperClass(Class<?> expected, CtClass<?> anonymousClass) {
 		assertEquals("There isn't a super interface if there is a super class", 0, anonymousClass.getSuperInterfaces().size());
-		assertEquals("There is a super class if there isn't a super interface", expected, anonymousClass.getSuperclass().getActualClass());
+		assertSame("There is a super class if there isn't a super interface", expected, anonymousClass.getSuperclass().getActualClass());
 	}
 
 	private void assertSuperInterface(Class<?> expected, CtClass<?> anonymousClass) {
 		assertNull("There isn't super class if there is a super interface", anonymousClass.getSuperclass());
-		assertEquals("There is a super interface if there isn't super class", expected, anonymousClass.getSuperInterfaces().toArray(new CtTypeReference[0])[0].getActualClass());
+		assertSame("There is a super interface if there isn't super class", expected, anonymousClass.getSuperInterfaces().toArray(new CtTypeReference[0])[0].getActualClass());
 	}
 
 	private void assertIsAnonymous(CtClass<?> anonymousClass) {
@@ -127,7 +128,7 @@ public class NewClassTest {
 	}
 
 	private void assertType(Class<?> typeExpected, CtNewClass<?> newClass) {
-		assertEquals("New class is typed by the class of the constructor", typeExpected, newClass.getType().getActualClass());
+		assertSame("New class is typed by the class of the constructor", typeExpected, newClass.getType().getActualClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -22,6 +22,7 @@ import spoon.testing.utils.ModelUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
@@ -56,7 +57,7 @@ public class EnumsTest {
 		final CtEnum<?> foo = (CtEnum) launcher.getFactory().Type().get(Foo.class);
 		assertEquals(1, foo.getFields().size());
 		assertEquals(1, foo.getFields().get(0).getAnnotations().size());
-		assertEquals(Deprecated.class, AnnotationTest.getActualClassFromAnnotation(
+		assertSame(Deprecated.class, AnnotationTest.getActualClassFromAnnotation(
 				foo.getFields().get(0).getAnnotations().get(0)));
 		assertEquals(
 				"public enum Foo {" + DefaultJavaPrettyPrinter.LINE_SEPARATOR + DefaultJavaPrettyPrinter.LINE_SEPARATOR

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -43,6 +43,7 @@ import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.Assert.assertThat;
@@ -183,9 +184,9 @@ public class FieldAccessTest {
 
 		final CtFieldAccess logFieldAccess = Query.getElements(build, new TypeFilter<>(CtFieldAccess.class)).get(0);
 
-		assertEquals(Logger.class, logFieldAccess.getType().getActualClass());
+		assertSame(Logger.class, logFieldAccess.getType().getActualClass());
 		assertEquals("LOG", logFieldAccess.getVariable().getSimpleName());
-		assertEquals(MyClass.class, logFieldAccess.getVariable().getDeclaringType().getActualClass());
+		assertSame(MyClass.class, logFieldAccess.getVariable().getDeclaringType().getActualClass());
 
 		String expectedLambda = "() -> {" + System.lineSeparator() + "    spoon.test.fieldaccesses.testclasses.MyClass.LOG.info(\"bla\");" + System.lineSeparator() + "}";
 		assertEquals(expectedLambda, logFieldAccess.getParent(CtLambda.class).toString());

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -189,7 +189,7 @@ public class GenericsTest {
 		assertTrue(tr3 instanceof CtTypeParameterReference);
 
 		assertEquals("File", trExtends.getSimpleName());
-		assertEquals(java.io.File.class, trExtends.getActualClass());
+		assertSame(java.io.File.class, trExtends.getActualClass());
 		assertEquals("T", tr2.getSimpleName());
 		assertEquals("T", tr3.getSimpleName());
 	}
@@ -281,7 +281,7 @@ public class GenericsTest {
 			assertEquals("java.util.Map.Entry", ref.toString());
 
 			// now visitCtTypeReference
-			assertEquals(java.util.Map.class, ref.getDeclaringType()
+			assertSame(java.util.Map.class, ref.getDeclaringType()
 					.getActualClass());
 			pp.visitCtTypeReference(ref);
 

--- a/src/test/java/spoon/test/interfaces/InterfaceTest.java
+++ b/src/test/java/spoon/test/interfaces/InterfaceTest.java
@@ -19,6 +19,7 @@ import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class InterfaceTest {
@@ -71,7 +72,7 @@ public class InterfaceTest {
 
 		final CtMethod<?> getZonedDateTimeMethod = ctInterface.getMethodsByName("getZonedDateTime").get(0);
 		assertTrue("Method in the sub interface must be a default method", getZonedDateTimeMethod.isDefaultMethod());
-		assertEquals("Interface of the default method must be the sub interface", ExtendsDefaultMethodInterface.class, getZonedDateTimeMethod.getDeclaringType().getActualClass());
+		assertSame("Interface of the default method must be the sub interface", ExtendsDefaultMethodInterface.class, getZonedDateTimeMethod.getDeclaringType().getActualClass());
 	}
 
 	@Test
@@ -83,7 +84,7 @@ public class InterfaceTest {
 
 		final CtMethod<?> getZonedDateTimeMethod = ctInterface.getMethodsByName("getZonedDateTime").get(0);
 		assertFalse("Method in the sub interface mustn't be a default method", getZonedDateTimeMethod.isDefaultMethod());
-		assertEquals("Interface of the default method must be the sub interface", RedefinesDefaultMethodInterface.class, getZonedDateTimeMethod.getDeclaringType().getActualClass());
+		assertSame("Interface of the default method must be the sub interface", RedefinesDefaultMethodInterface.class, getZonedDateTimeMethod.getDeclaringType().getActualClass());
 	}
 
 	@Test
@@ -95,7 +96,7 @@ public class InterfaceTest {
 
 		final CtMethod<?> getZoneIdMethod = ctInterface.getMethodsByName("getZoneId").get(0);
 		assertTrue("Method in the sub interface must be a static method", getZoneIdMethod.getModifiers().contains(ModifierKind.STATIC));
-		assertEquals("Interface of the static method must be the sub interface", ExtendsStaticMethodInterface.class, getZoneIdMethod.getDeclaringType().getActualClass());
+		assertSame("Interface of the static method must be the sub interface", ExtendsStaticMethodInterface.class, getZoneIdMethod.getDeclaringType().getActualClass());
 	}
 
 	@Test
@@ -107,6 +108,6 @@ public class InterfaceTest {
 
 		final CtMethod<?> getZoneIdMethod = ctInterface.getMethodsByName("getZoneId").get(0);
 		assertFalse("Method in the sub interface mustn't be a static method", getZoneIdMethod.getModifiers().contains(ModifierKind.STATIC));
-		assertEquals("Interface of the static method must be the sub interface", RedefinesStaticMethodInterface.class, getZoneIdMethod.getDeclaringType().getActualClass());
+		assertSame("Interface of the static method must be the sub interface", RedefinesStaticMethodInterface.class, getZoneIdMethod.getDeclaringType().getActualClass());
 	}
 }

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -425,7 +426,7 @@ public class LambdaTest {
 	}
 
 	private void assertTypedBy(Class<?> expectedType, CtTypeReference<?> type) {
-		assertEquals("Lambda must be typed", expectedType, type.getActualClass());
+		assertSame("Lambda must be typed", expectedType, type.getActualClass());
 	}
 
 	private void assertParametersSizeIs(int nbParameters, List<CtParameter<?>> parameters) {
@@ -438,7 +439,7 @@ public class LambdaTest {
 
 	private void assertParameterTypedBy(Class<?> expectedType, CtParameter<?> parameter) {
 		assertNotNull("Lambda has a parameter typed", parameter.getType());
-		assertEquals("Lambda has a parameter typed by", expectedType, parameter.getType().getActualClass());
+		assertSame("Lambda has a parameter typed by", expectedType, parameter.getType().getActualClass());
 	}
 
 	private void assertHasExpressionBody(CtLambda<?> lambda) {

--- a/src/test/java/spoon/test/limits/utils/InternalTest.java
+++ b/src/test/java/spoon/test/limits/utils/InternalTest.java
@@ -10,6 +10,7 @@ import spoon.test.limits.utils.testclasses.ContainInternalClass;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class InternalTest {
@@ -26,14 +27,14 @@ public class InternalTest {
 				"spoon.test.limits.utils.testclasses.ContainInternalClass$InternalClass",
 				c1.getQualifiedName());
 		assertEquals("spoon.test.limits.utils.testclasses", c1.getPackage().getQualifiedName());
-		assertEquals(ContainInternalClass.InternalClass.class, c1.getActualClass());
+		assertSame(ContainInternalClass.InternalClass.class, c1.getActualClass());
 
 		CtClass<?> c2 = classes.get(2);
 		assertEquals("InsideInternalClass", c2.getSimpleName());
 		assertEquals(
 				"spoon.test.limits.utils.testclasses.ContainInternalClass$InternalClass$InsideInternalClass",
 				c2.getQualifiedName());
-		assertEquals(ContainInternalClass.InternalClass.InsideInternalClass.class, c2.getActualClass());
+		assertSame(ContainInternalClass.InternalClass.InsideInternalClass.class, c2.getActualClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
+++ b/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
@@ -267,7 +267,7 @@ public class MethodReferenceTest {
 	}
 
 	private void assertTypedBy(Class<?> expected, CtTypeReference<?> type) {
-		assertEquals("Method reference must be typed.", expected, type.getActualClass());
+		assertSame("Method reference must be typed.", expected, type.getActualClass());
 	}
 
 	private void assertTargetedBy(String expected, CtExpression<?> target) {

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -65,7 +66,7 @@ public class SwitchCaseTest {
 				.get(0);
 
 		// Checks the selector is a string.
-		assertEquals(String.class,
+		assertSame(String.class,
 				ctSwitch.getSelector().getType().getActualClass());
 
 		// Checks all cases are strings.
@@ -74,7 +75,7 @@ public class SwitchCaseTest {
 				// default case
 				continue;
 			}
-			assertEquals(String.class,
+			assertSame(String.class,
 					aCase.getCaseExpression().getType().getActualClass());
 		}
 	}

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -53,7 +53,7 @@ public class PackageTest {
 		spoon.createCompiler(factory, SpoonResourceHelper.resources(classFilePath, packageInfoFilePath)).build();
 
 		CtClass<?> clazz = factory.Class().get(PackageTestClass.class);
-		Assert.assertEquals(PackageTestClass.class, clazz.getActualClass());
+		Assert.assertSame(PackageTestClass.class, clazz.getActualClass());
 
 		CtPackage ctPackage = clazz.getPackage();
 		Assert.assertEquals("spoon.test.pkg.name", ctPackage.getQualifiedName());
@@ -71,7 +71,7 @@ public class PackageTest {
 		Assert.assertEquals("This is test\nJavaDoc.", ctPackage.getComments().get(0).getContent());
 
 		CtAnnotation<?> annotation = ctPackage.getAnnotations().get(0);
-		Assert.assertEquals(Deprecated.class, annotation.getAnnotationType().getActualClass());
+		Assert.assertSame(Deprecated.class, annotation.getAnnotationType().getActualClass());
 		Assert.assertEquals(packageInfoFile.getCanonicalPath(), annotation.getPosition().getFile().getCanonicalPath());
 		Assert.assertEquals(5, annotation.getPosition().getLine());
 

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -202,7 +203,7 @@ public class TypeReferenceTest {
 	public void unboxTest() {
 		Factory factory = new Launcher().createFactory();
 		CtTypeReference<Boolean> boxedBoolean = factory.Class().createReference(Boolean.class);
-		assertEquals(boolean.class, boxedBoolean.unbox().getActualClass());
+		assertSame(boolean.class, boxedBoolean.unbox().getActualClass());
 	}
 
 	@Test
@@ -493,8 +494,8 @@ public class TypeReferenceTest {
 		CtTypeReference<Short> aShort = ModelUtils.createFactory().Type().SHORT;
 		CtTypeReference<Short> shortPrimitive = ModelUtils.createFactory().Type().SHORT_PRIMITIVE;
 
-		assertEquals(Short.class, aShort.getActualClass());
-		assertEquals(short.class, shortPrimitive.getActualClass());
+		assertSame(Short.class, aShort.getActualClass());
+		assertSame(short.class, shortPrimitive.getActualClass());
 
 	}
 
@@ -603,12 +604,12 @@ public class TypeReferenceTest {
 		assertEquals("?", s.getType().getActualTypeArguments().get(0).getSimpleName());
 		assertTrue(CtWildcardReference.class.isInstance(s.getType().getActualTypeArguments().get(0)));
 		assertEquals("Object", s.getType().getActualTypeArguments().get(0).getTypeDeclaration().getSimpleName());
-		assertEquals(Object.class, s.getType().getActualTypeArguments().get(0).getTypeDeclaration().getActualClass());
+		assertSame(Object.class, s.getType().getActualTypeArguments().get(0).getTypeDeclaration().getActualClass());
 
 		// some additional tests
 		CtLocalVariable<?> s2 = new Launcher().getFactory().Code().createCodeSnippetStatement("java.util.List<String> l = null").compile();
 		assertEquals("String", s2.getType().getActualTypeArguments().get(0).getSimpleName());
-		assertEquals(String.class, s2.getType().getActualTypeArguments().get(0).getTypeDeclaration().getActualClass());
+		assertSame(String.class, s2.getType().getActualTypeArguments().get(0).getTypeDeclaration().getActualClass());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
+++ b/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -90,7 +91,7 @@ public class ClassesTest {
 		assertNotNull(x.getType().getTypeDeclaration());
 
 		// but the actual class is known
-		assertEquals(ActionListener.class, x.getType().getActualClass());
+		assertSame(ActionListener.class, x.getType().getActualClass());
 
 		assertNotNull(y.getType().getDeclaration());
 

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -3,6 +3,7 @@ package spoon.test.targeted;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -88,7 +89,7 @@ public class TargetedExpressionTest {
 		final List<CtFieldAccess<?>> elements = constructor.getElements(new TypeFilter<>(CtFieldAccess.class));
 		assertEquals(2, elements.size());
 
-		assertEquals("Target is CtThisAccessImpl if there is a 'this' explicit.", CtThisAccessImpl.class, elements.get(0).getTarget().getClass());
+		assertSame("Target is CtThisAccessImpl if there is a 'this' explicit.", CtThisAccessImpl.class, elements.get(0).getTarget().getClass());
 		assertNotNull("Target isn't null if there is a 'this' explicit.", elements.get(1).getTarget());
 		assertTrue(elements.get(1).getTarget().isImplicit());
 	}
@@ -458,7 +459,7 @@ public class TargetedExpressionTest {
 			assertEquals(expected.declaringType.getQualifiedName(), fieldAccess.getVariable().getDeclaringType().getQualifiedName());
 		}
 		if (expected.targetClass != null) {
-			assertEquals(expected.targetClass, fieldAccess.getTarget().getClass());
+			assertSame(expected.targetClass, fieldAccess.getTarget().getClass());
 		} else if (expected.targetString != null) {
 			assertEquals(expected.targetString, fieldAccess.getTarget().toString());
 		}
@@ -476,7 +477,7 @@ public class TargetedExpressionTest {
 
 		// + two optional parts
 		if (expected.targetClass != null) {
-			assertEquals(expected.targetClass, invocation.getTarget().getClass());
+			assertSame(expected.targetClass, invocation.getTarget().getClass());
 		} else if (expected.targetString != null) {
 			assertEquals(expected.targetString, invocation.getTarget().toString());
 		}

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -323,7 +323,7 @@ public class TemplateTest {
 
 		CtField<?> toBeInserted = c1.getElements(
 				new NamedElementFilter<>(CtField.class,"toBeInserted")).get(0);
-		assertEquals(Date.class, toBeInserted.getType()
+		assertSame(Date.class, toBeInserted.getType()
 				.getActualTypeArguments().get(0).getActualClass());
 		assertEquals(
 				"java.util.List<java.util.Date> toBeInserted = new java.util.ArrayList<java.util.Date>();",

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -276,8 +276,8 @@ public class TypeTest {
 		assertNotNull(boundingType);
 		assertTrue(boundingType instanceof CtIntersectionTypeReference);
 		assertEquals(2, boundingType.asCtIntersectionTypeReference().getBounds().size());
-		assertEquals(Number.class, boundingType.asCtIntersectionTypeReference().getBounds().stream().collect(Collectors.toList()).get(0).getActualClass());
-		assertEquals(Comparable.class, boundingType.asCtIntersectionTypeReference().getBounds().stream().collect(Collectors.toList()).get(1).getActualClass());
+		assertSame(Number.class, boundingType.asCtIntersectionTypeReference().getBounds().stream().collect(Collectors.toList()).get(0).getActualClass());
+		assertSame(Comparable.class, boundingType.asCtIntersectionTypeReference().getBounds().stream().collect(Collectors.toList()).get(1).getActualClass());
 		assertEquals("public class Mole<NUMBER extends java.lang.Number & java.lang.Comparable<NUMBER>> {}", aMole.toString());
 	}
 

--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -60,12 +61,12 @@ public class VisibilityTest {
 		// Class must be imported.
 		final CtClass<?> aDouble = (CtClass<?>) factory.Type().get(spoon.test.visibility.testclasses.internal.Double.class);
 		assertNotNull(aDouble);
-		assertEquals(spoon.test.visibility.testclasses.internal.Double.class, aDouble.getActualClass());
+		assertSame(spoon.test.visibility.testclasses.internal.Double.class, aDouble.getActualClass());
 
 		// Class mustn't be imported.
 		final CtClass<?> aFloat = (CtClass<?>) factory.Type().get(spoon.test.visibility.testclasses.Float.class);
 		assertNotNull(aFloat);
-		assertEquals(spoon.test.visibility.testclasses.Float.class, aFloat.getActualClass());
+		assertSame(spoon.test.visibility.testclasses.Float.class, aFloat.getActualClass());
 
 		canBeBuilt(new File("./target/spooned/spoon/test/visibility_package/testclasses/"), 7);
 	}


### PR DESCRIPTION
Use assertSame to improve tests readability (express clearly intention of checking).