### PR TITLE
WiP: alternative fix(position): labeled statement

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -121,6 +121,7 @@ import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtConstructorCall;
@@ -425,6 +426,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 	@Override
 	public void endVisit(IntLiteral intLiteral, BlockScope scope) {
 		context.exit(intLiteral);
+	}
+
+	@Override
+	public void endVisit(LabeledStatement labeledStatement, BlockScope scope) {
+		context.exit(labeledStatement);
 	}
 
 	@Override
@@ -1175,7 +1181,14 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 	@Override
 	public boolean visit(LabeledStatement labeledStatement, BlockScope scope) {
-		context.label.push(new String(labeledStatement.label));
+		/*
+		 * Create helper implicit block which holds label until child statement node is available
+		 */
+		CtBlock<?> block = factory.Core().createBlock();
+		block.setLabel(new String(labeledStatement.label));
+		context.enter(block, labeledStatement);
+		//set implicit after position is build, so we know the position of the label
+		block.setImplicit(true);
 		return true;
 	}
 

--- a/src/test/java/spoon/test/position/testclasses/FooLabel.java
+++ b/src/test/java/spoon/test/position/testclasses/FooLabel.java
@@ -1,0 +1,37 @@
+package spoon.test.position.testclasses;
+
+public class FooLabel {
+
+	void m(boolean x) {
+		label1: while(x) {};
+		label2: getClass();
+		labelx: label3: new String();
+		getClass();
+		label4: x = false;
+		label5: /*c1*/ return;
+	}
+	
+	void m2(boolean x) {
+		label1: {label2: while(x);}
+		label1: label2: while(x);
+	}
+	void m3() {
+		label: {getClass();}
+	}
+	void m4() {
+		label: {getClass();}
+		label:;
+	}
+	void m5() {
+		switch (1) {
+			case 2:
+				label:;
+				laval3: label1: label2: while(true);
+		}
+	}
+	void m6(boolean x) {
+		labelW: while(x) {
+			try { label2: while(true); } finally {}
+		}
+	}
+}


### PR DESCRIPTION
This is alternative solution to #2432. I would prefer this solution. It needs less tricks.

The only tricky thing is the way how helper CtBlock is removed from the Spoon model in ParentExiter - see call of `jdtTreeBuilder.getContextBuilder().replaceContextElement(block, child, childJDT);`

@tdurieux do you see a better place/way, which allows to merge helper CtBlock with it's child statement?