### PR TITLE
refactor: remove redundant string operation

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -674,7 +674,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 		PrettyPrinter printer = new DefaultJavaPrettyPrinter(env);
 		printer.calculate(cu, toBePrinted);
 
-		return new ByteArrayInputStream(printer.getResult().toString().getBytes());
+		return new ByteArrayInputStream(printer.getResult().getBytes());
 	}
 
 	protected Environment getEnvironment() {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -99,7 +99,7 @@ public class JDTTreeBuilderHelper {
 	 */
 	static String computeAnonymousName(char[] anonymousQualifiedName) {
 		final String poolName = CharOperation.charToString(anonymousQualifiedName);
-		return poolName.substring(poolName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR) + 1, poolName.length());
+		return poolName.substring(poolName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR) + 1);
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -465,7 +465,7 @@ public class JDTTreeBuilderHelper {
 	CtTypeAccess<?> createTypeAccess(QualifiedNameReference qualifiedNameReference, CtFieldReference<?> fieldReference) {
 		final TypeBinding receiverType = qualifiedNameReference.actualReceiverType;
 		if (receiverType != null) {
-			final CtTypeReference<Object> qualifiedRef = jdtTreeBuilder.getReferencesBuilder().getQualifiedTypeReference(//
+			final CtTypeReference<Object> qualifiedRef = jdtTreeBuilder.getReferencesBuilder().getQualifiedTypeReference(
 					qualifiedNameReference.tokens, receiverType, qualifiedNameReference.fieldBinding().declaringClass.enclosingType(), new JDTTreeBuilder.OnAccessListener() {
 						@Override
 						public boolean onAccess(char[][] tokens, int index) {

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -285,7 +285,7 @@ public class GenericsTest {
 					.getActualClass());
 			pp.visitCtTypeReference(ref);
 
-			assertEquals("java.util.Map.Entry", pp.getResult().toString());
+			assertEquals("java.util.Map.Entry", pp.getResult());
 
 			CtField<?> y = type.getElements(new NamedElementFilter<>(CtField.class,"y"))
 					.get(0);

--- a/src/test/java/spoon/test/prettyprinter/LinesTest.java
+++ b/src/test/java/spoon/test/prettyprinter/LinesTest.java
@@ -54,7 +54,7 @@ public class LinesTest {
 		// contract: in line preserve mode, toString is not prefixed or suffixed by newlines
 		String meth = factory.Type().get("spoon.test.prettyprinter.testclasses.Validation").getMethodsByName("isIdentifier").get(0).toString();
 		// the added linebreaks due to line preservation are removed
-		assertFalse(Pattern.compile("^\\s", Pattern.DOTALL).asPredicate().test(meth.toString()));
+		assertFalse(Pattern.compile("^\\s", Pattern.DOTALL).asPredicate().test(meth));
 
 	}
 


### PR DESCRIPTION
1. Remove toString() on String
2. Simplify: poolName.substring(poolName.lastIndexOf(..., poolName.length());
`poolName.length()` is not needed, there is a method *substring(int beginIndex)* that processes string to the last element