### PR TITLE
refactor: remove redundant casts

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -153,7 +153,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 
 	@Override
 	protected void printTypes(List<CtType<?>> types) {
-		ElementSourceFragment rootFragment = (ElementSourceFragment) sourceCompilationUnit.getOriginalSourceFragment();
+		ElementSourceFragment rootFragment = sourceCompilationUnit.getOriginalSourceFragment();
 		runInContext(new SourceFragmentContextList(mutableTokenWriter, null, rootFragment.getChildrenFragments(), getChangeResolver()),
 				() -> {
 					for (CtType<?> t : types) {

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -1314,7 +1314,7 @@ public class GenericsTest {
 		CtMethod classMethod = (CtMethod)ctClass.getMethodsByName("visitCtConditional").get(0);
 
 		CtType<?> iface = launcher.getFactory().Type().get("spoon.test.generics.testclasses2.ISameSignature");
-		CtMethod ifaceMethod = (CtMethod)iface.getMethodsByName("visitCtConditional").get(0);
+		CtMethod ifaceMethod = iface.getMethodsByName("visitCtConditional").get(0);
 
 		ClassTypingContext ctcSub = new ClassTypingContext(ctClass.getReference());
 		assertTrue(ctcSub.isOverriding(classMethod, ifaceMethod));

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -42,7 +42,7 @@ public class SwitchCaseTest {
 
 		assertEquals(3, sw.getCases().size());
 
-		CtCase<?> c = (CtCase<?>) sw.getCases().get(0);
+		CtCase<?> c = sw.getCases().get(0);
 
 		assertEquals(0, ((CtLiteral<?>) c.getCaseExpression()).getValue());
 		assertEquals(2, c.getStatements().size());

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -296,7 +296,7 @@ public class VariableReferencesTest {
 				Integer firstValue = getLiteralValue((CtExpression<?>)inv.getArguments().get(l_argIdx));
 				//check that all found method invocations are using same key
 				list.forEach(inv2->{
-					assertEquals(firstValue, getLiteralValue((CtExpression<?>)inv2.getArguments().get(l_argIdx)));
+					assertEquals(firstValue, getLiteralValue(inv2.getArguments().get(l_argIdx)));
 				});
 				return firstValue;
 			}

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -65,8 +65,7 @@ public class TryCatchTest {
 						"" + "class X {" + "public void foo() {"
 								+ " try{}catch(java.lang.RuntimeException e){}"
 								+ "}};").compile();
-		CtTry tryStmt = (CtTry) clazz.getElements(new TypeFilter<>(CtTry.class)).get(
-				0);
+		CtTry tryStmt = clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
 		assertEquals(1, tryStmt.getCatchers().size());
 	}
 
@@ -81,8 +80,7 @@ public class TryCatchTest {
 								+ " try{}catch(RuntimeException e){java.lang.System.exit(0);}"
 								+ "      catch(Exception e){}" + "}"
 								+ "};").compile();
-		CtTry tryStmt = (CtTry) clazz.getElements(new TypeFilter<>(CtTry.class)).get(
-				0);
+		CtTry tryStmt = clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
 
 		// the first caught exception is RuntimeException
 		assertEquals(
@@ -104,7 +102,7 @@ public class TryCatchTest {
 						"" + "class X {" + "public void foo() {"
 								+ " try{}catch(RuntimeException | Error e){System.exit(0);}" + "}"
 								+ "};").compile();
-		CtTry tryStmt = (CtTry) clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
+		CtTry tryStmt = clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
 		List<CtCatch> catchers = tryStmt.getCatchers();
 		assertEquals(1, catchers.size());
 
@@ -217,7 +215,7 @@ public class TryCatchTest {
 						"" + "class X {" + "public void foo() {"
 								+ " try{}catch(RuntimeException e){System.exit(0);}" + "}"
 								+ "};").compile();
-		CtTry tryStmt = (CtTry) clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
+		CtTry tryStmt = clazz.getElements(new TypeFilter<>(CtTry.class)).get(0);
 		List<CtCatch> catchers = tryStmt.getCatchers();
 		assertEquals(1, catchers.size());
 


### PR DESCRIPTION
Casts from 'x' to 'x' (the same).