### PR TITLE
refactor: fix SonarQube - make field 'private', use accessor

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -184,6 +184,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	 *
 	 * @deprecated since Spoon 7.1.0, please use {{@link #getContext()}}
 	 */
+	@Deprecated
 	public PrintingContext context = new PrintingContext();
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -182,7 +182,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	/**
 	 * The printing context.
 	 */
-	public PrintingContext context = new PrintingContext();
+	private PrintingContext context = new PrintingContext();
 
 	/**
 	 * Handle imports of classes.

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -181,8 +181,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 	/**
 	 * The printing context.
+	 *
+	 * @deprecated since Spoon 7.1.0, please use {{@link #getContext()}}
 	 */
-	private PrintingContext context = new PrintingContext();
+	public PrintingContext context = new PrintingContext();
 
 	/**
 	 * Handle imports of classes.

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -173,7 +173,7 @@ public class ElementPrinterHelper {
 	 * Writes a statement.
 	 */
 	public void writeStatement(CtStatement statement) {
-		try (Writable _context = prettyPrinter.context.modify().setStatement(statement)) {
+		try (Writable _context = prettyPrinter.getContext().modify().setStatement(statement)) {
 			prettyPrinter.scan(statement);
 		}
 	}
@@ -255,7 +255,7 @@ public class ElementPrinterHelper {
 			printList(arguments.stream().filter(a -> !a.isImplicit())::iterator,
 				null, false, "<", false, false, ",", true, false, ">",
 				argument -> {
-					if (prettyPrinter.context.forceWildcardGenerics()) {
+					if (prettyPrinter.getContext().forceWildcardGenerics()) {
 						printer.writeSeparator("?");
 					} else {
 						prettyPrinter.scan(argument);


### PR DESCRIPTION
Change access level from 'public' to 'private'.
Use accessor in other places.

I even did not add an accessor - it existed so I used it. I assume that this public accessor (getContext()) was added to have this field private. Should not be a compatibility issue.