### PR TITLE
refactor: remove redundant initialization

### DIFF
--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -86,7 +86,7 @@ public class CtPathStringBuilder {
 		String token = tokenizer.getNextToken(MAIN_DELIMITERS);
 		while (token != null) {
 			String kind = token;
-			CtPathElement pathElement = null;
+			CtPathElement pathElement;
 			token = tokenizer.getNextToken(PATH_DELIMITERS);
 			if (token != null && token.length() == 1 && PATH_DELIMITERS.indexOf(token) >= 0) {
 				//nextToken is again path delimiter. It means there is no token value in between


### PR DESCRIPTION
CtPathElement pathElement = null;

This null assignment value is lost in:
- pathElement = new CtNamedPathElement(token, false); or
- pathElement = new CtTypedNameElement(load(token)); or
- pathElement = new CtRolePathElement(CtRole.fromName(token));

This time null is overriden by another values (returned from ctrs). Null is not useful anyhow in this case. It is confusing and (sometimes) dangerous (NPE risk).

To be deleted.