### PR TITLE
review: fix: fix compileAndReplaceSnippetsIn that was broken

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -198,7 +198,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	<C extends CtType<T>> C setNestedTypes(Set<CtType<?>> nestedTypes);
 
 	/**
-	 * Compiles and replace all the code snippets that are found in this type.
+	 * Replace all the code snippets that are found in this type by the corresponding Spoon AST.
 	 *
 	 * @see CtCodeSnippet
 	 * @see spoon.reflect.code.CtCodeSnippetExpression

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -30,7 +30,6 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.path.CtPath;
@@ -39,7 +38,6 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -50,6 +50,13 @@ public class SnippetCompilationHelper {
 	private static final String WRAPPER_CLASS_NAME = "Wrapper";
 	private static final String WRAPPER_METHOD_NAME = "wrap";
 
+	/**
+	 * Takes the class given as parameter, pretty-prints it, get the JDT'ast and the corrspondong Spoon AST
+	 * and finally replace all children of initialClass by the the fresh ones.
+	 *
+	 * This results that all snippets are now full-fledged ASTs.
+	 *
+	 */
 	public static void compileAndReplaceSnippetsIn(CtType<?> initialClass) {
 
 		Factory f = initialClass.getFactory();

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -65,7 +65,7 @@ public class SnippetCompilationHelper {
 		Map<CtPath, CtElement> elements2before = new HashMap<>();
 		Map<CtPath, CtElement> elements2after = new HashMap<>();
 		for (Object o : initialClass.filterChildren(new TypeFilter<>(CtCodeSnippet.class)).list()) {
-			CtElement el = (CtElement)o;
+			CtElement el = (CtElement) o;
 			elements2before.put(el.getPath(), el);
 		}
 		Factory f = initialClass.getFactory();

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -142,7 +142,6 @@ public class SnippetTest {
 
 		assertSame(snippetClass, factory.Type().get(snippetClass.getQualifiedName()));
 
-		staticMethod = factory.Type().get(snippetClass.getQualifiedName()).getMethod("staticMethod");
 		assertTrue(staticMethod.getBody().getLastStatement() instanceof CtInvocation<?>); // the last statement, i.e. the snippet, has been replaced by its real node: a CtInvocation
 		final CtInvocation<?> lastStatement = (CtInvocation<?>) staticMethod.getBody().getLastStatement();
 		final CtLocalVariableReference<?> reference = staticMethod.getElements(new TypeFilter<>(CtLocalVariable.class)).get(0).getReference();

--- a/src/test/resources/snippet/SnippetResources.java
+++ b/src/test/resources/snippet/SnippetResources.java
@@ -1,0 +1,13 @@
+package snippet.test.resources;
+
+public class SnippetResources {
+
+    public static void staticMethod() {
+        SnippetResources s = new SnippetResources();
+    }
+
+    public void method(int a) {
+        System.out.println(a);
+    }
+
+}


### PR DESCRIPTION
fix #2238

compileAndReplaceSnippetsIn was not tested at all, and probably broken due to a change in `CtPackage#addType` at some point.

