### PR TITLE
fix(sniper): skip separator after removed element

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -313,9 +313,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 			if (changeResolver == null) {
 				changeResolver = new ChangeResolver(getChangeCollector(), element);
 			}
-			if (changeResolver.hasChangedRole() == false) {
-				throw new SpoonException("The modified fragment has no changed roles?");
-			}
+			//changeResolver.hasChangedRole() is false when element is added
 			//something is changed in this element
 			superScanInContext(element, new SourceFragmentContextNormal(mutableTokenWriter, sourceFragment, changeResolver), false);
 		} else {

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
@@ -170,6 +170,7 @@ abstract class AbstractSourceFragmentContext implements SourceFragmentContext {
 	protected void printOriginSpacesUntilFragmentIndex(int fromIndex, int toIndex) {
 		//print all not yet printed comments which still exist in parent
 		boolean canPrintSpace = true;
+		boolean skipSpaceAfterDeletedElement = false;
 		for (int i = fromIndex; i < toIndex; i++) {
 			SourceFragment fragment = childFragments.get(i);
 			if (fragment instanceof ElementSourceFragment) {
@@ -194,9 +195,17 @@ abstract class AbstractSourceFragmentContext implements SourceFragmentContext {
 					}
 				}
 			} else if (isSpaceFragment(fragment) && canPrintSpace) {
-				mutableTokenWriter.getPrinterHelper().directPrint(fragment.getSourceCode());
+				if (!skipSpaceAfterDeletedElement) {
+					mutableTokenWriter.getPrinterHelper().directPrint(fragment.getSourceCode());
+				} else {
+					skipSpaceAfterDeletedElement = false;
+				}
 				//all whitespaces are in one fragment, so do not print next spaces without any comment in between
 				canPrintSpace = false;
+			} else {
+				//there are some non empty tokens, which were not printed (were removed from model)
+				//do not print next space, which represents the separator between removed tokens and next token
+				skipSpaceAfterDeletedElement = true;
 			}
 		}
 		setChildFragmentIdx(toIndex - 1);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -5,9 +5,11 @@ import spoon.Launcher;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.support.modelobs.ChangeCollector;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.test.prettyprinter.testclasses.ToBeChanged;
@@ -128,6 +130,20 @@ public class TestSniperPrinter {
 		}, (type, printed) -> {
 			String lastMemberString = "new List<?>[7][];";
 			assertIsPrintedWithExpectedChanges(type, printed, "\\Q" + lastMemberString + "\\E", lastMemberString + "\n\n\t" + context.newField.toString());
+		});
+	}
+
+	@Test
+	public void testPrintAfterRemoveOfFormalTypeParamsAndChangeOfReturnType() {
+		//contract: sniper printing after remove of formal type parameters and change of return type
+		testSniper(ToBeChanged.class.getName(), type -> {
+			//change the model
+			CtMethod<?> m = type.getMethodsByName("andSomeOtherMethod").get(0);
+			m.setFormalCtTypeParameters(Collections.emptyList());
+			m.setType((CtTypeReference) m.getFactory().Type().stringType());
+		}, (type, printed) -> {
+			// everything is the same but method formal type params and return type
+			assertIsPrintedWithExpectedChanges(type, printed, "\\Qpublic <T, K> void andSomeOtherMethod\\E", "public java.lang.String andSomeOtherMethod");
 		});
 	}
 


### PR DESCRIPTION
When the code
```java
<T> T method();
```
is refactored to
```java
AClass method();
//but sniper prints
 AClass method();
```
bug: SniperPrinter keeps space after `<T>`
expected: SniperPrinter removes space which as after removed `<T>`
