### PR TITLE
review: test: Method SignaturePrinter uses type erasure of parameter types

### DIFF
--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -26,6 +26,7 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.test.delete.testclasses.Adobada;
+import spoon.test.method.testclasses.Methods;
 import spoon.test.method.testclasses.Tacos;
 
 import java.util.ArrayList;
@@ -63,6 +64,29 @@ public class MethodTest {
 		assertEquals("public <T extends java.lang.String> void method1(T t) {" + System.lineSeparator() + "}", method1.toString());
 		method1 = aTacos.getMethod("method1", aTacos.getFactory().Type().objectType());
 		assertEquals("public <T> void method1(T t) {" + System.lineSeparator() + "}", method1.toString());
+	}
+
+	@Test
+	public void testMethodSignature() throws Exception {
+		//contract: method signature contains type erasure of parameter types
+		CtType<?> aTacos = buildClass(Methods.class);
+		int methodCount = 0;
+		for (CtMethod<?> method : aTacos.getMethods()) {
+			String name = method.getSimpleName();
+			String signatureParams;
+			if (name.startsWith("object")) {
+				signatureParams = "(java.lang.Object)";
+			} else if (name.startsWith("string")) {
+				signatureParams = "(java.lang.String)";
+			} else if (name.startsWith("list")) {
+				signatureParams = "(java.util.List)";
+			} else {
+				throw new AssertionError("Unexpected method " + name);
+			}
+			assertEquals(name + signatureParams, method.getSignature());
+			methodCount++;
+		}
+		assertTrue(methodCount > 15);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/method/testclasses/Methods.java
+++ b/src/test/java/spoon/test/method/testclasses/Methods.java
@@ -1,0 +1,24 @@
+package spoon.test.method.testclasses;
+
+import java.util.List;
+
+public interface Methods<U, V extends String> {
+	<T> void objectMethod1(T p);
+	<T extends Object> void objectMethod2(T p);
+	void objectMethod3(U p);
+	void objectMethod4(Object p);
+	
+	<T extends String> void stringMethod1(T p);
+	void stringMethod2(String p);
+	void stringMethod3(V p);
+	
+	<T extends List> void listMethod1(T p);
+	<T extends List<String>> void listMethod2(T p);
+	<T extends List<?>> void listMethod3(T p);
+	void listMethod4(List<?> p);
+	void listMethod5(List p);
+	void listMethod6(List<String> p);
+	void listMethod7(List<? extends String> p);
+	void listMethod8(List<? super String> p);
+	<T extends List<? extends String>> void listMethod9(T p);
+}


### PR DESCRIPTION
test which assures contract discussed in #2410 -
```java
<T extends List<String>> void m(T a);
<T extends List<Integer>> void m(T b);
<T extends List> void m(T c);
void m(List<String> d);
void m(List<?> e);
void m(List f);
```
all of them should have same signature: m(List)

... it looks like Spoon already works like that