### PR TITLE
refactor: use static imports for asserts in tests

### DIFF
--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -1,6 +1,5 @@
 package spoon;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import spoon.compiler.Environment;
@@ -15,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -28,14 +28,14 @@ public class LauncherTest {
 
 		final Environment environment = launcher.getEnvironment();
 		// specify the default values
-		Assert.assertFalse(environment.isAutoImports());
-		Assert.assertFalse(environment.isUsingTabulations());
-		Assert.assertFalse(environment.isPreserveLineNumbers());
+		assertFalse(environment.isAutoImports());
+		assertFalse(environment.isUsingTabulations());
+		assertFalse(environment.isPreserveLineNumbers());
 		assertEquals(4, environment.getTabulationSize());
-		Assert.assertTrue(environment.isCopyResources());
+		assertTrue(environment.isCopyResources());
 
 		JavaOutputProcessor processor = (JavaOutputProcessor) environment.getDefaultFileGenerator();
-		Assert.assertTrue(processor.getPrinter() instanceof DefaultJavaPrettyPrinter);
+		assertTrue(processor.getPrinter() instanceof DefaultJavaPrettyPrinter);
 
 		// now assertions on the model builder
 		final SpoonModelBuilder builder = launcher.getModelBuilder();
@@ -55,12 +55,12 @@ public class LauncherTest {
 		final Environment environment = launcher.getEnvironment();
 
 		// Verify if the environment is correct.
-		Assert.assertTrue(environment.isAutoImports());
-		Assert.assertTrue(environment.isUsingTabulations());
-		Assert.assertTrue(environment.isPreserveLineNumbers());
+		assertTrue(environment.isAutoImports());
+		assertTrue(environment.isUsingTabulations());
+		assertTrue(environment.isPreserveLineNumbers());
 		assertEquals(42, environment.getTabulationSize());
 		assertEquals(5, environment.getComplianceLevel());
-		Assert.assertFalse(environment.isCopyResources());
+		assertFalse(environment.isCopyResources());
 
 		final SpoonModelBuilder builder = launcher.getModelBuilder();
 		assertEquals(new File("spooned2").getCanonicalFile(), builder.getSourceOutputDirectory());

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -1,7 +1,6 @@
 package spoon.reflect.declaration;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import spoon.Launcher;
@@ -22,6 +21,9 @@ import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
@@ -48,77 +50,77 @@ public class CtTypeInformationTest {
 		{
 			final ClassTypingContext ctc = (ClassTypingContext) this.factory.createTypeAdapter(subClass);
 			//contract: at the beginning, the last resolved class is a subClass
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
 			//contract: this.isSubttypeOf(this) == true
-			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+			assertTrue(ctc.isSubtypeOf(subClass.getReference()));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(subinterface));
+			assertTrue(ctc.isSubtypeOf(subinterface));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(testInterface));
+			assertTrue(ctc.isSubtypeOf(testInterface));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(Comparable.class)));
+			assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(Comparable.class)));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
+			assertTrue(ctc.isSubtypeOf(extendObject));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(extendObject.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(extendObject.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
+			assertTrue(ctc.isSubtypeOf(arrayList));
 			//contract: ClassTypingContext#isSubtypeOf returns always the same results
-			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
-			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+			assertTrue(ctc.isSubtypeOf(extendObject));
+			assertTrue(ctc.isSubtypeOf(subClass.getReference()));
 
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(RandomAccess.class)));
+			assertTrue(ctc.isSubtypeOf(factory.createCtTypeReference(RandomAccess.class)));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(arrayList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(abstractList));
+			assertTrue(ctc.isSubtypeOf(abstractList));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(abstractList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(abstractList.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(abstractCollection));
+			assertTrue(ctc.isSubtypeOf(abstractCollection));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(abstractCollection.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(abstractCollection.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
-			Assert.assertTrue(ctc.isSubtypeOf(object));
+			assertTrue(ctc.isSubtypeOf(object));
 			//contract: ClassTypingContext did not scanned whole type hierarchy. It stopped on last class - even on java.lang.Object, which was needed to agree on isSubtypeOf
-			Assert.assertEquals(object.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
+			assertEquals(object.getQualifiedName(), getLastResolvedSuperclass(ctc).getQualifiedName());
 
 			//contract: ClassTypingContext returns false on a type which is not a sub type of ctc scope.
-			Assert.assertFalse(ctc.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
+			assertFalse(ctc.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
 			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
-			Assert.assertNull(getLastResolvedSuperclass(ctc));
+			assertNull(getLastResolvedSuperclass(ctc));
 			//contract: ClassTypingContext#isSubtypeOf returns always the same results
-			Assert.assertTrue(ctc.isSubtypeOf(arrayList));
-			Assert.assertTrue(ctc.isSubtypeOf(extendObject));
-			Assert.assertTrue(ctc.isSubtypeOf(subClass.getReference()));
+			assertTrue(ctc.isSubtypeOf(arrayList));
+			assertTrue(ctc.isSubtypeOf(extendObject));
+			assertTrue(ctc.isSubtypeOf(subClass.getReference()));
 		}
 
 		{
 			//now try directly a type which is not a supertype
 			final ClassTypingContext ctc2 = (ClassTypingContext) this.factory.createTypeAdapter(subClass);
 			//contract: at the beginning, the last resolved class is a subClass
-			Assert.assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc2).getQualifiedName());
+			assertEquals(subClass.getQualifiedName(), getLastResolvedSuperclass(ctc2).getQualifiedName());
 			//contract: ClassTypingContext returns false on a type which is not a sub type of ctc scope.
-			Assert.assertFalse(ctc2.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
+			assertFalse(ctc2.isSubtypeOf(factory.Type().createReference("java.io.InputStream")));
 			//contract: ClassTypingContext must scans whole type hierarchy if detecting subtypeof on type which is not a supertype
-			Assert.assertNull(getLastResolvedSuperclass(ctc2));
+			assertNull(getLastResolvedSuperclass(ctc2));
 
 			//contract: ClassTypingContext#isSubtypeOf returns always the same results
-			Assert.assertTrue(ctc2.isSubtypeOf(arrayList));
-			Assert.assertTrue(ctc2.isSubtypeOf(extendObject));
-			Assert.assertTrue(ctc2.isSubtypeOf(subClass.getReference()));
+			assertTrue(ctc2.isSubtypeOf(arrayList));
+			assertTrue(ctc2.isSubtypeOf(extendObject));
+			assertTrue(ctc2.isSubtypeOf(subClass.getReference()));
 		}
 	}
 
@@ -145,7 +147,7 @@ public class CtTypeInformationTest {
 		final CtType<?> extendsArrayList = this.factory.Type().get(ExtendsArrayList.class);
 
 		// only 1 method directly in this class
-		Assert.assertEquals(1, extendsArrayList.getMethods().size());
+		assertEquals(1, extendsArrayList.getMethods().size());
 
 		int nbMethodExtendedArrayList = extendsArrayList.getAllMethods().size();
 
@@ -156,29 +158,29 @@ public class CtTypeInformationTest {
 		assertEquals(nbMethodExtendedArrayList + 2, subClass.getAllMethods().size());
 
 		CtTypeReference<?> superclass = subClass.getSuperclass();
-		Assert.assertEquals(ExtendsArrayList.class.getName(), superclass.getQualifiedName());
+		assertEquals(ExtendsArrayList.class.getName(), superclass.getQualifiedName());
 
-		Assert.assertEquals(ExtendsArrayList.class.getName(), superclass.getQualifiedName());
+		assertEquals(ExtendsArrayList.class.getName(), superclass.getQualifiedName());
 
-		Assert.assertNotNull(superclass.getSuperclass());
+		assertNotNull(superclass.getSuperclass());
 
 		// test superclass of interface type reference
 		Set<CtTypeReference<?>> superInterfaces = subClass.getSuperInterfaces();
-		Assert.assertEquals(1, superInterfaces.size());
+		assertEquals(1, superInterfaces.size());
 		CtTypeReference<?> superinterface = superInterfaces.iterator().next();
-		Assert.assertEquals(Subinterface.class.getName(), superinterface.getQualifiedName());
-		Assert.assertNull(superinterface.getSuperclass());
+		assertEquals(Subinterface.class.getName(), superinterface.getQualifiedName());
+		assertNull(superinterface.getSuperclass());
 
 		// test superclass of interface
 		final CtType<?> type2 = this.factory.Type().get(Subinterface.class);
-		Assert.assertNull(type2.getSuperclass());
+		assertNull(type2.getSuperclass());
 
 		// the interface abstract method and the implementation method have the same signature
 		CtMethod<?> fooConcrete = subClass.getMethodsByName("foo").get(0);
 		CtMethod<?> fooAbstract = type2.getMethodsByName("foo").get(0);
 		assertEquals(fooConcrete.getSignature(), fooAbstract.getSignature());
 		// yet they are different AST node
-		Assert.assertNotEquals(fooConcrete, fooAbstract);
+		assertNotEquals(fooConcrete, fooAbstract);
 
 		assertEquals(subClass.getMethodsByName("foo").get(0).getSignature(),
 				type2.getMethodsByName("foo").get(0).getSignature());

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -2,7 +2,6 @@ package spoon.test.api;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -104,7 +103,7 @@ public class APITest {
 				"-i", "src/test/resources/spoon/test/api/",
 				"-o", "fancy/fake/apitest" // we shouldn't write anything anyway
 		});
-		Assert.assertEquals(3, l.size());
+		assertEquals(3, l.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -54,7 +54,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static java.util.Arrays.asList;
+import java.util.Arrays;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -648,26 +648,26 @@ public class MetamodelTest {
 		assertEquals(1, typeMembers.size());
 		assertEquals(1, ctClass.getTypeMembers().size());
 		assertSame(ctClass, field1.getDeclaringType());
-		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of add on RoleHandler collection adds the item into real collection too
 		typeMembers.add(field2);
 		assertSame(ctClass, field2.getDeclaringType());
-		assertThat(asList("field1", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field1", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of set on RoleHandler collection replaces the item in real collection
 		typeMembers.set(0, field3);
 		assertSame(ctClass, field3.getDeclaringType());
-		assertThat(asList("field3", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field3", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		typeMembers.set(1, field1);
-		assertThat(asList("field3", "field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field3", "field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(int) on RoleHandler collection removes the item in real collection
 		assertSame(field3, typeMembers.remove(0));
-		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(Object) which does not exist does nothing
 		assertFalse(typeMembers.remove(field2));
-		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(Object) on RoleHandler collection removes the item in real collection
 		assertTrue(typeMembers.remove(field1));
-		assertThat(asList(), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(Arrays.asList(), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -1,6 +1,5 @@
 package spoon.test.api;
 
-import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonAPI;
@@ -136,10 +135,10 @@ public class MetamodelTest {
 		Set<String> setterRoles = setters.stream().map(g -> ((CtFieldRead) g.getAnnotation(propertySetter).getValue("role")).getVariable().getSimpleName()).collect(Collectors.toSet());
 		Set<CtMethod<?>> isNotSetter = setters.stream().filter(m -> !(m.getSimpleName().startsWith("set") || m.getSimpleName().startsWith("add") || m.getSimpleName().startsWith("insert") || m.getSimpleName().startsWith("remove"))).collect(Collectors.toSet());
 
-		Assert.assertEquals(expectedRoles, getterRoles);
-		Assert.assertEquals(expectedRoles, setterRoles);
-		Assert.assertEquals(Collections.EMPTY_SET, isNotGetter);
-		Assert.assertEquals(Collections.EMPTY_SET, isNotSetter);
+		assertEquals(expectedRoles, getterRoles);
+		assertEquals(expectedRoles, setterRoles);
+		assertEquals(Collections.EMPTY_SET, isNotGetter);
+		assertEquals(Collections.EMPTY_SET, isNotSetter);
 	}
 
 	@Test
@@ -185,7 +184,7 @@ public class MetamodelTest {
 		assertTrue(result.contains("@spoon.reflect.annotations.MetamodelPropertyField(role = spoon.reflect.path.CtRole.IS_SHADOW)" + nl + "boolean isShadow;"));
 		assertTrue(result.contains("@spoon.reflect.annotations.MetamodelPropertyField(role = spoon.reflect.path.CtRole.TYPE)" + nl + "spoon.reflect.reference.CtTypeReference<T> type;"));
 		assertTrue(result.size() > 100);
-		Assert.assertEquals(Collections.emptyList(), fieldWithoutAnnotation);
+		assertEquals(Collections.emptyList(), fieldWithoutAnnotation);
 
 		final CtTypeReference propertySetter = factory.Type().get(PropertySetter.class).getReference();
 		final CtTypeReference propertyGetter = factory.Type().get(PropertyGetter.class).getReference();
@@ -649,26 +648,26 @@ public class MetamodelTest {
 		assertEquals(1, typeMembers.size());
 		assertEquals(1, ctClass.getTypeMembers().size());
 		assertSame(ctClass, field1.getDeclaringType());
-		Assert.assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of add on RoleHandler collection adds the item into real collection too
 		typeMembers.add(field2);
 		assertSame(ctClass, field2.getDeclaringType());
-		Assert.assertThat(asList("field1", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field1", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of set on RoleHandler collection replaces the item in real collection
 		typeMembers.set(0, field3);
 		assertSame(ctClass, field3.getDeclaringType());
-		Assert.assertThat(asList("field3", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field3", "field2"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		typeMembers.set(1, field1);
-		Assert.assertThat(asList("field3", "field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field3", "field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(int) on RoleHandler collection removes the item in real collection
 		assertSame(field3, typeMembers.remove(0));
-		Assert.assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(Object) which does not exist does nothing
 		assertFalse(typeMembers.remove(field2));
-		Assert.assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList("field1"), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 		//contract: call of remove(Object) on RoleHandler collection removes the item in real collection
 		assertTrue(typeMembers.remove(field1));
-		Assert.assertThat(asList(), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
+		assertThat(asList(), is(ctClass.filterChildren(new TypeFilter(CtField.class)).map((CtField e) -> e.getSimpleName()).list()));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -1,26 +1,7 @@
 package spoon.test.compilation;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.File;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
-import org.junit.Assert;
 import org.junit.Test;
-
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
@@ -46,6 +27,23 @@ import spoon.test.compilation.testclasses.Bar;
 import spoon.test.compilation.testclasses.IBar;
 import spoon.test.compilation.testclasses.Ifoo;
 import spoon.testing.utils.ModelUtils;
+
+import java.io.File;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class CompilationTest {
 
@@ -119,7 +117,7 @@ public class CompilationTest {
 
 		Class<?> aClass = urlClassLoader.loadClass("Simple");
 		Method m = aClass.getMethod("m");
-		Assert.assertEquals(42, m.invoke(aClass.newInstance()));
+		assertEquals(42, m.invoke(aClass.newInstance()));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -1,6 +1,5 @@
 package spoon.test.constructor;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import spoon.Launcher;
@@ -25,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -48,8 +48,8 @@ public class ConstructorTest {
 	public void testImplicitConstructor() throws Exception {
 		CtClass<?> ctType = (CtClass) ModelUtils.buildClass(ImplicitConstructor.class);
 
-		Assert.assertTrue(ctType.getConstructor().isImplicit());
-		Assert.assertFalse(aClass.getConstructor().isImplicit());
+		assertTrue(ctType.getConstructor().isImplicit());
+		assertFalse(aClass.getConstructor().isImplicit());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/executable/ExecutableRefTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableRefTest.java
@@ -1,6 +1,5 @@
 package spoon.test.executable;
 
-import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtAbstractInvocation;
@@ -26,6 +25,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static spoon.testing.utils.ModelUtils.build;
@@ -36,13 +36,13 @@ public class ExecutableRefTest {
 	@Test
 	public void methodTest() throws Exception {
 		CtAbstractInvocation<?> ctAbstractInvocation = this.getInvocationFromMethod("testMethod");
-		Assert.assertTrue(ctAbstractInvocation instanceof CtInvocation<?>);
+		assertTrue(ctAbstractInvocation instanceof CtInvocation<?>);
 
 		CtExecutableReference<?> executableReference = ctAbstractInvocation.getExecutable();
-		Assert.assertNotNull(executableReference);
+		assertNotNull(executableReference);
 
 		Method method = executableReference.getActualMethod();
-		Assert.assertNotNull(method);
+		assertNotNull(method);
 
 		assertEquals("Hello World",
 				method.invoke(null, ((CtLiteral<?>) ctAbstractInvocation.getArguments().get(0)).getValue()));
@@ -51,13 +51,13 @@ public class ExecutableRefTest {
 	@Test
 	public void constructorTest() throws Exception {
 		CtAbstractInvocation<?> ctAbstractInvocation = this.getInvocationFromMethod("testConstructor");
-		Assert.assertTrue(ctAbstractInvocation instanceof CtConstructorCall<?>);
+		assertTrue(ctAbstractInvocation instanceof CtConstructorCall<?>);
 
 		CtExecutableReference<?> executableReference = ctAbstractInvocation.getExecutable();
-		Assert.assertNotNull(executableReference);
+		assertNotNull(executableReference);
 
 		Constructor<?> constructor = executableReference.getActualConstructor();
-		Assert.assertNotNull(constructor);
+		assertNotNull(constructor);
 
 		assertEquals("Hello World",
 				constructor.newInstance(((CtLiteral<?>) ctAbstractInvocation.getArguments().get(0)).getValue()));
@@ -97,20 +97,20 @@ public class ExecutableRefTest {
 		Factory factory = build(ExecutableRefTestSource.class, MyIntf.class);
 
 		CtClass<ExecutableRefTestSource> clazz = factory.Class().get(ExecutableRefTestSource.class);
-		Assert.assertNotNull(clazz);
+		assertNotNull(clazz);
 
 		List<CtMethod<?>> methods = clazz.getMethodsByName(methodName);
 		assertEquals(1, methods.size());
 
 		CtMethod<?> ctMethod = methods.get(0);
 		CtBlock<?> ctBody = ctMethod.getBody();
-		Assert.assertNotNull(ctBody);
+		assertNotNull(ctBody);
 
 		List<CtStatement> ctStatements = ctBody.getStatements();
 		assertEquals(1, ctStatements.size());
 
 		CtStatement ctStatement = ctStatements.get(0);
-		Assert.assertTrue(ctStatement instanceof CtAbstractInvocation<?>);
+		assertTrue(ctStatement instanceof CtAbstractInvocation<?>);
 
 		return (CtAbstractInvocation<?>) ctStatement;
 	}

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -1,6 +1,5 @@
 package spoon.test.intercession;
 
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import spoon.Launcher;
@@ -36,6 +35,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -73,7 +73,7 @@ public class IntercessionTest {
 				.compile();
 		CtMethod<?> foo = (CtMethod<?>) clazz.getMethods().toArray()[0];
 		CtMethod<?> fooClone = foo.clone();
-		Assert.assertEquals(foo, fooClone);
+		assertEquals(foo, fooClone);
 		CtBlock<?> body = foo.getBody();
 		assertEquals(2, body.getStatements().size());
 
@@ -83,7 +83,7 @@ public class IntercessionTest {
 		assertEquals(3, body.getStatements().size());
 		assertSame(returnStmt, body.getStatements().get(2));
 
-		Assert.assertNotEquals(foo, fooClone);
+		assertNotEquals(foo, fooClone);
 	}
 
 	@Test
@@ -95,7 +95,7 @@ public class IntercessionTest {
 				.compile();
 		CtConstructor<?> foo = (CtConstructor<?>) clazz.getConstructors().toArray()[0];
 		CtConstructor<?> fooClone = foo.clone();
-		Assert.assertEquals(foo, fooClone);
+		assertEquals(foo, fooClone);
 
 		CtBlock<?> body = foo.getBody();
 
@@ -109,7 +109,7 @@ public class IntercessionTest {
 		assertEquals(2, body.getStatements().size());
 
 		// constructor are not equals anymore
-		Assert.assertNotEquals(foo, fooClone);
+		assertNotEquals(foo, fooClone);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -1,6 +1,5 @@
 package spoon.test.main;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,8 +38,8 @@ import spoon.reflect.visitor.CtBiScannerDefault;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.PrinterHelper;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.reflect.CtExtendedModifier;
+import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.test.parent.ParentTest;
 
 import java.io.ByteArrayOutputStream;
@@ -337,10 +336,10 @@ public class MainTest {
 				counterBiScan.scan++;
 				if (element == null) {
 					if (other != null) {
-						Assert.fail("element can't be null if other isn't null.");
+						fail("element can't be null if other isn't null.");
 					}
 				} else if (other == null) {
-					Assert.fail("other can't be null if element isn't null.");
+					fail("other can't be null if element isn't null.");
 				} else {
 					// contract: all elements have been cloned and are still equal
 					assertEquals(element, other);
@@ -433,7 +432,7 @@ public class MainTest {
 			Exception firstStack = allElements.put(ele, secondStack);
 			if (firstStack != null) {
 				if(firstStack == dummyException) {
-					Assert.fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele.toString() + " is shared");
+					fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele.toString() + " is shared");
 				}
 				//the element ele was already visited. It means it used on more places
 				//report the stacktrace of first and second usage, so that place can be found easily
@@ -449,7 +448,7 @@ public class MainTest {
 		
 		String report = problems.toString();
 		if (!report.isEmpty()) {
-			Assert.fail(report);
+			fail(report);
 		}
 	}
 

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -1,12 +1,10 @@
 package spoon.test.parent;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
-import spoon.test.intercession.IntercessionScanner;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
@@ -40,6 +38,7 @@ import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.UnsettableProperty;
+import spoon.test.intercession.IntercessionScanner;
 import spoon.test.replace.testclasses.Tacos;
 
 import java.util.ArrayDeque;
@@ -82,7 +81,7 @@ public class ParentTest {
 			minus.setRightHandOperand(literal);
 			minus.setLeftHandOperand(literal);
 		} catch (Exception e) {
-			Assert.fail();
+			fail();
 		}
 	}
 
@@ -214,7 +213,7 @@ public class ParentTest {
 	public static void checkParentContract(CtPackage pack) {
 		pack.filterChildren(null).forEach((CtElement elem) -> {
 			// there is always one parent
-			Assert.assertTrue("no parent for "+elem.getClass()+"-"+elem.getPosition(), elem.isParentInitialized());
+			assertTrue("no parent for "+elem.getClass()+"-"+elem.getPosition(), elem.isParentInitialized());
 		});
 
 		// the scanner and the parent are in correspondence

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -1,6 +1,5 @@
 package spoon.test.pkg;
 
-import org.junit.Assert;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -34,6 +33,8 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.Assert.assertThat;
@@ -53,33 +54,33 @@ public class PackageTest {
 		spoon.createCompiler(factory, SpoonResourceHelper.resources(classFilePath, packageInfoFilePath)).build();
 
 		CtClass<?> clazz = factory.Class().get(PackageTestClass.class);
-		Assert.assertSame(PackageTestClass.class, clazz.getActualClass());
+		assertSame(PackageTestClass.class, clazz.getActualClass());
 
 		CtPackage ctPackage = clazz.getPackage();
-		Assert.assertEquals("spoon.test.pkg.name", ctPackage.getQualifiedName());
-		Assert.assertEquals("", ctPackage.getDocComment());
+		assertEquals("spoon.test.pkg.name", ctPackage.getQualifiedName());
+		assertEquals("", ctPackage.getDocComment());
 		assertTrue(CtPackage.class.isAssignableFrom(ctPackage.getParent().getClass()));
 
 		ctPackage = (CtPackage) ctPackage.getParent();
-		Assert.assertEquals("spoon.test.pkg", ctPackage.getQualifiedName());
-		Assert.assertNotNull(ctPackage.getPosition());
-		Assert.assertEquals(packageInfoFile.getCanonicalPath(), ctPackage.getPosition().getFile().getCanonicalPath());
-		Assert.assertEquals(1, ctPackage.getPosition().getLine());
-		Assert.assertEquals(0, ctPackage.getPosition().getSourceStart());
-		Assert.assertEquals(71, ctPackage.getPosition().getSourceEnd());
-		Assert.assertEquals(1, ctPackage.getAnnotations().size());
-		Assert.assertEquals("This is test\nJavaDoc.", ctPackage.getComments().get(0).getContent());
+		assertEquals("spoon.test.pkg", ctPackage.getQualifiedName());
+		assertNotNull(ctPackage.getPosition());
+		assertEquals(packageInfoFile.getCanonicalPath(), ctPackage.getPosition().getFile().getCanonicalPath());
+		assertEquals(1, ctPackage.getPosition().getLine());
+		assertEquals(0, ctPackage.getPosition().getSourceStart());
+		assertEquals(71, ctPackage.getPosition().getSourceEnd());
+		assertEquals(1, ctPackage.getAnnotations().size());
+		assertEquals("This is test\nJavaDoc.", ctPackage.getComments().get(0).getContent());
 
 		CtAnnotation<?> annotation = ctPackage.getAnnotations().get(0);
-		Assert.assertSame(Deprecated.class, annotation.getAnnotationType().getActualClass());
-		Assert.assertEquals(packageInfoFile.getCanonicalPath(), annotation.getPosition().getFile().getCanonicalPath());
-		Assert.assertEquals(5, annotation.getPosition().getLine());
+		assertSame(Deprecated.class, annotation.getAnnotationType().getActualClass());
+		assertEquals(packageInfoFile.getCanonicalPath(), annotation.getPosition().getFile().getCanonicalPath());
+		assertEquals(5, annotation.getPosition().getLine());
 
 		assertTrue(CtPackage.class.isAssignableFrom(ctPackage.getParent().getClass()));
 
 		ctPackage = (CtPackage) ctPackage.getParent();
-		Assert.assertEquals("spoon.test", ctPackage.getQualifiedName());
-		Assert.assertEquals("", ctPackage.getDocComment());
+		assertEquals("spoon.test", ctPackage.getQualifiedName());
+		assertEquals("", ctPackage.getDocComment());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
+++ b/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
@@ -1,6 +1,5 @@
 package spoon.test.prettyprinter;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import spoon.Launcher;
@@ -11,12 +10,12 @@ import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.declaration.CtImport;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.TypeFilter;
@@ -61,8 +60,8 @@ public class QualifiedThisRefTest {
 		ctTypes.add(ctClass);
 		printer.getElementPrinterHelper().writeHeader(ctTypes, imports);
 		printer.scan(ctClass);
-		Assert.assertTrue(printer.getResult().contains("Object o = this"));
-		Assert.assertTrue(printer.getResult().contains("Object o2 = QualifiedThisRef.this"));
+		assertTrue(printer.getResult().contains("Object o = this"));
+		assertTrue(printer.getResult().contains("Object o2 = QualifiedThisRef.this"));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -1,6 +1,5 @@
 package spoon.test.replace;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import spoon.Launcher;
@@ -40,7 +39,10 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -210,23 +212,23 @@ public class ReplaceTest {
 		CtClass<?> sample = factory.Package().get("spoon.test.replace.testclasses")
 				.getType("Foo");
 
-		Assert.assertEquals(factory.Type().createReference(int.class), sample.getField("i").getType());
+		assertEquals(factory.Type().createReference(int.class), sample.getField("i").getType());
 
 		// replace with another type
 		CtField replacement = factory.Core().createField();
 		replacement.setSimpleName("i");
 		replacement.setType(factory.Type().createReference(double.class));
 		sample.getField("i").replace(replacement);
-		Assert.assertEquals(factory.Type().createReference(double.class), sample.getField("i").getType());
+		assertEquals(factory.Type().createReference(double.class), sample.getField("i").getType());
 
 		// replace with another name
 		replacement = factory.Core().createField();
 		replacement.setSimpleName("j");
 		replacement.setType(factory.Type().createReference(double.class));
 		sample.getField("i").replace(replacement);
-		Assert.assertNull(sample.getField("i"));
-		Assert.assertNotNull(sample.getField("j"));
-		Assert.assertEquals(factory.Type().createReference(double.class), sample.getField("j").getType());
+		assertNull(sample.getField("i"));
+		assertNotNull(sample.getField("j"));
+		assertEquals(factory.Type().createReference(double.class), sample.getField("j").getType());
 	}
 
 	@Test
@@ -234,16 +236,16 @@ public class ReplaceTest {
 		CtClass<?> sample = factory.Package().get("spoon.test.replace.testclasses")
 				.getType("Foo");
 
-		Assert.assertNotNull(sample.getMethod("foo"));
-		Assert.assertNull(sample.getMethod("notfoo"));
+		assertNotNull(sample.getMethod("foo"));
+		assertNull(sample.getMethod("notfoo"));
 
 		CtMethod bar = factory.Core().createMethod();
 		bar.setSimpleName("notfoo");
 		bar.setType(factory.Type().createReference(void.class));
 		sample.getMethod("foo").replace(bar);
 
-		Assert.assertNull(sample.getMethod("foo"));
-		Assert.assertNotNull(sample.getMethod("notfoo"));
+		assertNull(sample.getMethod("foo"));
+		assertNotNull(sample.getMethod("notfoo"));
 	}
 
 	@Test
@@ -251,8 +253,8 @@ public class ReplaceTest {
 		CtClass<?> sample = factory.Package().get("spoon.test.replace.testclasses")
 				.getType("Foo");
 
-		Assert.assertNotNull(sample.getMethod("foo"));
-		Assert.assertNull(sample.getMethod("notfoo"));
+		assertNotNull(sample.getMethod("foo"));
+		assertNull(sample.getMethod("notfoo"));
 
 		CtMethod bar = factory.Core().createMethod();
 		bar.setSimpleName("notfoo");
@@ -263,10 +265,10 @@ public class ReplaceTest {
 		int originCountOfMethods = sample.getTypeMembers().size();
 		sample.getMethod("foo").replace(Arrays.asList(bar, bar2));
 
-		Assert.assertNull(sample.getMethod("foo"));
-		Assert.assertNotNull(sample.getMethod("notfoo"));
-		Assert.assertNotNull(sample.getMethod("notfoo2"));
-		Assert.assertEquals(originCountOfMethods+1, sample.getTypeMembers().size());
+		assertNull(sample.getMethod("foo"));
+		assertNotNull(sample.getMethod("notfoo"));
+		assertNotNull(sample.getMethod("notfoo2"));
+		assertEquals(originCountOfMethods+1, sample.getTypeMembers().size());
 	}
 
 	@Test
@@ -276,14 +278,14 @@ public class ReplaceTest {
 
 		CtVariable<?> var = sample.getBody().getStatement(0);
 
-		Assert.assertTrue(var.getDefaultExpression() instanceof CtLiteral);
-		Assert.assertEquals(3, ((CtLiteral<?>) var.getDefaultExpression()).getValue());
+		assertTrue(var.getDefaultExpression() instanceof CtLiteral);
+		assertEquals(3, ((CtLiteral<?>) var.getDefaultExpression()).getValue());
 
 		CtLiteral replacement = factory.Core().createLiteral();
 		replacement.setValue(42);
 		var.getDefaultExpression().replace(replacement);
 
-		Assert.assertEquals(42, ((CtLiteral<?>) var.getDefaultExpression()).getValue());
+		assertEquals(42, ((CtLiteral<?>) var.getDefaultExpression()).getValue());
 
 	}
 
@@ -292,12 +294,12 @@ public class ReplaceTest {
 		CtMethod<?> sample = factory.Package().get("spoon.test.replace.testclasses")
 				.getType("Foo").getMethod("foo");
 
-		Assert.assertTrue(sample.getBody().getStatement(0) instanceof CtVariable);
+		assertTrue(sample.getBody().getStatement(0) instanceof CtVariable);
 
 		CtStatement replacement = factory.Core().createInvocation();
 		sample.getBody().getStatement(0).replace(replacement);
 
-		Assert.assertTrue(sample.getBody().getStatement(0) instanceof CtInvocation);
+		assertTrue(sample.getBody().getStatement(0) instanceof CtInvocation);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -93,7 +93,7 @@ public class SignatureTest {
 		SpoonModelBuilder builder = new JDTSnippetCompiler(factory, content);
 		try {
 			builder.build();
-			Assert.fail();
+			fail();
 		} catch (Exception e) {
 			// Must fail due to the unbound element "Complex.I"
 		}


### PR DESCRIPTION
Most of Spoon tests use statically imported asserts. This is a case when static imports helps. It is better to use assertEquals than Assert.assertEquals. The shorter variant is clear and more easy to use.