### PR TITLE
sonarqube: fix SonarQube warning in JDTTreeBuilderQuery.java

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -108,9 +108,7 @@ class JDTTreeBuilderQuery {
 	 * @return qualified name of the expected type.
 	 */
 	static String searchType(String typeName, ImportReference[] imports) {
-		if (typeName == null) {
-			return null;
-		} else if (imports == null) {
+		if (typeName == null || imports == null) {
 			return null;
 		}
 		for (ImportReference anImport : imports) {


### PR DESCRIPTION
Fix SonarQube warning: *Remove this conditional structure or edit its code blocks so that they're not all the same.*