### PR TITLE
perf: CtQuery create log message only when log is enabled

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -370,7 +370,9 @@ public class CtQueryImpl implements CtQuery {
 				return true;
 			}
 			if (expectedClass != null && expectedClass.isAssignableFrom(input.getClass()) == false) {
-				log(this, input.getClass().getName() + " cannot be cast to " + expectedClass.getName(), input);
+				if (isLogging()) {
+					log(this, input.getClass().getName() + " cannot be cast to " + expectedClass.getName(), input);
+				}
 				return false;
 			}
 			return true;


### PR DESCRIPTION
This code is called quite often so the building of useless message has bad influence to query engine performance.