### PR TITLE
review: fix: CtArrayTypeReference type erasure

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -46,7 +46,8 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	public CtTypeReference<?> getComponentType() {
 		if (componentType == null) {
 			// a sensible default component type to facilitate object creation and testing
-			componentType = getFactory().Type().OBJECT;
+			componentType = getFactory().Type().objectType();
+			componentType.setParent(this);
 		}
 		return componentType;
 	}
@@ -101,6 +102,18 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 			return ((CtArrayTypeReference<?>) getComponentType()).getDimensionCount() + 1;
 		}
 		return 1;
+	}
+
+	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		CtTypeReference<?> originCT = getComponentType();
+		CtTypeReference<?> erasedCT = originCT.getTypeErasure();
+		if (originCT == erasedCT) {
+			return this;
+		}
+		CtArrayTypeReference<?> erased = this.clone();
+		erased.setComponentType(erasedCT);
+		return erased;
 	}
 
 	@Override

--- a/src/test/java/spoon/test/ctType/CtTypeParameterTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeParameterTest.java
@@ -86,7 +86,7 @@ public class CtTypeParameterTest {
 		}
 		Class<?> paramType = declExec.getParameterTypes()[paramIdx];
 		// contract the type erasure given with Java reflection is the same as the one computed by spoon
-		assertEquals("TypeErasure of executable param " + getTypeParamIdentification(typeParam), paramType.getName(), typeParam.getTypeErasure().toString());
+		assertEquals("TypeErasure of executable param " + getTypeParamIdentification(typeParam), paramType.getTypeName(), param.getType().getTypeErasure().toString());
 	}
 
 	private void checkParameterErasureOfExecutable(CtParameter<?> param) {
@@ -103,7 +103,7 @@ public class CtTypeParameterTest {
 		Class<?> paramType = declExec.getParameterTypes()[paramIdx];
 		assertEquals(0, typeErasure.getActualTypeArguments().size());
 		// contract the type erasure of the method parameter given with Java reflection is the same as the one computed by spoon
-		assertEquals("TypeErasure of executable " + exec.getSignature() + " parameter " + param.getSimpleName(), paramType.getName(), typeErasure.getQualifiedName());
+		assertEquals("TypeErasure of executable " + exec.getSignature() + " parameter " + param.getSimpleName(), paramType.getTypeName(), typeErasure.getQualifiedName());
 	}
 
 	private Executable getMethodByName(Class declClass, String simpleName) {

--- a/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
+++ b/src/test/java/spoon/test/ctType/testclasses/ErasureModelA.java
@@ -28,6 +28,8 @@ public class ErasureModelA<A, B extends Exception, C extends B, D extends List<B
 	// simple case
 	public void list(List<Object> x, List<List<Object>> y, List<String> z) {
 	}
+	
+	public <I, J extends C> void methodWithArray(I[] paramI, J... paramJ) {}
 
 	static class ModelB<A2,B2 extends Exception, C2 extends B2, D2 extends List<B2>> extends ErasureModelA<A2,B2,C2,D2> {
 		A2 paramA2;


### PR DESCRIPTION
fixes type erasure of array in methods like: `public <I extends String> void methodWithArray(I[] param)` where type erasure should be `String[]`