### PR TITLE
fix: comment of CtAnnotation value

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -496,8 +496,9 @@ class JDTCommentBuilder {
 			// if there is no parent, this will throw a ParentNotInitializedException
 			comment.getParent();
 		} catch (ParentNotInitializedException e) {
-			// as best effort the comment goes in the parent
-			commentParent.addComment(comment);
+			// that's a serious error, there is something to debug
+			LOGGER.error("\"" + comment + "\" cannot be added into the AST, with parent "+ commentParent.getClass()
+					+ "please report the bug by posting on https://github.com/INRIA/spoon/issues/2482");
 		}
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -491,13 +491,11 @@ class JDTCommentBuilder {
 		insertionVisitor.scan(commentParent);
 
 		// postcondition
-		try {
-			// now we make sure that there is a parent
-			// if there is no parent, this will throw a ParentNotInitializedException
-			comment.getParent();
-		} catch (ParentNotInitializedException e) {
+		// now we make sure that there is a parent
+		// if there is no parent
+		if (!comment.isParentInitialized()) {
 			// that's a serious error, there is something to debug
-			LOGGER.error("\"" + comment + "\" cannot be added into the AST, with parent "+ commentParent.getClass()
+			LOGGER.error("\"" + comment + "\" cannot be added into the AST, with parent " + commentParent.getClass()
 					+ "please report the bug by posting on https://github.com/INRIA/spoon/issues/2482");
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -489,10 +489,15 @@ class JDTCommentBuilder {
 			}
 		};
 		insertionVisitor.scan(commentParent);
+
+		// postcondition
 		try {
+			// now we make sure that there is a parent
+			// if there is no parent, this will throw a ParentNotInitializedException
 			comment.getParent();
 		} catch (ParentNotInitializedException e) {
-			LOGGER.error(comment + " is not added into the AST", e);
+ 			// as best effort the comment goes in the parent
+			commentParent.addComment(comment);
 		}
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -496,7 +496,7 @@ class JDTCommentBuilder {
 			// if there is no parent, this will throw a ParentNotInitializedException
 			comment.getParent();
 		} catch (ParentNotInitializedException e) {
- 			// as best effort the comment goes in the parent
+			// as best effort the comment goes in the parent
 			commentParent.addComment(comment);
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -39,6 +39,7 @@ import spoon.reflect.code.CtSwitch;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.position.BodyHolderSourcePosition;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.cu.position.DeclarationSourcePosition;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
@@ -65,6 +66,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -486,6 +488,11 @@ class JDTCommentBuilder {
 			@Override
 			public void visitCtModule(CtModule module) {
 				addCommentToNear(comment, new ArrayList<>(module.getModuleDirectives()));
+			}
+
+			@Override
+			public <A extends Annotation> void visitCtAnnotation(CtAnnotation<A> e) {
+				addCommentToNear(comment, new ArrayList<>(e.getValues().values()));
 			}
 		};
 		insertionVisitor.scan(commentParent);

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -997,7 +997,7 @@ public class CommentTest {
 				"-i", "src/test/resources/ConfigPlugin.java"
 		});
 		// the comment should be associated to the expression in the annotation
-		assertEquals("prevent users from disabling", launcher.getFactory().Type().get("net.runelite.client.plugins.config.ConfigPlugin").getAnnotations().get(0).filterChildren(new TypeFilter<>(CtComment.class)).list().get(0).toString());
+		assertEquals("// prevent users from disabling", launcher.getFactory().Type().get("net.runelite.client.plugins.config.ConfigPlugin").getAnnotations().get(0).filterChildren(new TypeFilter<>(CtComment.class)).list().get(0).toString());
 
 	}
 

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -989,6 +989,20 @@ public class CommentTest {
 		assertEquals("Keep old {@link RootNode} and ignore requests to add new {@link RootNode}", comments.get(0).getContent());
 	}
 
+
+	@Test
+	public void testBug2209() {
+		final Launcher launcher = new Launcher();
+		launcher.run(new String[]{
+				"-i", "src/test/resources/ConfigPlugin.java"
+		});
+		// no exception should be thrown
+		// and the comment is still available
+		assertEquals("prevent users from disabling", launcher.getFactory().Type().get("net.runelite.client.plugins.config.ConfigPlugin").getAnnotations().get(0).getComments().get(0).getContent());
+
+	}
+
+
 	@Test
 	public void testInlineCommentIfBlock() {
 		// contract: when creating an inline comment from a string with line separators, it throws an exception to create block comment

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -996,9 +996,8 @@ public class CommentTest {
 		launcher.run(new String[]{
 				"-i", "src/test/resources/ConfigPlugin.java"
 		});
-		// no exception should be thrown
-		// and the comment is still available
-		assertEquals("prevent users from disabling", launcher.getFactory().Type().get("net.runelite.client.plugins.config.ConfigPlugin").getAnnotations().get(0).getComments().get(0).getContent());
+		// the comment should be associated to the expression in the annotation
+		assertEquals("prevent users from disabling", launcher.getFactory().Type().get("net.runelite.client.plugins.config.ConfigPlugin").getAnnotations().get(0).filterChildren(new TypeFilter<>(CtComment.class)).list().get(0).toString());
 
 	}
 

--- a/src/test/resources/ConfigPlugin.java
+++ b/src/test/resources/ConfigPlugin.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.config;
+
+import com.google.common.eventbus.Subscribe;
+import java.awt.image.BufferedImage;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.inject.Inject;
+import javax.swing.SwingUtilities;
+import net.runelite.client.config.ChatColorConfig;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.config.RuneLiteConfig;
+import net.runelite.client.events.PluginChanged;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.util.ImageUtil;
+
+@PluginDescriptor(
+	name = "Configuration",
+	loadWhenOutdated = true,
+	hidden = true // prevent users from disabling
+)
+public class ConfigPlugin extends Plugin
+{
+	@Inject
+	private ClientToolbar clientToolbar;
+
+	@Inject
+	private ConfigManager configManager;
+
+	@Inject
+	private PluginManager pluginManager;
+
+	@Inject
+	private ScheduledExecutorService executorService;
+
+	@Inject
+	private RuneLiteConfig runeLiteConfig;
+
+	@Inject
+	private ChatColorConfig chatColorConfig;
+
+	private ConfigPanel configPanel;
+	private NavigationButton navButton;
+
+	@Override
+	protected void startUp() throws Exception
+	{
+		configPanel = new ConfigPanel(pluginManager, configManager, executorService, runeLiteConfig, chatColorConfig);
+
+		final BufferedImage icon = ImageUtil.getResourceStreamFromClass(getClass(), "config_icon.png");
+
+		navButton = NavigationButton.builder()
+			.tooltip("Configuration")
+			.icon(icon)
+			.priority(0)
+			.panel(configPanel)
+			.build();
+
+		clientToolbar.addNavigation(navButton);
+	}
+
+	@Override
+	protected void shutDown() throws Exception
+	{
+		clientToolbar.removeNavigation(navButton);
+	}
+
+	@Subscribe
+	public void onPluginChanged(PluginChanged event)
+	{
+		SwingUtilities.invokeLater(configPanel::refreshPluginList);
+	}
+}


### PR DESCRIPTION
fix #2209 

Note that it's a partial fix, the comment should be added to the expression inside the annotation, but it's still much better than the dirty exception in logs of before.