### PR TITLE
fix: Incorrect comparison

### DIFF
--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -242,7 +242,7 @@ public class JavaReflectionTreeBuilderTest {
 						Set<ModifierKind> otherModifiers = ((CtModifiable) currentDiff.other).getModifiers();
 						if (type.isInterface()) {
 							if (removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT)
-									.equals(removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT))) {
+									.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT))) {
 								//it is OK, that type memebers of interface differs in public abstract modifiers
 								return;
 							}
@@ -251,7 +251,7 @@ public class JavaReflectionTreeBuilderTest {
 							if (type2 != null) {
 								if (type2.isInterface()) {
 									if (removeModifiers(elementModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/)
-											.equals(removeModifiers(elementModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/))) {
+											.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/))) {
 										//it is OK, that type memebers of interface differs in public abstract modifiers
 										return;
 									}

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -241,8 +241,8 @@ public class JavaReflectionTreeBuilderTest {
 						Set<ModifierKind> elementModifiers = ((CtModifiable) currentDiff.element).getModifiers();
 						Set<ModifierKind> otherModifiers = ((CtModifiable) currentDiff.other).getModifiers();
 						if (type.isInterface()) {
-							if (removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT)
-									.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT))) {
+							if (removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT, ModifierKind.FINAL)
+									.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC, ModifierKind.ABSTRACT, ModifierKind.FINAL))) {
 								//it is OK, that type memebers of interface differs in public abstract modifiers
 								return;
 							}
@@ -250,8 +250,8 @@ public class JavaReflectionTreeBuilderTest {
 							CtType<?> type2 = type.getDeclaringType();
 							if (type2 != null) {
 								if (type2.isInterface()) {
-									if (removeModifiers(elementModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/)
-											.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC/*, ModifierKind.STATIC, ModifierKind.FINAL*/))) {
+									if (removeModifiers(elementModifiers, ModifierKind.PUBLIC, ModifierKind.FINAL/*, ModifierKind.STATIC*/)
+											.equals(removeModifiers(otherModifiers, ModifierKind.PUBLIC, ModifierKind.FINAL/*, ModifierKind.STATIC*/))) {
 										//it is OK, that type memebers of interface differs in public abstract modifiers
 										return;
 									}


### PR DESCRIPTION
Fix incorrect comparison (#2483 Warning 3)

When I fixed equals arguments, tests failed:

```
java.lang.AssertionError: Found 3 problems:
Diff on path: #[modifier]
Shadow: final enum RequiresModifier {

    STATIC,
    TRANSITIVE;}
Normal: enum RequiresModifier {

    STATIC,
    TRANSITIVE;}

Diff on path: #[modifier]
Shadow: final enum CommentType {

    FILE,
    JAVADOC,
    INLINE,
    BLOCK;}
Normal: enum CommentType {

    /**
     * before the package line (typically the license)
     */
    FILE,
    /**
     * JavaDoc comment: before methods, fields, types
     */
    JAVADOC,
    /**
     * Inline comment (//)
     */
    INLINE,
    /**
     * Block comment (/* *\/)
     */
    BLOCK;}

Diff on path: #[modifier]
Shadow: final enum TagType {

    AUTHOR,
    DEPRECATED,
    EXCEPTION,
    PARAM,
    RETURN,
    SEE,
    SERIAL,
    SERIAL_DATA,
    SERIAL_FIELD,
    SINCE,
    THROWS,
    VERSION,
    UNKNOWN;
    public boolean hasParam() {
    }

    public static spoon.reflect.code.CtJavaDocTag.TagType tagFromName(java.lang.String tagName) {
    }

    public java.lang.String toString() {
    }
}
Normal: /**
 * Define the possible type for a tag
 */
enum TagType {

    AUTHOR,
    DEPRECATED,
    EXCEPTION,
    PARAM,
    RETURN,
    SEE,
    SERIAL,
    SERIAL_DATA,
    SERIAL_FIELD,
    SINCE,
    THROWS,
    VERSION,
    UNKNOWN;

    ....
```

So I fixed modifiers as well.