### PR TITLE
WiP: fix: CtType#getMethod, CtType#getConstructor

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -85,13 +85,7 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 				continue;
 			}
 			CtConstructor<T> c = (CtConstructor<T>) typeMember;
-			boolean cont = c.getParameters().size() == parameterTypes.length;
-			for (int i = 0; cont && (i < c.getParameters().size()) && (i < parameterTypes.length); i++) {
-				if (!parameterTypes[i].getQualifiedName().equals(c.getParameters().get(i).getType().getQualifiedName())) {
-					cont = false;
-				}
-			}
-			if (cont) {
+			if (hasSameParameters(c, parameterTypes)) {
 				return c;
 			}
 		}


### PR DESCRIPTION
1) `CtType#getMethod` and `CtType#getConstructor` are now using same algorithm `CtTypeImpl#hasSameParameters` for matching of parameter types. 

2) CtTypeImpl#hasSameParameters is using *type erasure* to check if parameters are matching.