### PR TITLE
Refactor fix code inspection - use instanceof

### DIFF
--- a/src/test/java/spoon/test/parent/ContractOnSettersParametrizedTest.java
+++ b/src/test/java/spoon/test/parent/ContractOnSettersParametrizedTest.java
@@ -137,14 +137,14 @@ public class ContractOnSettersParametrizedTest<T extends CtVisitable> {
 				// we check that setParent has been called
 
 				// directly the element
-				if (CtElement.class.isInstance(argument)
+				if (argument instanceof CtElement
 				  && setter.getAnnotation(UnsettableProperty.class) == null) {
 					nAssertsOnParent++;
 					assertTrue(((CtElement)argument).hasParent(receiver));
 				}
 
 				// the element is in a list
-				if (Collection.class.isInstance(argument)
+				if (argument instanceof Collection
 						&& setter.getAnnotation(UnsettableProperty.class) == null) {
 					nAssertsOnParentInList++;
 					assertTrue(((CtElement)((Collection)argument).iterator().next()).hasParent(receiver));

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -602,7 +602,7 @@ public class TypeReferenceTest {
 		// contract2: getTypeDeclaration returns a CtTYpe representing Object as the compiler does
 		CtLocalVariable<?> s = new Launcher().getFactory().Code().createCodeSnippetStatement("java.util.List<?> l = null").compile();
 		assertEquals("?", s.getType().getActualTypeArguments().get(0).getSimpleName());
-		assertTrue(CtWildcardReference.class.isInstance(s.getType().getActualTypeArguments().get(0)));
+		assertTrue(s.getType().getActualTypeArguments().get(0) instanceof CtWildcardReference);
 		assertEquals("Object", s.getType().getActualTypeArguments().get(0).getTypeDeclaration().getSimpleName());
 		assertSame(Object.class, s.getType().getActualTypeArguments().get(0).getTypeDeclaration().getActualClass());
 


### PR DESCRIPTION
To improve readability I used an *instanceof* operator.