### PR TITLE
refactor: change keySet to entrySet to improve performance (SonarQube fix)

### DIFF
--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -98,11 +98,10 @@ public class SnippetCompilationHelper {
 		newClass.replace(initialClass);
 
 		// and we replace the snippets
-		for (CtPath p : elements2before.keySet()) {
-			CtElement toReplace = elements2before.get(p);
-			toReplace.replace(elements2after.get(p));
+		for (Map.Entry<CtPath, CtElement> ctPath : elements2before.entrySet()) {
+			CtElement toReplace = ctPath.getValue();
+			toReplace.replace(elements2after.get(ctPath.getKey()));
 		}
-
 	}
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st)


### PR DESCRIPTION
*keySet()* is obsolete and slower construct, use *entrySet()* instead

https://stackoverflow.com/questions/8962459/java-collections-keyset-vs-entryset-in-map

This is SonarQube fix - Iterate over the "entrySet" instead of the "keySet".