### PR TITLE
review: refactor: SignaturePrinter prints type parameter bounds, no name

### DIFF
--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -25,6 +25,7 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.CtScanner;
 
 /**
@@ -84,7 +85,20 @@ public class SignaturePrinter extends CtScanner {
 
 	@Override
 	public void visitCtTypeParameterReference(CtTypeParameterReference ref) {
-		write(ref.getQualifiedName());
+		/*
+		 * signature doesn't contain name of type parameter reference,
+		 * because these three methods declarations:
+		 * 	<T extends String> void m(T a);
+		 * 	<S extends String> void m(S b);
+		 * 	void m(String c)
+		 * Should have the same signature.
+		 */
+		scan(ref.getBoundingType());
+	}
+
+	@Override
+	public void visitCtWildcardReference(CtWildcardReference ref) {
+		write(ref.getSimpleName());
 		if (!ref.isDefaultBoundingType() || !ref.getBoundingType().isImplicit()) {
 			if (ref.isUpper()) {
 				write(" extends ");

--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -103,7 +103,7 @@ public class MethodTest {
 		boolean compareFound = false;
 		for (CtMethod<?> method : allMethods) {
 			if ("compare".equals(method.getSimpleName())) {
-				assertEquals("compare(T,T)", method.getSignature());
+				assertEquals("compare(java.lang.Object,java.lang.Object)", method.getSignature());
 				compareFound = true;
 			}
 		}

--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -119,7 +119,7 @@ public class ExecutableReferenceGenericTest {
 
 		//T has more information in the invocation than its declaration because of the argument type
 		//assertEquals(expectedMethod1, refsMethod2.get(0).getDeclaration());
-		assertEquals("method1(T extends java.lang.String)", execRefsMethods2.getSignature());
+		assertEquals("method1(java.lang.String)", execRefsMethods2.getSignature());
 		assertEquals(expectedMethod1, refsMethod2.get(1).getDeclaration());
 		assertEquals(expectedMethod5, refsMethod2.get(2).getDeclaration());
 	}
@@ -172,7 +172,7 @@ public class ExecutableReferenceGenericTest {
 		CtExecutable execRefsMethods2 = refsMethodA.get(0).getDeclaration();
 		//T has more information in the invocation than its declaration because of the argument type
 		//	assertEquals(expectedMethod1, refsMethodA.get(0).getDeclaration());
-		assertEquals("method1(T extends java.lang.String)", execRefsMethods2.getSignature());
+		assertEquals("method1(java.lang.String)", execRefsMethods2.getSignature());
 	}
 
 	@Test


### PR DESCRIPTION
Signature shouldn't contain name of type parameter reference, because these three methods declarations:
```java
<T extends String> void m(T a);
<S extends String> void m(S b);
void m(String c)
```
Should have the same signature: `m(String)`

WDYT?