### PR TITLE
can be closed: fix: shadow elements are built using correct factory

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -528,19 +528,10 @@ public class TypeFactory extends SubFactory {
 			if (shadowClass == null) {
 				CtType<T> newShadowClass;
 				try {
-					newShadowClass = new JavaReflectionTreeBuilder(createFactory()).scan((Class<T>) cl);
+					newShadowClass = new JavaReflectionTreeBuilder(factory).scan((Class<T>) cl);
 				} catch (Throwable e) {
 					throw new SpoonClassNotFoundException("cannot create shadow class: " + cl.getName(), e);
 				}
-				newShadowClass.setFactory(factory);
-				newShadowClass.accept(new CtScanner() {
-					@Override
-					public void scan(CtElement element) {
-						if (element != null) {
-							element.setFactory(factory);
-						}
-					}
-				});
 				this.shadowCache.put(cl, newShadowClass);
 				return newShadowClass;
 			} else {

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -19,6 +19,7 @@ package spoon.support.visitor;
 import spoon.processing.Processor;
 import spoon.processing.TraversalStrategy;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.CtScanner;
 
@@ -30,6 +31,8 @@ public class ProcessingVisitor extends CtScanner {
 	Factory factory;
 
 	Processor<?> processor;
+
+	protected boolean skipShadow = true;
 
 	/**
 	 * The constructor.
@@ -65,6 +68,10 @@ public class ProcessingVisitor extends CtScanner {
 	@SuppressWarnings("unchecked")
 	public void scan(CtElement e) {
 		if (e == null) {
+			return;
+		}
+		if (skipShadow && e instanceof CtShadowable && ((CtShadowable) e).isShadow()) {
+			//do not process shadow elements
 			return;
 		}
 		Processor<CtElement> p = (Processor<CtElement>) processor;

--- a/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
+++ b/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
@@ -201,8 +201,9 @@ public class MethodReferenceTest {
 		assertNull(bMethod.getReference().getOverridingExecutable());
 
 		// get super method of a class available in classpath (Object)
-		final CtMethod toStringMethod = model.getElements(
-				new NamedElementFilter<>(CtMethod.class,"toString")).get(0);
+		final CtMethod toStringMethod = model.getElements((CtMethod m) ->
+			"toString".equals(m.getSimpleName()) 
+			&& "UnknownSuperClass".equals(m.getParent(CtType.class).getSimpleName())).get(0);
 		assertNotNull(toStringMethod.getAnnotation(overrideRef));
 		assertNotNull(toStringMethod.getReference().getOverridingExecutable());
 	}


### PR DESCRIPTION
I do not know details now, but it happened that shadow type contains some elements, which points to wrong (temporary) factory instead to `Factory` of client's main `Launcher`.

So I made this PR to create shadow elements directly with normal Factory. It causes that they are consistently added into that Factory and that they are accessible from that Factory - of course. 
May be it is not wanted (see question #2546) ...

This PR experiments with idea of having shadow classes as part of normal Factory (after they are built once)