### PR TITLE
fix: CtExpressionImpl#setTypeCasts(null) calls change listener now

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
@@ -60,6 +60,7 @@ public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements C
 
 	@Override
 	public <C extends CtExpression<T>> C setTypeCasts(List<CtTypeReference<?>> casts) {
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CAST, this.typeCasts, new ArrayList<>(this.typeCasts));
 		if (casts == null || casts.isEmpty()) {
 			this.typeCasts = CtElementImpl.emptyList();
 			return (C) this;
@@ -67,7 +68,6 @@ public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements C
 		if (this.typeCasts == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.typeCasts = new ArrayList<>(CASTS_CONTAINER_DEFAULT_CAPACITY);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CAST, this.typeCasts, new ArrayList<>(this.typeCasts));
 		this.typeCasts.clear();
 		for (CtTypeReference<?> cast : casts) {
 			addTypeCast(cast);


### PR DESCRIPTION
Problem: call of `setTypeCasts(null)` changes property value but change listener is not called.

I do not plan to write a test for that bug. I am working on refactoring of all such methods, so such test would be thrown away later anyway.

But that bug has to be fixed to have Sniper mode working.