### PR TITLE
fix(test): remove ignored # from the path

### DIFF
--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -117,7 +117,7 @@ public class PathTest {
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(1, results.size());
 		// When role match a map but no key is provided, all of them must be returned
-		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value")
+		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar#annotation[index=0]#value")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(1, results.size());
 

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -138,7 +138,7 @@ public class PathTest {
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(0, results.size());
 		//match a non existing field of an annotation (Test non existing element of a map)
-		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar##annotation[index=0]#value[key=misspelled]")
+		results = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.bar#annotation[index=0]#value[key=misspelled]")
 				.evaluateOn(factory.getModel().getRootPackage());
 		assertEquals(0, results.size());
 	}


### PR DESCRIPTION
I checked the CtPath string parser and duplicated ## is understood as #. I think that it is mistake to have ## there.
@nharrand WDYT?