### PR TITLE
refactor: fix documentation errors in JarLauncher.java

### DIFF
--- a/src/main/java/spoon/JarLauncher.java
+++ b/src/main/java/spoon/JarLauncher.java
@@ -38,7 +38,7 @@ public class JarLauncher extends Launcher {
 	boolean decompile = false;
 
 	/**
-	 * JarLauncher basic constructor. Uses the defauld Decompiler (CFR)
+	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
 	 */
@@ -48,7 +48,7 @@ public class JarLauncher extends Launcher {
 
 
 	/**
-	 * JarLauncher basic constructor. Uses the defauld Decompiler (CFR)
+	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
 	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
@@ -58,7 +58,7 @@ public class JarLauncher extends Launcher {
 	}
 
 	/**
-	 * JarLauncher basic constructor. Uses the defauld Decompiler (CFR)
+	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
 	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
@@ -69,7 +69,7 @@ public class JarLauncher extends Launcher {
 	}
 
 	/**
-	 * JarLauncher basic constructor. Uses the defauld Decompiler (CFR)
+	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
 	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
@@ -80,7 +80,7 @@ public class JarLauncher extends Launcher {
 	}
 
 	/**
-	 * JarLauncher constructor. Uses the defauld Decompiler (CFR)
+	 * JarLauncher constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
 	 * @param decompiledSrcPath path to directory where decompiled source will be outputted

--- a/src/main/java/spoon/JarLauncher.java
+++ b/src/main/java/spoon/JarLauncher.java
@@ -51,7 +51,7 @@ public class JarLauncher extends Launcher {
 	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
-	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
+	 * @param decompiledSrcPath path to directory where decompiled source will be output
 	 */
 	public JarLauncher(String jarPath, String decompiledSrcPath) {
 		this(jarPath, decompiledSrcPath, (String) null);
@@ -61,7 +61,7 @@ public class JarLauncher extends Launcher {
 	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
-	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
+	 * @param decompiledSrcPath path to directory where decompiled source will be output
 	 * @param pom path to pom associated with the jar to be analyzed
 	 */
 	public JarLauncher(String jarPath, String decompiledSrcPath, String pom) {
@@ -72,7 +72,7 @@ public class JarLauncher extends Launcher {
 	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
-	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
+	 * @param decompiledSrcPath path to directory where decompiled source will be output
 	 * @param decompiler Instance implementing {@link spoon.decompiler.Decompiler} to be used
 	 */
 	public JarLauncher(String jarPath, String decompiledSrcPath, Decompiler decompiler) {
@@ -83,7 +83,7 @@ public class JarLauncher extends Launcher {
 	 * JarLauncher constructor. Uses the default Decompiler (CFR)
 	 *
 	 * @param jarPath path to the jar to be analyzed
-	 * @param decompiledSrcPath path to directory where decompiled source will be outputted
+	 * @param decompiledSrcPath path to directory where decompiled source will be output
 	 * @param pom path to pom associated with the jar to be analyzed
 	 * @param decompiler Instance implementing {@link spoon.decompiler.Decompiler} to be used
 	 */

--- a/src/main/java/spoon/JarLauncher.java
+++ b/src/main/java/spoon/JarLauncher.java
@@ -46,7 +46,6 @@ public class JarLauncher extends Launcher {
 		this(jarPath, null, (String) null);
 	}
 
-
 	/**
 	 * JarLauncher basic constructor. Uses the default Decompiler (CFR)
 	 *
@@ -131,7 +130,6 @@ public class JarLauncher extends Launcher {
 			decompiler.decompile(jar.getAbsolutePath());
 		}
 
-
 		if (pomPath != null) {
 			File srcPom =  new File(pomPath);
 			if (!srcPom.exists() || !srcPom.isFile()) {
@@ -164,5 +162,4 @@ public class JarLauncher extends Launcher {
 	protected Decompiler getDefaultDecompiler() {
 		return new CFRDecompiler(decompiledSrc);
 	}
-
 }


### PR DESCRIPTION
Additional question:

Should lines
- (117) throw new SpoonException("Jar " + jar.getPath() + "not found.");
- (136) throw new SpoonException("Pom " + srcPom.getPath() + "not found.");

be changed to:

- (117) throw new SpoonException("Jar " + jar.getPath() + **" not found."**);
- (136) throw new SpoonException("Pom " + srcPom.getPath() + **" not found."**);

?