### PR TITLE
fix: ignore changes on elements without parent

### DIFF
--- a/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
+++ b/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
@@ -29,7 +29,7 @@ public class SourceFragmentCreator extends ChangeCollector {
 	@Override
 	protected void onChange(CtElement currentElement, CtRole role) {
 		if (!currentElement.isParentInitialized()) {
-			//parent is not initialized. It is just creation of an temporary element
+			//parent is not initialized. It is just creation of a temporary element
 			//ignore such "change"
 			return;
 		}

--- a/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
+++ b/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
@@ -28,9 +28,13 @@ import spoon.support.sniper.internal.ElementSourceFragment;
 public class SourceFragmentCreator extends ChangeCollector {
 	@Override
 	protected void onChange(CtElement currentElement, CtRole role) {
+		if (!currentElement.isParentInitialized()) {
+			//parent is not initialized. It is just creation of an temporary element
+			//ignore such "change"
+			return;
+		}
 		CompilationUnit cu = currentElement.getPosition().getCompilationUnit();
 		if (cu != null) {
-
 			//getOriginalSourceFragment is not only a getter, it actually
 			//builds a tree of SourceFragments of compilation unit of the modified element
 			cu.getOriginalSourceFragment();


### PR DESCRIPTION
SniperPrinter change collector listens on changes ... but spoon produces many ... many change events during normal analyzing tasks (no real changing of model). For example just creation of type references or adapting generic types creates many temporary AST node instances, which are not really connected to the AST... but they produce change requests.

This PR tries to filter out at least those events whose element has no parent.

... but there are still other temporary elements which has set parent, but has no connection from parent to temporary element. This check is more expensive ... so it is better to run analyzing code using `ChangeCollector.runWithoutChangeListener`... without that change collector soon eats many GB of memory and fails.