### PR TITLE
refactor: remove redundant casts

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -625,7 +625,7 @@ public class ReferenceBuilder {
 				main.setSimpleName(m.group(1));
 				final String[] split = m.group(2).split(",");
 				for (String parameter : split) {
-					((CtTypeReference) main).addActualTypeArgument(getTypeParameterReference(parameter.trim()));
+					main.addActualTypeArgument(getTypeParameterReference(parameter.trim()));
 				}
 			}
 		} else if (Character.isUpperCase(name.charAt(0))) {
@@ -923,7 +923,7 @@ public class ReferenceBuilder {
 	<T> CtVariableReference<T> getVariableReference(MethodBinding methbin) {
 		CtFieldReference<T> ref = this.jdtTreeBuilder.getFactory().Core().createFieldReference();
 		ref.setSimpleName(new String(methbin.selector));
-		ref.setType((CtTypeReference<T>) getTypeReference(methbin.returnType));
+		ref.setType(getTypeReference(methbin.returnType));
 
 		if (methbin.declaringClass != null) {
 			ref.setDeclaringType(getTypeReference(methbin.declaringClass));
@@ -970,7 +970,7 @@ public class ReferenceBuilder {
 			if (localVariableBinding.declaration instanceof Argument && localVariableBinding.declaringScope instanceof MethodScope) {
 				CtParameterReference<T> ref = this.jdtTreeBuilder.getFactory().Core().createParameterReference();
 				ref.setSimpleName(new String(varbin.name));
-				ref.setType((CtTypeReference<T>) getTypeReference(varbin.type));
+				ref.setType(getTypeReference(varbin.type));
 				return ref;
 			} else if (localVariableBinding.declaration.binding instanceof CatchParameterBinding) {
 				CtCatchVariableReference<T> ref = this.jdtTreeBuilder.getFactory().Core().createCatchVariableReference();
@@ -997,7 +997,7 @@ public class ReferenceBuilder {
 			return ref;
 		}
 		ref.setSimpleName(new String(binding.name));
-		ref.setType((CtTypeReference<T>) getTypeReference(binding.searchType));
+		ref.setType(getTypeReference(binding.searchType));
 		return ref;
 	}
 

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -149,7 +149,7 @@ public class LambdaTest {
 
 		assertTypedBy(Predicate.class, lambda.getType());
 		assertParametersSizeIs(1, lambda.getParameters());
-		final CtParameter<?> parameter = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter);
 		assertParameterIsNamedBy("p", parameter);
 		assertHasExpressionBody(lambda);
@@ -165,10 +165,10 @@ public class LambdaTest {
 
 		assertTypedBy(Foo.CheckPersons.class, lambda.getType());
 		assertParametersSizeIs(2, lambda.getParameters());
-		final CtParameter<?> parameter1 = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter1 = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter1);
 		assertParameterIsNamedBy("p1", parameter1);
-		final CtParameter<?> parameter2 = (CtParameter<?>) lambda.getParameters().get(1);
+		final CtParameter<?> parameter2 = lambda.getParameters().get(1);
 		assertParameterTypedBy(Foo.Person.class, parameter2);
 		assertParameterIsNamedBy("p2", parameter2);
 		assertHasExpressionBody(lambda);
@@ -184,7 +184,7 @@ public class LambdaTest {
 
 		assertTypedBy(Predicate.class, lambda.getType());
 		assertParametersSizeIs(1, lambda.getParameters());
-		final CtParameter<?> parameter = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter);
 		assertParameterIsNamedBy("p", parameter);
 		assertHasExpressionBody(lambda);
@@ -200,10 +200,10 @@ public class LambdaTest {
 
 		assertTypedBy(Foo.CheckPersons.class, lambda.getType());
 		assertParametersSizeIs(2, lambda.getParameters());
-		final CtParameter<?> parameter1 = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter1 = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter1);
 		assertParameterIsNamedBy("p1", parameter1);
-		final CtParameter<?> parameter2 = (CtParameter<?>) lambda.getParameters().get(1);
+		final CtParameter<?> parameter2 = lambda.getParameters().get(1);
 		assertParameterTypedBy(Foo.Person.class, parameter2);
 		assertParameterIsNamedBy("p2", parameter2);
 		assertHasExpressionBody(lambda);
@@ -233,7 +233,7 @@ public class LambdaTest {
 
 		assertTypedBy(Predicate.class, lambda.getType());
 		assertParametersSizeIs(1, lambda.getParameters());
-		final CtParameter<?> parameter = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter);
 		assertParameterIsNamedBy("p", parameter);
 		assertStatementBody(lambda);
@@ -252,7 +252,7 @@ public class LambdaTest {
 
 		assertTypedBy(Predicate.class, lambda.getType());
 		assertParametersSizeIs(1, lambda.getParameters());
-		final CtParameter<?> parameter = (CtParameter<?>) lambda.getParameters().get(0);
+		final CtParameter<?> parameter = lambda.getParameters().get(0);
 		assertParameterTypedBy(Foo.Person.class, parameter);
 		assertParameterIsNamedBy("p", parameter);
 		assertHasExpressionBody(lambda);
@@ -355,7 +355,7 @@ public class LambdaTest {
 	@Test
 	public void testEqualsLambdaParameterRef() {
 		CtLambda<?> lambda = getLambdaInFooByNumber(8);
-		CtParameter<?> param = (CtParameter<?>)lambda.getParameters().get(0);
+		CtParameter<?> param = lambda.getParameters().get(0);
 		CtParameterReference paramRef1 = param.getReference();
 		CtParameterReference paramRef2 = lambda.filterChildren(new TypeFilter<>(CtParameterReference.class)).first();
 		assertTrue(paramRef1.equals(paramRef2));

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -81,7 +81,7 @@ public class ParameterTest {
 						.getElements(new TypeFilter<>(CtParameter.class));
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
-			CtTypeReference refType = (CtTypeReference) param.getReference().getType();
+			CtTypeReference refType = param.getReference().getType();
 			assertEquals(launcher.getFactory().Type().STRING, refType);
 		}
 
@@ -92,7 +92,7 @@ public class ParameterTest {
 				.getElements(new TypeFilter<>(CtParameter.class));
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
-			CtTypeReference refType = (CtTypeReference) param.getReference().getType();
+			CtTypeReference refType = param.getReference().getType();
 			assertEquals(launcher.getFactory().Type().INTEGER, refType);
 		}
 
@@ -103,7 +103,7 @@ public class ParameterTest {
 				.getElements(new TypeFilter<>(CtParameter.class));
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
-			CtTypeReference refType = (CtTypeReference) param.getReference().getType();
+			CtTypeReference refType = param.getReference().getType();
 			// unknown parameters have no type
 			assertNull(refType);
 		}

--- a/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/MethodsRefactoringTest.java
@@ -296,7 +296,7 @@ public class MethodsRefactoringTest {
 	}
 	private boolean removeSame(Collection list, Object item) {
 		for (Iterator iter = list.iterator(); iter.hasNext();) {
-			Object object = (Object) iter.next();
+			Object object = iter.next();
 			if(object==item) {
 				iter.remove();
 				return true;

--- a/src/test/java/spoon/test/replace/ReplaceParametrizedTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceParametrizedTest.java
@@ -93,7 +93,7 @@ public class ReplaceParametrizedTest<T extends CtVisitable> {
 			assertNotNull(argument);
 
 			// we create a fresh object
-			CtElement receiver = ((CtElement) o).clone();
+			CtElement receiver = o.clone();
 
 			RoleHandler rh = RoleHandlerHelper.getRoleHandler(o.getClass(), mmField.getRole());
 

--- a/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
+++ b/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
@@ -39,8 +39,7 @@ public class StaticAccessTest {
 
     @Test
     public void testReferences() {
-
-        CtType<?> type = (CtType<?>) factory.Type().get("spoon.test.staticFieldAccess.StaticAccessBug");
+        CtType<?> type = factory.Type().get("spoon.test.staticFieldAccess.StaticAccessBug");
         CtBlock<?> block = type.getMethod("references").getBody();
         assertTrue(block.getStatement(0).toString().contains("Extends.MY_STATIC_VALUE"));
         assertTrue(block.getStatement(1).toString().contains("Extends.MY_OTHER_STATIC_VALUE"));


### PR DESCRIPTION
Casts from 'x' to 'x' (the same).