### PR TITLE
review: feat: PatternParameterConfigurator substitute by element

### DIFF
--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -749,6 +749,19 @@ public class PatternParameterConfigurator {
 	}
 
 	/**
+	 * Elements will be substituted by parameter value
+	 * @param elements to be substituted elements
+	 * @return {@link PatternParameterConfigurator} to support fluent API
+	 */
+	public PatternParameterConfigurator byElement(CtElement... elements) {
+		ParameterInfo pi = getCurrentParameter();
+		for (CtElement element : elements) {
+			addSubstitutionRequest(pi, element);
+		}
+		return this;
+	}
+
+	/**
 	 * Attribute defined by `role` of all elements matched by {@link Filter} will be substituted by parameter value
 	 * @param role {@link CtRole}, which defines to be substituted elements
 	 * @param filter {@link Filter}, which defines to be substituted elements
@@ -760,6 +773,20 @@ public class PatternParameterConfigurator {
 			.forEach((CtElement ele) -> {
 				addSubstitutionRequest(pi, ele, role);
 			});
+		return this;
+	}
+
+	/**
+	 * Attribute defined by `role` of `element`  will be substituted by parameter value
+	 * @param role {@link CtRole}, which defines to be substituted elements
+	 * @param element to be substituted element
+	 * @return {@link PatternParameterConfigurator} to support fluent API
+	 */
+	public PatternParameterConfigurator byRole(CtRole role, CtElement... elements) {
+		ParameterInfo pi = getCurrentParameter();
+		for (CtElement element : elements) {
+			addSubstitutionRequest(pi, element, role);
+		}
 		return this;
 	}
 

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -1571,6 +1571,34 @@ public class PatternTest {
 		}
 	}
 
+	@Test
+	public void testSubstituteExactElements() {
+		//contract: one can substitute exactly defined element
+		final Launcher launcher = new Launcher();
+		launcher.setArgs(new String[] {"--output-type", "nooutput" });
+		launcher.addInputResource("./src/test/java/spoon/test/template/testclasses/logger/Logger.java");
+
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+
+		final CtClass<?> aTargetType = launcher.getFactory().Class().get(Logger.class);
+		CtMethod tobeSubstititedMethod = aTargetType.getMethodsByName("enter").get(0);
+		Pattern pattern = PatternBuilder.create(aTargetType)
+			.configurePatternParameters(pb -> {
+				//substitute NAME of method
+				pb.parameter("methodName").byRole(CtRole.NAME, tobeSubstititedMethod);
+				//substitute Body of method
+				pb.parameter("methodBody").byElement(tobeSubstititedMethod.getBody());
+			}).build();
+		
+		List<Match> matches = pattern.getMatches(aTargetType);
+		assertEquals(1, matches.size());
+		Match match = matches.get(0);
+		assertSame(aTargetType, match.getMatchingElement());
+		assertEquals("enter", match.getParameters().getValue("methodName"));
+		assertSame(tobeSubstititedMethod.getBody(), match.getParameters().getValue("methodBody"));
+	}
+
 	private Map<String, Object> getMap(Match match, String name) {
 		Object v = match.getParametersMap().get(name);
 		assertNotNull(v);


### PR DESCRIPTION
Extends API of PatternParameterConfigurator, by way individual CtElements may be substituted by pattern parameter. It is similar like `PatternParameterConfigurator#byFilter`, just elements are explicitly listed.

It is needed by `PatternDetector` feature ... coming soon.