### PR TITLE
WIP: feature: Pattern detector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
       <artifactId>maven-invoker</artifactId>
       <version>3.0.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.gumtreediff</groupId>
+      <artifactId>core</artifactId>
+      <version>2.1.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -25,6 +25,7 @@ import spoon.processing.ProblemFixer;
 import spoon.processing.ProcessingManager;
 import spoon.processing.Processor;
 import spoon.processing.ProcessorProperties;
+import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.PrettyPrinter;
@@ -35,6 +36,7 @@ import spoon.support.sniper.SniperJavaPrettyPrinter;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -441,4 +443,18 @@ public interface Environment {
 	 *                                 contains multiple times the same class
 	 */
 	void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations);
+
+	/**
+	 * @return list of {@link Processor}, which are used to validate and fix model before it's printing
+	 *
+	 * Note: by default the validators depends on {@link #isAutoImports()}
+	 */
+	List<Processor<CtCompilationUnit>> getCompilationUnitValidators();
+
+	/**
+	 * @param compilationUnitValidators list of {@link Processor}, which have to be used to validate and fix model before it's printing
+	 *
+	 * Note: once this method is called, the calling of {@link #setAutoImports(boolean)} makes no sense
+	 */
+	void setCompilationUnitValidators(List<Processor<CtCompilationUnit>> compilationUnitValidators);
 }

--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -27,8 +27,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -52,6 +50,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
 import spoon.support.compiler.FileSystemFolder;
+import spoon.support.util.internal.MapUtils;
 import spoon.support.visitor.ClassTypingContext;
 
 /**
@@ -423,7 +422,7 @@ public class Metamodel {
 	 */
 	private MetamodelConcept getOrCreateConcept(CtType<?> type) {
 		String conceptName = getConceptName(type);
-		return getOrCreate(nameToConcept, conceptName,
+		return MapUtils.getOrCreate(nameToConcept, conceptName,
 				() -> new MetamodelConcept(conceptName),
 				mmConcept -> initializeConcept(type, mmConcept));
 	}
@@ -519,23 +518,6 @@ public class Metamodel {
 		}
 	}
 
-	static <K, V> V getOrCreate(Map<K, V> map, K key, Supplier<V> valueCreator) {
-		return getOrCreate(map, key, valueCreator, null);
-	}
-	/**
-	 * @param initializer is called immediately after the value is added to the map
-	 */
-	static <K, V> V getOrCreate(Map<K, V> map, K key, Supplier<V> valueCreator, Consumer<V> initializer) {
-		V value = map.get(key);
-		if (value == null) {
-			value = valueCreator.get();
-			map.put(key, value);
-			if (initializer != null) {
-				initializer.accept(value);
-			}
-		}
-		return value;
-	}
 	static <T> boolean addUniqueObject(Collection<T> col, T o) {
 		if (containsObject(col, o)) {
 			return false;
@@ -551,7 +533,6 @@ public class Metamodel {
 		}
 		return false;
 	}
-
 
 	/**
 	 * @param method a start method

--- a/src/main/java/spoon/metamodel/MetamodelConcept.java
+++ b/src/main/java/spoon/metamodel/MetamodelConcept.java
@@ -16,8 +16,6 @@
  */
 package spoon.metamodel;
 
-import static spoon.metamodel.Metamodel.addUniqueObject;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,6 +29,7 @@ import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
+import spoon.support.util.internal.MapUtils;
 import spoon.support.visitor.ClassTypingContext;
 
 /**
@@ -92,7 +91,7 @@ public class MetamodelConcept {
 
 
 	MetamodelProperty getOrCreateMMField(CtRole role) {
-		return Metamodel.getOrCreate(role2Property, role, () -> new MetamodelProperty(role.getCamelCaseName(), role, this));
+		return MapUtils.getOrCreate(role2Property, role, () -> new MetamodelProperty(role.getCamelCaseName(), role, this));
 	}
 
 	/**
@@ -153,7 +152,7 @@ public class MetamodelConcept {
 		if (superType == this) {
 			throw new SpoonException("Cannot add supertype to itself");
 		}
-		if (addUniqueObject(superConcepts, superType)) {
+		if (Metamodel.addUniqueObject(superConcepts, superType)) {
 			superType.subConcepts.add(this);
 			superType.role2Property.forEach((role, superMMField) -> {
 				MetamodelProperty mmField = getOrCreateMMField(role);

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -17,7 +17,6 @@
 package spoon.metamodel;
 
 import static spoon.metamodel.Metamodel.addUniqueObject;
-import static spoon.metamodel.Metamodel.getOrCreate;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -44,6 +43,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 import spoon.support.util.RtHelper;
+import spoon.support.util.internal.MapUtils;
 
 /**
  * Represents a property of the Spoon metamodel.
@@ -131,7 +131,7 @@ public class MetamodelProperty {
 		if (createIfNotExist) {
 			MMMethod mmMethod = new MMMethod(this, method);
 			roleMethods.add(mmMethod);
-			getOrCreate(methodsByKind, mmMethod.getKind(), () -> new ArrayList<>()).add(mmMethod);
+			MapUtils.getOrCreate(methodsByKind, mmMethod.getKind(), () -> new ArrayList<>()).add(mmMethod);
 			MMMethod conflict = roleMethodsBySignature.put(mmMethod.getSignature(), mmMethod);
 			if (conflict != null) {
 				throw new SpoonException("Conflict on " + getOwner().getName() + "." + name + " method signature: " + mmMethod.getSignature());

--- a/src/main/java/spoon/pattern/Match.java
+++ b/src/main/java/spoon/pattern/Match.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.PrinterHelper;
+import spoon.support.StandardEnvironment;
 import spoon.support.util.ImmutableMap;
 
 /**
@@ -107,13 +109,30 @@ public class Match {
 
 	@Override
 	public String toString() {
-		StringBuilder sb = new StringBuilder();
-		sb.append("{\n");
-		sb.append(parameters.toString());
-		sb.append("\n}\n----------");
+		PrinterHelper printer = new PrinterHelper(new StandardEnvironment());
+		printer.write("{").writeln();
+		printParameters(printer);
+		printer.write("}").writeln();
+		printer.write("----------").writeln();
+		printMatchingElements(printer);
+		return printer.toString();
+	}
+
+	/**
+	 * Prints matched parameter values
+	 * @param printer to be used {@link PrinterHelper}
+	 */
+	public void printParameters(PrinterHelper printer) {
+		printer.write(parameters.toString()).writeln();
+	}
+
+	/**
+	 * Prints matched elements
+	 * @param printer to be used {@link PrinterHelper}
+	 */
+	public void printMatchingElements(PrinterHelper printer) {
 		for (int i = 0; i < matchingElements.size(); i++) {
-			sb.append("\n").append(i + 1).append(") ").append(matchingElements.get(i));
+			printer.write("" + (i + 1) + ") " + matchingElements.get(i));
 		}
-		return sb.toString();
 	}
 }

--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -70,11 +70,11 @@ public class PatternBuilder {
 	 * @return new instance of {@link PatternBuilder}
 	 */
 	public static PatternBuilder create(List<? extends CtElement> patternModel) {
-		return new PatternBuilder(patternModel);
+		return new PatternBuilder(patternModel).configureTargetType();
 	}
 
 	public static PatternBuilder create(CtElement... elems) {
-		return new PatternBuilder(Arrays.asList(elems));
+		return new PatternBuilder(Arrays.asList(elems)).configureTargetType();
 	}
 
 	private final List<CtElement> patternModel;
@@ -120,11 +120,15 @@ public class PatternBuilder {
 		this.valueConvertor = new ValueConvertorImpl();
 		patternNodes = ElementNode.create(this.patternModel, patternElementToSubstRequests);
 		patternQuery = new PatternBuilder.PatternQuery(getFactory().Query(), patternModel);
+	}
+
+	protected PatternBuilder configureTargetType() {
 		if (this.templateTypeRef != null) {
 			configurePatternParameters(pb -> {
 				pb.parameter(TARGET_TYPE).byType(this.templateTypeRef).setValueType(CtTypeReference.class);
 			});
 		}
+		return this;
 	}
 
 	private CtTypeReference<?> getDeclaringTypeRef(List<? extends CtElement> template) {
@@ -503,7 +507,11 @@ public class PatternBuilder {
 		return this;
 	}
 
-	CtTypeReference<?> getTemplateTypeRef() {
+	/**
+	 * @return {@link CtTypeReference}, which refers the declaring type of template element.
+	 * In other words: reference to type which holds template
+	 */
+	public CtTypeReference<?> getTemplateTypeRef() {
 		return templateTypeRef;
 	}
 }

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -26,6 +26,7 @@ import spoon.pattern.internal.ResultHolder;
 import spoon.pattern.internal.matcher.Matchers;
 import spoon.pattern.internal.matcher.TobeMatched;
 import spoon.pattern.internal.parameter.ParameterInfo;
+import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.meta.ContainerKind;
 import spoon.reflect.path.CtRole;
@@ -43,12 +44,15 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 
+import org.apache.log4j.Logger;
+
 import static spoon.pattern.internal.matcher.TobeMatched.getMatchedParameters;
 
 /**
  * Generates/Matches a copy of a single CtElement AST node with all it's children (whole AST tree of the root CtElement)
  */
 public class ElementNode extends AbstractPrimitiveMatcher {
+	private static final Logger LOGGER = Logger.getLogger(ElementNode.class);
 
 	/**
 	 * Creates an implicit {@link ElementNode}, which contains all non derived attributes of `element` and all it's children
@@ -322,6 +326,16 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 		for (Map.Entry<MetamodelProperty, RootNode> e : roleToNode.entrySet()) {
 			parameters = matchesRole(parameters, (CtElement) target, e.getKey(), e.getValue());
 			if (parameters == null) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Field\n:" + e.getKey()
+							+ "\n-------------------------------"
+							+ "\ndoesn't match expected element:\n"	+ e.getKey().getValue(templateElement)
+							+ "\nwith real element:\n" + e.getKey().getValue(target)
+							+ "\n-------------------------------"
+							+ "\non template:\n" + templateElement
+							+ "\non target:\n" + target
+							+ "\n***********************************");
+				}
 				return null;
 			}
 		}
@@ -350,6 +364,7 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 		roleToSkippedClass.put(CtRole.IS_IMPLICIT, new Class[]{Object.class});
 		roleToSkippedClass.put(CtRole.TYPE, new Class[]{CtExecutableReference.class});
 		roleToSkippedClass.put(CtRole.DECLARING_TYPE, new Class[]{CtExecutableReference.class});
+		roleToSkippedClass.put(CtRole.IS_IMPLICIT, new Class[]{CtThisAccess.class});
 	}
 
 	/**

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -354,7 +354,11 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 			//each item of attribute value (item of List/Set/Map) has to be matched individually
 			tobeMatched = TobeMatched.create(parameters, mmField.getContainerKind(), mmField.getValue(target));
 		}
-		return getMatchedParameters(attrNode.matchTargets(tobeMatched, RootNode.MATCH_ALL));
+		ImmutableMap match = getMatchedParameters(attrNode.matchTargets(tobeMatched, RootNode.MATCH_ALL));
+		if (match == null) {
+			this.getClass();
+		}
+		return match;
 	}
 
 	private static final Map<CtRole, Class[]> roleToSkippedClass = new HashMap<>();

--- a/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
@@ -142,15 +142,23 @@ public abstract class AbstractParameterInfo implements ParameterInfo {
 			}
 			if (newValue != null && existingValue.getClass().equals(newValue.getClass())) {
 				if (newValue instanceof CtTypeReference) {
-					if (((CtTypeReference<?>) newValue).getTypeErasure().equals(((CtTypeReference<?>) existingValue).getTypeErasure())) {
-						//accept type references with different erasure
+					//accept type references with different erasure
+					CtTypeReference<?> erasedNewValue = ((CtTypeReference<?>) newValue).getTypeErasure();
+					CtTypeReference<?> erasedExistingValue = ((CtTypeReference<?>) existingValue).getTypeErasure();
+					if (erasedExistingValue.isSubtypeOf(erasedNewValue)) {
+						//keep existing value which is equal or subtype of new value
 						return existingValue;
+					}
+					if (erasedNewValue.isSubtypeOf(erasedExistingValue)) {
+						//keep new value which is equal or subtype of existing value
+						return erasedNewValue;
 					}
 				}
 			}
 			// another value would be inserted. TemplateMatcher does not support
 			// matching of different values for the same template parameter
-			Launcher.LOGGER.debug("incongruent match on parameter " + getName() + " with value " + newValue);
+			Launcher.LOGGER.debug("incongruent match on parameter " + getName() + "\nexisting value:\n" + existingValue
+					+ "\nnew value:\n" + newValue);
 			return NO_MERGE;
 		}
 		return newValue;

--- a/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
@@ -142,6 +142,7 @@ public abstract class AbstractParameterInfo implements ParameterInfo {
 			}
 			if (newValue != null && existingValue.getClass().equals(newValue.getClass())) {
 				if (newValue instanceof CtTypeReference) {
+					/*
 					//accept type references with different erasure
 					CtTypeReference<?> erasedNewValue = ((CtTypeReference<?>) newValue).getTypeErasure();
 					CtTypeReference<?> erasedExistingValue = ((CtTypeReference<?>) existingValue).getTypeErasure();
@@ -152,6 +153,11 @@ public abstract class AbstractParameterInfo implements ParameterInfo {
 					if (erasedNewValue.isSubtypeOf(erasedExistingValue)) {
 						//keep new value which is equal or subtype of existing value
 						return erasedNewValue;
+					}
+					*/
+					if (((CtTypeReference<?>) newValue).getTypeErasure().equals(((CtTypeReference<?>) existingValue).getTypeErasure())) {
+						//accept type references with different erasure
+						return existingValue;
 					}
 				}
 			}

--- a/src/main/java/spoon/pattern_detector/CodeInfo.java
+++ b/src/main/java/spoon/pattern_detector/CodeInfo.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+import com.github.gumtreediff.actions.ActionGenerator;
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.actions.model.Delete;
+import com.github.gumtreediff.actions.model.Insert;
+import com.github.gumtreediff.actions.model.Move;
+import com.github.gumtreediff.actions.model.Update;
+import com.github.gumtreediff.matchers.CompositeMatchers;
+import com.github.gumtreediff.matchers.MappingStore;
+import com.github.gumtreediff.matchers.Matcher;
+import com.github.gumtreediff.tree.ITree;
+
+import spoon.pattern_detector.internal.UpdateNode;
+import spoon.pattern_detector.internal.gumtree.SpoonTree;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtPath;
+
+/**
+ * Gum tree information related to a code
+ */
+class CodeInfo {
+	/**
+	 * The code of this {@link CodeInfo}
+	 */
+	final List<? extends CtElement> elements;
+	/**
+	 * The gum tree of `elements`
+	 */
+	final ITree codeGumTree;
+
+	CodeInfo(List<? extends CtElement> elements, ITree codeGumTree) {
+		super();
+		this.elements = elements;
+		this.codeGumTree = codeGumTree;
+	}
+
+	private CtElement getCommonAncestor() {
+		Collection<? extends CtElement> items = elements;
+		while (items.size() > 1) {
+			Set<CtElement> ancestors = Collections.newSetFromMap(new IdentityHashMap<>());
+			for (CtElement item : items) {
+				ancestors.add(item.getParent());
+			}
+			items = ancestors;
+		}
+		return items.iterator().next();
+	}
+
+	@Override
+	public String toString() {
+		CtElement ancestor = getCommonAncestor();
+		CtPath path = ancestor.getPath();
+		CtPath relPathOfFirst = elements.get(0).getPath().relativePath(ancestor);
+		return path.toString() + "|" + relPathOfFirst.toString();
+	}
+
+	/**
+	 * Computes differences between this {@link CodeInfo} and `codeInfo`
+	 * @param codeInfo to be compared code
+	 * @return {@link List} of edit {@link Action}s
+	 */
+	List<Action> getGumTreeDifferences(CodeInfo codeInfo) {
+		ITree t1 = codeGumTree;
+		ITree t2 = codeInfo.getGumTree();
+		MappingStore mappings = new MappingStore();
+		final Matcher matcher = new CompositeMatchers.ClassicGumtree(t1, t2, mappings);
+		matcher.match();
+
+		final ActionGenerator actionGenerator = new ActionGenerator(t1, t2, matcher.getMappings());
+		List<Action> actions = actionGenerator.generate();
+		if (t1.getParent() != null) {
+			t1.setParent(null);
+		}
+		if (t2.getParent() != null) {
+			t2.setParent(null);
+		}
+		actions = removeTransitiveActions(actions);
+		//add action mapping to nodes of second tree
+		List<Action> mappedActions = new ArrayList<>(actions.size());
+		for (Action action : actions) {
+			ITree srcNode = action.getNode();
+			if (action instanceof Delete) {
+			} else if (action instanceof Insert) {
+			} else if (action instanceof Update) {
+				srcNode = getUsefullParent(srcNode);
+				ITree dest = mappings.getDst(srcNode);
+				action = new UpdateNode(srcNode, dest);
+			} else if (action instanceof Move) {
+			}
+			mappedActions.add(action);
+		}
+		return mappedActions;
+	}
+
+	private ITree getUsefullParent(ITree node) {
+		Object value = ((SpoonTree) node.getParent()).getValue();
+		if (value instanceof CtLiteral) {
+			//pattern parameter has to be CtLiteral element instead of it's value
+			return node.getParent();
+		}
+		return node;
+	}
+
+	ITree getGumTree() {
+		return codeGumTree;
+	}
+	/**
+	 * The delete of parent node causes that each child node has delete action too.
+	 * This function keeps only action, which deletes parent node. Actions about delete of children are removed
+	 * @param actions list of all actions
+	 * @return list of root actions only
+	 */
+	private List<Action> removeTransitiveActions(List<Action> actions) {
+		Set<ITree> actionNodes = Collections.newSetFromMap(new IdentityHashMap<>());
+		for (Action action : actions) {
+			actionNodes.add(action.getNode());
+		}
+		List<Action> rootActions = new ArrayList<>();
+		for (Action action : actions) {
+			if (actionNodes.contains(action.getNode().getParent())) {
+				//there is another action which manipulates parent node of this action. Ignore this action
+				continue;
+			}
+			rootActions.add(action);
+		}
+		return rootActions;
+	}
+}

--- a/src/main/java/spoon/pattern_detector/DiffCodeInfo.java
+++ b/src/main/java/spoon/pattern_detector/DiffCodeInfo.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector;
+
+import java.util.List;
+
+import com.github.gumtreediff.actions.model.Action;
+
+/**
+ * Gum tree information related to a code
+ */
+class DiffCodeInfo {
+	final CodeInfo primaryCodeInfo;
+	final CodeInfo secondaryCodeInfo;
+	final List<Action> diffActions;
+
+	DiffCodeInfo(CodeInfo primaryCodeInfo, CodeInfo secondaryCodeInfo, List<Action> diffActions) {
+		super();
+		this.primaryCodeInfo = primaryCodeInfo;
+		this.secondaryCodeInfo = secondaryCodeInfo;
+		this.diffActions = diffActions;
+	}
+}

--- a/src/main/java/spoon/pattern_detector/FoundPattern.java
+++ b/src/main/java/spoon/pattern_detector/FoundPattern.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.tree.ITree;
+
+import spoon.SpoonException;
+import spoon.pattern.Match;
+import spoon.pattern.Pattern;
+import spoon.pattern.PatternBuilder;
+import spoon.pattern_detector.internal.ActionToParameter;
+import spoon.pattern_detector.internal.UpdateNode;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.PrinterHelper;
+import spoon.support.util.internal.MapUtils;
+
+/**
+ * Represents a pattern found by a {@link PatternDetector}
+ */
+public class FoundPattern {
+	private final CodeInfo primaryCodeInfo;
+	//elements of the code, which produced and matches this pattern
+	private final List<DiffCodeInfo> matchingCodeInfos = new ArrayList<>();
+	//primary tree nodes mapped to diff actions each matching code. The index of item in matchingCodeInfos fits to index of Action
+	private Map<ITree, List<Action>> nodeToActions = new IdentityHashMap<>();
+	//pattern based on codeElements, where each action from updateAction is a parameter
+	private Pattern pattern;
+
+	FoundPattern(CodeInfo codeInfo) {
+		primaryCodeInfo = codeInfo;
+	}
+
+	/**
+	 * @return count of matching code fragments
+	 */
+	public int getCountOfMatches() {
+		return matchingCodeInfos.size() + 1;
+	}
+
+	/**
+	 * @param otherGumTree
+	 * @param code
+	 * @return true if code of other gum tree was merged with this pattern
+	 */
+	boolean addMerge(CodeInfo codeInfo) {
+		List<Action> actions = primaryCodeInfo.getGumTreeDifferences(codeInfo);
+		List<UpdateNode> updateActions = (List) actions.stream().filter((Action a) -> (a instanceof UpdateNode)).collect(Collectors.toList());
+		if (updateActions.size() != actions.size()) {
+			//there are other then Update actions. Cannot actually merge with foundPattern
+			return false;
+		}
+		int idxOfMatchingCodeInfo = matchingCodeInfos.size();
+		matchingCodeInfos.add(new DiffCodeInfo(primaryCodeInfo, codeInfo, actions));
+
+		for (UpdateNode action : updateActions) {
+			List<Action> update = MapUtils.getOrCreate(nodeToActions, action.getNode(), () -> new ArrayList<>());
+			addOnIndex(update, idxOfMatchingCodeInfo, action);
+		}
+		//reset the pattern cache
+		this.pattern = null;
+		return true;
+	}
+
+	private static <T> void addOnIndex(List<T> list, int idx, T value) {
+		while (list.size() < idx) {
+			list.add(null);
+		}
+		list.add(value);
+	}
+
+	private Match match(List<? extends CtElement> code) {
+		List<Match> matches = new ArrayList<>();
+		pattern.forEachMatch(code, match -> {
+			matches.add(match);
+		});
+		if (matches.size() == 1) {
+			return matches.get(0);
+		}
+		return null;
+	}
+
+	/**
+	 * @return {@link Pattern}, which matches all similar code fragments, which belong to this {@link FoundPattern}
+	 */
+	public Pattern getPattern() {
+		if (pattern == null) {
+			PatternBuilder pb = new MyPatternBuilder(primaryCodeInfo.elements);
+			ActionToParameter actionToParameterMapper = new ActionToParameter(pb);
+			int nrProcessed = 0;
+			for (ITree node : primaryCodeInfo.codeGumTree.preOrder()) {
+				List<Action> allActions = nodeToActions.get(node);
+				Action action = ActionToParameter.getFirstNotNull(allActions);
+				if (action != null) {
+					//assert that nodeToActions model is consistent
+					if (nodeToActions.get(action.getNode()) == null) {
+						throw new SpoonException("Unexpected action found");
+					}
+					actionToParameterMapper.applyAction(action, allActions);
+					nrProcessed++;
+				}
+			}
+			if (nrProcessed != nodeToActions.size()) {
+				//this would mean a bug in concept. We have to traverse actions in different way
+				throw new SpoonException("Some tree actions were not found!");
+			}
+			pattern = actionToParameterMapper.build();
+		}
+		return pattern;
+	}
+
+	/**
+	 * Extended {@link PatternBuilder}, which doesn't automatically creates parameter targetType.
+	 */
+	private static class MyPatternBuilder extends PatternBuilder {
+		MyPatternBuilder(List<? extends CtElement> elements) {
+			super(elements);
+		}
+	}
+
+	@Override
+	public String toString() {
+		PrinterHelper sb = new PrinterHelper(primaryCodeInfo.elements.get(0).getFactory().getEnvironment());
+		sb.write("/*-------------------------------------").writeln();
+		int idx = 1;
+		for (CodeInfo code : getAllCodeInfos()) {
+			sb.write("" + (idx++) + ") " + code.toString()).writeln();
+			sb.incTab();
+			printMatchingParameters(sb, code);
+			sb.decTab();
+		}
+		sb.write("----------------------------------------*/").writeln();
+		sb.write(getPattern().print(false));
+		return sb.toString();
+	}
+
+	private List<CodeInfo> getAllCodeInfos() {
+		List<CodeInfo> allCIs = new ArrayList<>(getCountOfMatches());
+		allCIs.add(primaryCodeInfo);
+		for (DiffCodeInfo diffCodeInfo : matchingCodeInfos) {
+			allCIs.add(diffCodeInfo.secondaryCodeInfo);
+		}
+		return allCIs;
+	}
+
+	private void printMatchingParameters(PrinterHelper sb, CodeInfo code) {
+		List<Match> matches = new ArrayList<>();
+		getPattern().forEachMatch(code.elements, match -> {
+			matches.add(match);
+			printMatch(sb, match);
+		});
+		if (matches.isEmpty()) {
+			sb.write("NO MATCH!").writeln();
+			return;
+		}
+	}
+
+	private void printMatch(PrinterHelper sb, Match match) {
+		match.printParameters(sb);
+	}
+}

--- a/src/main/java/spoon/pattern_detector/PatternDetector.java
+++ b/src/main/java/spoon/pattern_detector/PatternDetector.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import spoon.pattern.internal.node.ListOfNodes;
+import spoon.pattern_detector.internal.gumtree.SpoonGumTreeBuilder;
+import spoon.reflect.code.CtComment;
+import spoon.reflect.declaration.CtElement;
+
+/**
+ * Detects patterns in code
+ */
+public class PatternDetector {
+
+	private final List<FoundPattern> foundPatterns = new ArrayList<>();
+	private final SpoonGumTreeBuilder gumTreeBuilder = new SpoonGumTreeBuilder();
+	/**
+	 * List of all different patterns, which are needed to represent the processed code
+	 */
+	private final List<ListOfNodes> patterns = new ArrayList<>();
+
+	/**
+	 * check if the code matches with some known pattern. If yes, then done.
+	 * If part is matching, then add variable into patterns to make it matching too
+	 * If not matching at all then add new pattern
+	 * @param code the element where we detect patterns
+	 */
+	public void matchCode(CtElement code) {
+		matchCode(Collections.singletonList(code));
+	}
+
+	/**
+	 * check if the code matches with some known pattern. If yes, then done.
+	 * If part is matching, then add variable into patterns to make it matching too
+	 * If not matching at all then add new pattern
+	 * @param code the elements where we detect patterns
+	 */
+	public void matchCode(List<? extends CtElement> code) {
+		CodeInfo codeInfo = createCodeInfo(code);
+		for (FoundPattern existingPattern : foundPatterns) {
+			//found differences between already foundPattern and new code
+			if (existingPattern.addMerge(codeInfo)) {
+				//existingPattern accepts this new code
+				//we are done
+				return;
+			}
+		}
+		//no existing pattern can be merged with code
+		//add new pattern
+		foundPatterns.add(new FoundPattern(codeInfo));
+	}
+
+	private CodeInfo createCodeInfo(List<? extends CtElement> code) {
+		return new CodeInfo(code, gumTreeBuilder.getTree(null, code));
+	}
+
+	public List<FoundPattern> getPatterns() {
+		return Collections.unmodifiableList(foundPatterns);
+	}
+
+	/**
+	 * @param ignoreComments true if comments have to be ignored
+	 * @return this to support fluent API
+	 */
+	public PatternDetector setIgnoreComments(boolean ignoreComments) {
+		if (ignoreComments) {
+			gumTreeBuilder.setFilter(e -> !(e instanceof CtComment));
+		} else {
+			gumTreeBuilder.setFilter(null);
+		}
+		return this;
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/ActionToParameter.java
+++ b/src/main/java/spoon/pattern_detector/internal/ActionToParameter.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiPredicate;
+
+import com.github.gumtreediff.actions.model.Action;
+import com.github.gumtreediff.actions.model.Update;
+
+import spoon.SpoonException;
+import spoon.pattern.Pattern;
+import spoon.pattern.PatternBuilder;
+import spoon.pattern_detector.internal.gumtree.SpoonTree;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
+import spoon.support.util.internal.MapUtils;
+
+/**
+ * Transforms gumtree action to Pattern parameter
+ */
+public class ActionToParameter {
+	private final PatternBuilder patternBuilder;
+	private int nextParamIdx = 0;
+	private Map<String, String> nameToParamName = new HashMap<>();
+	private Map<String, List<Action>> paramNameToAllActions = new HashMap<>();
+
+	public ActionToParameter(PatternBuilder patternBuilder) {
+		super();
+		this.patternBuilder = patternBuilder;
+	}
+
+	public void applyAction(Action action, List<Action> allActions) {
+		if (action instanceof Update) {
+			applyUpdate((Update) action, allActions);
+			return;
+		}
+		throw new SpoonException("GumTree action of type " + action.getClass() + " Not supported");
+	}
+
+	private void applyUpdate(Update action, List<Action> allActions) {
+		SpoonTree node = (SpoonTree) action.getNode();
+		SpoonTree parentNode = (SpoonTree) action.getNode().getParent();
+		CtElement parentElement = (CtElement) parentNode.getValue();
+		CtRole modifiedRole = node.getRole();
+		if (node.getValue() instanceof CtElement) {
+			CtElement element = (CtElement) node.getValue();
+			applyUpdateOfElement(parentElement, modifiedRole, element, allActions);
+		} else {
+			Object value = node.getValue();
+			applyUpdateOfPrimitiveValue(parentElement, modifiedRole, value);
+		}
+	}
+
+	/**
+	 * Make pattern parameter for `parentElement` with role `modifiedRole` and origin value `element`
+	 */
+	private void applyUpdateOfElement(CtElement parentElement, CtRole modifiedRole, CtElement element, List<Action> allActions) {
+		String paramName = detectParamName(element, allActions);
+		//detect whether we need a new parameter or we can reuse existing
+		patternBuilder.configurePatternParameters(pb -> {
+			pb.parameter(paramName).byElement(element);
+		});
+//		throw new SpoonException("Role " + modifiedRole + " not supported on reference.");
+	}
+
+	/**
+	 * Make pattern parameter for `parentElement` with role `modifiedRole` and origin primitive `value`
+	 */
+	private void applyUpdateOfPrimitiveValue(CtElement parentElement, CtRole modifiedRole, Object value) {
+		if (modifiedRole == CtRole.NAME) {
+			if (value instanceof String) {
+				String name = (String) value;
+				String paramName = MapUtils.getOrCreate(nameToParamName, name, this::getNextParamName);
+				patternBuilder.configurePatternParameters(pb -> {
+					pb.parameter(paramName).byRole(CtRole.NAME, parentElement);
+				});
+				return;
+			}
+		}
+		throw new SpoonException("Primitive CtRole." + modifiedRole + " not supported on " + parentElement.getClass() + " and value: " + String.valueOf(value));
+	}
+
+	private String detectParamName(CtElement element, List<Action> allActions) {
+		//we can reuse older parameter if it has same parameter value in definition node and this node for primary pattern and each matching code
+		for (Map.Entry<String, List<Action>> e : paramNameToAllActions.entrySet()) {
+			String paramName = e.getKey();
+			List<Action> actionsOfParameter = e.getValue();
+			if (actionValuesEquals(actionsOfParameter, allActions, (element1, element2) -> {
+				return element1.equals(element2);
+			})) {
+				//all current parameter values are equal to parameter values of parameter with `paramName`. We can use that existing parameter
+				return paramName;
+			}
+		}
+		String paramName = getNextParamName();
+		paramNameToAllActions.put(paramName, allActions);
+		return paramName;
+	}
+
+	private boolean actionValuesEquals(List<Action> actions1, List<Action> actions2, BiPredicate<CtElement, CtElement> consumer) {
+		int length = Math.max(actions1.size(), actions2.size());
+		if (!consumer.test(getPrimaryElement(actions1), getPrimaryElement(actions2))) {
+			return false;
+		}
+		for (int i = 0; i < length; i++) {
+			if (!consumer.test(getSecondaryElement(actions1, i), getSecondaryElement(actions2, i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private CtElement getPrimaryElement(List<Action> actions) {
+		//take the value from primary code
+		Action action = getFirstNotNull(actions);
+		return (CtElement) ((SpoonTree) action.getNode()).getValue();
+	}
+
+	private CtElement getSecondaryElement(List<Action> actions, int idx) {
+		if (idx < actions.size()) {
+			//take Action with differences for matched code of index `idx`;
+			Action action = actions.get(idx);
+			if (action != null) {
+				//there is update action for matched code of index `idx`;
+				return (CtElement) ((SpoonTree) ((UpdateNode) action).getNewNode()).getValue();
+			}
+		}
+		//there is no action for code of index `idx` because this code is same as primary code at this position
+		//take the value from primary code
+		return getPrimaryElement(actions);
+	}
+
+	private Action getActionByIdx(List<Action> actions, int idx) {
+		return null;
+	}
+
+	private String getNextParamName() {
+		return "param" + String.valueOf(nextParamIdx++);
+	}
+
+	public Pattern build() {
+		return patternBuilder.build();
+	}
+
+	public static <T> T getFirstNotNull(List<T> list) {
+		if (list == null) {
+			return null;
+		}
+		for (T t : list) {
+			if (t != null) {
+				return t;
+			}
+		}
+		throw new SpoonException("The list is empty");
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/DeleteNode.java
+++ b/src/main/java/spoon/pattern_detector/internal/DeleteNode.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector.internal;
+
+import com.github.gumtreediff.actions.model.Delete;
+import com.github.gumtreediff.tree.ITree;
+
+/**
+ * Extension of gum tree {@link Delete} action
+ */
+//TODO delete it
+public class DeleteNode extends Delete {
+	public DeleteNode(ITree node) {
+		super(node);
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/InsertNode.java
+++ b/src/main/java/spoon/pattern_detector/internal/InsertNode.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector.internal;
+
+import com.github.gumtreediff.actions.model.Insert;
+import com.github.gumtreediff.tree.ITree;
+
+/**
+ * Extension of gum tree {@link Insert} action
+ */
+//TODO delete it
+public class InsertNode extends Insert {
+	public InsertNode(ITree node, ITree parent, int pos) {
+		super(node, parent, pos);
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/MoveNode.java
+++ b/src/main/java/spoon/pattern_detector/internal/MoveNode.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector.internal;
+
+import com.github.gumtreediff.actions.model.Move;
+import com.github.gumtreediff.tree.ITree;
+
+/**
+ * Extension of gum tree {@link Move} action
+ */
+//TODO delete it
+public class MoveNode extends Move {
+	public MoveNode(ITree node, ITree parent, int pos) {
+		super(node, parent, pos);
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/UpdateNode.java
+++ b/src/main/java/spoon/pattern_detector/internal/UpdateNode.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern_detector.internal;
+
+import com.github.gumtreediff.actions.model.Update;
+import com.github.gumtreediff.tree.ITree;
+
+/**
+ * Extension of gum tree {@link Update} action, which contains node from second
+ * tree
+ */
+public class UpdateNode extends Update {
+
+	private ITree newNode;
+
+	public UpdateNode(ITree node, ITree newNode) {
+		super(node, newNode.getLabel());
+		this.newNode = newNode;
+	}
+
+	/**
+	 * @return {@link ITree} from second gum tree, which represents new node -
+	 *         after update
+	 */
+	public ITree getNewNode() {
+		return newNode;
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonGumTreeBuilder.java
+++ b/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonGumTreeBuilder.java
@@ -1,0 +1,71 @@
+/*
+ * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006 INRIA Futurs <renaud.pawlak@inria.fr>
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.pattern_detector.internal.gumtree;
+
+import java.util.List;
+
+import com.github.gumtreediff.tree.ITree;
+import com.github.gumtreediff.tree.TreeContext;
+import com.github.gumtreediff.tree.TreeUtils;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.visitor.Filter;
+
+/**
+ * Scanner to create a GumTree's Tree representation for a Spoon AST.
+ */
+public class SpoonGumTreeBuilder {
+	public static final String SPOON_OBJECT = "spoon_object";
+	public static final String DESTINATION_NODE = "dest_node";
+
+	private final SpoonTreeContext treeContext = new SpoonTreeContext();
+	private Filter<? super CtElement> filter;
+
+	/**
+	 * @param roleInParent the role all elements of code in their parent
+	 * @param code the list of spoon elements
+	 * @return Gum tree of all elements in `code`
+	 */
+	public ITree getTree(CtRole roleInParent, List<? extends CtElement> code) {
+		final ITree root = treeContext.createTree(-1, "", "root", null);
+		TreeScanner scanner = new TreeScanner(treeContext, root);
+		if (filter != null) {
+			scanner.setFilter(filter);
+		}
+		for (CtElement element : code) {
+			scanner.scan(roleInParent, element);
+		}
+		root.refresh();
+		TreeUtils.postOrderNumbering(root);
+		TreeUtils.computeHeight(root);
+		return root;
+	}
+
+	public TreeContext getTreeContext() {
+		return treeContext;
+	}
+
+	/**
+	 * @param filter only elements which matches filter will be transformed to gumtree.
+	 * If element doesn't match it is ignored including it's children
+	 */
+	public SpoonGumTreeBuilder setFilter(Filter<? super CtElement> filter) {
+		this.filter = filter;
+		return this;
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonTree.java
+++ b/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonTree.java
@@ -1,0 +1,101 @@
+/*
+ * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006 INRIA Futurs <renaud.pawlak@inria.fr>
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.pattern_detector.internal.gumtree;
+
+import com.github.gumtreediff.tree.ITree;
+import com.github.gumtreediff.tree.Tree;
+
+import spoon.reflect.path.CtRole;
+
+/**
+ * Extension of Tree, which maps to node or attribute value of Spoon AST
+ */
+public class SpoonTree extends Tree {
+	private final Object value;
+
+	public SpoonTree(int type, String label, Object value) {
+		super(type, label);
+		this.value = value;
+	}
+
+	protected SpoonTree(SpoonTree other) {
+		super(other);
+		this.value = other.value;
+	}
+
+	public Object getValue() {
+		return value;
+	}
+
+	public Tree deepCopy() {
+		Tree copy = new SpoonTree(this);
+		for (ITree child : getChildren()) {
+			copy.addChild(child.deepCopy());
+		}
+		return copy;
+	}
+
+	@Override
+	public String toShortString() {
+		CtRole role = getRole();
+		String roleName = role == null ? "root" : role.name();
+		String label = getLabel();
+		if (label == null) {
+			label = "";
+		}
+		StringBuilder sb = new StringBuilder();
+		sb.append(roleName).append(":\"").append(label).append("\"");
+		if (children.size() > 0) {
+			sb.append("[").append(children.size()).append("]");
+		}
+		if (value != null) {
+			String className = value.getClass().getSimpleName();
+			sb.append(" ").append(className).append("->").append(value.toString());
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public String toString() {
+		return toShortString();
+	}
+
+	public CtRole getRole() {
+		int type = getType();
+		if (type < 0) {
+			return null;
+		}
+		return CtRole.values()[type];
+	}
+
+	@Override
+	public Object getMetadata(String key) {
+		if (key == SpoonGumTreeBuilder.SPOON_OBJECT) {
+			return value;
+		}
+		return super.getMetadata(key);
+	}
+
+	@Override
+	public Object setMetadata(String key, Object value) {
+		if (key == SpoonGumTreeBuilder.SPOON_OBJECT) {
+			throw new UnsupportedOperationException();
+		}
+		return super.setMetadata(key, value);
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonTreeContext.java
+++ b/src/main/java/spoon/pattern_detector/internal/gumtree/SpoonTreeContext.java
@@ -1,0 +1,37 @@
+/*
+ * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006 INRIA Futurs <renaud.pawlak@inria.fr>
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+package spoon.pattern_detector.internal.gumtree;
+
+import com.github.gumtreediff.tree.ITree;
+import com.github.gumtreediff.tree.TreeContext;
+
+/**
+ * Extension of Tree, which maps to node or attribute value of Spoon AST
+ */
+public class SpoonTreeContext extends TreeContext {
+
+	public ITree createTree(int type, String label, String typeLabel, Object value) {
+		registerTypeLabel(type, typeLabel);
+		return new SpoonTree(type, label, value);
+	}
+
+	@Override
+	public ITree createTree(int type, String label, String typeLabel) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/src/main/java/spoon/pattern_detector/internal/gumtree/TreeScanner.java
+++ b/src/main/java/spoon/pattern_detector/internal/gumtree/TreeScanner.java
@@ -1,0 +1,129 @@
+package spoon.pattern_detector.internal.gumtree;
+
+import com.github.gumtreediff.tree.ITree;
+
+import spoon.SpoonException;
+import spoon.metamodel.Metamodel;
+import spoon.metamodel.MetamodelConcept;
+import spoon.metamodel.MetamodelProperty;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtScanner;
+import spoon.reflect.visitor.Filter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Stack;
+
+public class TreeScanner extends CtScanner {
+	public static final String NOTYPE = "<notype>";
+	private final SpoonTreeContext treeContext;
+	private final Stack<ITree> nodes = new Stack<>();
+	private Filter<? super CtElement> filter;
+
+	TreeScanner(SpoonTreeContext treeContext, ITree root) {
+		this.treeContext = treeContext;
+		nodes.push(root);
+	}
+
+	@Override
+	public void scan(CtRole role, CtElement element) {
+		if (element == null) {
+			return;
+		}
+		/* We have to keep implicit statements to understand `this.field` and `field` as same pattern.
+		if (element.isImplicit()) {
+			return;
+		}
+		*/
+		if (filter != null && !filter.matches(element)) {
+			return;
+		}
+		String elementLabel = null;
+		boolean scanChildren = true;
+		if (element instanceof CtTypeReference && !(element instanceof CtTypeParameterReference)) {
+			CtTypeReference<?> typeRef = (CtTypeReference<?>) element;
+			elementLabel = typeRef.toString();
+			scanChildren = false;
+		}
+		ITree node = createNode(role, element, elementLabel);
+		pushNodeToTree(node);
+		try {
+			if (scanChildren) {
+				//add primitive attributes as first child nodes
+				MetamodelConcept mmc = Metamodel.getInstance().getConcept(element.getClass());
+				if (element instanceof CtMethod) {
+					this.getClass();
+				}
+				for (MetamodelProperty property : mmc.getProperties()) {
+					if (CtElement.class.isAssignableFrom(property.getTypeofItems().getActualClass())) {
+						continue;
+					}
+					if (property.getRole() == CtRole.MODIFIER) {
+						this.getClass();
+					}
+					if (ignoredRoles.contains(property.getRole()) || property.isDerived()) {
+						continue;
+					}
+					//it is primitive role, which doesn't hold CtElement
+					Collection<Object>  values = property.getRoleHandler().asCollection(element);
+					for (Object object : values) {
+						if (object != null) {
+							node.addChild(createNode(property.getRole(), object, getPrimitiveLabel(object)));
+						}
+					}
+				}
+				super.scan(role, element);
+			}
+		} finally {
+			nodes.pop();
+		}
+	}
+
+	private static final Set<CtRole> ignoredRoles = new HashSet<>(Arrays.asList(CtRole.POSITION, CtRole.IS_IMPLICIT, CtRole.IS_SHADOW));
+
+	private void pushNodeToTree(ITree node) {
+		ITree parent = nodes.peek();
+		if (parent != null) { // happens when nodes.push(null)
+			parent.addChild(node);
+		}
+		nodes.push(node);
+	}
+
+	private ITree createNode(CtRole roleInParent, Object element, String label) {
+		if (roleInParent == null) {
+			return treeContext.createTree(-2, label, "ROOT", element);
+		}
+		return treeContext.createTree(roleInParent.ordinal(), label, roleInParent.name(), element);
+	}
+
+	private String getPrimitiveLabel(Object value) {
+		if (value instanceof String) {
+			return "str:" + (String) value;
+		}
+		if (value instanceof Boolean) {
+			return "bool:" + ((Boolean) value).toString();
+		}
+		if (value instanceof Number) {
+			return "number:" + ((Number) value).toString();
+		}
+		if (value instanceof Enum) {
+			return "enum:" + ((Enum) value).name();
+		}
+		throw new SpoonException("Unsupported primitive value of class " + value.getClass().getName());
+	}
+
+	/**
+	 * @param filter only elements which matches filter will be transformed to gumtree.
+	 * If element doesn't match it is ignored including it's children
+	 */
+	public TreeScanner setFilter(Filter<? super CtElement> filter) {
+		this.filter = filter;
+		return this;
+	}
+}

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -402,4 +402,13 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 */
 	List<CtElement> getDirectChildren();
 
+	/**
+	 * @return pretty printed source code of this element.
+	 *
+	 * Note: `implicit` elements are not printed.
+	 * The model is not modified by printing.
+	 * It means it doesn't try to fix model inconsistencies (if any)
+	 * so invalid model causes printing of invalid sources.
+	 */
+	String print();
 }

--- a/src/main/java/spoon/reflect/visitor/AbstractCompilationUnitImportsProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/AbstractCompilationUnitImportsProcessor.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import spoon.SpoonException;
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtTargetedExpression;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtVariableReference;
+import spoon.reflect.visitor.chain.CtScannerListener;
+import spoon.reflect.visitor.chain.ScanningMode;
+import spoon.support.Experimental;
+
+/**
+ */
+@Experimental
+abstract class AbstractCompilationUnitImportsProcessor<T extends CtScanner, U> extends AbstractProcessor<CtCompilationUnit> {
+
+	@Override
+	public void process(CtCompilationUnit cu) {
+		process(createScanner(), cu);
+	}
+
+	protected static void process(CtScanner scanner, CtCompilationUnit cu) {
+		scanner.enter(cu);
+		switch (cu.getUnitType()) {
+		case MODULE_DECLARATION:
+		case UNKNOWN:
+			break;
+		case PACKAGE_DECLARATION:
+			// we need to compute imports only for package annotations and package comments
+			// we don't want to get all imports coming from content of package
+			CtPackage pack = cu.getDeclaredPackage();
+			scanner.scan(pack.getAnnotations());
+			break;
+		case TYPE_DECLARATION:
+			for (CtTypeReference<?> typeRef : cu.getDeclaredTypeReferences()) {
+				scanner.scan(typeRef.getTypeDeclaration());
+			}
+			break;
+		}
+		scanner.exit(cu);
+	}
+
+	protected abstract T createRawScanner();
+
+	protected CtScannerListener createScannerListener(T scanner) {
+		return new ScannerListener(scanner);
+	}
+
+	//The set of roles whose values are always kept implicit
+	protected static Set<CtRole> IGNORED_ROLES_WHEN_IMPLICIT = new HashSet<>(Arrays.asList(
+			//e.g. List<String> s = new ArrayList</*keep me implicit*/>();
+			CtRole.TYPE_ARGUMENT,
+			//e.g. List<?/* extends Object*/>
+			CtRole.BOUNDING_TYPE,
+			//e.g. (/*implicit type of parameter*/ p) -> {}
+			CtRole.TYPE
+	));
+
+	protected class ScannerListener implements CtScannerListener {
+		protected T scanner;
+		protected Set<CtRole> ignoredRoles = IGNORED_ROLES_WHEN_IMPLICIT;
+
+		ScannerListener(T scanner) {
+			super();
+			this.scanner = scanner;
+		}
+
+		@Override
+		public ScanningMode enter(CtRole role, CtElement element) {
+			if (element == null) {
+				return ScanningMode.SKIP_ALL;
+			}
+			if (role == CtRole.VARIABLE && element instanceof CtVariableReference) {
+				//ignore variable reference of field access. The accessType is relevant here instead.
+				return ScanningMode.SKIP_ALL;
+			}
+			if (element.isParentInitialized()) {
+				CtElement parent = element.getParent();
+				if (role == CtRole.DECLARING_TYPE && element instanceof CtTypeReference) {
+					if (parent instanceof CtFieldReference) {
+						//ignore the declaring type of field reference. It is not relevant for Imports
+						return ScanningMode.SKIP_ALL;
+					}
+					if (parent instanceof CtExecutableReference) {
+						/*
+						 * ignore the declaring type of type executable like
+						 * anVariable.getSomeInstance().callMethod()
+						 * The declaring type of `callMethod` method is not relevant for Imports
+						 */
+						return ScanningMode.SKIP_ALL;
+					} else if (parent instanceof CtTypeReference) {
+						//continue. This is relevant for import
+					} else {
+						//May be this can never happen
+						throw new SpoonException("Check this case. Is it relvant or not?");
+					}
+				}
+				if (role == CtRole.TYPE && element instanceof CtTypeReference) {
+					if (parent instanceof CtFieldReference) {
+						//ignore the type of field references. It is not relevant for Imports
+						return ScanningMode.SKIP_ALL;
+					}
+					if (parent instanceof CtExecutableReference) {
+						CtElement parent2 = null;
+						if (element.isParentInitialized()) {
+							parent2 = parent.getParent();
+						}
+						if (parent2 instanceof CtConstructorCall<?>) {
+							//new SomeType(); is relevant for import
+							//continue
+						} else {
+							/*
+							 * ignore the return type of executable reference. It is not relevant for Imports
+							 * anVariable.getSomeInstance().callMethod()
+							 * The return type `callMethod` method is not relevant for Imports
+							 */
+							return ScanningMode.SKIP_ALL;
+						}
+					}
+					/*
+					 * CtTypeReference
+					 * CtMethod, CtField, ...
+					 * continue. This is relevant for import
+					 */
+				}
+				if (role == CtRole.ARGUMENT_TYPE) {
+					/*
+					 * ignore the type of parameter of CtExecutableReference
+					 * It is not relevant for Imports.
+					 */
+					return ScanningMode.SKIP_ALL;
+				}
+			}
+			if (element.isImplicit() && ignoredRoles.contains(role)) {
+				//ignore implicit actual type arguments
+				return ScanningMode.SKIP_ALL;
+			}
+			onEnter(getContext(scanner), role, element);
+			return ScanningMode.NORMAL;
+		}
+	}
+
+	protected abstract U getContext(T scanner);
+
+	protected T createScanner() {
+		T scanner = createRawScanner();
+		if (scanner instanceof EarlyTerminatingScanner) {
+			CtScannerListener listener = createScannerListener(scanner);
+			if (listener != null) {
+				((EarlyTerminatingScanner) scanner).setListener(listener);
+			}
+		}
+		return scanner;
+	}
+
+	protected void onEnter(U context, CtRole role, CtElement element) {
+
+		if (element instanceof CtTargetedExpression) {
+			CtTargetedExpression<?, ?> targetedExpression = (CtTargetedExpression<?, ?>) element;
+			CtExpression<?> target = targetedExpression.getTarget();
+			if (target == null) {
+				return;
+			}
+			handleTargetedExpression(context, role, targetedExpression, target);
+		} else if (element instanceof CtTypeReference<?>) {
+			//we have to visit only PURE CtTypeReference. No CtArrayTypeReference, CtTypeParameterReference, ...
+			element.accept(new CtAbstractVisitor() {
+				@Override
+				public <T> void visitCtTypeReference(CtTypeReference<T> reference) {
+					handleTypeReference(context, role, (CtTypeReference<?>) element);
+				}
+			});
+		}
+	}
+
+	protected abstract void handleTypeReference(U context, CtRole role, CtTypeReference<?> element);
+
+	protected abstract void handleTargetedExpression(U context, CtRole role, CtTargetedExpression<?, ?> targetedExpression, CtExpression<?> target);
+
+	/**
+	 * @return parent of `element`, but only if it's type is `type`
+	 */
+	protected static <T extends CtElement> T getParentIfType(CtElement element, Class<T> type) {
+		if (element == null || !element.isParentInitialized()) {
+			return null;
+		}
+		CtElement parent = element.getParent();
+		if (type.isInstance(parent)) {
+			return type.cast(parent);
+		}
+		return null;
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/DefaultImportComparator.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultImportComparator.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import java.util.Comparator;
+
+import spoon.reflect.declaration.CtImport;
+import spoon.reflect.declaration.CtImportKind;
+
+
+/**
+ * Defines order of imports:
+ * 1) imports are ordered alphabetically
+ * 2) static imports are last
+ */
+public class DefaultImportComparator implements Comparator<CtImport> {
+
+	@Override
+	public int compare(CtImport imp1, CtImport imp2) {
+		int dif = getImportKindOrder(imp1.getImportKind()) - getImportKindOrder(imp2.getImportKind());
+		if (dif != 0) {
+			return dif;
+		}
+		String str1 = removeSuffixSemicolon(imp1.toString());
+		String str2 = removeSuffixSemicolon(imp2.toString());
+		return str1.compareTo(str2);
+	}
+
+	private static String removeSuffixSemicolon(String str) {
+		if (str.endsWith(";")) {
+			return str.substring(0, str.length() - 1);
+		}
+		return str;
+	}
+
+	private int getImportKindOrder(CtImportKind importKind) {
+		switch (importKind) {
+		case TYPE:
+		case ALL_TYPES:
+			return 0;
+		default:
+			return 1;
+		}
+	}
+
+}

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -343,6 +343,7 @@ public class ElementPrinterHelper {
 	/**
 	 * Write the compilation unit header.
 	 */
+	@Deprecated
 	public void writeHeader(List<CtType<?>> types, Collection<CtImport> imports) {
 		if (!types.isEmpty()) {
 			for (CtType<?> ctType : types) {
@@ -361,6 +362,7 @@ public class ElementPrinterHelper {
 	/**
 	 * Write the compilation unit footer.
 	 */
+	@Deprecated
 	public void writeFooter(List<CtType<?>> types) {
 		if (!types.isEmpty()) {
 			for (CtType<?> ctType : types) {

--- a/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtTargetedExpression;
+import spoon.reflect.code.CtThisAccess;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.Experimental;
+
+
+/**
+ * Removes all imports from compilation unit and forces fully qualified identifiers
+ */
+@Experimental
+public class ForceFullyQualifiedProcessor extends AbstractCompilationUnitImportsProcessor<LexicalScopeScanner, LexicalScope> {
+
+	@Override
+	protected LexicalScopeScanner createRawScanner() {
+		return new LexicalScopeScanner();
+	}
+
+	@Override
+	protected LexicalScope getContext(LexicalScopeScanner scanner) {
+		return scanner.getCurrentLexicalScope();
+	}
+
+	@Override
+	protected void handleTypeReference(LexicalScope nameScope, CtRole role, CtTypeReference<?> reference) {
+		if (reference.isImplicitParent() || reference.isImplicit()) {
+			if (isThisAccess(reference)) {
+				//do not force FQ names in this access
+				return;
+			}
+			if (isTypeReferenceToEnclosingType(nameScope, reference)) {
+				//it is the reference to the enclosing class
+				//do not use FQ names for that
+				return;
+			}
+			//force fully qualified name
+			reference.setImplicit(false);
+			reference.setImplicitParent(false);
+		}
+	}
+
+	protected boolean isTypeReferenceToEnclosingType(LexicalScope nameScope, CtTypeReference<?> reference) {
+//		String qName = reference.getQualifiedName();
+//		return Boolean.TRUE == nameScope.forEachElementByName(reference.getSimpleName(), named -> {
+//			if (named instanceof CtType) {
+//				CtType<?> type = (CtType<?>) named;
+//				if (qName.equals(type.getQualifiedName())) {
+//					return Boolean.TRUE;
+//				}
+//			}
+//			return null;
+//		});
+		//expected by LambdaTest
+		CtType<?> enclosingType = reference.getParent(CtType.class);
+		return enclosingType == null ? false : reference.getQualifiedName().equals(enclosingType.getQualifiedName());
+	}
+
+	@Override
+	protected void handleTargetedExpression(LexicalScope nameScope, CtRole role, CtTargetedExpression<?, ?> targetedExpression, CtExpression<?> target) {
+		if (!target.isImplicit()) {
+			return;
+		}
+		if (target instanceof CtThisAccess) {
+			//the non implicit this access is not forced
+			return;
+		}
+		if (target instanceof CtTypeAccess) {
+			CtTypeAccess<?> typeAccess = (CtTypeAccess<?>) target;
+			if (isThisAccess(typeAccess)) {
+				//do not force FQ names for `this` access
+				return;
+			}
+			if (isTypeReferenceToEnclosingType(nameScope, typeAccess.getAccessedType())) {
+				//it is the reference to the enclosing class
+				//do not use FQ names for that
+				return;
+			}
+		}
+		target.setImplicit(false);
+	}
+
+	private boolean isThisAccess(CtTypeReference<?> typeRef) {
+		return getParentIfType(getParentIfType(typeRef, CtTypeAccess.class), CtThisAccess.class) != null;
+	}
+
+	private boolean isThisAccess(CtTypeAccess<?> typeAccess) {
+		return getParentIfType(typeAccess, CtThisAccess.class) != null;
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtTargetedExpression;
+import spoon.reflect.code.CtThisAccess;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.Experimental;
+
+
+/**
+ * Marks package references implicit so all type will get imported
+ */
+@Experimental
+public class ForceImportProcessor extends AbstractCompilationUnitImportsProcessor<LexicalScopeScanner, LexicalScope> {
+
+	@Override
+	protected LexicalScopeScanner createRawScanner() {
+		return new LexicalScopeScanner();
+	}
+
+	@Override
+	protected LexicalScope getContext(LexicalScopeScanner scanner) {
+		return scanner.getCurrentLexicalScope();
+	}
+
+	@Override
+	protected void handleTypeReference(LexicalScope nameScope, CtRole role, CtTypeReference<?> reference) {
+		if (reference.getPackage() != null) {
+			//force import of package of top level types only
+			reference.setImplicitParent(true);
+		} else {
+			//it is a reference to an child type
+			//if it is a reference in scope of parent type declaration then make it implicit, else keep it as it is
+			CtType<?> contextType = reference.getParent(CtType.class);
+			if (contextType != null) {
+				CtType<?> topLevelType = contextType.getTopLevelType();
+				CtTypeReference<?> referenceDeclaringType = reference.getDeclaringType();
+				if (referenceDeclaringType != null && referenceDeclaringType.getQualifiedName().equals(topLevelType.getQualifiedName())) {
+					//the reference to direct child type has to be made implicit
+					reference.setImplicitParent(true);
+					return;
+				} else {
+					//reference to deeper nested child type or to child type from different type has to be kept as it is
+				}
+			}
+			//else it is a reference to a child type from different compilation unit
+			//keep it as it is (usually explicit)
+			//but we have to mark top level declaring type as imported, because it is not visited individually
+			CtTypeReference<?> topLevelTypeRef = reference;
+			while (topLevelTypeRef != null && topLevelTypeRef.getPackage() == null) {
+				topLevelTypeRef = topLevelTypeRef.getDeclaringType();
+			}
+			if (topLevelTypeRef != null) {
+				topLevelTypeRef.setImplicitParent(true);
+			}
+		}
+	}
+
+
+	protected void handleTargetedExpression(LexicalScope nameScope, CtRole role, CtTargetedExpression<?, ?> targetedExpression, CtExpression<?> target) {
+		if (target.isImplicit()) {
+			return;
+		}
+		if (target instanceof CtThisAccess) {
+			//force implicit this access
+			target.setImplicit(true);
+			return;
+		}
+		if (target instanceof CtTypeAccess) {
+			CtTypeAccess<?> typeAccess = (CtTypeAccess<?>) target;
+			//we might force import of static fields and methods here ... but it is not wanted by default
+		}
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -28,6 +28,7 @@ import java.util.Set;
  * The import scanner API might still change in future release, that's why it is marked as experimental.
  */
 @Experimental
+@Deprecated
 public interface ImportScanner {
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -65,6 +65,7 @@ import java.util.regex.Pattern;
 /**
  * A scanner that calculates the imports for a given model.
  */
+@Deprecated
 public class ImportScannerImpl extends CtScanner implements ImportScanner {
 
 	private static final Collection<String> namesPresentInJavaLang8 =

--- a/src/main/java/spoon/reflect/visitor/ImportValidator.java
+++ b/src/main/java/spoon/reflect/visitor/ImportValidator.java
@@ -1,0 +1,352 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import spoon.SpoonException;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTargetedExpression;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtImport;
+import spoon.reflect.declaration.CtImportKind;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtPackageReference;
+import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeMemberWildcardImportReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.Experimental;
+import spoon.support.util.ModelList;
+import spoon.support.visitor.ClassTypingContext;
+
+
+/**
+ * Updates list of import statements of compilation unit following {@link CtElement#isImplicit()}.
+ * It doesn't call {@link CtElement#setImplicit(boolean)}.
+ * It doesn't fix wrong used implicit which causes conflicts. The fixing is task of {@link NameConflictValidator}
+ */
+@Experimental
+public class ImportValidator extends AbstractCompilationUnitImportsProcessor<ImportValidator.MyScanner, ImportValidator.Context> {
+
+	private Comparator<CtImport> importComparator;
+	private boolean canAddImports = true;
+	private boolean canRemoveImports = true;
+
+	@Override
+	protected MyScanner createRawScanner() {
+		return new MyScanner();
+	}
+
+	@Override
+	protected Context getContext(MyScanner scanner) {
+		return scanner.context;
+	}
+
+	@Override
+	protected void handleTargetedExpression(Context context, CtRole role, CtTargetedExpression<?, ?> targetedExpression, CtExpression<?> target) {
+		if (target != null && target.isImplicit()) {
+			if (target instanceof CtTypeAccess) {
+				if (targetedExpression instanceof CtFieldAccess) {
+					context.addImport(((CtFieldAccess<?>) targetedExpression).getVariable());
+				} else if (targetedExpression instanceof CtInvocation) {
+					CtExecutableReference<?> execRef = ((CtInvocation<?>) targetedExpression).getExecutable();
+					if (execRef.isStatic()) {
+						context.addImport(execRef);
+					}
+				}
+			} else if (target instanceof CtVariableAccess) {
+				throw new SpoonException("TODO");
+			}
+		}
+	}
+
+	@Override
+	protected void handleTypeReference(Context context, CtRole role, CtTypeReference<?> reference) {
+		if (reference.isImplicit()) {
+			/*
+			 * the reference is implicit. E.g. `assertTrue();`
+			 * where type `org.junit.Assert` is implicit
+			 */
+			CtTargetedExpression<?, ?> targetedExpr = getParentIfType(getParentIfType(reference, CtTypeAccess.class), CtTargetedExpression.class);
+			if (targetedExpr != null) {
+				if (targetedExpr instanceof CtInvocation<?>) {
+					CtInvocation<?> invocation = (CtInvocation<?>) targetedExpr;
+					//import static method
+					context.addImport(invocation.getExecutable());
+				} else if (targetedExpr instanceof CtFieldAccess<?>) {
+					//import static field
+					CtFieldAccess<?> fieldAccess = (CtFieldAccess<?>) targetedExpr;
+					context.addImport(fieldAccess.getVariable());
+				}
+			}
+			//else do nothing. E.g. in case of implicit type of lambda parameter
+			//`(e) -> {...}`
+		} else if (reference.isImplicitParent()) {
+			/*
+			 * the package is implicit. E.g. `Assert.assertTrue`
+			 * where package `org.junit` is implicit
+			 */
+			context.addImport(reference);
+		}
+	}
+
+	class Context {
+		private CtCompilationUnit compilationUnit;
+		private Map<String, CtImport> computedImports;
+		private String packageQName;
+		private Set<String> typeRefQNames;
+
+		Context(CtCompilationUnit cu) {
+			this.compilationUnit = cu;
+			CtPackage pckg = cu.getDeclaredPackage();
+			if (pckg != null) {
+				this.packageQName = pckg.getReference().getQualifiedName();
+			}
+			this.typeRefQNames = cu.getDeclaredTypeReferences().stream().map(CtTypeReference::getQualifiedName).collect(Collectors.toSet());
+			computedImports = new HashMap<>();
+		}
+
+		Factory getFactory() {
+			return compilationUnit.getFactory();
+		}
+
+		void addImport(CtReference ref) {
+			if (ref == null) {
+				return;
+			}
+			//check that we do not add reference to a local type
+			CtTypeReference<?> typeRef;
+			if (ref instanceof CtExecutableReference) {
+				typeRef = ((CtExecutableReference<?>) ref).getDeclaringType();
+			} else if (ref instanceof CtFieldReference<?>) {
+				typeRef = ((CtFieldReference<?>) ref).getDeclaringType();
+			} else if (ref instanceof CtTypeReference<?>) {
+				typeRef = (CtTypeReference<?>) ref;
+			} else {
+				throw new SpoonException("Unexpected reference type " + ref.getClass());
+			}
+			CtTypeReference<?> topLevelTypeRef = typeRef.getTopLevelType();
+			if (typeRefQNames.contains(topLevelTypeRef.getQualifiedName())) {
+				//it is reference to a type of this CompilationUnit. Do not add it
+				return;
+			}
+			CtPackageReference packageRef = topLevelTypeRef.getPackage();
+			if (packageRef == null) {
+				throw new SpoonException("Type reference has no package");
+			}
+			if ("java.lang".equals(packageRef.getQualifiedName())) {
+				//java.lang is always imported implicitly. Ignore it
+				return;
+			}
+			if (Objects.equals(packageQName, packageRef.getQualifiedName())) {
+				//it is reference to a type of the same package. Do not add it
+				return;
+			}
+			String importRefID = getImportRefID(ref);
+			if (!computedImports.containsKey(importRefID)) {
+				computedImports.put(importRefID, getFactory().Type().createImport(ref));
+			}
+		}
+
+		void onComilationUnitProcessed(CtCompilationUnit compilationUnit) {
+			ModelList<CtImport> existingImports = compilationUnit.getImports();
+			Set<CtImport> computedImports = new HashSet<>(this.computedImports.values());
+			for (CtImport oldImport : new ArrayList<>(existingImports)) {
+				if (!computedImports.remove(oldImport)) {
+					if (oldImport.getImportKind() == CtImportKind.ALL_TYPES) {
+						if (removeAllTypeImportWithPackage(computedImports, ((CtPackageReference) oldImport.getReference()).getQualifiedName())) {
+							//this All types import still imports some type. Keep it
+							continue;
+						}
+					}
+					if (oldImport.getImportKind() == CtImportKind.ALL_STATIC_MEMBERS) {
+						if (removeAllStaticTypeMembersImportWithType(computedImports, ((CtTypeMemberWildcardImportReference) oldImport.getReference()).getTypeReference())) {
+							//this All types import still imports some type. Keep it
+							continue;
+						}
+					}
+					//the import doesn't exist in computed imports. Remove it
+					if (canRemoveImports) {
+						existingImports.remove(oldImport);
+					}
+				}
+			}
+
+			//add new imports
+			if (canAddImports) {
+				existingImports.addAll(computedImports);
+			}
+			if (importComparator != null) {
+				existingImports.set(existingImports.stream().sorted(importComparator).collect(Collectors.toList()));
+			}
+		}
+	}
+
+	/**
+	 * @return fast unique identification of reference. It is not the same like printing of import, because it needs to handle access path.
+	 */
+	private static String getImportRefID(CtReference ref) {
+		if (ref == null) {
+			throw new SpoonException("Null import refrence");
+		}
+		if (ref instanceof CtFieldReference) {
+			CtFieldReference fieldRef = (CtFieldReference) ref;
+			return fieldRef.getDeclaringType().getQualifiedName() + "." + fieldRef.getSimpleName();
+		}
+		if (ref instanceof CtExecutableReference) {
+			CtExecutableReference execRef = (CtExecutableReference) ref;
+			return execRef.getDeclaringType().getQualifiedName() + "." + execRef.getSimpleName();
+		}
+		if (ref instanceof CtTypeMemberWildcardImportReference) {
+			CtTypeMemberWildcardImportReference wildRef = (CtTypeMemberWildcardImportReference) ref;
+			return wildRef.getTypeReference().getQualifiedName() + ".*";
+		}
+		if (ref instanceof CtTypeReference) {
+			CtTypeReference typeRef = (CtTypeReference) ref;
+			return typeRef.getQualifiedName();
+		}
+		throw new SpoonException("Unexpected import type: " + ref.getClass());
+	}
+
+	/**
+	 * removes all type imports with the same package from the `imports`
+	 * @return true if at least one import with the same package exists
+	 */
+	private boolean removeAllTypeImportWithPackage(Set<CtImport> imports, String packageName) {
+		boolean found = false;
+		for (Iterator iter = imports.iterator(); iter.hasNext();) {
+			CtImport newImport = (CtImport) iter.next();
+			if (newImport.getImportKind() == CtImportKind.TYPE) {
+				CtTypeReference<?> typeRef = (CtTypeReference<?>) newImport.getReference();
+				if (typeRef.getPackage() != null && packageName.equals(typeRef.getPackage().getQualifiedName())) {
+					found = true;
+					if (canRemoveImports) {
+						iter.remove();
+					}
+				}
+			}
+		}
+		return found;
+	}
+
+	/**
+	 * removes all static type member imports with the same type from `imports`
+	 * @return true if at least one import with the same type exists
+	 */
+	private boolean removeAllStaticTypeMembersImportWithType(Set<CtImport> imports, CtTypeReference<?> typeRef) {
+		//the cached type hierarchy of typeRef
+		ClassTypingContext contextOfTypeRef = new ClassTypingContext(typeRef);
+		Iterator<CtImport> iter = imports.iterator();
+		class Visitor extends CtAbstractImportVisitor {
+			boolean found = false;
+			@Override
+			public <T> void visitFieldImport(CtFieldReference<T> fieldReference) {
+				checkType(fieldReference.getDeclaringType());
+			}
+			@Override
+			public <T> void visitMethodImport(CtExecutableReference<T> executableReference) {
+				checkType(executableReference.getDeclaringType());
+			}
+			void checkType(CtTypeReference<?> importTypeRef) {
+				if (contextOfTypeRef.isSubtypeOf(importTypeRef)) {
+					found = true;
+					if (canRemoveImports) {
+						iter.remove();
+					}
+				}
+			}
+		}
+		Visitor visitor = new Visitor();
+		while (iter.hasNext()) {
+			iter.next().accept(visitor);
+		}
+		return visitor.found;
+	}
+
+	class MyScanner extends EarlyTerminatingScanner<Void> {
+		Context context;
+		@Override
+		protected void enter(CtElement e) {
+			if (e instanceof CtCompilationUnit) {
+				context = new Context((CtCompilationUnit) e);
+			}
+		}
+
+		@Override
+		protected void exit(CtElement e) {
+			if (e instanceof CtCompilationUnit) {
+				context.onComilationUnitProcessed((CtCompilationUnit) e);
+			}
+		}
+	}
+
+	/**
+	 * @return true if this processor is allowed to add new imports
+	 */
+	public boolean isCanAddImports() {
+		return canAddImports;
+	}
+
+	/**
+	 * @param canAddImports true if this processor is allowed to add new imports
+	 */
+	public ImportValidator setCanAddImports(boolean canAddImports) {
+		this.canAddImports = canAddImports;
+		return this;
+	}
+
+	/**
+	 * @return true if this processor is allowed to remove imports
+	 */
+	public boolean isCanRemoveImports() {
+		return canRemoveImports;
+	}
+
+	/**
+	 * @param canRemoveImports true if this processor is allowed to remove imports
+	 */
+	public ImportValidator setCanRemoveImports(boolean canRemoveImports) {
+		this.canRemoveImports = canRemoveImports;
+		return this;
+	}
+
+	public Comparator<CtImport> getImportComparator() {
+		return importComparator;
+	}
+
+	public ImportValidator setImportComparator(Comparator<CtImport> importComparator) {
+		this.importComparator = importComparator;
+		return this;
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/MinimalImportScanner.java
@@ -25,6 +25,7 @@ import spoon.reflect.reference.CtTypeReference;
  * A scanner dedicated to import only the necessary packages, @see spoon.test.variable.AccessFullyQualifiedTest
  *
  */
+@Deprecated
 public class MinimalImportScanner extends ImportScannerImpl implements ImportScanner {
 	/**
 	 * This method use @link{ImportScannerImpl#isTypeInCollision} to import a ref only if there is a collision

--- a/src/main/java/spoon/reflect/visitor/NameConflictValidator.java
+++ b/src/main/java/spoon/reflect/visitor/NameConflictValidator.java
@@ -1,0 +1,310 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.reflect.visitor;
+
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtTargetedExpression;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtPackageReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.Experimental;
+
+
+/**
+ * Detects conflict of
+ *
+ * 1) Example: conflict of field name with an variable name and fixes it by making field target explicit.
+ * <code><pre>
+ * class A {
+ *  int xxx;
+ *  void m(String xxx) {
+ *    this.xxx //the target `this.` must be explicit, otherwise parameter `String xxx` hides it
+ *  }
+ * }
+ *</pre></code>
+ *
+ * 2) Example: conflict of package name with an variable name and fixes it by making field target implicit.
+ * <code><pre>
+ * class A {
+ *  int com;
+ *  void m() {
+ *    com.package.Type.doSomething(); //the package `com` is in conflict with field `com`. Must be imported
+ *  }
+ * }
+ *</pre></code>
+ */
+@Experimental
+public class NameConflictValidator extends AbstractCompilationUnitImportsProcessor<LexicalScopeScanner, LexicalScope> {
+
+	@Override
+	protected LexicalScopeScanner createRawScanner() {
+		return new LexicalScopeScanner();
+	}
+
+	@Override
+	protected LexicalScope getContext(LexicalScopeScanner scanner) {
+		return scanner.getCurrentLexicalScope();
+	}
+
+	@Override
+	protected void handleTargetedExpression(LexicalScope nameScope, CtRole role, CtTargetedExpression<?, ?> targetedExpression, CtExpression<?> target) {
+		if (targetedExpression instanceof CtFieldAccess<?>) {
+			CtFieldAccess<?> fieldAccess = (CtFieldAccess<?>) targetedExpression;
+			if (target.isImplicit()) {
+				/*
+				 * target is implicit, check whether there is no conflict with an local variable, catch variable or parameter
+				 * in case of conflict make it explicit, otherwise the field access is shadowed by that variable.
+				 * Search for potential variable declaration until we found a class which declares or inherits this field
+				 */
+				final CtField<?> field = fieldAccess.getVariable().getFieldDeclaration();
+				if (field != null) {
+					final String fieldName = field.getSimpleName();
+					nameScope.forEachElementByName(fieldName, named -> {
+						if (named instanceof CtMethod) {
+							//the methods with same name are no problem for field access
+							return null;
+						}
+						if (named == field) {
+							return true;
+						}
+						//another variable declaration was found which is hiding the field declaration for this field access. Make the field access explicit
+						target.setImplicit(false);
+						return false;
+					});
+				}
+			}
+			if (!target.isImplicit()) {
+				//the target should be visible in sources
+				if (target instanceof CtTypeAccess) {
+					//the type has to be visible in sources
+					CtTypeAccess<?> typeAccess = (CtTypeAccess<?>) target;
+					CtTypeReference<?> accessedTypeRef = typeAccess.getAccessedType();
+					checkConflictOfTypeReference(nameScope, accessedTypeRef);
+				}
+			}
+		}
+	}
+
+	@Override
+	protected void handleTypeReference(LexicalScope nameScope, CtRole role, CtTypeReference<?> ref) {
+		if (ref.isImplicit()) {
+			/*
+			 * the reference is implicit. E.g. `assertTrue();`
+			 * when the type `org.junit.Assert` is implicit
+			 */
+			//check if targeted expression is in conflict
+			CtTargetedExpression<?, ?> targetedExpr = getParentIfType(getParentIfType(ref, CtTypeAccess.class), CtTargetedExpression.class);
+			if (targetedExpr instanceof CtInvocation<?>) {
+				CtInvocation<?> invocation = (CtInvocation<?>) targetedExpr;
+				CtExecutableReference<?> importedReference = invocation.getExecutable();
+				CtExecutable<?> importedElement = importedReference.getExecutableDeclaration();
+				if (importedElement == null) {
+					//we have no access to executable - probably no class path mode
+					//What to do? Keep it as it is? Or make it fully qualified?
+					//keep it as it is for now.
+					return;
+				}
+				if (importedElement instanceof CtMethod) {
+					//check if statically imported field or method simple name is not in conflict
+					nameScope.forEachElementByName(importedReference.getSimpleName(), named -> {
+						if (named instanceof CtMethod<?>) {
+							//the method call can be in conflict with Method name only
+							if (isSameStaticImport(named, importedElement)) {
+								//we have found import of the same method
+								return true;
+							}
+							ref.setImplicit(false);
+							ref.setImplicitParent(true);
+							return false;
+						}
+						//no conflict with type or field name
+						return null;
+					});
+				}
+			} else if (targetedExpr instanceof CtFieldAccess<?>) {
+				CtFieldAccess<?> fieldAccess = (CtFieldAccess<?>) targetedExpr;
+				CtFieldReference<?> importedReference = fieldAccess.getVariable();
+				CtElement importedElement = importedReference.getFieldDeclaration();
+				if (importedElement == null) {
+					//we have no access to executable - probably no class path mode
+					//What to do? Keep it as it is? Or make it fully qualified?
+					//keep it as it is for now.
+					return;
+				}
+				//check if statically imported field or method simple name is not in conflict
+				nameScope.forEachElementByName(importedReference.getSimpleName(), named -> {
+					if (named instanceof CtMethod<?>) {
+						//field access cannot be in conflict with method name
+						return null;
+					}
+					if (named == importedElement) {
+						//we have found import of the same field
+						return true;
+					}
+					//else there is a conflict. Make type explicit and package implicit
+					ref.setImplicit(false);
+					ref.setImplicitParent(true);
+					return false;
+				});
+			}
+			//else do nothing like in case of implicit type of lambda parameter
+			//`(e) -> {...}`
+		}
+		if (!ref.isImplicit() && ref.isImplicitParent()) {
+			/*
+			 * the package is implicit. E.g. `Assert.assertTrue`
+			 * where package `org.junit` is implicit
+			 */
+			String refQName = ref.getQualifiedName();
+			//check if type simple name is not in conflict
+			nameScope.forEachElementByName(ref.getSimpleName(), named -> {
+				if (named instanceof CtMethod) {
+					//the methods with same name are no problem for field access
+					return null;
+				}
+				if (named instanceof CtType) {
+					CtType<?> type = (CtType<?>) named;
+					if (refQName.equals(type.getQualifiedName())) {
+						//we have found a declaration of type of the ref. We can use implicit
+						return true;
+					}
+				}
+				//we have found a variable, field or type of different name
+				ref.setImplicit(false);
+				ref.setImplicitParent(false);
+				return false;
+			});
+		} //else it is already fully qualified
+		checkConflictOfTypeReference(nameScope, ref);
+	}
+
+	/**
+	 * if typeRef package name or simple name is in conflict with any name from nameScope then
+	 * solve that conflict by package or type implicit
+	 */
+	private void checkConflictOfTypeReference(LexicalScope nameScope, CtTypeReference<?> typeRef) {
+		if (typeRef == null) {
+			return;
+		}
+		if (!typeRef.isImplicitParent()) {
+			//we have to print fully qualified type name
+			//is the first part of package name in conflict with something else?
+			if (isPackageNameConflict(nameScope, typeRef)) {
+				//the package must be imported, then simple name might be used in this scope
+				typeRef.setImplicitParent(true);
+				if (isSimpleNameConflict(nameScope, typeRef)) {
+					//there is conflict with simple name too
+					typeRef.setImplicit(true);
+				}
+			}
+		} else {
+			if (!typeRef.isImplicit()) {
+				if (isSimpleNameConflict(nameScope, typeRef)) {
+					//there is conflict with simple name
+					//use qualified name
+					typeRef.setImplicitParent(false);
+				}
+			}
+		}
+	}
+
+	private boolean isPackageNameConflict(LexicalScope nameScope, CtTypeReference<?> typeRef) {
+		String fistPackageName = getFirstPackageQName(typeRef);
+		if (fistPackageName != null) {
+			return Boolean.TRUE == nameScope.forEachElementByName(fistPackageName, named -> {
+				if (named instanceof CtMethod) {
+					//same method name is not a problem
+					return null;
+				}
+				//the package name is in conflict with field name, variable or type name
+				return Boolean.TRUE;
+			});
+		}
+		return false;
+	}
+
+	private boolean isSimpleNameConflict(LexicalScope nameScope, CtTypeReference<?> typeRef) {
+		String typeQName = typeRef.getQualifiedName();
+		//the package name is in conflict check whether type name is in conflict
+		return Boolean.TRUE == nameScope.forEachElementByName(typeRef.getSimpleName(), named -> {
+			if (named instanceof CtMethod) {
+				//same method name is not a problem
+				return null;
+			}
+			if (named instanceof CtType) {
+				CtType<?> type = (CtType<?>) named;
+				if (typeQName.equals(type.getQualifiedName())) {
+					//we found the referenced type declaration -> ok, we can use simple name in this scope
+					return Boolean.FALSE;
+				}
+				//we found another type with same simple name -> conflict
+			}
+			//there is conflict with simple name
+			return Boolean.TRUE;
+		});
+	}
+
+	private String getFirstPackageQName(CtTypeReference<?> typeRef) {
+		if (typeRef != null) {
+			CtPackageReference packRef = typeRef.getPackage();
+			if (packRef != null) {
+				String qname = packRef.getQualifiedName();
+				if (qname != null && qname.length() > 0) {
+					int idx = qname.indexOf('.');
+					if (idx < 0) {
+						idx = qname.length();
+					}
+					return qname.substring(0, idx);
+				}
+			}
+		}
+		return null;
+	}
+	/**
+	 * @return true if two methods can come from same static import
+	 *
+	 * For example `import static org.junit.Assert.assertEquals;`
+	 * imports methods with signatures:
+	 * assertEquals(Object, Object)
+	 * assertEquals(Object[], Object[])
+	 * assertEquals(long, long)
+	 * ...
+	 */
+	private static boolean isSameStaticImport(CtNamedElement m1, CtNamedElement m2) {
+		if (m1 instanceof CtTypeMember && m2 instanceof CtTypeMember) {
+			if (m1.getSimpleName().equals(m2.getSimpleName())) {
+				CtType<?> declType1 = ((CtTypeMember) m1).getDeclaringType();
+				CtType<?> declType2 = ((CtTypeMember) m2).getDeclaringType();
+				//may be we should check isSubTypeOf instead
+				return declType1 == declType2;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
@@ -30,6 +30,11 @@ import java.util.Map;
 public interface PrettyPrinter {
 
 	/**
+	 * Prints the compilation unit of module-info, package-info or types.
+	 */
+	String printCompilationUnit(CtCompilationUnit compilationUnit);
+
+	/**
 	 * Prints the package info.
 	 * It always resets the printing context at the beginning of this process.
 	 */
@@ -40,6 +45,12 @@ public interface PrettyPrinter {
 	 * It always resets the printing context at the beginning of this process.
 	 */
 	String printModuleInfo(CtModule module);
+
+	/**
+	 * Prints the types of one compilation unit
+	 * It always resets the printing context at the beginning of this process.
+	 */
+	String printTypes(CtType<?>... type);
 
 	/**
 	 * Gets the contents of the compilation unit.

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -432,12 +432,10 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			// we need first to go through the whole model before getting the right reference for imports
 			unit.traverse(builder, unit.scope);
 		});
-		if (getFactory().getEnvironment().isAutoImports()) {
-			//we need first imports before we can place comments. Mainly comments on imports need that
-			forEachCompilationUnit(unitList, SpoonProgress.Process.IMPORT, unit -> {
-				new JDTImportBuilder(unit, factory).build();
-			});
-		}
+		//we need first imports before we can place comments. Mainly comments on imports need that
+		forEachCompilationUnit(unitList, SpoonProgress.Process.IMPORT, unit -> {
+			new JDTImportBuilder(unit, factory).build();
+		});
 		if (getFactory().getEnvironment().isCommentsEnabled()) {
 			forEachCompilationUnit(unitList, SpoonProgress.Process.COMMENT_LINKING, unit -> {
 				new JDTCommentBuilder(unit, factory).build();

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -825,7 +825,6 @@ public class JDTTreeBuilder extends ASTVisitor {
 		return true;
 	}
 
-
 	@Override
 	public boolean visit(ReferenceExpression referenceExpression, BlockScope blockScope) {
 		context.enter(helper.createExecutableReferenceExpression(referenceExpression), referenceExpression);
@@ -939,7 +938,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		CtTypeReference<Object> objectCtTypeReference = references.buildTypeReference(arrayTypeReference, scope);
 		final CtTypeAccess<Object> typeAccess = factory.Code().createTypeAccess(objectCtTypeReference);
 		if (typeAccess.getAccessedType() instanceof CtArrayTypeReference) {
-			((CtArrayTypeReference) typeAccess.getAccessedType()).getArrayType().setAnnotations(this.references.buildTypeReference(arrayTypeReference, scope).getAnnotations());
+			CtTypeReference<?> arrayType = ((CtArrayTypeReference) typeAccess.getAccessedType()).getArrayType();
+			arrayType.setAnnotations(this.references.buildTypeReference(arrayTypeReference, scope).getAnnotations());
+			arrayType.setImplicitParent(true);
 		}
 		context.enter(typeAccess, arrayTypeReference);
 		return true;
@@ -1441,7 +1442,10 @@ public class JDTTreeBuilder extends ASTVisitor {
 			context.enter(helper.createVariableAccess(qualifiedNameRef), qualifiedNameRef);
 			return true;
 		} else if (qualifiedNameRef.binding instanceof TypeBinding) {
-			context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.getTypeReference((TypeBinding) qualifiedNameRef.binding)), qualifiedNameRef);
+			TypeBinding typeBinding = (TypeBinding) qualifiedNameRef.binding;
+			CtTypeReference<?> typeRef = references.getTypeReference(typeBinding);
+			helper.handleImplicit(typeBinding.getPackage(), qualifiedNameRef, null, typeRef);
+			context.enter(factory.Code().createTypeAccessWithoutCloningReference(typeRef), qualifiedNameRef);
 			return true;
 		} else if (qualifiedNameRef.binding instanceof ProblemBinding) {
 			if (context.stack.peek().element instanceof CtInvocation) {
@@ -1499,7 +1503,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		} else if (singleNameReference.binding instanceof VariableBinding) {
 			context.enter(helper.createVariableAccess(singleNameReference), singleNameReference);
 		} else if (singleNameReference.binding instanceof TypeBinding) {
-			context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.getTypeReference((TypeBinding) singleNameReference.binding)), singleNameReference);
+			context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.getTypeReference((TypeBinding) singleNameReference.binding).setImplicitParent(true)), singleNameReference);
 		} else if (singleNameReference.binding instanceof ProblemBinding) {
 			if (context.stack.peek().element instanceof CtInvocation && Character.isUpperCase(CharOperation.charToString(singleNameReference.token).charAt(0))) {
 				context.enter(helper.createTypeAccessNoClasspath(singleNameReference), singleNameReference);
@@ -1587,7 +1591,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 			context.enter(helper.createCatchVariable(singleTypeReference), singleTypeReference);
 			return true;
 		}
-		context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.buildTypeReference(singleTypeReference, scope)), singleTypeReference);
+		CtTypeReference<?> typeRef = references.buildTypeReference(singleTypeReference, scope);
+		if (typeRef != null) {
+			typeRef.setImplicitParent(true);
+		}
+		context.enter(factory.Code().createTypeAccessWithoutCloningReference(typeRef), singleTypeReference);
 		return true;
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -657,7 +657,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				if (child instanceof CtThisAccess) {
 					final CtTypeReference<?> declaringType = invocation.getExecutable().getDeclaringType();
 					if (declaringType != null && invocation.getExecutable().isStatic() && child.isImplicit()) {
-						invocation.setTarget(jdtTreeBuilder.getFactory().Code().createTypeAccess(declaringType, declaringType.isAnonymous()));
+						invocation.setTarget(jdtTreeBuilder.getFactory().Code().createTypeAccess(declaringType, true));
 					} else {
 						invocation.setTarget((CtThisAccess<?>) child);
 					}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -25,7 +25,6 @@ import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
@@ -285,14 +284,21 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String toString() {
+		return print(true);
+	}
+
+	@Override
+	public String print() {
+		return print(false);
+	}
+
+	private String print(boolean forceFullyQualified) {
 		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(getFactory().getEnvironment());
+		printer.setForceFullyQualified(forceFullyQualified);
+		//the printer is created here directly without any ImportValidator
+		//which would change the model content - it is not wanted!
 		String errorMessage = "";
 		try {
-			// we do not want to compute imports of for CtImport and CtReference
-			// as it may change the print of a reference
-			if (!(this instanceof CtImport) && !(this instanceof CtReference)) {
-				printer.getImportsContext().computeImports(this);
-			}
 			printer.scan(this);
 		} catch (ParentNotInitializedException ignore) {
 			LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -100,10 +100,10 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	@SuppressWarnings("unchecked")
 	public CtExecutable<T> getDeclaration() {
 		final CtTypeReference<?> typeRef = getDeclaringType();
-		if (typeRef == null || typeRef.getDeclaration() == null) {
+		if (typeRef == null || typeRef.getTypeDeclaration() == null) {
 			return null;
 		}
-		return getCtExecutable(typeRef.getDeclaration());
+		return getCtExecutable(typeRef.getTypeDeclaration());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -158,7 +158,7 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 		if (declaringType == null) {
 			return null;
 		}
-		CtType<?> type = declaringType.getDeclaration();
+		CtType<?> type = declaringType.getTypeDeclaration();
 		if (type != null) {
 			return (CtField<T>) type.getField(getSimpleName());
 		}

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -142,7 +142,11 @@ public class ElementSourceFragment implements SourceFragment {
 	public void addTreeOfSourceFragmentsOfElement(CtElement element) {
 		Deque<ElementSourceFragment> parents = new ArrayDeque<>();
 		parents.push(this);
-		//scan all children of `element` and build tree of SourceFragments
+		/*
+		 * scan all children of `element` and build tree of SourceFragments
+		 * Note: we cannot skip implicit elements,
+		 * because CtBlock can be implicit but contains non implicit elements, which has to be processed.
+		 */
 		new EarlyTerminatingScanner<Void>() {
 			@Override
 			protected void enter(CtElement e) {
@@ -303,6 +307,12 @@ public class ElementSourceFragment implements SourceFragment {
 			firstChild = fragment;
 		} else {
 			firstChild = firstChild.add(fragment);
+		}
+		if (fragment.getElement() instanceof CtElement) {
+			CtElement fragmentEleParent = ((CtElement) fragment.getElement()).getParent();
+			if (element != fragmentEleParent && !(element instanceof CtCompilationUnit) && fragmentEleParent.getPosition().isValidPosition()) {
+				throw new SpoonException("Inconsistent child fragment " + fragment.getElement().getClass() + " has unexpected parent " + element.getClass());
+			}
 		}
 	}
 

--- a/src/main/java/spoon/support/util/ImmutableMapImpl.java
+++ b/src/main/java/spoon/support/util/ImmutableMapImpl.java
@@ -109,7 +109,11 @@ public class ImmutableMapImpl implements ImmutableMap {
 			if (sb.length() > 0) {
 				sb.append("\n");
 			}
-			sb.append(name).append('=').append(map.get(name));
+			Object value = map.get(name);
+			sb.append(name).append('=').append(value);
+			if (value != null) {
+				sb.append(" : ").append(value.getClass().getTypeName());
+			}
 		}
 	}
 

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -25,6 +25,7 @@ import spoon.metamodel.MetamodelConcept;
 import spoon.metamodel.Metamodel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
@@ -220,7 +221,7 @@ public class CtScannerTest {
 
 	@Test
 	public void testScan() {
-		// contract: all AST nodes are visisted through method "scan"
+		// contract: all AST nodes are visited through method "scan"
 		Launcher launcher;
 		launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
@@ -256,14 +257,22 @@ public class CtScannerTest {
 				super.exit(o);
 			}
 		});
+		
+		//top comment of file belongs to compilation unit which is not visited by standard scanning
+		//so count comments of these compilation units
+		int countOfCommentsInCompilationUnits = 0;
+		for (CompilationUnit cu : launcher.getFactory().CompilationUnit().getMap().values()) {
+			countOfCommentsInCompilationUnits += cu.getComments().size();
+		}
+
 		// interesting, this is never called because of covariance, only CtElement or Collection is called
 		assertEquals(0, counter.nObject);
 		// this is a coarse-grain check to see if the scanner changes
 		// no more exec ref in paramref
 		// also takes into account the comments
-		assertEquals(3655, counter.nElement);
-		assertEquals(2435, counter.nEnter);
-		assertEquals(2435, counter.nExit);
+		assertEquals(3655, counter.nElement + countOfCommentsInCompilationUnits);
+		assertEquals(2435, counter.nEnter + countOfCommentsInCompilationUnits);
+		assertEquals(2435, counter.nExit + countOfCommentsInCompilationUnits);
 
 		// contract: all AST nodes which are part of Collection or Map are visited first by method "scan(Collection|Map)" and then by method "scan(CtElement)"
 		Counter counter2 = new Counter();

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -439,7 +439,7 @@ public class APITest {
 		assertEquals("A", l.getSimpleName());
 		assertEquals(1, l.getMethods().size());
 		assertEquals("m", l.getMethodsByName("m").get(0).getSimpleName());
-		assertEquals("System.out.println(\"yeah\")", l.getMethodsByName("m").get(0).getBody().getStatement(0).toString());
+		assertEquals("java.lang.System.out.println(\"yeah\")", l.getMethodsByName("m").get(0).getBody().getStatement(0).toString());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/api/collections/patterns/ListPatterns.java
+++ b/src/test/java/spoon/test/api/collections/patterns/ListPatterns.java
@@ -1,0 +1,144 @@
+package spoon.test.api.collections.patterns;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import spoon.pattern.Pattern;
+import spoon.pattern.PatternBuilder;
+import spoon.pattern.PatternBuilderHelper;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtProvidedService;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.reflect.declaration.CtElementImpl;
+import spoon.template.Local;
+
+public class ListPatterns extends CtElementImpl {
+
+	private List<ItemType> $field$ = CtElementImpl.emptyList();
+
+	@Local
+	public static Pattern fieldPattern(Factory factory) {
+		return PatternBuilder.create(new PatternBuilderHelper(factory.Class().get(ListPatterns.class)).setTypeMember("$field$").getPatternElements())
+		.configurePatternParameters(pb -> {
+			pb.parameter("propertyName").byString("$field$");
+			pb.parameter("itemType").byType(ItemType.class);
+		}).build();
+	}
+
+	public List<ItemType> get$UCPropertyName$() {
+		if ($unmodifiable$) {
+			return Collections.unmodifiableList(this.$field$);
+		} else {
+			return this.$field$;
+		}
+	}
+	
+	@Local
+	boolean $unmodifiable$;
+	
+	@Local
+	public static Pattern getListPattern(Factory factory) {
+		return PatternBuilder.create(new PatternBuilderHelper(factory.Class().get(ListPatterns.class)).setTypeMember("get$UCPropertyName$").getPatternElements())
+		.configurePatternParameters(pb -> {
+			pb.parameter("ucPropertyName").bySubstring("$UCPropertyName$");
+			pb.parameter("propertyName").byString("$field$");
+			pb.parameter("itemType").byType(ItemType.class);
+			pb.parameter("annotations").byRole(CtRole.ANNOTATION, new TypeFilter<>(CtMethod.class));
+			pb.parameter("isUnmodifiable").byReferenceName("$unmodifiable$").matchInlinedStatements();
+		}).build();
+	}
+
+	public <T extends ListPatterns> T set$UCPropertyName$s(List<ItemType> $paramName$) {
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.IMPLEMENTATION_TYPE, this.$field$, new ArrayList<>(this.$field$));
+		if ($paramName$ == null || $paramName$.isEmpty()) {
+			this.$field$ = CtElementImpl.emptyList();
+			return (T) this;
+		}
+
+		if (this.$field$ == CtElementImpl.<ItemType>emptyList()) {
+			this.$field$ = new ArrayList<>();
+		}
+		this.$field$.clear();
+		for (ItemType usedType : $paramName$) {
+			this.add$UCPropertyName$(usedType);
+		}
+
+		return (T) this;
+	}
+	
+	@Local
+	public static Pattern setListPattern(Factory factory) {
+		return PatternBuilder.create(new PatternBuilderHelper(factory.Class().get(ListPatterns.class)).setTypeMember("set$UCPropertyName$s").getPatternElements())
+		.configurePatternParameters(pb -> {
+			pb.parameter("ucPropertyName").bySubstring("$UCPropertyName$");
+			pb.parameter("propertyName").byString("$field$");
+			pb.parameter("paramName").byString("$paramName$");
+			pb.parameter("itemType").byType(ItemType.class);
+			pb.parameter("roleType").byReferenceName("IMPLEMENTATION_TYPE");
+			pb.parameter("annotations").byRole(CtRole.ANNOTATION, new TypeFilter<>(CtMethod.class));
+			pb.parameter("genericTypeName").byString("T");
+		}).build();
+	}
+
+	public <T extends ListPatterns> T add$UCPropertyName$(ItemType $paramName$) {
+		if ($paramName$ == null) {
+			return (T) this;
+		}
+		if (this.$field$ == CtElementImpl.<ItemType>emptyList()) {
+			if ($useArraySize$) {
+				this.$field$ = new ArrayList<>($arraySize$);
+			} else {
+				this.$field$ = new ArrayList<>();
+			}
+		}
+
+		if ($case1$) { 
+			getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.IMPLEMENTATION_TYPE, this.$field$, $paramName$);
+			$paramName$.setParent(this);
+		} else {
+		    $paramName$.setParent(this);
+		    getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.IMPLEMENTATION_TYPE, this.$field$, $paramName$);
+		}
+		this.$field$.add($paramName$);
+		return (T) this;
+	}
+	
+	boolean $case1$;
+	boolean $useArraySize$;
+	int $arraySize$;
+	
+
+	@Local
+	public static Pattern addItemPattern(Factory factory) {
+		return PatternBuilder.create(new PatternBuilderHelper(factory.Class().get(ListPatterns.class)).setTypeMember("add$UCPropertyName$").getPatternElements())
+		.configurePatternParameters(pb -> {
+			pb.parameter("ucPropertyName").bySubstring("$UCPropertyName$");
+			pb.parameter("propertyName").byString("$field$");
+			pb.parameter("paramName").byString("$paramName$");
+			pb.parameter("itemType").byType(ItemType.class);
+			pb.parameter("roleType").byReferenceName("IMPLEMENTATION_TYPE");
+			pb.parameter("annotations").byRole(CtRole.ANNOTATION, new TypeFilter<>(CtMethod.class));
+			pb.parameter("genericTypeName").byString("T");
+			pb.parameter("arraySize").byReferenceName("$arraySize$");
+			pb.parameter("case1").byReferenceName("$case1$").matchInlinedStatements();
+			pb.parameter("useArraySize").byReferenceName("$useArraySize$").matchInlinedStatements();
+			
+		}).build();
+	}
+
+	@Local
+	@Override
+	public void accept(CtVisitor visitor) {
+		// TODO Auto-generated method stub
+		
+	}
+}
+
+interface ItemType extends CtElement {
+}

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -272,9 +272,10 @@ public class CommentTest {
 		Factory f = getSpoonFactory();
 		CtClass<?> type = (CtClass<?>) f.Type().get(InlineComment.class);
 		List<CtComment> comments = type.getComments();
-		assertEquals(6, comments.size());
+		List<CtComment> compilationUnitComments = type.getPosition().getCompilationUnit().getComments();
+		assertEquals(6, comments.size() + compilationUnitComments.size());
 		type.removeComment(comments.get(0));
-		assertEquals(5, type.getComments().size());
+		assertEquals(5, type.getComments().size() +  + compilationUnitComments.size());
 	}
 
 	@Test
@@ -282,25 +283,25 @@ public class CommentTest {
 		Factory f = getSpoonFactory();
 		CtClass<?> type = (CtClass<?>) f.Type().get(InlineComment.class);
 		String strType = type.toString();
+		
+		List<CtComment> compilationUnitComments = type.getPosition().getCompilationUnit().getComments();
+		assertEquals(2, compilationUnitComments.size());
+		assertEquals(CtComment.CommentType.BLOCK, compilationUnitComments.get(0).getCommentType());
+		assertEquals("Top File\nLine 2", compilationUnitComments.get(0).getContent());
+		assertEquals("Bottom File", compilationUnitComments.get(1).getContent());
 
 		List<CtComment> comments = type.getElements(new TypeFilter<>(CtComment.class));
 		// verify that the number of comment present in the AST is correct
-		assertEquals(69, comments.size());
+		assertEquals(67, comments.size());
 
 		// verify that all comments present in the AST are printed
 		for (CtComment comment : comments) {
-			if (comment.getCommentType() == CtComment.CommentType.FILE) {
-				// the header of the file is not printed with the toString
-				continue;
-			}
 			assertNotNull(comment.getParent());
 			assertTrue(comment.toString() + ":" + comment.getParent() + " is not printed", strType.contains(comment.toString()));
 		}
 
-		assertEquals(6, type.getComments().size());
-		assertEquals(CtComment.CommentType.FILE, type.getComments().get(0).getCommentType());
-		assertEquals(createFakeComment(f, "comment class"), type.getComments().get(1));
-		assertEquals("Bottom File", type.getComments().get(5).getContent());
+		assertEquals(4, type.getComments().size());
+		assertEquals(createFakeComment(f, "comment class"), type.getComments().get(0));
 
 		CtField<?> field = type.getField("field");
 		assertEquals(4, field.getComments().size());
@@ -480,24 +481,23 @@ public class CommentTest {
 		Factory f = getSpoonFactory();
 		CtClass<?> type = (CtClass<?>) f.Type().get(BlockComment.class);
 		String strType = type.toString();
+		
+		List<CtComment> compilationUnitComments = type.getPosition().getCompilationUnit().getComments();
+		assertEquals(2, compilationUnitComments.size());
+		assertEquals("Bottom File", compilationUnitComments.get(1).getContent());
 
 		List<CtComment> comments = type.getElements(new TypeFilter<>(CtComment.class));
 		// verify that the number of comment present in the AST is correct
-		assertEquals(52, comments.size());
+		assertEquals(50, comments.size());
 
 		// verify that all comments present in the AST are printed
 		for (CtComment comment : comments) {
-			if (comment.getCommentType() == CtComment.CommentType.FILE) {
-				// the header of the file is not printed with the toString
-				continue;
-			}
 			assertNotNull(comment.getParent());
 			assertTrue(comment.toString() + ":" + comment.getParent() + " is not printed", strType.contains(comment.toString()));
 		}
 
-		assertEquals(5, type.getComments().size());
-		assertEquals(createFakeBlockComment(f, "comment class"), type.getComments().get(1));
-		assertEquals("Bottom File", type.getComments().get(4).getContent());
+		assertEquals(3, type.getComments().size());
+		assertEquals(createFakeBlockComment(f, "comment class"), type.getComments().get(0));
 
 		CtField<?> field = type.getField("field");
 		assertEquals(2, field.getComments().size());
@@ -795,6 +795,7 @@ public class CommentTest {
 	@Test
 	public void testDocumentationContract() throws Exception {
 		// contract: all metamodel classes must be commented with an example.
+		
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -99,6 +99,37 @@ public class CompilationTest {
     }
 
 	@Test
+	public void compileTestWithImportStaticWildcard() {
+
+		/*
+			Test the compilation of a java file with an import static with wildcard
+		 */
+
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/compilation/");
+		launcher.getEnvironment().setShouldCompile(true);
+		launcher.getEnvironment().setAutoImports(true);
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.getEnvironment().setCommentEnabled(true);
+		launcher.getEnvironment().setBinaryOutputDirectory("target/spooned-classes/");
+		launcher.getEnvironment().setSourceOutputDirectory(new File("target/spooned/"));
+		launcher.run();
+
+		SpoonModelBuilder compiler = launcher.createCompiler();
+		boolean compile = compiler.compile(SpoonModelBuilder.InputType.CTTYPES);
+		final String nl = System.getProperty("line.separator");
+		assertTrue(
+				nl + "the compilation should succeed: " + nl +
+						((JDTBasedSpoonCompiler) compiler).getProblems()
+								.stream()
+								.filter(IProblem::isError)
+								.map(CategorizedProblem::toString)
+								.collect(Collectors.joining(nl)),
+				compile
+		);
+	}
+
+	@Test
 	public void compileCommandLineTest() {
 		// the --compile option works, shouldCompile is set
 
@@ -298,7 +329,7 @@ public class CompilationTest {
 	public void testPrecompile() {
 		// without precompile
 		Launcher l = new Launcher();
-		l.setArgs(new String[] {"--noclasspath", "-i", "src/test/resources/compilation/"});
+		l.setArgs(new String[]{"--noclasspath", "-i", "src/test/resources/compilation/"});
 		l.buildModel();
 		CtClass klass = l.getFactory().Class().get("compilation.Bar");
 		// without precompile, actualClass does not exist (an exception is thrown)
@@ -309,7 +340,7 @@ public class CompilationTest {
 
 		// with precompile
 		Launcher l2 = new Launcher();
-		l2.setArgs(new String[] {"--precompile", "--noclasspath", "-i", "src/test/resources/compilation/"});
+		l2.setArgs(new String[]{"--precompile", "--noclasspath", "-i", "src/test/resources/compilation/"});
 		l2.buildModel();
 		CtClass klass2 = l2.getFactory().Class().get("compilation.Bar");
 		// with precompile, actualClass is not null
@@ -319,7 +350,7 @@ public class CompilationTest {
 
 		// precompile can be used to compile processors on the fly
 		Launcher l3 = new Launcher();
-		l3.setArgs(new String[] {"--precompile", "--noclasspath", "-i", "src/test/resources/compilation/", "-p", "compilation.SimpleProcessor"});
+		l3.setArgs(new String[]{"--precompile", "--noclasspath", "-i", "src/test/resources/compilation/", "-p", "compilation.SimpleProcessor"});
 		l3.run();
 	}
 
@@ -351,9 +382,9 @@ public class CompilationTest {
 	@Test
 	public void testSingleClassLoader() throws Exception {
 		/*
-		*  contract: the environment exposes a classloader configured by the spoonclass path,
-		*  there is one class loader, so the loaded classes are compatible
-		*/
+		 *  contract: the environment exposes a classloader configured by the spoonclass path,
+		 *  there is one class loader, so the loaded classes are compatible
+		 */
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(new FileSystemFolder("./src/test/resources/classloader-test"));
 		File outputBinDirectory = new File("./target/classloader-test");
@@ -429,9 +460,9 @@ public class CompilationTest {
 				} catch (SpoonClassNotFoundException ignore) { }
 			}
 		});
-		
+
 		//JDK 9 has implicit constructor, while JDK 8 has not
-		assertTrue(l.size()>=2);
+		assertTrue(l.size() >= 2);
 		assertTrue(l.contains("KJHKY"));
 		assertSame(MyClassLoader.class, launcher.getEnvironment().getInputClassLoader().getClass());
 	}
@@ -443,7 +474,7 @@ public class CompilationTest {
 		String expected = "target/classes/";
 
 		File f = new File(expected);
-		URL[] urls = { f.toURL() };
+		URL[] urls = {f.toURL()};
 		URLClassLoader urlClassLoader = new URLClassLoader(urls);
 		Launcher launcher = new Launcher();
 		launcher.getEnvironment().setInputClassLoader(urlClassLoader);
@@ -463,7 +494,7 @@ public class CompilationTest {
 
 		File f = new File(file);
 		URL url = new URL(distantJar);
-		URL[] urls = { f.toURL(), url };
+		URL[] urls = {f.toURL(), url};
 		URLClassLoader urlClassLoader = new URLClassLoader(urls);
 		Launcher launcher = new Launcher();
 		try {

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -107,7 +107,7 @@ public class ConstructorCallTest {
 		assertEquals("", implicitArrayTyped.toString());
 		assertEquals("AtomicLong[]", implicitArrayTyped.getSimpleName());
 		assertTrue(implicitArrayTyped.getComponentType().isImplicit());
-		assertEquals("", implicitArrayTyped.getComponentType().toString());
+		assertEquals("", implicitArrayTyped.getComponentType().print());
 		assertEquals("AtomicLong", implicitArrayTyped.getComponentType().getSimpleName());
 	}
 

--- a/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
@@ -181,7 +181,8 @@ public class NewClassTest {
 		assertEquals("With", anonymousClass.getSuperclass().getSimpleName());
 		assertEquals("org.apache.lucene.store.Lock$With", anonymousClass.getSuperclass().getQualifiedName());
 		assertEquals("Lock", anonymousClass.getSuperclass().getDeclaringType().getSimpleName());
-		assertEquals("org.apache.lucene.store.Lock.With", anonymousClass.getSuperclass().toString());
+		//superclass is implicit so toString is empty
+		assertEquals("", anonymousClass.getSuperclass().toString());
 		assertEquals("1", anonymousClass.getSimpleName());
 		assertEquals("2", secondNewClass.getAnonymousClass().getSimpleName());
 		assertEquals(1, anonymousClass.getMethods().size());

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -43,6 +43,7 @@ import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Query;
+import spoon.reflect.visitor.NameConflictValidator;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.fieldaccesses.testclasses.B;
@@ -436,8 +437,8 @@ public class FieldAccessTest {
 		final CtClass<B> aClass = launcher.getFactory().Class().get(B.class);
 
 		// now static fields are used with the name of the parent class
-		assertEquals("A.myField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(0).toString());
-		assertEquals("finalField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(1).toString());
+		assertEquals("A.myField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(0).print());
+		assertEquals("finalField", aClass.getElements(new TypeFilter<>(CtFieldWrite.class)).get(1).print());
 	}
 	@Test
 	public void testFieldAccessAutoExplicit() throws Exception {
@@ -449,6 +450,8 @@ public class FieldAccessTest {
  		assertEquals("age", ageFR.getParent().toString());
  		//add local variable declaration which hides the field declaration 
  		method.getBody().insertBegin((CtStatement) mouse.getFactory().createCodeSnippetStatement("int age = 1").compile());
+ 		//run model validator to fix the problem
+ 		new NameConflictValidator().process(mouse.getPosition().getCompilationUnit());
 		//now the field access must use explicit "this."
  		assertEquals("this.age", ageFR.getParent().toString());
 	}

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -49,12 +49,10 @@ import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.support.StandardEnvironment;
 import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.reflect.reference.CtTypeParameterReferenceImpl;
 import spoon.support.reflect.reference.CtTypeReferenceImpl;
@@ -175,7 +173,7 @@ public class GenericsTest {
 
 		// the diamond is resolved to String but we don't print it, so we use the fully qualified name.
 		assertTrue(val.getType().getActualTypeArguments().get(0).isImplicit());
-		assertEquals("", val.getType().getActualTypeArguments().get(0).toString());
+		assertEquals("", val.getType().getActualTypeArguments().get(0).print());
 		assertEquals("java.lang.String", val.getType().getActualTypeArguments().get(0).getQualifiedName());
 		assertEquals("new java.util.ArrayList<>()",val.toString());
 	}
@@ -291,21 +289,18 @@ public class GenericsTest {
 			CtField<?> x = type.getElements(new NamedElementFilter<>(CtField.class,"x"))
 					.get(0);
 			CtTypeReference<?> ref = x.getType();
-			DefaultJavaPrettyPrinter pp = new DefaultJavaPrettyPrinter(
-					new StandardEnvironment());
 
 			// qualifed name
 			assertEquals("java.util.Map$Entry", ref.getQualifiedName());
 
-			// toString uses DefaultJavaPrettyPrinter
+			// toString uses DefaultJavaPrettyPrinter with forced fully qualified names
 			assertEquals("java.util.Map.Entry", ref.toString());
 
-			// now visitCtTypeReference
 			assertSame(java.util.Map.class, ref.getDeclaringType()
 					.getActualClass());
-			pp.visitCtTypeReference(ref);
 
-			assertEquals("java.util.Map.Entry", pp.getResult());
+			//print prints model following implicit same like in origin source
+			assertEquals("Map.Entry", ref.print());
 
 			CtField<?> y = type.getElements(new NamedElementFilter<>(CtField.class,"y"))
 					.get(0);

--- a/src/test/java/spoon/test/imports/ImportScannerTest.java
+++ b/src/test/java/spoon/test/imports/ImportScannerTest.java
@@ -338,7 +338,7 @@ public class ImportScannerTest {
 		//check that there is still javadoc comment which contains "List"
 		assertTrue(type.getMethodsByName("m").get(0).getComments().toString().contains("List"));
 		{
-			DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(type.getFactory().getEnvironment());
+			PrettyPrinter printer = type.getFactory().getEnvironment().createPrettyPrinter();
 			printer.calculate(type.getPosition().getCompilationUnit(), Arrays.asList(type));
 			assertFalse(printer.getResult().contains("import java.util.List;"));
 		}

--- a/src/test/java/spoon/test/imports/testclasses/StaticNoOrdered.java
+++ b/src/test/java/spoon/test/imports/testclasses/StaticNoOrdered.java
@@ -15,6 +15,8 @@ public class StaticNoOrdered {
 
     public void testMachin() {
         assertEquals("bla","truc");
+        assertEquals(7,12);
+        assertEquals(new String[0],new String[0]);
         Test test = new Test() {
             @Override
             public Class<? extends Annotation> annotationType() {

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -30,6 +30,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.CtScanner;
 import spoon.support.reflect.code.CtJavaDocImpl;
+import spoon.test.imports.ImportTest;
 import spoon.test.javadoc.testclasses.Bar;
 
 import static org.junit.Assert.assertEquals;
@@ -64,7 +65,7 @@ public class JavaDocTest {
 				+ "    public <T> CtAnnotationType<?> create(CtPackage owner, String simpleName) {" + System.lineSeparator()
 				+ "        return null;" + System.lineSeparator()
 				+ "    }" + System.lineSeparator()
-				+ "}", aClass.toString());
+				+ "}", ImportTest.printByPrinter(aClass));
 
 		// contract: getDocComment never returns null, it returns an empty string if no comment
 		assertEquals("", aClass.getDocComment());

--- a/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
+++ b/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
@@ -42,8 +42,6 @@ import static org.junit.Assert.assertTrue;
  */
 public class ImportBuilderTest {
 
-	private static final String nl = System.getProperty("line.separator");
-
 	@Test
 	public void testWithNoImport() {
 		// contract: when the source code has no import, none is created when building model
@@ -72,7 +70,7 @@ public class ImportBuilderTest {
 		assertEquals(1, imports.size());
 
 		CtImport ref = imports.iterator().next();
-		assertEquals("import spoon.test.annotation.testclasses.GlobalAnnotation;" + nl, ref.toString());
+		assertEquals("import spoon.test.annotation.testclasses.GlobalAnnotation;", ref.toString());
 		assertTrue(ref.getReference() instanceof CtTypeReference);
 
 		CtTypeReference refType = (CtTypeReference) ref.getReference();
@@ -85,7 +83,8 @@ public class ImportBuilderTest {
 		Launcher spoon = new Launcher();
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/ClassWithInvocation.java");
 		spoon.getEnvironment().setAutoImports(false);
-		spoon.buildModel();
+		//build and print model. During printing the autoImport==false validators are applied
+		spoon.run();
 
 		CtClass classA = spoon.getFactory().Class().get(ClassWithInvocation.class);
 		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
@@ -170,7 +169,7 @@ public class ImportBuilderTest {
 		assertEquals(1, imports.size());
 		CtImport ctImport = imports.iterator().next();
 		assertEquals(CtImportKind.ALL_STATIC_MEMBERS, ctImport.getImportKind());
-		assertEquals("import static spoon.test.jdtimportbuilder.testclasses.staticimport.DependencySubClass.*;" + nl, ctImport.toString());
+		assertEquals("import static spoon.test.jdtimportbuilder.testclasses.staticimport.DependencySubClass.*;", ctImport.toString());
 	}
 
 	@Test
@@ -191,6 +190,6 @@ public class ImportBuilderTest {
 		CtImport ctImport = imports.iterator().next();
 
 		assertEquals(CtImportKind.ALL_STATIC_MEMBERS, ctImport.getImportKind());
-		assertEquals("import static jdtimportbuilder.itf.DumbItf.*;" + nl, ctImport.toString());
+		assertEquals("import static jdtimportbuilder.itf.DumbItf.*;", ctImport.toString());
 	}
 }

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -26,6 +26,7 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
@@ -41,6 +42,7 @@ import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.LambdaFilter;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.imports.ImportTest;
 import spoon.test.lambda.testclasses.Bar;
 import spoon.test.lambda.testclasses.Foo;
 import spoon.test.lambda.testclasses.Kuu;
@@ -286,7 +288,7 @@ public class LambdaTest {
 						+ "    java.lang.System.err.println(\"Enjoy, you have more than 18.\");" + System
 						.lineSeparator()
 						+ "}";
-		assertEquals("Condition must be well printed", expected, condition.toString());
+		assertEquals("Condition must be well printed", expected, printByPrinter(condition));
 	}
 
 	@Test
@@ -303,7 +305,8 @@ public class LambdaTest {
 		final CtParameter<?> ctParameterFirstLambda = lambda1.getParameters().get(0);
 		assertEquals("s", ctParameterFirstLambda.getSimpleName());
 		assertTrue(ctParameterFirstLambda.getType().isImplicit());
-		assertEquals("", ctParameterFirstLambda.getType().toString());
+		assertEquals("", ctParameterFirstLambda.getType().print());
+		assertEquals("spoon.test.lambda.testclasses.Bar.SingleSubscriber<? super T>", ctParameterFirstLambda.getType().toString());
 		assertEquals("SingleSubscriber", ctParameterFirstLambda.getType().getSimpleName());
 	}
 	@Test
@@ -330,7 +333,8 @@ public class LambdaTest {
 
 		final CtArrayTypeReference typeParameter = (CtArrayTypeReference) ctParameter.getType();
 		assertTrue(typeParameter.getComponentType().isImplicit());
-		assertEquals("", typeParameter.getComponentType().toString());
+		assertEquals("", typeParameter.getComponentType().print());
+		assertEquals("java.lang.Object", typeParameter.getComponentType().toString());
 		assertEquals("Object", typeParameter.getComponentType().getSimpleName());
 	}
 
@@ -342,13 +346,15 @@ public class LambdaTest {
 		final CtParameter<?> firstParam = lambda.getParameters().get(0);
 		assertEquals("rs", firstParam.getSimpleName());
 		assertTrue(firstParam.getType().isImplicit());
-		assertEquals("", firstParam.getType().toString());
+		assertEquals("", firstParam.getType().print());
+		assertEquals("java.sql.ResultSet", firstParam.getType().toString());
 		assertEquals("ResultSet", firstParam.getType().getSimpleName());
 
 		final CtParameter<?> secondParam = lambda.getParameters().get(1);
 		assertEquals("i", secondParam.getSimpleName());
 		assertTrue(secondParam.getType().isImplicit());
-		assertEquals("", secondParam.getType().toString());
+		assertEquals("", secondParam.getType().print());
+		assertEquals("int", secondParam.getType().toString());
 		assertEquals("int", secondParam.getType().getSimpleName());
 	}
 
@@ -473,7 +479,11 @@ public class LambdaTest {
 	}
 
 	private void assertIsWellPrinted(String expected, CtLambda<?> lambda) {
-		assertEquals("Lambda must be well printed", expected, lambda.toString());
+		assertEquals("Lambda must be well printed", expected, printByPrinter(lambda));
+	}
+	
+	private static String printByPrinter(CtElement element) {
+		return ImportTest.printByPrinter(element);
 	}
 
 	// note that the lambda number in simple name depends on the classloader

--- a/src/test/java/spoon/test/pattern_detector/PatternDetectorTest.java
+++ b/src/test/java/spoon/test/pattern_detector/PatternDetectorTest.java
@@ -1,0 +1,290 @@
+package spoon.test.pattern_detector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Test;
+
+import spoon.pattern.Match;
+import spoon.pattern_detector.FoundPattern;
+import spoon.pattern_detector.PatternDetector;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.test.pattern_detector.testclasses.Kopernik;
+import spoon.test.pattern_detector.testclasses.TargetType_1;
+import spoon.test.pattern_detector.testclasses.TargetType_2;
+import spoon.testing.utils.ModelUtils;
+
+public class PatternDetectorTest {
+
+	@Test
+	public void testDetectPatternFromOneElement() throws Exception {
+		//contract: one element produces pattern with no parameters
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method = type.getNestedType("A").getMethodsByName("mars").get(0);
+
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(1, detectedPattern.getCountOfMatches());
+		//there is no pattern parameter
+		assertTrue(detectedPattern.getPattern().getParameterInfos().isEmpty());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method));
+	}
+
+	@Test
+	public void testDetectPatternFromTwoMethodsWithDifferentNames() throws Exception {
+		//contract: two similar methods with different method and parameter names produces pattern with 2 parameters
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("A").getMethodsByName("mars").get(0);
+		CtMethod<?> method2 = type.getNestedType("B").getMethodsByName("saturn").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(3, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+	}
+	
+	@Test
+	public void testDetectPatternFromThreeMethodsWithDifferentNames() throws Exception {
+		//contract: three similar methods with different method and parameter names produces pattern with 2 parameters
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("A").getMethodsByName("mars").get(0);
+		CtMethod<?> method2 = type.getNestedType("B").getMethodsByName("saturn").get(0);
+		CtMethod<?> method3 = type.getNestedType("C").getMethodsByName("merkur").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		pd.matchCode(method3);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(3, detectedPattern.getCountOfMatches());
+		assertEquals(3, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method3));
+	}
+
+	@Test
+	public void testDetectPatternFromThreeMethodsWithDifferentNamesLastMethodBringsMoreChanges() throws Exception {
+		//contract: three similar methods with different method and parameter names produces pattern with parameters
+		//last method needs different parameters then second method
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("A").getMethodsByName("mars").get(0);
+		CtMethod<?> method2 = type.getNestedType("B").getMethodsByName("saturn").get(0);
+		CtMethod<?> method3 = type.getNestedType("D").getMethodsByName("mars").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		pd.matchCode(method3);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(3, detectedPattern.getCountOfMatches());
+		assertEquals(4, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method3));
+	}
+
+	@Test
+	public void testDetectPatternFromDifferentExpressions() throws Exception {
+		//contract: pattern detected from `return x` and  `return x + 0` - different size of AST
+		//last method needs different parameters then second method
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("A").getMethodsByName("mars").get(0);
+		CtMethod<?> method2 = type.getNestedType("E").getMethodsByName("mars").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(1, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+	}
+
+	@Test
+	public void testEachLiteralHasOwnParameter() throws Exception {
+		//contract: nodes with same value may share parameter as long as all values are same
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		
+		PatternDetector pd = new PatternDetector();
+		
+		CtMethod<?> method1 = type.getNestedType("Literals").getMethodsByName("m").get(0);
+		pd.matchCode(method1);
+		CtMethod<?> method2 = type.getNestedType("Literals_Same").getMethodsByName("m").get(0);
+		pd.matchCode(method2);
+
+		{	//pattern shares parameters because all code fragments has same values
+			List<FoundPattern> detectedPatterns = pd.getPatterns();
+			assertEquals(1, detectedPatterns.size());
+			FoundPattern detectedPattern = detectedPatterns.get(0);
+			assertEquals(2, detectedPattern.getCountOfMatches());
+			assertEquals(1, detectedPattern.getPattern().getParameterInfos().size());
+			checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+			checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+		}
+
+		CtMethod<?> method3 = type.getNestedType("Literals_Different").getMethodsByName("m").get(0);
+		pd.matchCode(method3);
+		{
+			List<FoundPattern> detectedPatterns = pd.getPatterns();
+			assertEquals(1, detectedPatterns.size());
+			FoundPattern detectedPattern = detectedPatterns.get(0);
+			assertEquals(3, detectedPattern.getCountOfMatches());
+			assertEquals(3, detectedPattern.getPattern().getParameterInfos().size());
+			checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+			checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+			checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method3));
+		}
+		
+	}
+	
+	@Test
+	public void testReturnFieldOfDifferentType() throws Exception {
+		//contract: literals have own parameter. Never use shared variable for them
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("ReturnField_1").getMethodsByName("getA").get(0);
+		CtMethod<?> method2 = type.getNestedType("ReturnField_2").getMethodsByName("getB").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(4, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+	}
+
+	@Test
+	public void testTargetType() throws Exception {
+		//contract: The targetType parameter doesn't breaks detected pattern
+		Factory factory = ModelUtils.build(TargetType_1.class, TargetType_2.class);
+		CtMethod<?> method1 = factory.Type().get(TargetType_1.class).getMethodsByName("call").get(0);
+		CtMethod<?> method2 = factory.Type().get(TargetType_2.class).getMethodsByName("call").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		//method1 uses targetType for all type references to TargetType_1 
+		pd.matchCode(method1);
+		//method2 reference to TargetType_1 can use parameter targetType which is TargetType_2  
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(1, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+	}
+
+	@Test
+	public void testIgnoreThisAccess() throws Exception {
+		//contract: The `this.field` and `field` is understood as one access to the field
+		CtType<?> type = ModelUtils.buildClass(Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("ThisAccess_1").getMethodsByName("thisAccess").get(0);
+		CtMethod<?> method2 = type.getNestedType("ThisAccess_2").getMethodsByName("thisAccess").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(1, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+	}
+
+	@Test
+	public void testIgnoreComments() throws Exception {
+		//contract: The comments can be ignored during pattern detection
+		CtType<?> type = ModelUtils.buildClass(launcher -> {
+			launcher.getEnvironment().setCommentEnabled(true);
+		}, Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("Comments_1").getMethodsByName("comment").get(0);
+		CtMethod<?> method2 = type.getNestedType("Comments_2").getMethodsByName("comment").get(0);
+		
+		PatternDetector pd = new PatternDetector().setIgnoreComments(true);
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(1, detectedPatterns.size());
+		FoundPattern detectedPattern = detectedPatterns.get(0);
+		assertEquals(2, detectedPattern.getCountOfMatches());
+		assertEquals(0, detectedPattern.getPattern().getParameterInfos().size());
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method1));
+		/*
+		 	the method with comments doesn't matches the pattern without comments - OK for now.
+			We do not enforce this behavior as test, because it is not wanted, but understandable
+		
+		checkPatternMatchesCodeAndGeneratesSameCode(detectedPattern, Collections.singletonList(method2));
+		*/
+	}
+
+	@Test
+	public void testSeeComments() throws Exception {
+		//contract: The comments can be used in pattern detection too
+		CtType<?> type = ModelUtils.buildClass(launcher -> {
+			launcher.getEnvironment().setCommentEnabled(true);
+		}, Kopernik.class);
+		CtMethod<?> method1 = type.getNestedType("Comments_1").getMethodsByName("comment").get(0);
+		CtMethod<?> method2 = type.getNestedType("Comments_2").getMethodsByName("comment").get(0);
+		
+		PatternDetector pd = new PatternDetector();
+		pd.matchCode(method1);
+		pd.matchCode(method2);
+		List<FoundPattern> detectedPatterns = pd.getPatterns();
+		
+		assertEquals(2, detectedPatterns.size());
+	}
+
+	public static void checkPatternMatchesCodeAndGeneratesSameCode(FoundPattern pattern, List<? extends CtElement> code) {
+		//1) match code using pattern
+		List<Match> matches = new ArrayList<>();
+		pattern.getPattern().forEachMatch(code, match -> matches.add(match));
+		//2) there is exactly one match
+		assertEquals(1, matches.size());
+		Match match = matches.get(0);
+		//2) generate node code using pattern and match parameters
+		List<CtElement> generatedFromPattern = pattern.getPattern().generator().generate(CtElement.class, match.getParameters());
+		//sanity check that code is really generated
+		assertNotSame(code.get(0), generatedFromPattern.get(0));
+		//check that code and generated code are same
+		assertEquals(code, generatedFromPattern);
+	}
+}

--- a/src/test/java/spoon/test/pattern_detector/testclasses/Kopernik.java
+++ b/src/test/java/spoon/test/pattern_detector/testclasses/Kopernik.java
@@ -1,0 +1,103 @@
+package spoon.test.pattern_detector.testclasses;
+
+import java.util.Collections;
+import java.util.List;
+
+import spoon.reflect.code.CtStatement;
+
+public class Kopernik {
+	class A {
+		int mars(int x) {
+			System.out.println("I am Mars with temperature: " + x);
+			return x + 0;
+		}
+	}
+	class B {
+		int saturn(int y) {
+			System.out.println("I am Saturn with temperature: " + y);
+			return y + 0;
+		}
+	}
+	class C {
+		int merkur(int temparature) {
+			System.out.println("I am Merku with temperature: " + temparature);
+			return temparature + 0;
+		}
+	}
+	class D {
+		int mars(int x) {
+			System.out.println("I am Mars with temperature: " + x);
+			return x + 1;
+		}
+	}
+	class E {
+		Integer mars(int x) {
+			System.out.println("I am Mars with temperature: " + x);
+			return x + 0;
+		}
+	}
+	class F {
+		Integer saturn() {
+			System.out.println("I am Saturn");
+			return null;
+		}
+	}
+	class Literals {
+		void m() {
+			int a = 0;
+			int b = 0;
+			int c = 0;
+		}
+	}
+	class Literals_Same {
+		void m() {
+			int a = 1;
+			int b = 1;
+			int c = 0;
+		}
+	}
+	class Literals_Different {
+		void m() {
+			int a = 0;
+			int b = 1;
+			int c = 1;
+		}
+	}
+	class ReturnField_1 {
+		List<String> a;
+		List<String> getA() {
+			return a;
+		}
+	}
+	class ReturnField_2 {
+		List<Integer> b;
+		List<Integer> getB() {
+			return b;
+		}
+	}
+	class ThisAccess_1 {
+		List lst;
+		public void thisAccess(CtStatement statement) {
+			if (this.lst == Collections.emptyList()) {
+				return;
+			}
+		}
+	}
+	class ThisAccess_2 {
+		List lst;
+		public void thisAccess(CtStatement statement) {
+			if (lst == Collections.emptyList()) {
+				return;
+			}
+		}
+	}
+	class Comments_1 {
+		public void comment() {
+			//xx
+		}
+	}
+	class Comments_2 {
+		public void comment() {
+		}
+	}
+}

--- a/src/test/java/spoon/test/pattern_detector/testclasses/TargetType_1.java
+++ b/src/test/java/spoon/test/pattern_detector/testclasses/TargetType_1.java
@@ -1,0 +1,10 @@
+package spoon.test.pattern_detector.testclasses;
+
+public class TargetType_1 {
+	int f;
+	public void call() {
+		f = 0;
+		TargetType_1.m();
+	}
+	static void m() {};
+}

--- a/src/test/java/spoon/test/pattern_detector/testclasses/TargetType_2.java
+++ b/src/test/java/spoon/test/pattern_detector/testclasses/TargetType_2.java
@@ -1,0 +1,9 @@
+package spoon.test.pattern_detector.testclasses;
+
+public class TargetType_2 {
+	int f;
+	public void call() {
+		f = 0;
+		TargetType_1.m();
+	}
+}

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -743,7 +743,7 @@ public class PositionTest {
 		BodyHolderSourcePosition bhsp = (BodyHolderSourcePosition) annonClass.getPosition();
 		int start = annonClass.getPosition().getSourceStart();
 		int end = annonClass.getPosition().getSourceEnd();
-		assertEquals("Consumer<Set<?>>() {\r\n" + 
+		assertEquals("{\r\n" + 
 				"			@Override\r\n" + 
 				"			public void accept(Set<?> t) {\r\n" + 
 				"			}\r\n" + 

--- a/src/test/java/spoon/test/position/TestSourceFragment.java
+++ b/src/test/java/spoon/test/position/TestSourceFragment.java
@@ -19,7 +19,8 @@ package spoon.test.position;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static spoon.testing.utils.ModelUtils.buildClass;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,11 +35,12 @@ import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
-import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -49,7 +51,6 @@ import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.reflect.cu.CompilationUnitImpl;
 import spoon.support.reflect.cu.position.SourcePositionImpl;
 import spoon.test.position.testclasses.AnnonymousClassNewIface;
-import spoon.test.position.testclasses.Expressions;
 import spoon.test.position.testclasses.FooField;
 import spoon.test.position.testclasses.FooSourceFragments;
 import spoon.test.position.testclasses.NewArrayList;
@@ -207,6 +208,57 @@ public class TestSourceFragment {
 		checkElementFragments(((CtAssignment)foo.getMethodsByName("m5").get(0).getBody().getStatement(0)).getAssignment(),"7.2");
 				 
 	}
+	
+	@Test
+	public void testSourceFragmentsOfCompilationUnit() throws Exception {
+		//contract: SourceFragments of compilation unit children like, package declaration, imports, types
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(false);
+		launcher.getEnvironment().setCommentEnabled(true);
+		SpoonModelBuilder comp = launcher.createCompiler();
+		comp.addInputSources(SpoonResourceHelper.resources("./src/test/java/" + FooSourceFragments.class.getName().replace('.', '/') + ".java"));
+		comp.build();
+		Factory f = comp.getFactory();
+		
+		final CtType<?> foo = f.Type().get(FooSourceFragments.class);
+		CtCompilationUnit compilationUnit = foo.getPosition().getCompilationUnit();
+		
+		ElementSourceFragment fragment = compilationUnit.getOriginalSourceFragment();
+		List<SourceFragment> children = fragment.getChildrenFragments();
+		assertEquals(11, children.size());
+		assertEquals("/**\n" + 
+				" * Javadoc at top of file\n" + 
+				" */", children.get(0).getSourceCode());
+		assertEquals("\n", children.get(1).getSourceCode());
+		assertEquals("/* comment before package declaration*/\n" + 
+				"package spoon.test.position.testclasses;", children.get(2).getSourceCode());
+		assertEquals("\n\n", children.get(3).getSourceCode());
+		assertEquals("/*\n" + 
+				" * Comment before import\n" + 
+				" */\n" + 
+				"import java.lang.Deprecated;", children.get(4).getSourceCode());
+		assertEquals("\n\n", children.get(5).getSourceCode());
+		assertEquals("import java.lang.Class;", children.get(6).getSourceCode());
+		assertEquals("\n\n", children.get(7).getSourceCode());
+		assertTrue(((ElementSourceFragment) children.get(8)).getElement() instanceof CtClass);
+		assertStartsWith("/*\n" + 
+				" * Comment before type\n" + 
+				" */\n" + 
+				"public class FooSourceFragments", children.get(8).getSourceCode());
+		assertEndsWith("//after last type member\n}", children.get(8).getSourceCode());
+		assertEquals("\n\n", children.get(9).getSourceCode());
+		assertEquals("//comment at the end of file", children.get(10).getSourceCode());
+	}
+	
+
+	private void assertStartsWith(String expectedPrefix, String real) {
+		assertEquals(expectedPrefix, real.substring(0, Math.min(expectedPrefix.length(), real.length())));
+	}
+
+	private void assertEndsWith(String expectedSuffix, String real) {
+		int len = real.length();
+		assertEquals(expectedSuffix, real.substring(Math.max(0, len - expectedSuffix.length()), len));
+	}
 
 	@Test
 	public void testSourceFragmentsOfFieldAccess() throws Exception {
@@ -302,6 +354,8 @@ public class TestSourceFragment {
 					"			}", children.get(2).getSourceCode().replaceAll("\\r|\\n", ""));
 			assertEquals("		", children.get(3).getSourceCode().replaceAll("\\r|\\n", ""));
 			assertEquals("}", children.get(4).getSourceCode());
+			
+			
 		}
 	}
 
@@ -336,14 +390,14 @@ public class TestSourceFragment {
 			if (item instanceof String[]) {
 				return "group("+Arrays.asList((String[]) item).toString() + ")";
 			}
-			return item;
-		}).collect(Collectors.toList()), groupedChildrenFragments.stream().map(item -> {
+			return "\"" + item.toString() + "\"";
+		}).collect(Collectors.joining(";")), groupedChildrenFragments.stream().map(item -> {
 			if (item instanceof CollectionSourceFragment) {
 				CollectionSourceFragment csf = (CollectionSourceFragment) item;
 				return "group("+ toCodeStrings(csf.getItems()).toString() + ")";
 			}
-			return item.getSourceCode();
-		}).collect(Collectors.toList()));
+			return "\"" + item.getSourceCode() + "\"";
+		}).collect(Collectors.joining(";")));
 	}
 	
 	private static List<String> toCodeStrings(List<SourceFragment> csf) {

--- a/src/test/java/spoon/test/position/testclasses/FooSourceFragments.java
+++ b/src/test/java/spoon/test/position/testclasses/FooSourceFragments.java
@@ -1,5 +1,19 @@
+/**
+ * Javadoc at top of file
+ */
+/* comment before package declaration*/
 package spoon.test.position.testclasses;
 
+/*
+ * Comment before import
+ */
+import java.lang.Deprecated;
+
+import java.lang.Class;
+
+/*
+ * Comment before type
+ */
 public class FooSourceFragments {
 	void m1(int x) {
 		if(x > 0){this.getClass();}else{/*empty*/}
@@ -28,5 +42,7 @@ public class FooSourceFragments {
 	void m5(double f) {
 		f = 7.2;
 	}
-
+	//after last type member
 }
+
+//comment at the end of file

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -176,8 +176,8 @@ public class PrinterTest {
 		//delete the field, so the model is broken.
 		//It may happen during substitution operations and then it is helpful to display descriptive error message
 		type.getField("testedField").delete();
-		//contract: printer fails with descriptive exception and not with NPE
-		assertEquals("/* ERROR: Missing field \"testedField\", please check your model. The code may not compile. */ testedField = 1", type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString());
+		//contract: printer doesn't fail, but prints the field reference even if there is no declaration visible
+		assertEquals("testedField = 1", type.getMethodsByName("failingMethod").get(0).getBody().getStatement(0).toString());
 	}
 
 	private final Set<String> separators = new HashSet<>(Arrays.asList("->","::","..."));

--- a/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
@@ -4,13 +4,18 @@ import spoon.test.prettyprinter.testclasses.sub.Constants;
 
 import static org.junit.Assert.assertTrue;
 
+import static java.lang.System.out;
+
 
 /**
  * Created by urli on 30/01/2017.
  */
 public class ImportStatic {
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args, java.lang.String[] args2,
+    		String args3, java.lang.String args4) throws Exception {
         assertTrue("blabla".equals("toto"));
+        out.println(Constants.READY);
         System.out.println(Constants.READY);
+        java.lang.System.out.println(Constants.READY);
     }
 }

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -664,17 +664,17 @@ public class TypeReferenceTest {
 		// contract: CtTypeReference#isImplicitParent can be used read / write implicit value of the parent
 		CtType<?> type = ModelUtils.buildClass(SuperAccess.class);
 		CtTypeReference<?> typeRef = type.getSuperclass();
-		assertFalse(typeRef.isImplicitParent());
-		assertFalse(typeRef.getPackage().isImplicit());
-		
-		//calling of setImplicitParent influences implicitnes of parent
-		typeRef.setImplicitParent(true);
 		assertTrue(typeRef.isImplicitParent());
 		assertTrue(typeRef.getPackage().isImplicit());
-
-		//calling of setImplicit on parent influences return value of isImplicitParent
-		typeRef.getPackage().setImplicit(false);
+		
+		//calling of setImplicitParent influences implicitnes of parent
+		typeRef.setImplicitParent(false);
 		assertFalse(typeRef.isImplicitParent());
 		assertFalse(typeRef.getPackage().isImplicit());
+
+		//calling of setImplicit on parent influences return value of isImplicitParent
+		typeRef.getPackage().setImplicit(true);
+		assertTrue(typeRef.isImplicitParent());
+		assertTrue(typeRef.getPackage().isImplicit());
 	}
 }

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -191,8 +191,8 @@ public class TargetedExpressionTest {
 		final List<CtFieldAccess<?>> staticElements = staticInit.getElements(new TypeFilter<>(CtFieldAccess.class));
 		assertEquals(1, staticElements.size());
 
-		// Changing behaviour when writing static field, it is now writed using the class name
-		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedTypeAccess).result("p"), staticElements.get(0));
+		// Changing behaviour when writing static field, it is now written using the class name
+		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedTypeAccess).result("spoon.test.targeted.testclasses.Foo.p"), staticElements.get(0));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/variable/AccessFullyQualifiedFieldTest.java
+++ b/src/test/java/spoon/test/variable/AccessFullyQualifiedFieldTest.java
@@ -90,8 +90,9 @@ public class AccessFullyQualifiedFieldTest {
 		String output = "target/spooned-" + this.getClass().getSimpleName() + "-StaticMethod/";
 		String pathResource = "src/test/java/spoon/test/variable/testclasses/BurritosStaticMethod.java";
 		String result = this.buildResourceAndReturnResult(pathResource, output);
-
-		assertTrue("The inner class should contain call using import", result.contains(" toto();"));
+		//the package name `spoon.test.variable.testclasses` cannot be used in FQN mode because it is shadowed by local variable `spoon`
+		//so use at least Type name
+		assertTrue("The inner class should contain call using import", result.contains(" BurritosStaticMethod.toto();"));
 		canBeBuilt(output, 7);
 	}
 

--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -172,6 +172,6 @@ public class VisibilityTest {
 		}).get(0);
 		assertNotNull(ctInvocation.getTarget());
 		assertTrue(ctInvocation.getTarget().isImplicit());
-		assertEquals("bound()", ctInvocation.toString());
+		assertEquals("bound()", ctInvocation.print());
 	}
 }


### PR DESCRIPTION
It is reverse operation for the "Matching code by Pattern".
The set of Spoon ASTs can be processed by PatternDetector, which produces "minimal" set of Patterns, which matches processed ASTs.

What it is good for? If client wants to automatically replace some algorithms, then s/he has to 
1) detect which algorithms exist in target area (using PatternDetector)
2) manually check all detected patterns, and optionally merge some of them into more generic pattern
3) for each existing pattern, write a new pattern 
4) match code for existing patterns and for each match generate code using new pattern and replace old code by new code
... and complex refactoring is done in safe way ... at least it is an idea how it might work ;-)

For example I plan to use that to refactor all Spoon model property accessor methods to fix all problems found by #1922.