### PR TITLE
fix: Pattern can match a Type

### DIFF
--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -25,9 +25,11 @@ import spoon.pattern.internal.node.ParameterNode;
 import spoon.pattern.internal.node.RootNode;
 import spoon.pattern.internal.node.StringNode;
 import spoon.pattern.internal.parameter.AbstractParameterInfo;
+import spoon.pattern.internal.parameter.ComputedParameterInfo;
 import spoon.pattern.internal.parameter.ListParameterInfo;
 import spoon.pattern.internal.parameter.MapParameterInfo;
 import spoon.pattern.internal.parameter.ParameterInfo;
+import spoon.pattern.internal.parameter.SimpleNameOfTypeReferenceParameterComputer;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
@@ -232,7 +234,9 @@ public class PatternParameterConfigurator {
 		CtType<?> type2 = queryModel().filterChildren((CtType<?> t) -> t.getQualifiedName().equals(typeQName)).first();
 		if (type2 != null) {
 			//Substitute name of template too
-			addSubstitutionRequest(pi, type2, CtRole.NAME);
+			ComputedParameterInfo piName = new ComputedParameterInfo(SimpleNameOfTypeReferenceParameterComputer.INSTANCE, pi);
+			piName.setParameterValueType(String.class);
+			addSubstitutionRequest(piName, type2, CtRole.NAME);
 		}
 		return this;
 	}

--- a/src/main/java/spoon/pattern/internal/parameter/ComputedParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ComputedParameterInfo.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern.internal.parameter;
+
+import java.util.List;
+import java.util.function.Function;
+
+import spoon.SpoonException;
+import spoon.pattern.internal.ResultHolder;
+import spoon.reflect.factory.Factory;
+import spoon.support.util.ImmutableMap;
+
+/**
+ * Represents a parameter which is related to a value of another parameter.
+ * For example parameter which represents CtTypeReference has a value `abc.sample.AType`
+ * And computed parameter which represents name of type referenced by CtTypeReference
+ * has a computed String value `AType`
+ */
+public class ComputedParameterInfo extends AbstractParameterInfo {
+
+	private final ParameterComputer computer;
+
+	public ComputedParameterInfo(ParameterComputer computer, ParameterInfo next) {
+		super(next);
+		this.computer = computer;
+	}
+
+	@Override
+	protected String getPlainName() {
+		return getWrappedName(getContainerName());
+	}
+
+	@Override
+	protected String getWrappedName(String containerName) {
+		return containerName + "$" + computer.getName();
+	}
+
+	@Override
+	protected Object addValueAs(Object container, Function<Object, Object> merger) {
+		//do not try to match on computed value
+		return container;
+	}
+
+	@Override
+	protected List<Object> getEmptyContainer() {
+		throw new SpoonException("ComputedParameterInfo#getEmptyContainer should not be used");
+	}
+	@Override
+	public <T> void getValueAs(Factory factory, ResultHolder<T> result, ImmutableMap parameters) {
+		ResultHolder<?> inputHolder = computer.createInputHolder();
+		super.getValueAs(factory, inputHolder, parameters);
+		computer.computeValue((ResultHolder) result, inputHolder);
+	}
+}

--- a/src/main/java/spoon/pattern/internal/parameter/ParameterComputer.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ParameterComputer.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern.internal.parameter;
+
+import spoon.pattern.internal.ResultHolder;
+
+/**
+ * Computes a value of {@link ComputedParameterInfo}
+ * I - type of input value
+ * O - type of computed value
+ */
+public interface ParameterComputer {
+
+	/**
+	 * @return user friendly name of this computer
+	 */
+	String getName();
+
+	/**
+	 * @return holder for input value
+	 */
+	ResultHolder<?> createInputHolder();
+
+	/**
+	 * @param outputHolder holds result of computation
+	 * @param inputHolder holds input of computation
+	 */
+	void computeValue(ResultHolder<Object> outputHolder, ResultHolder<?> inputHolder);
+}

--- a/src/main/java/spoon/pattern/internal/parameter/SimpleNameOfTypeReferenceParameterComputer.java
+++ b/src/main/java/spoon/pattern/internal/parameter/SimpleNameOfTypeReferenceParameterComputer.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.pattern.internal.parameter;
+
+import spoon.pattern.internal.ResultHolder;
+import spoon.reflect.reference.CtTypeReference;
+
+/**
+ * a {@link ParameterComputer} which computes simpleName of {@link CtTypeReference}
+ */
+public class SimpleNameOfTypeReferenceParameterComputer implements ParameterComputer {
+
+	public static final SimpleNameOfTypeReferenceParameterComputer INSTANCE = new SimpleNameOfTypeReferenceParameterComputer();
+
+	@Override
+	public String getName() {
+		return "simpleName";
+	}
+
+	@Override
+	public ResultHolder<?> createInputHolder() {
+		return new ResultHolder.Single<>(CtTypeReference.class);
+	}
+
+	@Override
+	public void computeValue(ResultHolder<Object> outputHolder, ResultHolder<?> inputHolder) {
+		String name = null;
+		CtTypeReference<?> typeRef = ((ResultHolder.Single<CtTypeReference<?>>) inputHolder).getResult();
+		if (typeRef != null) {
+			name = typeRef.getSimpleName();
+		}
+		outputHolder.addResult(name);
+	}
+}


### PR DESCRIPTION
During writing test for #2530, I tried to make Pattern which matches whole type and have found that it doesn't work.

Reason: AST of type consists of at least 2 related parameters:
1) String CtType#simpleName - in the name of the type
2) CtTypeReference qualifiedName - in each self reference to the type

Until this PR Pattern made only one parameter with type CtTypeReference. It was ok as long as Pattern is used for generating of types, because generator is able to convert CtTypeReference to `String simpleName`.

But when we match such Pattern, it doesn't work/matches because there is no way how to create CtTypeReference (with fully qualified name) from the simple name of the type.

This PR contains solution which introduces new internal `ParameterInfo` ...  `ComputedParameterInfo`, whose value is computed from primary parameter info. The computation algorithm is defined by interface `ParameterComputer`.  There is also first implementation of that `ParameterComputer` interface:  `SimpleNameOfTypeReferenceParameterComputer`, which returns simple name of CtTypeReference and during matching ignores simple type name, so type matching works.