### PR TITLE
refactor: fix code inspection unn. qualified statically imported element

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
@@ -33,10 +33,6 @@ import spoon.reflect.visitor.chain.CtScannerListener;
 import spoon.reflect.visitor.chain.ScanningMode;
 import spoon.support.SpoonClassNotFoundException;
 
-import static spoon.reflect.visitor.chain.ScanningMode.NORMAL;
-import static spoon.reflect.visitor.chain.ScanningMode.SKIP_ALL;
-import static spoon.reflect.visitor.chain.ScanningMode.SKIP_CHILDREN;
-
 /**
  * Expects a {@link CtTypeInformation} as input
  * and produces all super classes and super interfaces recursively.<br>
@@ -139,9 +135,9 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 		@Override
 		public ScanningMode enter(CtElement element) {
 			if (visitedSet.add(((CtTypeInformation) element).getQualifiedName())) {
-				return NORMAL;
+				return ScanningMode.NORMAL;
 			}
-			return SKIP_ALL;
+			return ScanningMode.SKIP_ALL;
 		}
 		@Override
 		public void exit(CtElement element) {
@@ -243,17 +239,17 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 			return;
 		}
 		ScanningMode mode = enter(typeRef, isClass);
-		if (mode == SKIP_ALL) {
+		if (mode == ScanningMode.SKIP_ALL) {
 			//listener decided to not visit that input. Finish
 			return;
 		}
 		if (includingSelf) {
 			sendResult(typeRef, outputConsumer);
 			if (query.isTerminated()) {
-				mode = SKIP_CHILDREN;
+				mode = ScanningMode.SKIP_CHILDREN;
 			}
 		}
-		if (mode == NORMAL) {
+		if (mode == ScanningMode.NORMAL) {
 			if (isClass == false) {
 				visitSuperInterfaces(typeRef, outputConsumer);
 				if (interfacesExtendObject) {
@@ -321,11 +317,11 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 
 	private void sendResultWithListener(CtTypeReference<?> classRef, boolean isClass, CtConsumer<Object> outputConsumer, CtConsumer<CtTypeReference<?>> runNext) {
 		ScanningMode mode = enter(classRef, isClass);
-		if (mode == SKIP_ALL) {
+		if (mode == ScanningMode.SKIP_ALL) {
 			return;
 		}
 		sendResult(classRef, outputConsumer);
-		if (mode == NORMAL && query.isTerminated() == false) {
+		if (mode == ScanningMode.NORMAL && query.isTerminated() == false) {
 			runNext.accept(classRef);
 		}
 		exit(classRef, isClass);
@@ -338,7 +334,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 
 	private ScanningMode enter(CtTypeReference<?> type, boolean isClass) {
 		if (listener == null) {
-			return NORMAL;
+			return ScanningMode.NORMAL;
 		}
 		if (listener instanceof Listener) {
 			Listener typeListener = (Listener) listener;

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtInvocation;
@@ -34,9 +35,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.STATEMENT;
-
 public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	private static final long serialVersionUID = 1L;
 
@@ -49,11 +47,11 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 		}
 		@Override
 		protected CtRole getRole() {
-			return STATEMENT;
+			return CtRole.STATEMENT;
 		}
 		@Override
 		protected int getDefaultCapacity() {
-			return BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
+			return ModelElementContainerDefaultCapacities.BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
 		}
 		@Override
 		protected void onSizeChanged(int newSize) {

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
@@ -30,10 +31,6 @@ import spoon.support.reflect.declaration.CtElementImpl;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.CASE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.CASE;
-import static spoon.reflect.path.CtRole.STATEMENT;
 
 public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 	private static final long serialVersionUID = 1L;
@@ -64,7 +61,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		if (caseExpression != null) {
 			caseExpression.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CASE, caseExpression, this.caseExpression);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.CASE, caseExpression, this.caseExpression);
 		this.caseExpression = caseExpression;
 		return (T) this;
 	}
@@ -75,7 +72,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 			this.statements = CtElementImpl.emptyList();
 			return (T) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, STATEMENT, this.statements, new ArrayList<>(this.statements));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.STATEMENT, this.statements, new ArrayList<>(this.statements));
 		this.statements.clear();
 		for (CtStatement stmt : statements) {
 			addStatement(stmt);
@@ -90,7 +87,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 
 	private void ensureModifiableStatementsList() {
 		if (this.statements == CtElementImpl.<CtStatement>emptyList()) {
-			this.statements = new ArrayList<>(CASE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
+			this.statements = new ArrayList<>(ModelElementContainerDefaultCapacities.CASE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
 		}
 	}
 
@@ -101,7 +98,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		}
 		this.ensureModifiableStatementsList();
 		statement.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, STATEMENT, this.statements, index, statement);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.STATEMENT, this.statements, index, statement);
 		statements.add(index, statement);
 		return (T) this;
 	}
@@ -197,7 +194,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		if (statements == CtElementImpl.<CtStatement>emptyList()) {
 			return;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, STATEMENT, statements, statements.indexOf(statement), statement);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.STATEMENT, statements, statements.indexOf(statement), statement);
 		statements.remove(statement);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtExpression;
@@ -41,17 +42,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static spoon.reflect.ModelElementContainerDefaultCapacities.CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.NAME;
-import static spoon.reflect.path.CtRole.MULTI_TYPE;
-
 public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatchVariable<T> {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = CtRole.NAME)
 	String name = "";
 
-	@MetamodelPropertyField(role = MULTI_TYPE)
+	@MetamodelPropertyField(role = CtRole.MULTI_TYPE)
 	List<CtTypeReference<?>> types = emptyList();
 
 	@MetamodelPropertyField(role = CtRole.MODIFIER)
@@ -121,7 +118,7 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 
 	@Override
 	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simpleName, this.name);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.NAME, simpleName, this.name);
 		this.name = simpleName;
 		return (C) this;
 	}
@@ -138,10 +135,10 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 			return (T) this;
 		}
 		if (types == CtElementImpl.<CtTypeReference<?>>emptyList()) {
-			types = new ArrayList<>(CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY);
+			types = new ArrayList<>(ModelElementContainerDefaultCapacities.CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY);
 		}
 		type.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, MULTI_TYPE, this.types, type);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.MULTI_TYPE, this.types, type);
 		types.add(type);
 		return (T) this;
 	}
@@ -151,7 +148,7 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 		if (this.types == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			return false;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, MULTI_TYPE, types, types.indexOf(ref), ref);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.MULTI_TYPE, types, types.indexOf(ref), ref);
 		return types.remove(ref);
 	}
 
@@ -162,7 +159,7 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 
 	@Override
 	public <T extends CtMultiTypedElement> T setMultiTypes(List<CtTypeReference<?>> types) {
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, MULTI_TYPE, this.types, new ArrayList<>(this.types));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.MULTI_TYPE, this.types, new ArrayList<>(this.types));
 		if (types == null || types.isEmpty()) {
 			this.types = CtElementImpl.emptyList();
 			return (T) this;

--- a/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
@@ -22,9 +22,6 @@ import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
-import static spoon.reflect.path.CtRole.COMMENT_CONTENT;
-import static spoon.reflect.path.CtRole.TYPE;
-
 public class CtCommentImpl extends CtStatementImpl implements CtComment {
 	private static final long serialVersionUID = 1L;
 
@@ -48,7 +45,7 @@ public class CtCommentImpl extends CtStatementImpl implements CtComment {
 
 	@Override
 	public <E extends CtComment> E setContent(String content) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, COMMENT_CONTENT, content, this.content);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.COMMENT_CONTENT, content, this.content);
 		this.content = content;
 		return (E) this;
 	}
@@ -60,7 +57,7 @@ public class CtCommentImpl extends CtStatementImpl implements CtComment {
 
 	@Override
 	public <E extends CtComment> E setCommentType(CommentType commentType) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, commentType, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, commentType, this.type);
 		type = commentType;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
@@ -36,11 +36,6 @@ import spoon.support.reflect.CtModifierHandler;
 
 import java.util.Set;
 
-import static spoon.reflect.path.CtRole.DEFAULT_EXPRESSION;
-import static spoon.reflect.path.CtRole.IS_INFERRED;
-import static spoon.reflect.path.CtRole.NAME;
-import static spoon.reflect.path.CtRole.TYPE;
-
 public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVariable<T> {
 	private static final long serialVersionUID = 1L;
 
@@ -89,14 +84,14 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 		if (defaultExpression != null) {
 			defaultExpression.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
 		this.defaultExpression = defaultExpression;
 		return (C) this;
 	}
 
 	@Override
 	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simpleName, this.name);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.NAME, simpleName, this.name);
 		this.name = simpleName;
 		return (C) this;
 	}
@@ -106,7 +101,7 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 		if (type != null) {
 			type.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
 		return (C) this;
 	}
@@ -190,7 +185,7 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 
 	@Override
 	public <U extends CtLocalVariable<T>> U setInferred(boolean inferred) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_INFERRED, inferred, this.inferred);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_INFERRED, inferred, this.inferred);
 		this.inferred = inferred;
 		return (U) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -63,10 +63,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.TYPE;
-import static spoon.reflect.path.CtRole.VALUE;
-
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotation}.
  *
@@ -192,7 +188,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 		} else {
 			// Add the new value.
 			expression.setParent(this);
-			getFactory().getEnvironment().getModelChangeListener().onMapAdd(this, VALUE, this.elementValues, elementName, expression);
+			getFactory().getEnvironment().getModelChangeListener().onMapAdd(this, CtRole.VALUE, this.elementValues, elementName, expression);
 			elementValues.put(elementName, expression);
 		}
 		return (T) this;
@@ -464,14 +460,14 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 		if (annotationType != null) {
 			annotationType.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, annotationType, this.annotationType);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, annotationType, this.annotationType);
 		this.annotationType = (CtTypeReference<A>) annotationType;
 		return (T) this;
 	}
 
 	@Override
 	public <T extends CtAnnotation<A>> T setElementValues(Map<String, Object> values) {
-		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, VALUE, this.elementValues, new HashMap<>(elementValues));
+		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, CtRole.VALUE, this.elementValues, new HashMap<>(elementValues));
 		this.elementValues.clear();
 		for (Entry<String, Object> e : values.entrySet()) {
 			addValue(e.getKey(), e.getValue());
@@ -481,7 +477,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	public <T extends CtAnnotation<A>> T setValues(Map<String, CtExpression> values) {
-		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, VALUE, this.elementValues, new HashMap<>(elementValues));
+		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, CtRole.VALUE, this.elementValues, new HashMap<>(elementValues));
 		this.elementValues.clear();
 		for (Entry<String, CtExpression> e : values.entrySet()) {
 			addValue(e.getKey(), e.getValue());
@@ -535,7 +531,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.declaration;
 
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
@@ -38,10 +39,6 @@ import spoon.support.reflect.CtModifierHandler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.TYPE_PARAMETER;
 
 public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConstructor<T> {
 	private static final long serialVersionUID = 1L;
@@ -102,9 +99,9 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 			return (C) this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			this.formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			this.formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, TYPE_PARAMETER, this.formalCtTypeParameters, new ArrayList<>(this.formalCtTypeParameters));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, new ArrayList<>(this.formalCtTypeParameters));
 		this.formalCtTypeParameters.clear();
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
 			addFormalCtTypeParameter(formalTypeParameter);
@@ -117,9 +114,9 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 		if (formalTypeParameter == null) {
 			return (C) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
 		formalTypeParameter.setParent(this);
 		formalCtTypeParameters.add(formalTypeParameter);
@@ -131,7 +128,7 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 		if (!formalCtTypeParameters.contains(formalTypeParameter)) {
 			return false;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
 		return formalCtTypeParameters.remove(formalTypeParameter);
 	}
 
@@ -196,7 +193,7 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -20,6 +20,7 @@ import org.apache.log4j.Logger;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.CtModelImpl;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtJavaDoc;
@@ -74,13 +75,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Iterator;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.ModelElementContainerDefaultCapacities.COMMENT_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.ANNOTATION;
-import static spoon.reflect.path.CtRole.COMMENT;
-import static spoon.reflect.path.CtRole.IS_IMPLICIT;
-import static spoon.reflect.path.CtRole.POSITION;
 
 /**
  * Contains the default implementation of most CtElement methods.
@@ -225,7 +219,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			this.annotations = emptyList();
 			return (E) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
 		this.annotations.clear();
 		for (CtAnnotation<? extends Annotation> annot : annotations) {
 			addAnnotation(annot);
@@ -245,10 +239,10 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			return (E) this;
 		}
 		if (this.annotations == CtElementImpl.<CtAnnotation<? extends Annotation>>emptyList()) {
-			this.annotations = new ArrayList<>(ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY);
+			this.annotations = new ArrayList<>(ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY);
 		}
 		annotation.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, ANNOTATION, this.annotations, annotation);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.ANNOTATION, this.annotations, annotation);
 		this.annotations.add(annotation);
 		return (E) this;
 	}
@@ -258,7 +252,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (this.annotations == CtElementImpl.<CtAnnotation<? extends Annotation>>emptyList()) {
 			return false;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, ANNOTATION, annotations, annotations.indexOf(annotation), annotation);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.ANNOTATION, annotations, annotations.indexOf(annotation), annotation);
 		return this.annotations.remove(annotation);
 	}
 
@@ -279,7 +273,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (position == null) {
 			position = SourcePosition.NOPOSITION;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, POSITION, position, this.position);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.POSITION, position, this.position);
 		this.position = position;
 		return (E) this;
 	}
@@ -330,7 +324,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public <E extends CtElement> E setImplicit(boolean implicit) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_IMPLICIT, implicit, this.implicit);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_IMPLICIT, implicit, this.implicit);
 		this.implicit = implicit;
 		return (E) this;
 	}
@@ -544,10 +538,10 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			return (E) this;
 		}
 		if (this.comments == CtElementImpl.<CtComment>emptyList()) {
-			comments = new ArrayList<>(COMMENT_CONTAINER_DEFAULT_CAPACITY);
+			comments = new ArrayList<>(ModelElementContainerDefaultCapacities.COMMENT_CONTAINER_DEFAULT_CAPACITY);
 		}
 		comment.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, COMMENT, this.comments, comment);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.COMMENT, this.comments, comment);
 		comments.add(comment);
 		return (E) this;
 	}
@@ -557,7 +551,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		if (this.comments == CtElementImpl.<CtComment>emptyList()) {
 			return (E) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, COMMENT, comments, comments.indexOf(comment), comment);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.COMMENT, comments, comments.indexOf(comment), comment);
 		this.comments.remove(comment);
 		return (E) this;
 	}
@@ -568,7 +562,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			this.comments = emptyList();
 			return (E) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, COMMENT, this.comments, new ArrayList<>(this.comments));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.COMMENT, this.comments, new ArrayList<>(this.comments));
 		this.comments.clear();
 		for (CtComment comment : comments) {
 			addComment(comment);

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -36,10 +36,6 @@ import spoon.support.reflect.CtModifierHandler;
 
 import java.util.Set;
 
-import static spoon.reflect.path.CtRole.DEFAULT_EXPRESSION;
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.TYPE;
-
 /**
  * The implementation for {@link spoon.reflect.declaration.CtField}.
  *
@@ -95,7 +91,7 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 		if (defaultExpression != null) {
 			defaultExpression.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
 		this.defaultExpression = defaultExpression;
 		return (C) this;
 	}
@@ -105,7 +101,7 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 		if (type != null) {
 			type.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
 		return (C) this;
 	}
@@ -183,7 +179,7 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -17,6 +17,7 @@
 package spoon.support.reflect.declaration;
 
 import spoon.refactoring.Refactoring;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
@@ -37,12 +38,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.IS_DEFAULT;
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.TYPE;
-import static spoon.reflect.path.CtRole.TYPE_PARAMETER;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtMethod}.
@@ -82,7 +77,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		if (type != null) {
 			type.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.returnType);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.returnType);
 		this.returnType = type;
 		return (C) this;
 	}
@@ -94,7 +89,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 
 	@Override
 	public <C extends CtMethod<T>> C setDefaultMethod(boolean defaultMethod) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_DEFAULT, defaultMethod, this.defaultMethod);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_DEFAULT, defaultMethod, this.defaultMethod);
 		this.defaultMethod = defaultMethod;
 		return (C) this;
 	}
@@ -106,13 +101,13 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 
 	@Override
 	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, TYPE_PARAMETER, this.formalCtTypeParameters, new ArrayList<>(this.formalCtTypeParameters));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, new ArrayList<>(this.formalCtTypeParameters));
 		if (formalTypeParameters == null || formalTypeParameters.isEmpty()) {
 			this.formalCtTypeParameters = CtElementImpl.emptyList();
 			return (C) this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			this.formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			this.formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
 		this.formalCtTypeParameters.clear();
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
@@ -127,9 +122,9 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 			return (C) this;
 		}
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		formalTypeParameter.setParent(this);
 		formalCtTypeParameters.add(formalTypeParameter);
 		return (C) this;
@@ -140,7 +135,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			return false;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
 		return formalCtTypeParameters.remove(formalTypeParameter);
 	}
 
@@ -209,7 +204,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -31,10 +31,6 @@ import spoon.support.util.ModelSet;
 
 import java.util.Set;
 
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.SUB_PACKAGE;
-import static spoon.reflect.path.CtRole.CONTAINED_TYPE;
-
 /**
  * The implementation for {@link spoon.reflect.declaration.CtPackage}.
  *
@@ -43,7 +39,7 @@ import static spoon.reflect.path.CtRole.CONTAINED_TYPE;
 public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	private static final long serialVersionUID = 1L;
 
-	@MetamodelPropertyField(role = SUB_PACKAGE)
+	@MetamodelPropertyField(role = CtRole.SUB_PACKAGE)
 	protected ModelSet<CtPackage> packs = new ModelSet<CtPackage>(QualifiedNameComparator.INSTANCE) {
 		private static final long serialVersionUID = 1L;
 		@Override
@@ -53,7 +49,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 		@Override
 		protected CtRole getRole() {
-			return SUB_PACKAGE;
+			return CtRole.SUB_PACKAGE;
 		}
 
 		@Override
@@ -80,7 +76,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 		}
 	};
 
-	@MetamodelPropertyField(role = CONTAINED_TYPE)
+	@MetamodelPropertyField(role = CtRole.CONTAINED_TYPE)
 	private ModelSet<CtType<?>> types = new ModelSet<CtType<?>>(QualifiedNameComparator.INSTANCE) {
 		private static final long serialVersionUID = 1L;
 		@Override
@@ -222,7 +218,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 		return getQualifiedName();
 	}
 
-	@MetamodelPropertyField(role = IS_SHADOW)
+	@MetamodelPropertyField(role = CtRole.IS_SHADOW)
 	boolean isShadow;
 
 	@Override
@@ -232,7 +228,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -36,10 +36,6 @@ import spoon.support.reflect.CtModifierHandler;
 
 import java.util.Set;
 
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.IS_VARARGS;
-import static spoon.reflect.path.CtRole.TYPE;
-
 /**
  * The implementation for {@link spoon.reflect.declaration.CtParameter}.
  *
@@ -93,7 +89,7 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 		if (type != null) {
 			type.setParent(this);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
 		return (C) this;
 	}
@@ -105,7 +101,7 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 
 	@Override
 	public <C extends CtParameter<T>> C setVarArgs(boolean varArgs) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_VARARGS, varArgs, this.varArgs);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_VARARGS, varArgs, this.varArgs);
 		this.varArgs = varArgs;
 		return (C) this;
 	}
@@ -177,7 +173,7 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -18,6 +18,7 @@ package spoon.support.reflect.declaration;
 
 import spoon.SpoonException;
 import spoon.refactoring.Refactoring;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtAnnotation;
@@ -69,16 +70,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
-import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
-import static spoon.reflect.path.CtRole.CONSTRUCTOR;
-import static spoon.reflect.path.CtRole.FIELD;
-import static spoon.reflect.path.CtRole.INTERFACE;
-import static spoon.reflect.path.CtRole.IS_SHADOW;
-import static spoon.reflect.path.CtRole.METHOD;
-import static spoon.reflect.path.CtRole.NESTED_TYPE;
-import static spoon.reflect.path.CtRole.TYPE_PARAMETER;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtType}.
@@ -152,15 +143,15 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			member.setParent(this);
 			CtRole role;
 			if (member instanceof CtMethod) {
-				role = METHOD;
+				role = CtRole.METHOD;
 			} else if (member instanceof CtConstructor) {
-				role = CONSTRUCTOR;
+				role = CtRole.CONSTRUCTOR;
 			} else if (member instanceof CtField) {
-				role = FIELD;
+				role = CtRole.FIELD;
 			} else if (member instanceof CtAnonymousExecutable) {
-				role = ANNONYMOUS_EXECUTABLE;
+				role = CtRole.ANNONYMOUS_EXECUTABLE;
 			} else {
-				role = NESTED_TYPE;
+				role = CtRole.NESTED_TYPE;
 			}
 			getFactory().getEnvironment().getModelChangeListener().onListAdd(this, role, this.typeMembers, position, member);
 			if (position < typeMembers.size()) {
@@ -176,15 +167,15 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	public boolean removeTypeMember(CtTypeMember member) {
 		CtRole role;
 		if (member instanceof CtMethod) {
-			role = METHOD;
+			role = CtRole.METHOD;
 		} else if (member instanceof CtConstructor) {
-			role = CONSTRUCTOR;
+			role = CtRole.CONSTRUCTOR;
 		} else if (member instanceof CtField) {
-			role = FIELD;
+			role = CtRole.FIELD;
 		} else if (member instanceof CtAnonymousExecutable) {
-			role = ANNONYMOUS_EXECUTABLE;
+			role = CtRole.ANNONYMOUS_EXECUTABLE;
 		} else {
-			role = NESTED_TYPE;
+			role = CtRole.NESTED_TYPE;
 		}
 		if (typeMembers.size() == 1) {
 			if (typeMembers.contains(member)) {
@@ -240,7 +231,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			this.typeMembers.removeAll(oldFields);
 			return (C) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, FIELD, this.typeMembers, new ArrayList<>(oldFields));
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.FIELD, this.typeMembers, new ArrayList<>(oldFields));
 		typeMembers.removeAll(oldFields);
 		for (CtField<?> field : fields) {
 			addField(field);
@@ -300,7 +291,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@Override
 	public <C extends CtType<T>> C setNestedTypes(Set<CtType<?>> nestedTypes) {
 		Set<CtType<?>> oldNestedTypes = getNestedTypes();
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, NESTED_TYPE, typeMembers, oldNestedTypes);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.NESTED_TYPE, typeMembers, oldNestedTypes);
 		if (nestedTypes == null || nestedTypes.isEmpty()) {
 			this.typeMembers.removeAll(oldNestedTypes);
 			return (C) this;
@@ -641,14 +632,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			interfaces = new QualifiedNameBasedSortedSet<>();
 		}
 		interfac.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, INTERFACE, this.interfaces, interfac);
+		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, CtRole.INTERFACE, this.interfaces, interfac);
 		interfaces.add(interfac);
 		return (C) this;
 	}
 
 	@Override
 	public <S> boolean removeSuperInterface(CtTypeReference<S> interfac) {
-		getFactory().getEnvironment().getModelChangeListener().onSetDelete(this, INTERFACE, interfaces, interfac);
+		getFactory().getEnvironment().getModelChangeListener().onSetDelete(this, CtRole.INTERFACE, interfaces, interfac);
 		if (interfaces == CtElementImpl.<CtTypeReference<?>>emptySet()) {
 			return false;
 		} else if (interfaces.size() == 1) {
@@ -671,13 +662,13 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, TYPE_PARAMETER, formalCtTypeParameters, new ArrayList<>(formalCtTypeParameters));
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.TYPE_PARAMETER, formalCtTypeParameters, new ArrayList<>(formalCtTypeParameters));
 		if (formalTypeParameters == null || formalTypeParameters.isEmpty()) {
 			this.formalCtTypeParameters = CtElementImpl.emptyList();
 			return (C) this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			this.formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			this.formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
 		this.formalCtTypeParameters.clear();
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
@@ -692,10 +683,10 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 			return (C) this;
 		}
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
-			formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
+			formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
 		}
 		formalTypeParameter.setParent(this);
-		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		formalCtTypeParameters.add(formalTypeParameter);
 		return (C) this;
 	}
@@ -705,7 +696,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			return false;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.TYPE_PARAMETER, formalCtTypeParameters, formalCtTypeParameters.indexOf(formalTypeParameter), formalTypeParameter);
 		return formalCtTypeParameters.remove(formalTypeParameter);
 	}
 
@@ -914,7 +905,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@Override
 	public <C extends CtType<T>> C setMethods(Set<CtMethod<?>> methods) {
 		Set<CtMethod<?>> allMethods = getMethods();
-		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, METHOD, this.typeMembers, new ArrayList(allMethods));
+		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.METHOD, this.typeMembers, new ArrayList(allMethods));
 		typeMembers.removeAll(allMethods);
 		if (methods == null || methods.isEmpty()) {
 			return (C) this;
@@ -941,7 +932,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		if (this.interfaces == CtElementImpl.<CtTypeReference<?>>emptySet()) {
 			this.interfaces = new QualifiedNameBasedSortedSet<>();
 		}
-		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(this, INTERFACE, this.interfaces, new HashSet<>(this.interfaces));
+		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(this, CtRole.INTERFACE, this.interfaces, new HashSet<>(this.interfaces));
 		this.interfaces.clear();
 		for (CtTypeReference<?> anInterface : interfaces) {
 			addSuperInterface(anInterface);
@@ -1004,7 +995,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public <E extends CtShadowable> E setShadow(boolean isShadow) {
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
 		return (E) this;
 	}


### PR DESCRIPTION
@surli 
@monperrus 
@pvojtechovsky 

The problem: *There is a static import in a file. Then fully qualified name of an entity (method/field) is used. It is redundancy.*

*Also static imports decrease readability!*
https://carlosbecker.com/posts/avoid-static-imports/

Example of problematic code (both: a) and b) in ONE file)
a) using static import: `import static spoon.reflect.path.CtRole.VALUE;` (problem per se)
b) using fully qualified name: `CtRole.VALUE` (redundancy!)

Solution 1: *Use short name (i.e. remove class name, class prefix). It removes redundancy but code still contains static imports!*
Solution 2: *Change static imports to ordinary imports. Both problems solved! No redundancy & no static imports!*

Solution 2:
using an ordinary import: `import spoon.reflect.path.CtRole;` (no static import)
using fully qualified name: `CtRole.VALUE` (no redundancy!)

**This PR solves only problem when there is a static import and then fully qualified name is used.
I recommend to kick out ALL static imports excluding the most obvious ones: JUnit and mocks assertions: import static org.junit.Assert.assertEquals;. However even better is not using static imports at all.**

**Could we implement a Checkstyle rule to ban static imports in tests and production code? I can change all static imports to ordinary ones (not a big effort).**

Lack of static imports has also another advantage. All assertions have consistent syntax: Assert.assertionName(). Currently we have mix of two styles:
- spoon/support/compiler/classpath/ComputeClasspathTest.java ->Assert.assertEquals (with class prefix)
- spoon/reflect/ast/CloneTest.java -> assertTrue (without class prefix)

Consistency is valuable (small benefit but still).