### PR TITLE
fix: Unreachable code

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -691,7 +691,7 @@ public class PositionBuilder {
 					if (content[off] == '\r') {
 						//we have found end of this comment
 						//skip windows \n too if any
-						if (content[off] == '\n') {
+						if (off < maxOff && content[off + 1] == '\n') {
 							off++;
 						}
 						return off;


### PR DESCRIPTION
Fix unreachable code (#2483 Warning 2)

I'm not quite sure what to do with that one, but there is definitely an error here (unreachable code):
```
if (content[off] == '\r') {
    if (content[off] == '\n') {

```