### PR TITLE
refactor: use contains() to improve readability

### DIFF
--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -88,7 +88,7 @@ public class CtPathStringBuilder {
 			String kind = token;
 			CtPathElement pathElement = null;
 			token = tokenizer.getNextToken(PATH_DELIMITERS);
-			if (token != null && token.length() == 1 && PATH_DELIMITERS.indexOf(token) >= 0) {
+			if (token != null && token.length() == 1 && PATH_DELIMITERS.contains(token)) {
 				//nextToken is again path delimiter. It means there is no token value in between
 				throw new CtPathException("Path value is missing");
 			}

--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -62,12 +62,9 @@ public class CtNamedPathElement extends AbstractPathElement<CtElement, CtElement
 	}
 
 	private boolean canBeRegExpPattern(String str) {
-		if (str.indexOf("()") >= 0) {
-			//this is acceptable by RegExp, but is in conflict with method signature
-			//and it makes no sense for regexp
-			return false;
-		}
-		return true;
+		//this is acceptable by RegExp, but is in conflict with method signature
+		//and it makes no sense for regexp
+		return !str.contains("()");
 	}
 
 	public String getPattern() {

--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -62,8 +62,8 @@ public class CtNamedPathElement extends AbstractPathElement<CtElement, CtElement
 	}
 
 	private boolean canBeRegExpPattern(String str) {
-		//this is acceptable by RegExp, but is in conflict with method signature
-		//and it makes no sense for regexp
+		// if there is "()", it refers to a method signature
+		// so it cannot be a RegExp
 		return !str.contains("()");
 	}
 


### PR DESCRIPTION
- use contains() to clearly say intentions (both commits)
- simplify method *canBeRegExpPattern* (one commit)