### PR TITLE
feature: CtPath accepts names and signatures on List

### DIFF
--- a/doc/path.md
+++ b/doc/path.md
@@ -27,6 +27,19 @@ path = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.fo
 List<CtElement> l = path.evaluateOn(root)
 ```
 
+## Path syntax
+
+There can be used following path elements:
+* `.<name>` which denotes a child elements with name `name`.
+* `#<role>` which denotes all children on `CtRole` `role`
+* `[<attr1Name>=<attr1Value>;...;<attrN_Name>=<attrN_Value>]`  which applies a extra filter on the children
+
+### Path filter attributes
+* `name=<somename>` - filter which accepts only elements with `somename`. E.g. `#field[name=abc]`
+* `signature=<somesignature>` - filter which accepts only methods and constructors with signature `somesignature`.
+	Example of method signature: `#method[signature=compare(java.lang.String,java.lang.String)]`
+	Example of constructor signature: `#constructor[signature=(int)]`
+* `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. E.g. `#typeMember[index=4]`
 
 ## CtPathStringBuilder
 

--- a/doc/path.md
+++ b/doc/path.md
@@ -6,58 +6,45 @@ keywords: quering, query, path, ast, elements
 
 `CtPath` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPath.html)) 
 defines the path to a `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) 
-in a model. For example, `.spoon.test.path.testclasses.Foo.foo#body#statement[index=0]` represents the first statement of the body of method foo.
-
+in a model, similarly to XPath for XML. For example, `.spoon.test.path.testclasses.Foo.foo#body#statement[index=0]` represents the first statement of the body of method foo.
 A `CtPath`is based on: names of elements (eg `foo`), and roles of elements with respect to their parent (eg `body`).
 A role is a relation between two AST nodes.
 For instance, a "then" branch in a if/then/else is a role (and not an node). All roles can be found in `CtRole`. In addition, each getter or setter in the metamodel is annotated with its role.
 
-To build a path, there are several possibilities:
- 
-* method `getPath` in `CtElement`
-* `CtPathStringBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html)).
-it creates a path object from a string according to a 
-syntax inspired from XPath and CSS selectors.
-* the low-level `CtPathBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html)), it defines a fluent api to build  your path. 
+## Evaluating paths
 
-To evaluate a path, ie getting the elements represented by it, use `evaluateOn(List<CtElement>)`
+Paths are used to find code elements, from a given root elements. 
 
 ```java
 path = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
 List<CtElement> l = path.evaluateOn(root)
 ```
 
-## Path syntax
+## Creating paths
 
-There can be used following path elements:
-* `.<name>` which denotes a child elements with name `name`.
-* `#<role>` which denotes all children on `CtRole` `role`
-* `[<attr1Name>=<attr1Value>;...;<attrN_Name>=<attrN_Value>]`  which applies a extra filter on the children
+### From an existing element
 
-### Path filter attributes
-* `name=<somename>` - filter which accepts only elements with `somename`. E.g. `#field[name=abc]`
-* `signature=<somesignature>` - filter which accepts only methods and constructors with signature `somesignature`.
-	Example of method signature: `#method[signature=compare(java.lang.String,java.lang.String)]`
-	Example of constructor signature: `#constructor[signature=(int)]`
-* `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. E.g. `#typeMember[index=4]`
-
-## CtPathStringBuilder
-
-`CtPathStringBuilder` exposes only one method to build a path from a string. 
-
-- `fromString(String)` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html#fromString-java.lang.String-)) 
-builds a path from a string representation.
-
-For instance, if we want the first statement in the body of method `foo`, declared 
-in the class `spoon.test.path.testclasses.Foo`. 
+Method `getPath` in `CtElement` returns a path
 
 ```java
-new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
+CtPath path = anElement.getPath();
 ```
 
-## CtPathBuilder
+### From a string
 
-`CtPathBuilder` exposes the following methods:
+`CtPathStringBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html)), creates a path object from a string according to the following 
+syntax. 
+* `.<name>` which denotes a child elements with name `name`, eg `.fr.inria.Spoon` (the fully qualified name)
+* `#<role>` which denotes all children on `CtRole` `role` .statements, `#body#statement[index=2]#else` is the else branch of the second statement of a method body
+* `name=<somename>` - filter which accepts only elements with `somename`. E.g. `#field[name=abc]`
+* `signature=<somesignature>` - filter which accepts only methods and constructors with signature `somesignature`.
+  * Example of method signature: `#method[signature=compare(java.lang.String,java.lang.String)]`
+  * Example of constructor signature: `#constructor[signature=(int)]`
+* `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. the fourth type memeber in a class `#typeMember[index=4]`
+
+### From the API
+
+The low-level `CtPathBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html)), it defines a fluent api to build  your path:
 
 - `name(String, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#name-java.lang.String-java.lang.String:A...-)) 
 adds a name matcher to the current path.
@@ -77,13 +64,7 @@ a project. Use `CtPathBuilder` like the example below.
 new CtPathBuilder().recursiveWildcard().name("toto").role(CtPathRole.DEFAULT_VALUE).build();
 ```
 
-The corresponding string syntax would be:
-
-```java
-new CtPathStringBuilder().fromString("**.toto#defaultValue");
-```
-
-The order in instructions is important and have a meaning. These two pieces of code below have
+Warning: The order in instructions is important and have a meaning. These two pieces of code below have
 a different meaning. The first one takes all toto elements in the project. The second takes 
 the first element named by "toto" at the root of your project and after, makes a search recursively
 in your project according to the rest of your path request.

--- a/doc/path.md
+++ b/doc/path.md
@@ -40,7 +40,7 @@ syntax.
 * `signature=<somesignature>` - filter which accepts only methods and constructors with signature `somesignature`.
   * Example of method signature: `#method[signature=compare(java.lang.String,java.lang.String)]`
   * Example of constructor signature: `#constructor[signature=(int)]`
-* `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. the fourth type memeber in a class `#typeMember[index=4]`
+* `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. the fifth type memeber in a class `#typeMember[index=4]`
 
 ### From the API
 

--- a/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.path;
 
+import spoon.reflect.CtModelImpl;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
@@ -38,6 +39,19 @@ import java.util.Objects;
  * Created by nharrand on 21/02/2018.
  */
 public class CtElementPathBuilder {
+	private boolean useNamesInPath = true;
+
+	/**
+	 * Build absolute path to a CtElement el.
+	 *
+	 * @throws CtPathException is thrown when root is not a parent of el.
+	 *
+	 * @param el : the element to which the CtPath leads to
+	 * @return CtPath from model root package to el
+	 */
+	public CtPath fromElement(CtElement el) throws CtPathException {
+		return fromElement(el, el.getParent(CtModelImpl.CtRootPackage.class));
+	}
 	/**
 	 * Build path to a CtElement el, from one of its parent.
 	 *
@@ -67,40 +81,42 @@ public class CtElementPathBuilder {
 
 				case LIST: {
 					//Element needs to be differentiated from its brothers
-					String[] pair = getArg(cur);
-					String attrName = pair[0];
-					String name = pair[1];
-					if (name != null) {
-						//the path with name is more readable, so prefer name instead of index
-						if (role.getSubRoles().size() > 0) {
-							//there are subroles.
-							role = role.getMatchingSubRoleFor(cur);
-							pathElement = new CtRolePathElement(role);
-						}
-						pathElement.addArgument(attrName, name);
-						//check list to check if argument is unique
-						List<CtElement> list = roleHandler.asList(parent);
-						//Assumes that List's order is deterministic.
-						List<CtElement> filteredList = new ArrayList<>();
-						int index = -1;
-						for (CtElement item : list) {
-							String[] pair2 = getArg(item);
-							String attrName2 = pair2[0];
-							String name2 = pair2[1];
-							if (Objects.equals(name, name2) && Objects.equals(attrName, attrName2)) {
-								//we found an element with same name
-								if (item == cur) {
-									//we found cur element. Remember it's index
-									index = filteredList.size();
-								}
-								filteredList.add(item);
+					if (useNamesInPath) {
+						String[] pair = getArg(cur);
+						String attrName = pair[0];
+						String name = pair[1];
+						if (name != null) {
+							//the path with name is more readable, so prefer name instead of index
+							if (role.getSubRoles().size() > 0) {
+								//there are subroles.
+								role = role.getMatchingSubRoleFor(cur);
+								pathElement = new CtRolePathElement(role);
 							}
+							pathElement.addArgument(attrName, name);
+							//check list to check if argument is unique
+							List<CtElement> list = roleHandler.asList(parent);
+							//Assumes that List's order is deterministic.
+							List<CtElement> filteredList = new ArrayList<>();
+							int index = -1;
+							for (CtElement item : list) {
+								String[] pair2 = getArg(item);
+								String attrName2 = pair2[0];
+								String name2 = pair2[1];
+								if (Objects.equals(name, name2) && Objects.equals(attrName, attrName2)) {
+									//we found an element with same name
+									if (item == cur) {
+										//we found cur element. Remember it's index
+										index = filteredList.size();
+									}
+									filteredList.add(item);
+								}
+							}
+							if (filteredList.size() > 1 && index >= 0) {
+								//there is more then one element with that name. Use index too
+								pathElement.addArgument("index", String.valueOf(index));
+							}
+							break;
 						}
-						if (filteredList.size() > 1 && index >= 0) {
-							//there is more then one element with that name. Use index too
-							pathElement.addArgument("index", String.valueOf(index));
-						}
-						break;
 					}
 
 					List list = roleHandler.asList(parent);
@@ -173,5 +189,18 @@ public class CtElementPathBuilder {
 			return sign.substring(idx);
 		}
 		return sign;
+	}
+
+	/**
+	 * Configures what kind of path is generated for List based attributes<br>
+	 * A) #superRole[index=x] - always use index to identify item of List. For example `#typeMember[index=7]`. Such paths are fast.
+	 * B) #subRole[name=x] - use simpleName or signature of List item if possible. Use the most specific role too.
+	 * 	For example `#field[name=counter]` or `#method[signature=getCounter()]`. Such paths are more readable but slower.
+	 * @param useNamesInPath if true then names are used instead of index
+	 * @return this to support fluent API
+	 */
+	public CtElementPathBuilder setUseNamesInPath(boolean useNamesInPath) {
+		this.useNamesInPath = useNamesInPath;
+		return this;
 	}
 }

--- a/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
@@ -74,7 +74,7 @@ public class CtElementPathBuilder {
 						//the path with name is more readable, so prefer name instead of index
 						if (role.getSubRoles().size() > 0) {
 							//there are subroles.
-							role = role.getSubRole(cur);
+							role = role.getMatchingSubRoleFor(cur);
 							pathElement = new CtRolePathElement(role);
 						}
 						pathElement.addArgument(attrName, name);

--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -17,13 +17,18 @@
 package spoon.reflect.path;
 
 
+import spoon.SpoonException;
+import spoon.reflect.path.impl.AbstractPathElement;
 import spoon.reflect.path.impl.CtNamedPathElement;
 import spoon.reflect.path.impl.CtPathElement;
 import spoon.reflect.path.impl.CtPathImpl;
 import spoon.reflect.path.impl.CtTypedNameElement;
 import spoon.reflect.path.impl.CtRolePathElement;
 
-import java.util.regex.Matcher;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.NoSuchElementException;
+import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 /**
@@ -56,6 +61,12 @@ public class CtPathStringBuilder {
 		}
 	}
 
+	private static final String MAIN_DELIMITERS = ".#/";
+	private static final String PATH_DELIMITERS = ".#/[";
+	private static final String ARG_NAME_DELIMITERS = "=";
+
+	private static Pattern NAME_MATCHER = Pattern.compile("\\w+");
+
 	/**
 	 * Build path from a string representation.
 	 *
@@ -69,34 +80,119 @@ public class CtPathStringBuilder {
 	 * / : match with a element type (for example, to match all classes, use /CtClass
 	 */
 	public CtPath fromString(String pathStr) throws CtPathException {
-		Matcher matcher = pathPattern.matcher(pathStr);
-
 		CtPathImpl path = new CtPathImpl();
-		while (matcher.find()) {
-			String kind = matcher.group(1);
 
+		Tokenizer tokenizer = new Tokenizer(pathStr);
+		String token = tokenizer.getNextToken(MAIN_DELIMITERS);
+		while (token != null) {
+			String kind = token;
 			CtPathElement pathElement = null;
+			token = tokenizer.getNextToken(PATH_DELIMITERS);
+			if (token != null && token.length() == 1 && PATH_DELIMITERS.indexOf(token) >= 0) {
+				//nextToken is again path delimiter. It means there is no token value in between
+				throw new CtPathException("Path value is missing");
+			}
 			if (CtNamedPathElement.STRING.equals(kind)) {
-				pathElement = new CtNamedPathElement(matcher.group(2));
+				//reg exp cannot be used in string, because `.` and `[` are reserved characters for CtPath
+				pathElement = new CtNamedPathElement(token, false);
 			} else if (CtTypedNameElement.STRING.equals(kind)) {
-				pathElement = new CtTypedNameElement(load(matcher.group(2)));
+				pathElement = new CtTypedNameElement(load(token));
 			} else if (CtRolePathElement.STRING.equals(kind)) {
-				pathElement = new CtRolePathElement(CtRole.fromName(matcher.group(2)));
+				pathElement = new CtRolePathElement(CtRole.fromName(token));
+			} else {
+				throw new CtPathException("Unexpected token " + kind);
 			}
-
-			String args = matcher.group(4);
-			if (args != null) {
-				for (String arg : args.split(";")) {
-					Matcher argmatcher = argumentPattern.matcher(arg);
-					if (argmatcher.matches()) {
-						pathElement.addArgument(argmatcher.group(1), argmatcher.group(2));
+			token = tokenizer.getNextToken(PATH_DELIMITERS);
+			if (AbstractPathElement.ARGUMENT_START.equals(token)) {
+				while (true) {
+					String argName = tokenizer.getNextToken(ARG_NAME_DELIMITERS);
+					if (!NAME_MATCHER.matcher(argName).matches()) {
+						throw new CtPathException("Argument name must be a word, but is: " + argName);
 					}
+					token = tokenizer.getNextToken(ARG_NAME_DELIMITERS);
+					if (!AbstractPathElement.ARGUMENT_NAME_SEPARATOR.equals(token)) {
+						throw new CtPathException("Expects " + AbstractPathElement.ARGUMENT_NAME_SEPARATOR);
+					}
+					token = parseArgumentValue(tokenizer, argName, pathElement);
+					if ("]".equals(token)) {
+						break;
+					}
+					//read next argument
 				}
+				token = tokenizer.getNextToken(MAIN_DELIMITERS);
 			}
-
 			path.addLast(pathElement);
 		}
 		return path;
+	}
+
+	private static final String ARG_VALUE_DELIMITERS = "[];()";
+
+	/**
+	 * @return last token
+	 */
+	private String parseArgumentValue(Tokenizer tokenizer, String argName, CtPathElement pathElement) {
+		StringBuilder argValue = new StringBuilder();
+		Deque<String> stack = new ArrayDeque<>();
+		while (true) {
+			String token = tokenizer.getNextToken(ARG_VALUE_DELIMITERS);
+			if ("(".equals(token) || "[".equals(token)) {
+				//starts bracket
+				stack.push(token);
+			} else if (stack.size() > 0) {
+				//we are in some brackets. Just wait for end of bracket
+				if (")".equals(token)) {
+					//closing bracket
+					String kind = stack.pop();
+					if (!"(".equals(kind)) {
+						throw new CtPathException("Unexpected end of bracket " + token);
+					}
+				} else if ("]".equals(token)) {
+					//closing bracket
+					String kind = stack.pop();
+					if (!"[".equals(kind)) {
+						throw new CtPathException("Unexpected end of bracket " + token);
+					}
+				}
+			} else if ("]".equals(token) || ";".equals(token)) {
+				//finished reading of argument value
+				pathElement.addArgument(argName, argValue.toString());
+				return token;
+			}
+			argValue.append(token);
+		}
+	}
+
+	private static class Tokenizer {
+		StringTokenizer tokenizer;
+		int length;
+		int off;
+		Tokenizer(String str) {
+			length = str.length();
+			off = 0;
+			tokenizer = new StringTokenizer(str, MAIN_DELIMITERS, true);
+		}
+
+		String getNextToken(String delimiters) {
+			try {
+				if (off >= length) {
+					return null;
+				}
+				String token = tokenizer.nextToken(delimiters);
+				off += token.length();
+				return token;
+			} catch (NoSuchElementException e) {
+				throw new SpoonException("Unexpected error", e);
+			}
+		}
+	}
+
+	private String getNextToken(StringTokenizer tokenizer, String newDelimeters) {
+		try {
+			return tokenizer.nextToken(newDelimeters);
+		} catch (NoSuchElementException e) {
+			return null;
+		}
 	}
 
 }

--- a/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
@@ -29,6 +29,9 @@ import java.util.TreeMap;
  * Partial implementation for CtPathElement
  */
 public abstract class AbstractPathElement<P extends CtElement, T extends CtElement> implements CtPathElement<P, T> {
+	public static final String ARGUMENT_START = "[";
+	public static final String ARGUMENT_END = "]";
+	public static final String ARGUMENT_NAME_SEPARATOR = "=";
 
 	private Map<String, String> arguments = new TreeMap<>();
 

--- a/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
@@ -24,10 +24,10 @@ import spoon.reflect.path.CtPathException;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * A CtPathElement that define some roles for matching.
@@ -58,7 +58,7 @@ public class CtRolePathElement extends AbstractPathElement<CtElement, CtElement>
 		return STRING + getRole().toString() + getParamString();
 	}
 
-	private CtElement getFromSet(Set set, String name) throws CtPathException {
+	private CtElement getFromSet(Collection<?> set, String name) throws CtPathException {
 		for (Object o: set) {
 			if (o instanceof CtNamedElement) {
 				if (((CtNamedElement) o).getSimpleName().equals(name)) {
@@ -89,19 +89,32 @@ public class CtRolePathElement extends AbstractPathElement<CtElement, CtElement>
 						}
 						break;
 
-					case LIST:
+					case LIST: {
+						Collection<CtElement> subMatches;
+						if (getArguments().containsKey("name")) {
+							String name = getArguments().get("name");
+							subMatches = new CtNamedPathElement(name).scanElements(roleHandler.asList(root));
+						} else if (getArguments().containsKey("signature")) {
+							String sign = getArguments().get("signature");
+							subMatches = new CtNamedPathElement(sign).scanElements(roleHandler.asList(root));
+						} else {
+							subMatches = roleHandler.asList(root);
+						}
 						if (getArguments().containsKey("index")) {
 							int index = Integer.parseInt(getArguments().get("index"));
-							if (index < roleHandler.asList(root).size()) {
-								matchs.add((CtElement) roleHandler.asList(root).get(index));
+							if (index < subMatches.size()) {
+								matchs.add((CtElement) new ArrayList<>(subMatches).get(index));
 							}
 						} else {
-							matchs.addAll(roleHandler.asList(root));
+							matchs.addAll(subMatches);
 						}
 						break;
-
+					}
 					case SET:
-						if (getArguments().containsKey("name")) {
+						if (getArguments().containsKey("signature")) {
+							String sign = getArguments().get("signature");
+							matchs.addAll(new CtNamedPathElement(sign).scanElements(roleHandler.asSet(root)));
+						} else if (getArguments().containsKey("name")) {
 							String name = getArguments().get("name");
 							try {
 								CtElement match = getFromSet(roleHandler.asSet(root), name);

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -18,7 +18,6 @@ package spoon.support.reflect.declaration;
 
 import org.apache.log4j.Logger;
 import spoon.Launcher;
-import spoon.reflect.CtModelImpl;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
@@ -591,7 +590,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public CtPath getPath() {
-		return new CtElementPathBuilder().fromElement(this, getParent(CtModelImpl.CtRootPackage.class));
+		return new CtElementPathBuilder().fromElement(this);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -527,6 +527,7 @@ public class MainTest {
 					String pathStr = path.toString();
 					try {
 						CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
+						assertEquals(pathStr, pathRead.toString());
 						Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
 						//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
 						assertEquals(1, returnedElements.size());
@@ -534,7 +535,9 @@ public class MainTest {
 						//contract: Element -> Path -> String -> Path -> Element leads to the original element
 						assertSame(element, actualElement);
 					} catch (CtPathException e) {
-						fail("Path is either incorrectly generated or incorrectly read");
+						throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
+					} catch (AssertionError e) {
+						throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
 					}
 				}
 				super.scan(element);

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -238,6 +238,19 @@ public class PathTest {
 	}
 
 	@Test
+	public void testFastPathWithIndex() {
+		// contract: the path can still use index
+		CtType<?> fooClass = factory.Package().get("spoon.test.path.testclasses").getType("Foo");
+		CtMethod<Object> method = fooClass.getMethod("foo");
+		CtStatement ifStmt = ((CtIf) method.getBody()
+				.getStatement(2)).getElseStatement();
+
+		//check that path with index 
+		CtPath absPath = new CtElementPathBuilder().setUseNamesInPath(false).fromElement(ifStmt);
+		assertEquals("#subPackage[name=spoon]#subPackage[name=test]#subPackage[name=path]#subPackage[name=testclasses]#containedType[name=Foo]#typeMember[index=3]#body#statement[index=2]#else", absPath.toString());
+	}
+
+	@Test
 	public void testRoles() {
 		// get the then statement
 		CtType<?> fooClass = factory.Package().get("spoon.test.path.testclasses").getType("Foo");
@@ -252,6 +265,7 @@ public class PathTest {
 		// now we get the absolute path
 		CtPath absPath = path.evaluateOn(factory.getModel().getRootPackage()).get(0).getPath();
 		assertEquals("#subPackage[name=spoon]#subPackage[name=test]#subPackage[name=path]#subPackage[name=testclasses]#containedType[name=Foo]#method[signature=foo()]#body#statement[index=2]#else", absPath.toString());
+		
 
 		// contract: subpath enables to have relative path
 		CtPath subPath = absPath.relativePath(fooClass);

--- a/src/test/java/spoon/test/path/testclasses/Foo.java
+++ b/src/test/java/spoon/test/path/testclasses/Foo.java
@@ -1,12 +1,17 @@
 package spoon.test.path.testclasses;
 
-class Foo {
+import java.util.ArrayList;
+
+class Foo<T> extends ArrayList<T> {
 	Foo() {
 		super();
 	}
+	Foo(String s) {
+		this();
+	}
 
 	String toto = "salut";
-
+	
 	void foo() {
 		int x = 3;
 		x = x + 1;
@@ -18,6 +23,10 @@ class Foo {
 		}
 	}
 
+	String foo;
+	
+	class foo {}
+
 	@java.lang.SuppressWarnings("unchecked")
 	void bar(int i, int j) {
 		int x = 3;
@@ -26,4 +35,17 @@ class Foo {
 			x += 1;
 		}
 	}
+	void bar(int i) {
+	}
+	
+	void processors(String p, String p2) {
+	}
+	void processors(String... p) {
+	}
+	
+	void methodWithArgs(String[] arr) {
+		methodWithArgs(null);
+		processors(null, null);
+	}
+	
 }


### PR DESCRIPTION
I like the idea of CtPath for locating of nodes in AST (I plan to use it in Patterns and PatternDetector). But in my use cases it is problem that automatically generate path is not readable. For example :
```
#subPackage[name=testclasses]#containedType[name=Foo]#typeMember[index=2]
```
...typeMember with index 2 says nothing usefull.

This PR provides more readable automatically generated paths like
```
#subPackage[name=testclasses]#containedType[name=Foo]#field[name=someField]
#subPackage[name=testclasses]#containedType[name=Foo]#method[signature=someMethod()]
#subPackage[name=testclasses]#containedType[name=Foo]#constructor[signature=(int,java.lang.String)]
```

I like it a lot now, but there is little problem - the evaluation of such path is slower then before, because nothing is so fast like `List.get(index)`

Can we live with fact that paths are slower now?
Or should we make configurable which path generation strategy has to be used?

WDYT?