### PR TITLE
feature: print Pattern without parameter comments

### DIFF
--- a/src/main/java/spoon/pattern/Pattern.java
+++ b/src/main/java/spoon/pattern/Pattern.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import spoon.SpoonException;
 import spoon.pattern.internal.DefaultGenerator;
+import spoon.pattern.internal.PatternPrinter;
 import spoon.pattern.internal.matcher.MatchingScanner;
 import spoon.pattern.internal.node.ListOfNodes;
 import spoon.pattern.internal.parameter.ParameterInfo;
@@ -122,6 +123,14 @@ public class Pattern {
 			matches.add(match);
 		});
 		return matches;
+	}
+
+	/**
+	 * @param addParameterComments if true then it adds comments with parameter names
+	 * @return pattern printed as java sources
+	 */
+	public String print(boolean addParameterComments) {
+		return new PatternPrinter().setPrintParametersAsComments(addParameterComments).printNode(modelValueResolver);
 	}
 
 	@Override

--- a/src/main/java/spoon/pattern/internal/PatternPrinter.java
+++ b/src/main/java/spoon/pattern/internal/PatternPrinter.java
@@ -39,6 +39,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.PrinterHelper;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
@@ -54,6 +55,7 @@ public class PatternPrinter extends DefaultGenerator {
 	}
 
 	private List<ParamOnElement> params = new ArrayList<>();
+	private boolean printParametersAsComments = true;
 
 	public PatternPrinter() {
 		super(DEFAULT_FACTORY, null);
@@ -142,7 +144,7 @@ public class PatternPrinter extends DefaultGenerator {
 				params.add(paramOnElement);
 			}
 		}
-		if (isCommentVisible(ele) && !params.isEmpty()) {
+		if (isPrintParametersAsComments() && isCommentVisible(ele) && !params.isEmpty()) {
 			ele.addComment(ele.getFactory().Code().createComment(getSubstitutionRequestsDescription(ele, params), CommentType.BLOCK));
 			params.clear();
 		}
@@ -174,6 +176,9 @@ public class PatternPrinter extends DefaultGenerator {
 			}
 			if (type.isAssignableFrom(String.class)) {
 				return (T) parameterInfo.getName();
+			}
+			if (type.isAssignableFrom(CtTypeReference.class)) {
+				return (T) factory.Type().createReference(parameterInfo.getName());
 			}
 		}
 		return null;
@@ -248,5 +253,14 @@ public class PatternPrinter extends DefaultGenerator {
 			return name.substring(0, name.length() - 4);
 		}
 		return name;
+	}
+
+	public PatternPrinter setPrintParametersAsComments(boolean printParametersAsComments) {
+		this.printParametersAsComments = printParametersAsComments;
+		return this;
+	}
+
+	public boolean isPrintParametersAsComments() {
+		return printParametersAsComments;
 	}
 }

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -1219,7 +1219,27 @@ public class PatternTest {
 				"         */"+nl+"" +
 				"        statements();"+nl+"" +
 				"    }"+nl+"" +
-				"}"+nl, p.toString());
+				"}"+nl, p.print(true));
+	}
+
+	@Test
+	public void testPatternToStringNoComments() {
+		//contract: Pattern can be printed to String without parameters
+		String nl = System.getProperty("line.separator");
+		Factory f = ModelUtils.build(
+				new File("./src/test/java/spoon/test/template/testclasses/replace/DPPSample1.java"),
+				new File("./src/test/java/spoon/test/template/testclasses/replace")
+			);
+		Pattern p = OldPattern.createPatternFromMethodPatternModel(f);
+		assertEquals("if (useStartKeyword()) {" + nl + 
+				"    printer().writeSpace().writeKeyword(startKeyword()).writeSpace();" + nl + 
+				"}" + nl + 
+				"try (final spoon.reflect.visitor.ListPrinter lp = elementPrinterHelper().createListPrinter(startPrefixSpace(), start(), startSuffixSpace(), nextPrefixSpace(), next(), nextSuffixSpace(), endPrefixSpace(), end())) {" + nl + 
+				"    for (java.lang.Object item : getIterable()) {" + nl + 
+				"        lp.printSeparatorIfAppropriate();" + nl + 
+				"        statements();" + nl + 
+				"    }" + nl + 
+				"}" + nl, p.print(false));
 	}
 
 	@Test


### PR DESCRIPTION
Now it is possible to print pattern without parameter comments. This use case makes sense in PatternDetector reports, where parameter comments are not interesting ... and just make result less readable.