### PR TITLE
refactor: fix SonarQube - change 'String' to 'char' in string functions

### DIFF
--- a/src/main/java/spoon/internal/mavenlauncher/InheritanceModel.java
+++ b/src/main/java/spoon/internal/mavenlauncher/InheritanceModel.java
@@ -240,7 +240,7 @@ public class InheritanceModel {
 		try {
 			InheritanceModel model = readPOM(depPath.toString(), null, m2RepositoryPath, sourceType, environment);
 			if (model == null) {
-				int buildIndex = version.indexOf("-");
+				int buildIndex = version.indexOf('-');
 				if (buildIndex != -1) {
 					String build = version.substring(buildIndex + 1);
 					folderVersion = version.replace(build, "SNAPSHOT");

--- a/src/main/java/spoon/internal/mavenlauncher/TreeDependency.java
+++ b/src/main/java/spoon/internal/mavenlauncher/TreeDependency.java
@@ -90,12 +90,12 @@ public class TreeDependency {
 				}
 			} else {
 				String tmp = version;
-				int buildIndex = version.indexOf("-");
+				int buildIndex = version.indexOf('-');
 				if (buildIndex != -1) {
 					String build = version.substring(buildIndex + 1);
 					tmp = version.replace(build, "SNAPSHOT");
 				} else {
-					buildIndex = version.indexOf("-");
+					buildIndex = version.indexOf('-');
 				}
 				depPath = Paths.get(m2RepositoryPath, groupId.replaceAll("\\.", "/"), artifactId, tmp);
 				depFile = depPath.toFile();

--- a/src/main/java/spoon/internal/mavenlauncher/Version.java
+++ b/src/main/java/spoon/internal/mavenlauncher/Version.java
@@ -26,7 +26,7 @@ public class Version implements Comparable<Version> {
 
 	Version(String version) {
 		this.version = version;
-		int buildIndex = version.indexOf("-");
+		int buildIndex = version.indexOf('-');
 		if (buildIndex != -1) {
 			String build = version.substring(buildIndex + 1);
 			try {

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -706,8 +706,8 @@ public class CodeFactory extends SubFactory {
 		}
 		CtJavaDocTag docTag = factory.Core().createJavaDocTag();
 		if (type != null && type.hasParam()) {
-			int firstWord = content.indexOf(" ");
-			int firstLine = content.indexOf("\n");
+			int firstWord = content.indexOf(' ');
+			int firstLine = content.indexOf('\n');
 			if (firstLine < firstWord && firstLine >= 0) {
 				firstWord = firstLine;
 			}

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -210,14 +210,14 @@ public class ExecutableFactory extends SubFactory {
 	 */
 	public <T> CtExecutableReference<T> createReference(String signature) {
 		CtExecutableReference<T> executableRef = factory.Core().createExecutableReference();
-		String type = signature.substring(0, signature.indexOf(" "));
-		String declaringType = signature.substring(signature.indexOf(" ") + 1, signature.indexOf(CtExecutable.EXECUTABLE_SEPARATOR));
-		String executableName = signature.substring(signature.indexOf(CtExecutable.EXECUTABLE_SEPARATOR) + 1, signature.indexOf("("));
+		String type = signature.substring(0, signature.indexOf(' '));
+		String declaringType = signature.substring(signature.indexOf(' ') + 1, signature.indexOf(CtExecutable.EXECUTABLE_SEPARATOR));
+		String executableName = signature.substring(signature.indexOf(CtExecutable.EXECUTABLE_SEPARATOR) + 1, signature.indexOf('('));
 		executableRef.setSimpleName(executableName);
 		executableRef.setDeclaringType(factory.Type().createReference(declaringType));
 		CtTypeReference<T> typeRef = factory.Type().createReference(type);
 		executableRef.setType(typeRef);
-		String parameters = signature.substring(signature.indexOf("(") + 1, signature.indexOf(")"));
+		String parameters = signature.substring(signature.indexOf('(') + 1, signature.indexOf(')'));
 		List<CtTypeReference<?>> params = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		StringTokenizer t = new StringTokenizer(parameters, ",");
 		while (t.hasMoreTokens()) {

--- a/src/main/java/spoon/reflect/factory/FieldFactory.java
+++ b/src/main/java/spoon/reflect/factory/FieldFactory.java
@@ -143,8 +143,8 @@ public class FieldFactory extends SubFactory {
 	 */
 	public <T> CtFieldReference<T> createReference(String signature) {
 		CtFieldReference<T> fieldRef = factory.Core().createFieldReference();
-		String type = signature.substring(0, signature.indexOf(" "));
-		String declaringType = signature.substring(signature.indexOf(" ") + 1, signature.indexOf(CtField.FIELD_SEPARATOR));
+		String type = signature.substring(0, signature.indexOf(' '));
+		String declaringType = signature.substring(signature.indexOf(' ') + 1, signature.indexOf(CtField.FIELD_SEPARATOR));
 		String fieldName = signature.substring(signature.indexOf(CtField.FIELD_SEPARATOR) + 1);
 		fieldRef.setSimpleName(fieldName);
 		fieldRef.setDeclaringType(factory.Type().createReference(declaringType));

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -449,7 +449,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 						CtWildcardStaticTypeMemberReferenceImpl importRef = (CtWildcardStaticTypeMemberReferenceImpl) ctImport.getReference();
 						String importRefStr = importRef.getQualifiedName();
 
-						importRefStr = importRefStr.substring(0, importRefStr.lastIndexOf("."));
+						importRefStr = importRefStr.substring(0, importRefStr.lastIndexOf('.'));
 						if (qualifiedName.equals(importRefStr)) {
 							return this.setImportUsed(ctImport);
 						}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -176,7 +176,7 @@ class JDTCommentBuilder {
 		for (String aLine : lines) {
 			String line = aLine.trim();
 			if (line.startsWith(CtJavaDocTag.JAVADOC_TAG_PREFIX)) {
-				int endIndex = line.indexOf(" ");
+				int endIndex = line.indexOf(' ');
 				if (endIndex == -1) {
 					endIndex = line.length();
 				}

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -68,7 +68,7 @@ class JDTImportBuilder {
 			String importName = importRef.toString();
 			if (!importRef.isStatic()) {
 				if (importName.endsWith("*")) {
-					int lastDot = importName.lastIndexOf(".");
+					int lastDot = importName.lastIndexOf('.');
 					String packageName = importName.substring(0, lastDot);
 
 					// only get package from the model by traversing from rootPackage the model
@@ -86,7 +86,7 @@ class JDTImportBuilder {
 					}
 				}
 			} else {
-				int lastDot = importName.lastIndexOf(".");
+				int lastDot = importName.lastIndexOf('.');
 				String className = importName.substring(0, lastDot);
 				String methodOrFieldName = importName.substring(lastDot + 1);
 

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
@@ -85,9 +85,9 @@ public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 
 	@Override
 	public String getShortDescription() {
-		int indexEndSentence = this.getContent().indexOf(".");
+		int indexEndSentence = this.getContent().indexOf('.');
 		if (indexEndSentence == -1) {
-			indexEndSentence = this.getContent().indexOf("\n");
+			indexEndSentence = this.getContent().indexOf('\n');
 		}
 		if (indexEndSentence != -1) {
 			return this.getContent().substring(0, indexEndSentence + 1).trim();

--- a/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
@@ -104,7 +104,7 @@ public class CompilationUnitImpl implements CompilationUnit, FactoryAccessor {
 		}
 		for (CtType<?> t : getDeclaredTypes()) {
 			String name = getFile().getName();
-			name = name.substring(0, name.lastIndexOf("."));
+			name = name.substring(0, name.lastIndexOf('.'));
 			if (t.getSimpleName().equals(name)) {
 				return t;
 			}

--- a/src/test/java/spoon/test/imports/ImportScannerTest.java
+++ b/src/test/java/spoon/test/imports/ImportScannerTest.java
@@ -100,7 +100,7 @@ public class ImportScannerTest {
 			}
 
 			for (String computedImport : computedStaticImports) {
-				String typeOfStatic = computedImport.substring(0, computedImport.lastIndexOf("."));
+				String typeOfStatic = computedImport.substring(0, computedImport.lastIndexOf('.'));
 				if (!staticImports.contains(computedImport) && !typeImports.contains(typeOfStatic)) {
 					if (!unusedImports.containsKey(ctType)) {
 						unusedImports.put(ctType, new ArrayList<>());
@@ -119,7 +119,7 @@ public class ImportScannerTest {
 			}
 
 			for (String anImport : staticImports) {
-				String typeOfStatic = anImport.substring(0, anImport.lastIndexOf("."));
+				String typeOfStatic = anImport.substring(0, anImport.lastIndexOf('.'));
 				if (!computedStaticImports.contains(anImport) && !computedTypeImports.contains(typeOfStatic)) {
 					if (!missingImports.containsKey(ctType)) {
 						missingImports.put(ctType, new ArrayList<>());


### PR DESCRIPTION
SonarQube checker: *An indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.*