### PR TITLE
fix: Invalid column of the element, positioned before the first line separator

### DIFF
--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -77,6 +77,9 @@ public class SourcePositionImpl implements SourcePosition, Serializable {
 		if (length == 0) {
 			return -1;
 		}
+		if (lineSeparatorPositions[0] > position) {
+			return position;
+		}
 		int i;
 		for (i = 0; i < lineSeparatorPositions.length - 1; i++) {
 			if (lineSeparatorPositions[i] < position && (lineSeparatorPositions[i + 1] > position)) {

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1098,4 +1098,12 @@ public class PositionTest {
 		assertEquals(23, pos.getEndLine());
 		assertEquals(2, pos.getEndColumn());
 	}
+
+	@Test
+	public void testFirstLineColumn() throws Exception {
+		//contract: element, positioned before the first line separator in file, should have correct column
+		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/TestSimpleClass.java"));
+		CtType<?> type = build.Type().get("TestSimpleClass");
+		assertEquals(13, type.getPosition().getColumn());
+	}
 }

--- a/src/test/java/spoon/test/position/testclasses/TestSimpleClass.java
+++ b/src/test/java/spoon/test/position/testclasses/TestSimpleClass.java
@@ -1,0 +1,5 @@
+public class TestSimpleClass {
+    public int x;
+    public int y;
+    public int z;
+}


### PR DESCRIPTION
Hi! I've found that spoon gives incorrect column number for the element, positioned before the first line separator in file.

Consider the following file (TestSimpleClass.java):
```
public class TestSimpleClass {
    public int x;
    public int y;
    public int z;
}
```
If you try to get column from postion of this class, you will get -69, which is incorrect.
So, this PR is intended to fix that.