### PR TITLE
WiP: refactor: return types of Spoon model methods

### DIFF
--- a/src/main/java/spoon/reflect/code/BinaryOperatorKind.java
+++ b/src/main/java/spoon/reflect/code/BinaryOperatorKind.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This enumeration defines all the kinds of binary operators.
  */

--- a/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
@@ -16,15 +16,18 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.reference.CtExecutableReference;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.reference.CtExecutableReference;
 
 import static spoon.reflect.path.CtRole.ARGUMENT;
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
+
+
+
 
 /**
  * This code element defines an abstract invocation on a
@@ -46,7 +49,7 @@ public interface CtAbstractInvocation<T> extends CtElement {
 	 * Adds an argument expression to the invocation.
 	 */
 	@PropertySetter(role = ARGUMENT)
-	<C extends CtAbstractInvocation<T>> C addArgument(CtExpression<?> argument);
+	CtAbstractInvocation<T> addArgument(CtExpression<?> argument);
 
 	/**
 	 * Removes an argument expression from the invocation.
@@ -58,7 +61,7 @@ public interface CtAbstractInvocation<T> extends CtElement {
 	 * Sets the invocation's arguments.
 	 */
 	@PropertySetter(role = ARGUMENT)
-	<C extends CtAbstractInvocation<T>> C setArguments(List<CtExpression<?>> arguments);
+	CtAbstractInvocation<T> setArguments(List<CtExpression<?>> arguments);
 
 	/**
 	 * Returns the invoked executable.
@@ -70,5 +73,5 @@ public interface CtAbstractInvocation<T> extends CtElement {
 	 * Sets the invoked executable.
 	 */
 	@PropertySetter(role = EXECUTABLE_REF)
-	<C extends CtAbstractInvocation<T>> C setExecutable(CtExecutableReference<T> executable);
+	CtAbstractInvocation<T> setExecutable(CtExecutableReference<T> executable);
 }

--- a/src/main/java/spoon/reflect/code/CtAnnotationFieldAccess.java
+++ b/src/main/java/spoon/reflect/code/CtAnnotationFieldAccess.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.reference.CtFieldReference;
+
 import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.reference.CtFieldReference;
 
 import static spoon.reflect.path.CtRole.VARIABLE;
+
+
+
 
 /**
  * This code element defines an access to a annotation parameter variable.

--- a/src/main/java/spoon/reflect/code/CtArrayAccess.java
+++ b/src/main/java/spoon/reflect/code/CtArrayAccess.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a one-dimensional array access. When
@@ -37,7 +41,7 @@ public interface CtArrayAccess<T, E extends CtExpression<?>> extends CtTargetedE
 	 * Sets the expression that defines the index.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<C extends CtArrayAccess<T, E>> C setIndexExpression(CtExpression<Integer> expression);
+	CtArrayAccess<T, E> setIndexExpression(CtExpression<Integer> expression);
 
 	/**
 	 * Returns the expression that defines the index.

--- a/src/main/java/spoon/reflect/code/CtArrayRead.java
+++ b/src/main/java/spoon/reflect/code/CtArrayRead.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a read access to an array.
  *

--- a/src/main/java/spoon/reflect/code/CtArrayWrite.java
+++ b/src/main/java/spoon/reflect/code/CtArrayWrite.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a write access to an array.
  *

--- a/src/main/java/spoon/reflect/code/CtAssert.java
+++ b/src/main/java/spoon/reflect/code/CtAssert.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 
 /**
@@ -38,7 +42,7 @@ public interface CtAssert<T> extends CtStatement {
 	 * Sets the assert expression.
 	 */
 	@PropertySetter(role = CONDITION)
-	<A extends CtAssert<T>> A setAssertExpression(CtExpression<Boolean> asserted);
+	CtAssert<T> setAssertExpression(CtExpression<Boolean> asserted);
 
 	/**
 	 * Gets the expression of the assertion if defined.
@@ -50,7 +54,7 @@ public interface CtAssert<T> extends CtStatement {
 	 * Sets the expression of the assertion.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<A extends CtAssert<T>> A setExpression(CtExpression<T> expression);
+	CtAssert<T> setExpression(CtExpression<T> expression);
 
 	@Override
 	CtAssert<T> clone();

--- a/src/main/java/spoon/reflect/code/CtAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtAssignment.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.ASSIGNED;
+
+
+
 
 
 /**
@@ -47,7 +51,7 @@ public interface CtAssignment<T, A extends T> extends CtStatement, CtExpression<
 	 * Sets the assigned expression (left hand side - LHS).
 	 */
 	@PropertySetter(role = ASSIGNED)
-	<C extends CtAssignment<T, A>> C setAssigned(CtExpression<T> assigned);
+	CtAssignment<T, A> setAssigned(CtExpression<T> assigned);
 
 	@Override
 	CtAssignment<T, A> clone();

--- a/src/main/java/spoon/reflect/code/CtBinaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtBinaryOperator.java
@@ -16,12 +16,16 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import static spoon.reflect.path.CtRole.OPERATOR_KIND;
 import static spoon.reflect.path.CtRole.LEFT_OPERAND;
+import static spoon.reflect.path.CtRole.OPERATOR_KIND;
 import static spoon.reflect.path.CtRole.RIGHT_OPERAND;
+
+
+
 
 /**
  * This interface defines a binary operator.
@@ -52,19 +56,19 @@ public interface CtBinaryOperator<T> extends CtExpression<T> {
 	 * Sets the left-hand operand.
 	 */
 	@PropertySetter(role = LEFT_OPERAND)
-	<C extends CtBinaryOperator<T>> C setLeftHandOperand(CtExpression<?> expression);
+	CtBinaryOperator<T> setLeftHandOperand(CtExpression<?> expression);
 
 	/**
 	 * Sets the right-hand operand.
 	 */
 	@PropertySetter(role = RIGHT_OPERAND)
-	<C extends CtBinaryOperator<T>> C setRightHandOperand(CtExpression<?> expression);
+	CtBinaryOperator<T> setRightHandOperand(CtExpression<?> expression);
 
 	/**
 	 * Sets the kind of this binary operator.
 	 */
 	@PropertySetter(role = OPERATOR_KIND)
-	<C extends CtBinaryOperator<T>> C setKind(BinaryOperatorKind kind);
+	CtBinaryOperator<T> setKind(BinaryOperatorKind kind);
 
 	/**
 	 * Gets the kind of this binary operator.

--- a/src/main/java/spoon/reflect/code/CtBlock.java
+++ b/src/main/java/spoon/reflect/code/CtBlock.java
@@ -16,7 +16,11 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.template.TemplateParameter;
+
+
+
 
 /**
  * This code element represents a block of code, that is to say a list of

--- a/src/main/java/spoon/reflect/code/CtBodyHolder.java
+++ b/src/main/java/spoon/reflect/code/CtBodyHolder.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.CtElement;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtElement;
 
 import static spoon.reflect.path.CtRole.BODY;
+
+
+
 
 /**
  * This abstract code element defines an element, which contains a body
@@ -38,5 +42,5 @@ public interface CtBodyHolder extends CtElement {
 	 * If body is not a block, it is wrapped in a CtBlock which is semantically equivalent and eases transformation afterwards if required.
 	 */
 	@PropertySetter(role = BODY)
-	<T extends CtBodyHolder> T setBody(CtStatement body);
+	CtBodyHolder setBody(CtStatement body);
 }

--- a/src/main/java/spoon/reflect/code/CtBreak.java
+++ b/src/main/java/spoon/reflect/code/CtBreak.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a break statement.
  * Example:

--- a/src/main/java/spoon/reflect/code/CtCFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtCFlowBreak.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This abstract code element represents all the statements that break the
  * control flow of the program.

--- a/src/main/java/spoon/reflect/code/CtCase.java
+++ b/src/main/java/spoon/reflect/code/CtCase.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a case within a switch-case.
@@ -46,7 +50,7 @@ public interface CtCase<S> extends CtStatement, CtStatementList {
 	 * Sets the case expression.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtCase<S>> T setCaseExpression(CtExpression<S> caseExpression);
+	CtCase<S> setCaseExpression(CtExpression<S> caseExpression);
 
 	@Override
 	CtCase<S> clone();

--- a/src/main/java/spoon/reflect/code/CtCatch.java
+++ b/src/main/java/spoon/reflect/code/CtCatch.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.PARAMETER;
+
+
+
 
 
 /**
@@ -40,7 +44,7 @@ public interface CtCatch extends CtCodeElement, CtBodyHolder {
 	 * Sets the catch's parameter (a throwable).
 	 */
 	@PropertySetter(role = PARAMETER)
-	<T extends CtCatch> T setParameter(CtCatchVariable<? extends Throwable> parameter);
+	CtCatch setParameter(CtCatchVariable<? extends Throwable> parameter);
 
 	/**
 	 * Gets the catch's body.

--- a/src/main/java/spoon/reflect/code/CtCatchVariable.java
+++ b/src/main/java/spoon/reflect/code/CtCatchVariable.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.declaration.CtMultiTypedElement;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This code element defines an exception variable in a catch.
@@ -46,7 +49,7 @@ public interface CtCatchVariable<T> extends CtVariable<T>, CtMultiTypedElement, 
 
 	@Override
 	@UnsettableProperty
-	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
+	CtCatchVariable<T> setDefaultExpression(CtExpression<T> assignedExpression);
 
 	/**
 	 * Returns type reference of the exception variable in a catch.
@@ -58,5 +61,5 @@ public interface CtCatchVariable<T> extends CtVariable<T>, CtMultiTypedElement, 
 
 	@Override
 	@UnsettableProperty
-	<C extends CtTypedElement> C setType(CtTypeReference<T> type);
+	CtCatchVariable<T> setType(CtTypeReference<T> type);
 }

--- a/src/main/java/spoon/reflect/code/CtCodeElement.java
+++ b/src/main/java/spoon/reflect/code/CtCodeElement.java
@@ -16,7 +16,11 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.declaration.CtElement;
+
+
+
 
 /**
  * This interface is the root interface of the code elements.

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.support.compiler.SnippetCompilationError;
+
+
+
 
 /**
  * This element is a code snippet that must represent an expression and can thus

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
@@ -16,9 +16,13 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.compiler.SnippetCompilationError;
+
+
+
 
 /**
  * This element is a code snippet that must represent a statement and can thus

--- a/src/main/java/spoon/reflect/code/CtComment.java
+++ b/src/main/java/spoon/reflect/code/CtComment.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import static spoon.reflect.path.CtRole.COMMENT_TYPE;
 import static spoon.reflect.path.CtRole.COMMENT_CONTENT;
+import static spoon.reflect.path.CtRole.COMMENT_TYPE;
+
+
+
 
 /**
  * This code element defines a comment
@@ -66,7 +70,7 @@ public interface CtComment extends CtStatement {
 	String getContent();
 
 	@PropertySetter(role = COMMENT_CONTENT)
-	<E extends CtComment> E setContent(String content);
+	CtComment setContent(String content);
 
 	/**
 	 * Get the type of the comment
@@ -76,11 +80,11 @@ public interface CtComment extends CtStatement {
 	CommentType getCommentType();
 
 	@PropertySetter(role = COMMENT_TYPE)
-	<E extends CtComment> E setCommentType(CommentType commentType);
+	CtComment setCommentType(CommentType commentType);
 
 	@Override
 	CtComment clone();
 
 	/** Utility method to for casting the object, throws an exception if not of the correct type */
-	CtJavaDoc asJavaDoc();
+	CtComment asJavaDoc();
 }

--- a/src/main/java/spoon/reflect/code/CtConditional.java
+++ b/src/main/java/spoon/reflect/code/CtConditional.java
@@ -16,12 +16,16 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.ELSE;
 import static spoon.reflect.path.CtRole.THEN;
+
+
+
 
 
 /**
@@ -58,19 +62,19 @@ public interface CtConditional<T> extends CtExpression<T> {
 	 * Sets the "false" expression.
 	 */
 	@PropertySetter(role = ELSE)
-	<C extends CtConditional<T>> C setElseExpression(CtExpression<T> elseExpression);
+	CtConditional<T> setElseExpression(CtExpression<T> elseExpression);
 
 	/**
 	 * Sets the "true" expression.
 	 */
 	@PropertySetter(role = THEN)
-	<C extends CtConditional<T>> C setThenExpression(CtExpression<T> thenExpression);
+	CtConditional<T> setThenExpression(CtExpression<T> thenExpression);
 
 	/**
 	 * Sets the condition expression.
 	 */
 	@PropertySetter(role = CONDITION)
-	<C extends CtConditional<T>> C setCondition(CtExpression<Boolean> condition);
+	CtConditional<T> setCondition(CtExpression<Boolean> condition);
 
 	@Override
 	CtConditional<T> clone();

--- a/src/main/java/spoon/reflect/code/CtConstructorCall.java
+++ b/src/main/java/spoon/reflect/code/CtConstructorCall.java
@@ -16,18 +16,21 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import java.util.List;
 
 import static spoon.reflect.path.CtRole.TYPE;
 import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
+
+
+
 
 /**
  * This code element represents a constructor call.
@@ -59,7 +62,7 @@ public interface CtConstructorCall<T> extends CtTargetedExpression<T, CtExpressi
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
+	CtConstructorCall<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Delegate to the executable reference of the constructor call.
@@ -68,7 +71,7 @@ public interface CtConstructorCall<T> extends CtTargetedExpression<T, CtExpressi
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
+	CtConstructorCall<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 
 	@Override
 	CtConstructorCall<T> clone();

--- a/src/main/java/spoon/reflect/code/CtContinue.java
+++ b/src/main/java/spoon/reflect/code/CtContinue.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines the continue statement.
  * Example:

--- a/src/main/java/spoon/reflect/code/CtDo.java
+++ b/src/main/java/spoon/reflect/code/CtDo.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a <code>do</code> loop.
@@ -44,7 +48,7 @@ public interface CtDo extends CtLoop {
 	 * Sets the looping test as a boolean expression.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtDo> T setLoopingExpression(CtExpression<Boolean> expression);
+	CtDo setLoopingExpression(CtExpression<Boolean> expression);
 
 	@Override
 	CtDo clone();

--- a/src/main/java/spoon/reflect/code/CtExecutableReferenceExpression.java
+++ b/src/main/java/spoon/reflect/code/CtExecutableReferenceExpression.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.reference.CtExecutableReference;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtExecutableReference;
 
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
+
+
+
 
 /**
  * This abstract code element defines an expression which represents an executable reference.
@@ -48,7 +52,7 @@ public interface CtExecutableReferenceExpression<T, E extends CtExpression<?>> e
 	 * Sets the executable will be referenced by the expression.
 	 */
 	@PropertySetter(role = EXECUTABLE_REF)
-	<C extends CtExecutableReferenceExpression<T, E>> C setExecutable(CtExecutableReference<T> executable);
+	CtExecutableReferenceExpression<T, E> setExecutable(CtExecutableReference<T> executable);
 
 	@Override
 	CtExecutableReferenceExpression<T, E> clone();

--- a/src/main/java/spoon/reflect/code/CtExpression.java
+++ b/src/main/java/spoon/reflect/code/CtExpression.java
@@ -16,15 +16,18 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-import spoon.template.TemplateParameter;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtTypedElement;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.template.TemplateParameter;
 
 import static spoon.reflect.path.CtRole.CAST;
+
+
+
 
 /**
  * This abstract code element defines a typed expression.
@@ -44,13 +47,13 @@ public interface CtExpression<T> extends CtCodeElement, CtTypedElement<T>, Templ
 	 * Sets the type casts.
 	 */
 	@PropertySetter(role = CAST)
-	<C extends CtExpression<T>> C setTypeCasts(List<CtTypeReference<?>> types);
+	CtExpression<T> setTypeCasts(List<CtTypeReference<?>> types);
 
 	/**
 	 * Adds a type cast.
 	 */
 	@PropertySetter(role = CAST)
-	<C extends CtExpression<T>> C addTypeCast(CtTypeReference<?> type);
+	CtExpression<T> addTypeCast(CtTypeReference<?> type);
 
 	@Override
 	CtExpression<T> clone();

--- a/src/main/java/spoon/reflect/code/CtFieldAccess.java
+++ b/src/main/java/spoon/reflect/code/CtFieldAccess.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.reference.CtFieldReference;
+
 import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.reference.CtFieldReference;
 
 import static spoon.reflect.path.CtRole.VARIABLE;
+
+
+
 
 /**
  * This code element defines an access to a field variable (read and write)

--- a/src/main/java/spoon/reflect/code/CtFieldRead.java
+++ b/src/main/java/spoon/reflect/code/CtFieldRead.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a read access to a field.
  *

--- a/src/main/java/spoon/reflect/code/CtFieldWrite.java
+++ b/src/main/java/spoon/reflect/code/CtFieldWrite.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a write access to a field.
  *

--- a/src/main/java/spoon/reflect/code/CtFor.java
+++ b/src/main/java/spoon/reflect/code/CtFor.java
@@ -16,14 +16,17 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.FOR_INIT;
 import static spoon.reflect.path.CtRole.FOR_UPDATE;
+
+
+
 
 /**
  * This code element defines a for loop.
@@ -47,7 +50,7 @@ public interface CtFor extends CtLoop {
 	 * Sets the end-loop test expression.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtFor> T setExpression(CtExpression<Boolean> expression);
+	CtFor setExpression(CtExpression<Boolean> expression);
 
 	/**
 	 * Gets the <i>init</i> statements.
@@ -59,13 +62,13 @@ public interface CtFor extends CtLoop {
 	 * Adds an <i>init</i> statement.
 	 */
 	@PropertySetter(role = FOR_INIT)
-	<T extends CtFor> T addForInit(CtStatement statement);
+	CtFor addForInit(CtStatement statement);
 
 	/**
 	 * Sets the <i>init</i> statements.
 	 */
 	@PropertySetter(role = FOR_INIT)
-	<T extends CtFor> T setForInit(List<CtStatement> forInit);
+	CtFor setForInit(List<CtStatement> forInit);
 
 	/**
 	 * Removes an <i>init</i> statement.
@@ -83,13 +86,13 @@ public interface CtFor extends CtLoop {
 	 * Adds an <i>update</i> statement.
 	 */
 	@PropertySetter(role = FOR_UPDATE)
-	<T extends CtFor> T addForUpdate(CtStatement statement);
+	CtFor addForUpdate(CtStatement statement);
 
 	/**
 	 * Sets the <i>update</i> statements.
 	 */
 	@PropertySetter(role = FOR_UPDATE)
-	<T extends CtFor> T setForUpdate(List<CtStatement> forUpdate);
+	CtFor setForUpdate(List<CtStatement> forUpdate);
 
 	/**
 	 * Removes an <i>update</i> statement.

--- a/src/main/java/spoon/reflect/code/CtForEach.java
+++ b/src/main/java/spoon/reflect/code/CtForEach.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.FOREACH_VARIABLE;
+
+
+
 
 
 /**
@@ -50,13 +54,13 @@ public interface CtForEach extends CtLoop {
 	 * Sets the iterated expression (an iterable of an array).
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtForEach> T setExpression(CtExpression<?> expression);
+	CtForEach setExpression(CtExpression<?> expression);
 
 	/**
 	 * Sets the variable that references the currently iterated element.
 	 */
 	@PropertySetter(role = FOREACH_VARIABLE)
-	<T extends CtForEach> T setVariable(CtLocalVariable<?> variable);
+	CtForEach setVariable(CtLocalVariable<?> variable);
 
 	@Override
 	CtForEach clone();

--- a/src/main/java/spoon/reflect/code/CtIf.java
+++ b/src/main/java/spoon/reflect/code/CtIf.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.template.TemplateParameter;
@@ -23,6 +24,9 @@ import spoon.template.TemplateParameter;
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.ELSE;
 import static spoon.reflect.path.CtRole.THEN;
+
+
+
 
 /**
  * This code element represents an <code>if</code> statement.
@@ -61,19 +65,19 @@ public interface CtIf extends CtStatement, TemplateParameter<Void> {
 	 * condition.
 	 */
 	@PropertySetter(role = CONDITION)
-	<T extends CtIf> T setCondition(CtExpression<Boolean> expression);
+	CtIf setCondition(CtExpression<Boolean> expression);
 
 	/**
 	 * Sets the statement executed when the condition is false.
 	 */
 	@PropertySetter(role = ELSE)
-	<T extends CtIf> T setElseStatement(CtStatement elseStatement);
+	CtIf setElseStatement(CtStatement elseStatement);
 
 	/**
 	 * Sets the statement executed when the condition is true.
 	 */
 	@PropertySetter(role = THEN)
-	<T extends CtIf> T setThenStatement(CtStatement thenStatement);
+	CtIf setThenStatement(CtStatement thenStatement);
 
 	@Override
 	CtIf clone();

--- a/src/main/java/spoon/reflect/code/CtInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtInvocation.java
@@ -16,17 +16,20 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import java.util.List;
 
 import static spoon.reflect.path.CtRole.TYPE;
 import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
+
+
+
 
 /**
  * This code element defines a concrete invocation.
@@ -59,7 +62,7 @@ public interface CtInvocation<T> extends CtAbstractInvocation<T>, CtStatement, C
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
+	CtInvocation<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Delegate to the executable reference of the invocation.
@@ -68,7 +71,7 @@ public interface CtInvocation<T> extends CtAbstractInvocation<T>, CtStatement, C
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
+	CtInvocation<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 
 	/**
 	 * Return the type returned by the invocation. If the invocation is to a

--- a/src/main/java/spoon/reflect/code/CtJavaDoc.java
+++ b/src/main/java/spoon/reflect/code/CtJavaDoc.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.code;
 
-import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.support.DerivedProperty;
 
 import static spoon.reflect.path.CtRole.COMMENT_TAG;
+
+
+
 
 /**
  * This code element defines a javadoc comment
@@ -48,14 +51,14 @@ public interface CtJavaDoc extends CtComment {
 	 * @param tags the new list of tags
 	 */
 	@PropertySetter(role = COMMENT_TAG)
-	<E extends CtJavaDoc> E setTags(List<CtJavaDocTag> tags);
+	CtJavaDoc setTags(List<CtJavaDocTag> tags);
 
 	/**
 	 * Add a new tag at the end of the list
 	 * @param tag the new tag
 	 */
 	@PropertySetter(role = COMMENT_TAG)
-	<E extends CtJavaDoc> E addTag(CtJavaDocTag tag);
+	CtJavaDoc addTag(CtJavaDocTag tag);
 
 	/**
 	 * Add a new tag at the index position
@@ -63,21 +66,21 @@ public interface CtJavaDoc extends CtComment {
 	 * @param tag the new tag
 	 */
 	@PropertySetter(role = COMMENT_TAG)
-	<E extends CtJavaDoc> E addTag(int index, CtJavaDocTag tag);
+	CtJavaDoc addTag(int index, CtJavaDocTag tag);
 
 	/**
 	 * Remove a tag from the index
 	 * @param index the position of the tag to remove
 	 */
 	@PropertySetter(role = COMMENT_TAG)
-	<E extends CtJavaDoc> E removeTag(int index);
+	CtJavaDoc removeTag(int index);
 
 	/**
 	 * Remove a specific tag
 	 * @param tag the tag to remove
 	 */
 	@PropertySetter(role = COMMENT_TAG)
-	<E extends CtJavaDoc> E removeTag(CtJavaDocTag tag);
+	CtJavaDoc removeTag(CtJavaDocTag tag);
 
 	/**
 	 * Get the short summary of the javadoc (first sentence of the javadoc)

--- a/src/main/java/spoon/reflect/code/CtJavaDocTag.java
+++ b/src/main/java/spoon/reflect/code/CtJavaDocTag.java
@@ -16,13 +16,17 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.CtElement;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtElement;
 
 import static spoon.reflect.path.CtRole.COMMENT_CONTENT;
-import static spoon.reflect.path.CtRole.JAVADOC_TAG_VALUE;
 import static spoon.reflect.path.CtRole.DOCUMENTATION_TYPE;
+import static spoon.reflect.path.CtRole.JAVADOC_TAG_VALUE;
+
+
+
 
 /**
  * This code element defines a javadoc tag
@@ -97,14 +101,14 @@ public interface CtJavaDocTag extends CtElement {
 	 * @param type the type name
 	 */
 	@PropertySetter(role = DOCUMENTATION_TYPE)
-	<E extends CtJavaDocTag> E setType(String type);
+	CtJavaDocTag setType(String type);
 
 	/**
 	 * Define the type of the tag
 	 * @param type the new type
 	 */
 	@PropertySetter(role = DOCUMENTATION_TYPE)
-	<E extends CtJavaDocTag> E setType(TagType type);
+	CtJavaDocTag setType(TagType type);
 
 	/**
 	 * Get the content of the atg
@@ -118,7 +122,7 @@ public interface CtJavaDocTag extends CtElement {
 	 * @param content the new content of the tag
 	 */
 	@PropertySetter(role = COMMENT_CONTENT)
-	<E extends CtJavaDocTag> E setContent(String content);
+	CtJavaDocTag setContent(String content);
 
 	/**
 	 * Get the parameter of the tag return null when none is specified (only for @param and @throws)
@@ -132,7 +136,7 @@ public interface CtJavaDocTag extends CtElement {
 	 * @param param the parameter
 	 */
 	@PropertySetter(role = JAVADOC_TAG_VALUE)
-	<E extends CtJavaDocTag> E setParam(String param);
+	CtJavaDocTag setParam(String param);
 
 	@Override
 	CtJavaDocTag clone();

--- a/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.support.DerivedProperty;
 
 import static spoon.reflect.path.CtRole.TARGET_LABEL;
+
+
+
 
 /**
  * This abstract code element represents all the statements that break the
@@ -39,7 +43,7 @@ public interface CtLabelledFlowBreak extends CtCFlowBreak {
 	 * defined).
 	 */
 	@PropertySetter(role = TARGET_LABEL)
-	<T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel);
+	CtLabelledFlowBreak setTargetLabel(String targetLabel);
 
 	@DerivedProperty
 	CtStatement getLabelledStatement();

--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -16,17 +16,20 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 import spoon.support.UnsettableProperty;
 
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element represents the creation of a lambda. A lambda
@@ -78,12 +81,12 @@ public interface CtLambda<T> extends CtExpression<T>, CtExecutable<T> {
 	 * if the lambda already has a value in the body attribute.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<C extends CtLambda<T>> C setExpression(CtExpression<T> expression);
+	CtLambda<T> setExpression(CtExpression<T> expression);
 
 	@Override
 	CtLambda<T> clone();
 
 	@Override
 	@UnsettableProperty
-	<T1 extends CtExecutable<T>> T1 setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+	CtLambda<T> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 }

--- a/src/main/java/spoon/reflect/code/CtLiteral.java
+++ b/src/main/java/spoon/reflect/code/CtLiteral.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.VALUE;
+
+
+
 
 /**
  * This code element defines a literal value (an int, a string, etc).
@@ -44,7 +48,7 @@ public interface CtLiteral<T> extends CtExpression<T> {
 	 * Sets the actual value of the literal.
 	 */
 	@PropertySetter(role = VALUE)
-	<C extends CtLiteral<T>> C setValue(T value);
+	CtLiteral<T> setValue(T value);
 
 	/** Overriding return type, a clone of a CtLiteral returns a CtLiteral */
 	@Override

--- a/src/main/java/spoon/reflect/code/CtLocalVariable.java
+++ b/src/main/java/spoon/reflect/code/CtLocalVariable.java
@@ -16,6 +16,7 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtVariable;
@@ -24,6 +25,9 @@ import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.IS_INFERRED;
+
+
+
 
 /**
  * This code element defines a local variable definition (within an executable
@@ -68,7 +72,7 @@ public interface CtLocalVariable<T> extends CtStatement, CtVariable<T>, CtRHSRec
 
 	@Override
 	@UnsettableProperty
-	<U extends CtRHSReceiver<T>> U setAssignment(CtExpression<T> assignment);
+	CtLocalVariable<T> setAssignment(CtExpression<T> assignment);
 
 	/**
 	 * Return true if this variable's type is not explicitely defined in the source code, but was using the `var` keyword of Java 10.
@@ -81,6 +85,6 @@ public interface CtLocalVariable<T> extends CtStatement, CtVariable<T>, CtRHSRec
 	 * Warning: this method should only be used if compliance level is set to 10 or more.
 	 */
 	@PropertySetter(role = IS_INFERRED)
-	<U extends CtLocalVariable<T>> U setInferred(boolean inferred);
+	CtLocalVariable<T> setInferred(boolean inferred);
 
 }

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.template.TemplateParameter;
 
 import static spoon.reflect.path.CtRole.BODY;
+
+
+
 
 /**
  * This abstract code element defines a loop.

--- a/src/main/java/spoon/reflect/code/CtNewArray.java
+++ b/src/main/java/spoon/reflect/code/CtNewArray.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.DIMENSION;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines the inline creation of a new array.
@@ -47,13 +50,13 @@ public interface CtNewArray<T> extends CtExpression<T> {
 	 * Sets the expressions that define the array's dimensions.
 	 */
 	@PropertySetter(role = DIMENSION)
-	<C extends CtNewArray<T>> C setDimensionExpressions(List<CtExpression<Integer>> dimensions);
+	CtNewArray<T> setDimensionExpressions(List<CtExpression<Integer>> dimensions);
 
 	/**
 	 * Adds a dimension expression.
 	 */
 	@PropertySetter(role = DIMENSION)
-	<C extends CtNewArray<T>> C addDimensionExpression(CtExpression<Integer> dimension);
+	CtNewArray<T> addDimensionExpression(CtExpression<Integer> dimension);
 
 	/**
 	 * Removes a dimension expression.
@@ -71,13 +74,13 @@ public interface CtNewArray<T> extends CtExpression<T> {
 	 * Sets the initialization expressions.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<C extends CtNewArray<T>> C setElements(List<CtExpression<?>> expression);
+	CtNewArray<T> setElements(List<CtExpression<?>> expression);
 
 	/**
 	 * Adds an element.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<C extends CtNewArray<T>> C addElement(CtExpression<?> expression);
+	CtNewArray<T> addElement(CtExpression<?> expression);
 
 	/**
 	 * Removes an element.

--- a/src/main/java/spoon/reflect/code/CtNewClass.java
+++ b/src/main/java/spoon/reflect/code/CtNewClass.java
@@ -16,20 +16,23 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.NESTED_TYPE;
 import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
 
-/**
+
+
+
+
+public/**
  * This code element represents the creation of a anonymous class.
  *
 * Example:
@@ -45,7 +48,7 @@ import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
  * @param <T>
  * 		created type
  */
-public interface CtNewClass<T> extends CtConstructorCall<T> {
+interface CtNewClass<T> extends CtConstructorCall<T> {
 	/**
 	 * Delegate to the executable reference of the new class.
 	 *
@@ -63,7 +66,7 @@ public interface CtNewClass<T> extends CtConstructorCall<T> {
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
+	CtNewClass<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Delegate to the executable reference of the new class.
@@ -72,7 +75,7 @@ public interface CtNewClass<T> extends CtConstructorCall<T> {
 	 */
 	@Override
 	@PropertySetter(role = TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
+	CtNewClass<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 
 	/**
 	 * Gets the created class.
@@ -84,7 +87,7 @@ public interface CtNewClass<T> extends CtConstructorCall<T> {
 	 * Sets the created class.
 	 */
 	@PropertySetter(role = NESTED_TYPE)
-	<N extends CtNewClass> N setAnonymousClass(CtClass<?> anonymousClass);
+	CtNewClass<T> setAnonymousClass(CtClass<?> anonymousClass);
 
 	@Override
 	CtNewClass<T> clone();

--- a/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
+
+
+
 
 
 /**
@@ -37,7 +41,7 @@ public interface CtOperatorAssignment<T, A extends T> extends CtAssignment<T, A>
 	 * Sets the operator kind.
 	 */
 	@PropertySetter(role = OPERATOR_KIND)
-	<C extends CtOperatorAssignment<T, A>> C setKind(BinaryOperatorKind kind);
+	CtOperatorAssignment<T, A> setKind(BinaryOperatorKind kind);
 
 	/**
 	 * Gets the operator kind.

--- a/src/main/java/spoon/reflect/code/CtRHSReceiver.java
+++ b/src/main/java/spoon/reflect/code/CtRHSReceiver.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.CtField;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtField;
 
 import static spoon.reflect.path.CtRole.ASSIGNMENT;
+
+
+
 
 /**
  * Represents the right hand side of an assignment
@@ -38,5 +42,5 @@ public interface CtRHSReceiver<A> {
 	 * Sets the right-hand side expression (RHS) of the "=" operator.
 	 */
 	@PropertySetter(role = ASSIGNMENT)
-	<T extends CtRHSReceiver<A>> T setAssignment(CtExpression<A> assignment);
+	CtRHSReceiver<A> setAssignment(CtExpression<A> assignment);
 }

--- a/src/main/java/spoon/reflect/code/CtReturn.java
+++ b/src/main/java/spoon/reflect/code/CtReturn.java
@@ -16,13 +16,18 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.template.TemplateParameter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 
-/**
+
+
+
+
+public/**
  * This code element represents a <code>return</code> statement.
  *
  * Example:
@@ -36,7 +41,7 @@ import static spoon.reflect.path.CtRole.EXPRESSION;
  * </pre>
 
  */
-public interface CtReturn<R> extends CtCFlowBreak, TemplateParameter<Void> {
+interface CtReturn<R> extends CtCFlowBreak, TemplateParameter<Void> {
 
 	/**
 	 * Gets the returned expression.
@@ -48,7 +53,7 @@ public interface CtReturn<R> extends CtCFlowBreak, TemplateParameter<Void> {
 	 * Sets the returned expression.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtReturn<R>> T setReturnedExpression(CtExpression<R> returnedExpression);
+	CtReturn<R> setReturnedExpression(CtExpression<R> returnedExpression);
 
 	@Override
 	CtReturn<R> clone();

--- a/src/main/java/spoon/reflect/code/CtStatement.java
+++ b/src/main/java/spoon/reflect/code/CtStatement.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
-import spoon.reflect.declaration.ParentNotInitializedException;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.ParentNotInitializedException;
 
 import static spoon.reflect.path.CtRole.LABEL;
+
+
+
 
 /**
  * This abstract code element represents all the statements, which can be part
@@ -33,23 +37,23 @@ public interface CtStatement extends CtCodeElement {
 	/**
 	 * Inserts a statement after the current statement.
 	 */
-	<T extends CtStatement> T insertAfter(CtStatement statement) throws ParentNotInitializedException;
+	CtStatement insertAfter(CtStatement statement) throws ParentNotInitializedException;
 
 	/**
 	 * Inserts a statement list before the current statement.
 	 */
-	<T extends CtStatement> T insertAfter(CtStatementList statements) throws ParentNotInitializedException;
+	CtStatement insertAfter(CtStatementList statements) throws ParentNotInitializedException;
 
 	/**
 	 * Inserts a statement given as parameter before the current statement
 	 * (this).
 	 */
-	<T extends CtStatement> T insertBefore(CtStatement statement) throws ParentNotInitializedException;
+	CtStatement insertBefore(CtStatement statement) throws ParentNotInitializedException;
 
 	/**
 	 * Inserts a statement list before the current statement.
 	 */
-	<T extends CtStatement> T insertBefore(CtStatementList statements) throws ParentNotInitializedException;
+	CtStatement insertBefore(CtStatementList statements) throws ParentNotInitializedException;
 
 	/**
 	 * Gets the label of this statement if defined.
@@ -63,7 +67,7 @@ public interface CtStatement extends CtCodeElement {
 	 * Sets the label of this statement.
 	 */
 	@PropertySetter(role = LABEL)
-	<T extends CtStatement> T setLabel(String label);
+	CtStatement setLabel(String label);
 
 	@Override
 	CtStatement clone();

--- a/src/main/java/spoon/reflect/code/CtStatementList.java
+++ b/src/main/java/spoon/reflect/code/CtStatementList.java
@@ -16,14 +16,17 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.visitor.Filter;
 import spoon.support.DerivedProperty;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.STATEMENT;
+
+
+
 
 /**
  * This code element represents a list of statements. It is not a valid Java
@@ -41,72 +44,72 @@ public interface CtStatementList extends CtCodeElement, Iterable<CtStatement> {
 	 * Sets the statement list.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T setStatements(List<CtStatement> statements);
+	CtStatementList setStatements(List<CtStatement> statements);
 
 	/**
 	 * Adds a statement at the end of the list.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T addStatement(CtStatement statement);
+	CtStatementList addStatement(CtStatement statement);
 
 	/**
 	 * Inserts the given statement at a specific position in the list of statements
 	 * Shifts the statement currently at that position (if any) and any subsequent statements to the right (adds one to their indices).
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T addStatement(int index, CtStatement statement);
+	CtStatementList addStatement(int index, CtStatement statement);
 
 	/**
 	 * Inserts the given statement at the beginning of the block.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T insertBegin(CtStatement statement);
+	CtStatementList insertBegin(CtStatement statement);
 
 	/**
 	 * Inserts the given statement list at the beginning of the block.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T insertBegin(CtStatementList statements);
+	CtStatementList insertBegin(CtStatementList statements);
 
 	/**
 	 * Inserts the given statement at the end of the block.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T insertEnd(CtStatement statement);
+	CtStatementList insertEnd(CtStatement statement);
 
 	/**
 	 * Inserts the given statements at the end of the block.
 	 */
 	@PropertySetter(role = STATEMENT)
-	<T extends CtStatementList> T insertEnd(CtStatementList statements);
+	CtStatementList insertEnd(CtStatementList statements);
 
 	/**
 	 * Inserts the given statement before a set of insertion points given by a
 	 * filter.
 	 */
 	@DerivedProperty
-	<T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement);
+	CtStatementList insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement);
 
 	/**
 	 * Inserts the given statement list before a set of insertion points given
 	 * by a filter.
 	 */
 	@DerivedProperty
-	<T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements);
+	CtStatementList insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements);
 
 	/**
 	 * Inserts the given statement after a set of insertion points given by a
 	 * filter.
 	 */
 	@DerivedProperty
-	<T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement);
+	CtStatementList insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement);
 
 	/**
 	 * Inserts the given statement list after a set of insertion points given by
 	 * a filter.
 	 */
 	@DerivedProperty
-	<T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements);
+	CtStatementList insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements);
 
 	/**
 	 * Gets the ith statement of this block.

--- a/src/main/java/spoon/reflect/code/CtSuperAccess.java
+++ b/src/main/java/spoon/reflect/code/CtSuperAccess.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * This code element defines an access to super.

--- a/src/main/java/spoon/reflect/code/CtSwitch.java
+++ b/src/main/java/spoon/reflect/code/CtSwitch.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.CASE;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a switch statement.
@@ -57,7 +60,7 @@ public interface CtSwitch<S> extends CtStatement {
 	 * <code>Integer</code>, or an <code>enum</code> type
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtSwitch<S>> T setSelector(CtExpression<S> selector);
+	CtSwitch<S> setSelector(CtExpression<S> selector);
 
 	/**
 	 * Gets the list of cases defined for this switch.
@@ -69,13 +72,13 @@ public interface CtSwitch<S> extends CtStatement {
 	 * Sets the list of cases defined for this switch.
 	 */
 	@PropertySetter(role = CASE)
-	<T extends CtSwitch<S>> T setCases(List<CtCase<? super S>> cases);
+	CtSwitch<S> setCases(List<CtCase<? super S>> cases);
 
 	/**
 	 * Adds a case;
 	 */
 	@PropertySetter(role = CASE)
-	<T extends CtSwitch<S>> T addCase(CtCase<? super S> c);
+	CtSwitch<S> addCase(CtCase<? super S> c);
 
 	/**
 	 * Removes a case;

--- a/src/main/java/spoon/reflect/code/CtSynchronized.java
+++ b/src/main/java/spoon/reflect/code/CtSynchronized.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 
 /**
@@ -47,7 +51,7 @@ public interface CtSynchronized extends CtStatement {
 	 * Sets the expression that defines the monitored.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtSynchronized> T setExpression(CtExpression<?> expression);
+	CtSynchronized setExpression(CtExpression<?> expression);
 
 	/**
 	 * Gets the synchronized block.
@@ -59,7 +63,7 @@ public interface CtSynchronized extends CtStatement {
 	 * Sets the synchronized block.
 	 */
 	@PropertySetter(role = BODY)
-	<T extends CtSynchronized> T setBlock(CtBlock<?> block);
+	CtSynchronized setBlock(CtBlock<?> block);
 
 	@Override
 	CtSynchronized clone();

--- a/src/main/java/spoon/reflect/code/CtTargetedExpression.java
+++ b/src/main/java/spoon/reflect/code/CtTargetedExpression.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.TARGET;
+
+
+
 
 
 /**

--- a/src/main/java/spoon/reflect/code/CtThisAccess.java
+++ b/src/main/java/spoon/reflect/code/CtThisAccess.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines an access to this.
  *

--- a/src/main/java/spoon/reflect/code/CtThrow.java
+++ b/src/main/java/spoon/reflect/code/CtThrow.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.template.TemplateParameter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a <code>throw</code> statement.
@@ -42,7 +46,7 @@ public interface CtThrow extends CtCFlowBreak, TemplateParameter<Void> {
 	 * Sets the thrown expression (must be a throwable).
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtThrow> T setThrownExpression(CtExpression<? extends Throwable> thrownExpression);
+	CtThrow setThrownExpression(CtExpression<? extends Throwable> thrownExpression);
 
 	@Override
 	CtThrow clone();

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -16,15 +16,18 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.template.TemplateParameter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.CATCH;
 import static spoon.reflect.path.CtRole.FINALIZER;
+
+
+
 
 /**
  * This code element defines a <code>try</code> statement.
@@ -48,13 +51,13 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	 * Sets the <i>catchers</i> of this <code>try</code>.
 	 */
 	@PropertySetter(role = CATCH)
-	<T extends CtTry> T setCatchers(List<CtCatch> catchers);
+	CtTry setCatchers(List<CtCatch> catchers);
 
 	/**
 	 * Adds a catch block.
 	 */
 	@PropertySetter(role = CATCH)
-	<T extends CtTry> T addCatcher(CtCatch catcher);
+	CtTry addCatcher(CtCatch catcher);
 
 	/**
 	 * Removes a catch block.
@@ -81,7 +84,7 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	 * <code>finally</code> part).
 	 */
 	@PropertySetter(role = FINALIZER)
-	<T extends CtTry> T setFinalizer(CtBlock<?> finalizer);
+	CtTry setFinalizer(CtBlock<?> finalizer);
 
 	@Override
 	CtTry clone();

--- a/src/main/java/spoon/reflect/code/CtTryWithResource.java
+++ b/src/main/java/spoon/reflect/code/CtTryWithResource.java
@@ -16,12 +16,15 @@
  */
 package spoon.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.TRY_RESOURCE;
+
+
+
 
 /**
  * This code element defines a <code>try</code> with resource statement.
@@ -48,13 +51,13 @@ public interface CtTryWithResource extends CtTry {
 	 * from Java 7 with the <i>try-with-resource</i> statement.
 	 */
 	@PropertySetter(role = TRY_RESOURCE)
-	<T extends CtTryWithResource> T setResources(List<CtLocalVariable<?>> resources);
+	CtTryWithResource setResources(List<CtLocalVariable<?>> resources);
 
 	/**
 	 * Adds a resource.
 	 */
 	@PropertySetter(role = TRY_RESOURCE)
-	<T extends CtTryWithResource> T addResource(CtLocalVariable<?> resource);
+	CtTryWithResource addResource(CtLocalVariable<?> resource);
 
 	/**
 	 * Removes a resource.

--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -16,14 +16,17 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.ACCESSED_TYPE;
+
+
+
 
 /**
  * This code element represents a type reference usable as an expression.
@@ -69,7 +72,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	 * 		CtTypeReference.
 	 */
 	@PropertySetter(role = ACCESSED_TYPE)
-	<C extends CtTypeAccess<A>> C setAccessedType(CtTypeReference<A> accessedType);
+	CtTypeAccess<A> setAccessedType(CtTypeReference<A> accessedType);
 
 	/**
 	 * Returns always VOID.
@@ -82,7 +85,7 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 
 	@Override
 	@UnsettableProperty
-	<C extends CtTypedElement> C setType(CtTypeReference<Void> type);
+	CtTypeAccess<A> setType(CtTypeReference<Void> type);
 
 	@Override
 	CtTypeAccess<A> clone();

--- a/src/main/java/spoon/reflect/code/CtUnaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtUnaryOperator.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
+
+
+
 
 
 /**
@@ -46,13 +50,13 @@ public interface CtUnaryOperator<T> extends CtExpression<T>, CtStatement {
 	 * Sets the expression to which the operator is applied.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<C extends CtUnaryOperator> C setOperand(CtExpression<T> expression);
+	CtUnaryOperator<T> setOperand(CtExpression<T> expression);
 
 	/**
 	 * Sets the kind of this operator.
 	 */
 	@PropertySetter(role = OPERATOR_KIND)
-	<C extends CtUnaryOperator> C setKind(UnaryOperatorKind kind);
+	CtUnaryOperator<T> setKind(UnaryOperatorKind kind);
 
 	/**
 	 * Gets the kind of this operator.

--- a/src/main/java/spoon/reflect/code/CtVariableAccess.java
+++ b/src/main/java/spoon/reflect/code/CtVariableAccess.java
@@ -16,13 +16,17 @@
  */
 package spoon.reflect.code;
 
+
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.VARIABLE;
+
+
+
 
 /**
  * This code element defines an access to a variable (read and write).
@@ -43,7 +47,7 @@ public interface CtVariableAccess<T> extends CtExpression<T> {
 	 * Sets the reference to the accessed variable.
 	 */
 	@PropertySetter(role = VARIABLE)
-	<C extends CtVariableAccess<T>> C setVariable(CtVariableReference<T> variable);
+	CtVariableAccess<T> setVariable(CtVariableReference<T> variable);
 
 	@Override
 	CtVariableAccess<T> clone();

--- a/src/main/java/spoon/reflect/code/CtVariableRead.java
+++ b/src/main/java/spoon/reflect/code/CtVariableRead.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines an read access to a variable.
  *

--- a/src/main/java/spoon/reflect/code/CtVariableWrite.java
+++ b/src/main/java/spoon/reflect/code/CtVariableWrite.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This code element defines a write to a variable.
  *

--- a/src/main/java/spoon/reflect/code/CtWhile.java
+++ b/src/main/java/spoon/reflect/code/CtWhile.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.code;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 /**
  * This code element defines a <code>while</code> loop.
@@ -44,7 +48,7 @@ public interface CtWhile extends CtLoop {
 	 * Sets the looping boolean test expression.
 	 */
 	@PropertySetter(role = EXPRESSION)
-	<T extends CtWhile> T setLoopingExpression(CtExpression<Boolean> expression);
+	CtWhile setLoopingExpression(CtExpression<Boolean> expression);
 
 	@Override
 	CtWhile clone();

--- a/src/main/java/spoon/reflect/code/UnaryOperatorKind.java
+++ b/src/main/java/spoon/reflect/code/UnaryOperatorKind.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.code;
 
+
+
+
 /**
  * This enumeration defines all the kinds of unary operators.
  */

--- a/src/main/java/spoon/reflect/declaration/CtAnnotatedElementType.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotatedElementType.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.declaration;
 
+
+
+
 /**
  * This enum specifies the element type which is annotated by the annotation
  */

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -16,6 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLiteral;
@@ -24,16 +30,13 @@ import spoon.reflect.code.CtNewArray;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 import spoon.support.UnsettableProperty;
-
-import java.lang.annotation.Annotation;
-import java.util.List;
-import java.util.Map;
 
 import static spoon.reflect.path.CtRole.ANNOTATION_TYPE;
 import static spoon.reflect.path.CtRole.VALUE;
+
+
+
 
 /**
  * This element represents an annotation on an element.
@@ -82,7 +85,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * @return the value expression or null if not found.
 	 */
 	@PropertyGetter(role = VALUE)
-	<T extends CtExpression> T getValue(String key);
+	CtAnnotation<A> getValue(String key);
 
 	/** Returns the actual value of an annotation property */
 	@DerivedProperty
@@ -134,7 +137,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * 		reference to the type of this annotation
 	 */
 	@PropertySetter(role = ANNOTATION_TYPE)
-	<T extends CtAnnotation<A>> T setAnnotationType(CtTypeReference<? extends Annotation> type);
+	CtAnnotation<A> setAnnotationType(CtTypeReference<? extends Annotation> type);
 
 	/**
 	 * Set's this annotation's element names and their values. This is in the
@@ -143,7 +146,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * {@link spoon.reflect.reference.CtTypeReference}.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T setElementValues(Map<String, Object> values);
+	CtAnnotation<A> setElementValues(Map<String, Object> values);
 
 	/**
 	 * Set's this annotation's element names and their values. This is in the
@@ -151,7 +154,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * values.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T setValues(Map<String, CtExpression> values);
+	CtAnnotation<A> setValues(Map<String, CtExpression> values);
 
 	/**
 	 * Returns the element which is annotated by this annotation.
@@ -159,7 +162,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * @return annotated {@link spoon.reflect.declaration.CtElement}
 	 */
 	@DerivedProperty // the annotation is contained by the element not the other way around
-	CtElement getAnnotatedElement();
+	CtAnnotation<A> getAnnotatedElement();
 
 	/**
 	 * Returns the type of the element which is annotated by this annotation.
@@ -173,38 +176,38 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	 * Adds a new key-value pair for this annotation
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T addValue(String elementName, Object value);
+	CtAnnotation<A> addValue(String elementName, Object value);
 
 	/**
 	 * Adds a new key-literal pair for this annotation.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T addValue(String elementName, CtLiteral<?> value);
+	CtAnnotation<A> addValue(String elementName, CtLiteral<?> value);
 
 	/**
 	 * Adds a new key-array pair for this annotation.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T addValue(String elementName, CtNewArray<? extends CtExpression> value);
+	CtAnnotation<A> addValue(String elementName, CtNewArray<? extends CtExpression> value);
 
 	/**
 	 * Adds a new key-field access pair for this annotation.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T addValue(String elementName, CtFieldAccess<?> value);
+	CtAnnotation<A> addValue(String elementName, CtFieldAccess<?> value);
 
 	/**
 	 * Adds a new key-annotation pair for this annotation.
 	 */
 	@PropertySetter(role = VALUE)
-	<T extends CtAnnotation<A>> T addValue(String elementName, CtAnnotation<?> value);
+	CtAnnotation<A> addValue(String elementName, CtAnnotation<?> value);
 
 	@Override
 	CtAnnotation<A> clone();
 
 	@Override
 	@UnsettableProperty
-	<C extends CtExpression<A>> C setTypeCasts(List<CtTypeReference<?>> types);
+	CtAnnotation<A> setTypeCasts(List<CtTypeReference<?>> types);
 
 	static CtAnnotatedElementType getAnnotatedElementTypeForCtElement(CtElement element) {
 		if (element == null) {

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
@@ -16,18 +16,20 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.code.CtBodyHolder;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-import spoon.support.UnsettableProperty;
 
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.DEFAULT_EXPRESSION;
+
+
+
 
 /**
  * This element defines an annotation method declared in an annotation type.
@@ -43,24 +45,24 @@ public interface CtAnnotationMethod<T> extends CtMethod<T> {
 	 * Sets the default expression assigned to the annotation method.
 	 */
 	@PropertySetter(role = DEFAULT_EXPRESSION)
-	<C extends CtAnnotationMethod<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
+	CtAnnotationMethod<T> setDefaultExpression(CtExpression<T> assignedExpression);
 
 	@Override
 	CtAnnotationMethod<T> clone();
 
 	@Override
 	@UnsettableProperty
-	<T1 extends CtBodyHolder> T1 setBody(CtStatement body);
+	CtAnnotationMethod<T> setBody(CtStatement body);
 
 	@Override
 	@UnsettableProperty
-	<T1 extends CtExecutable<T>> T1 setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+	CtAnnotationMethod<T> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+	CtAnnotationMethod<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
 
 	@Override
 	@UnsettableProperty
-	<T1 extends CtExecutable<T>> T1 setParameters(List<CtParameter<?>> parameters);
+	CtAnnotationMethod<T> setParameters(List<CtParameter<?>> parameters);
 }

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
-import spoon.support.DerivedProperty;
-import spoon.support.UnsettableProperty;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This element defines an annotation type.
@@ -40,28 +43,28 @@ public interface CtAnnotationType<T extends Annotation> extends CtType<T> {
 	 * The method passed as parameter must be a {@link CtAnnotationMethod}.
 	 */
 	@Override
-	<M, C extends CtType<T>> C addMethod(CtMethod<M> method);
+	<M> CtAnnotationType<T> addMethod(CtMethod<M> method);
 
 	/**
 	 * {@inheritDoc}
 	 * The methods passed as parameter must be typed by {@link CtAnnotationMethod}.
 	 */
 	@Override
-	<C extends CtType<T>> C setMethods(Set<CtMethod<?>> methods);
+	CtAnnotationType<T> setMethods(Set<CtMethod<?>> methods);
 
 	@Override
 	CtAnnotationType<T> clone();
 
 	@Override
 	@UnsettableProperty
-	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+	CtAnnotationType<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<T>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
+	CtAnnotationType<T> setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
+	CtAnnotationType<T> setSuperclass(CtTypeReference<?> superClass);
 
 }

--- a/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
@@ -16,11 +16,14 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
-import spoon.support.UnsettableProperty;
 
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This element defines an anonymous executable block declaration in a class.
@@ -33,26 +36,26 @@ public interface CtAnonymousExecutable extends CtExecutable<Void>, CtTypeMember 
 
 	@Override
 	@UnsettableProperty
-	<C extends CtNamedElement> C setSimpleName(String simpleName);
+	CtAnonymousExecutable setSimpleName(String simpleName);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtExecutable<Void>> T setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+	CtAnonymousExecutable setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtExecutable<Void>> T setParameters(List<CtParameter<?>> parameters);
+	CtAnonymousExecutable setParameters(List<CtParameter<?>> parameters);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtTypedElement> C setType(CtTypeReference<Void> type);
+	CtAnonymousExecutable setType(CtTypeReference<Void> type);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtExecutable<Void>> T addParameter(CtParameter<?> parameter);
+	CtAnonymousExecutable addParameter(CtParameter<?> parameter);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtExecutable<Void>> T addThrownType(CtTypeReference<? extends Throwable> throwType);
+	CtAnonymousExecutable addThrownType(CtTypeReference<? extends Throwable> throwType);
 
 }

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -16,18 +16,21 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
+import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-import java.util.Set;
-
-import static spoon.reflect.path.CtRole.CONSTRUCTOR;
 import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
+import static spoon.reflect.path.CtRole.CONSTRUCTOR;
+
+
+
 
 /**
  * This element represents a class declaration.
@@ -72,7 +75,7 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	 * Sets the anonymous blocks of this class.
 	 */
 	@PropertySetter(role = ANNONYMOUS_EXECUTABLE)
-	<C extends CtClass<T>> C setAnonymousExecutables(List<CtAnonymousExecutable> e);
+	CtClass<T> setAnonymousExecutables(List<CtAnonymousExecutable> e);
 
 	/**
 	 * Add an anonymous block to this class.
@@ -81,7 +84,7 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = ANNONYMOUS_EXECUTABLE)
-	<C extends CtClass<T>> C addAnonymousExecutable(CtAnonymousExecutable e);
+	CtClass<T> addAnonymousExecutable(CtAnonymousExecutable e);
 
 	/**
 	 * Remove an anonymous block to this class.
@@ -96,13 +99,13 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 	 * Sets the constructors for this class.
 	 */
 	@PropertySetter(role = CONSTRUCTOR)
-	<C extends CtClass<T>> C setConstructors(Set<CtConstructor<T>> constructors);
+	CtClass<T> setConstructors(Set<CtConstructor<T>> constructors);
 
 	/**
 	 * Adds a constructor to this class.
 	 */
 	@PropertySetter(role = CONSTRUCTOR)
-	<C extends CtClass<T>> C addConstructor(CtConstructor<T> constructor);
+	CtClass<T> addConstructor(CtConstructor<T> constructor);
 
 	/**
 	 * Removes a constructor from this class.
@@ -137,5 +140,5 @@ public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
 
 	@Override
 	@UnsettableProperty
-	<C extends CtStatement> C setLabel(String label);
+	CtClass<T> setLabel(String label);
 }

--- a/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
+++ b/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.SNIPPET;
+
+
+
 
 /**
  * This interface represents snippets of source code that can be used in the AST
@@ -37,7 +41,7 @@ public interface CtCodeSnippet {
 	 * Sets the textual value of the code.
 	 */
 	@PropertySetter(role = SNIPPET)
-	<C extends CtCodeSnippet> C setValue(String value);
+	CtCodeSnippet setValue(String value);
 
 	/**
 	 * Gets the textual value of the code.

--- a/src/main/java/spoon/reflect/declaration/CtConstructor.java
+++ b/src/main/java/spoon/reflect/declaration/CtConstructor.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
+
 import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.NAME;
+
+
+
 
 /**
  * This element defines a constructor declaration.
@@ -39,9 +43,9 @@ public interface CtConstructor<T> extends CtExecutable<T>, CtTypeMember, CtForma
 
 	@Override
 	@UnsettableProperty
-	<C extends CtTypedElement> C setType(CtTypeReference<T> type);
+	CtConstructor<T> setType(CtTypeReference<T> type);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtNamedElement> C setSimpleName(String simpleName);
+	CtConstructor<T> setSimpleName(String simpleName);
 }

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -16,7 +16,17 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import spoon.processing.FactoryAccessor;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.SourcePositionHolder;
@@ -28,21 +38,13 @@ import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Root;
 import spoon.reflect.visitor.chain.CtQueryable;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static spoon.reflect.path.CtRole.ANNOTATION;
-import static spoon.reflect.path.CtRole.COMMENT;
 import static spoon.reflect.path.CtRole.IS_IMPLICIT;
 import static spoon.reflect.path.CtRole.POSITION;
+
+
+
 
 /**
  * This interface is the root interface for the metamodel elements (any program
@@ -157,7 +159,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = ANNOTATION)
-	<E extends CtElement> E addAnnotation(CtAnnotation<? extends Annotation> annotation);
+	CtElement addAnnotation(CtAnnotation<? extends Annotation> annotation);
 
 	/**
 	 * Remove an annotation for this element
@@ -174,7 +176,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * {@link CtComment} or create a new  javadoc {@link CtComment} if
 	 * no javadoc {@link CtComment} is available on this object.
 	 */
-	<E extends CtElement> E setDocComment(String docComment);
+	CtElement setDocComment(String docComment);
 
 	/**
 	 * Sets the position in the Java source file. Note that this information is
@@ -185,7 +187,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * 		of this element in the input source files
 	 */
 	@PropertySetter(role = POSITION)
-	<E extends CtElement> E setPosition(SourcePosition position);
+	CtElement setPosition(SourcePosition position);
 
 	/**
 	 * Gets the child elements annotated with the given annotation type's
@@ -213,7 +215,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * Sets this element to be implicit.
 	 */
 	@PropertySetter(role = IS_IMPLICIT)
-	<E extends CtElement> E setImplicit(boolean b);
+	CtElement setImplicit(boolean b);
 
 	/**
 	 * Calculates and returns the set of all the types referenced by this
@@ -236,13 +238,13 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param position
 	 * 		of this element and all children in the input source file
 	 */
-	<E extends CtElement> E setPositions(SourcePosition position);
+	CtElement setPositions(SourcePosition position);
 
 	/**
 	 * Sets the annotations for this element.
 	 */
 	@PropertySetter(role = ANNOTATION)
-	<E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
+	CtElement setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
 
 	/**
 	 * Gets the parent of current reference.
@@ -304,12 +306,12 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	/**
 	 * Saves a bunch of metadata inside an Element
 	 */
-	<E extends CtElement> E setAllMetadata(Map<String, Object> metadata);
+	CtElement setAllMetadata(Map<String, Object> metadata);
 
 	/**
 	 * Saves metadata inside an Element.
 	 */
-	<E extends CtElement> E putMetadata(String key, Object val);
+	CtElement putMetadata(String key, Object val);
 
 	/**
 	 * Retrieves metadata stored in an element. Returns null if it does not exist.
@@ -330,7 +332,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * Set the comment list
 	 */
 	@PropertySetter(role = COMMENT)
-	<E extends CtElement> E setComments(List<CtComment> comments);
+	CtElement setComments(List<CtComment> comments);
 
 	/**
 	 * The list of comments
@@ -345,14 +347,14 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param comment the comment
 	 */
 	@PropertySetter(role = COMMENT)
-	<E extends CtElement> E addComment(CtComment comment);
+	CtElement addComment(CtComment comment);
 
 	/**
 	 * Remove a comment
 	 * @param comment the comment to remove
 	 */
 	@PropertySetter(role = COMMENT)
-	<E extends CtElement> E removeComment(CtComment comment);
+	CtElement removeComment(CtComment comment);
 
 	/**
 	 * Clone the element which calls this method in a new object.
@@ -378,7 +380,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param role the role of the field to be set
 	 * @param value to be assigned to this field.
 	 */
-	<E extends CtElement, T> E  setValueByRole(CtRole role, T value);
+	< T> CtElement  setValueByRole(CtRole role, T value);
 
 	/**
 	 * Return the path from the model root to this CtElement, eg `.spoon.test.path.Foo.foo#body#statement[index=0]`

--- a/src/main/java/spoon/reflect/declaration/CtEnum.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnum.java
@@ -16,14 +16,17 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-import spoon.support.UnsettableProperty;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.VALUE;
+
+
+
 
 /**
  * This element represents an enumeration declaration.
@@ -43,7 +46,7 @@ public interface CtEnum<T extends Enum<?>> extends CtClass<T> {
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = VALUE)
-	<C extends CtEnum<T>> C addEnumValue(CtEnumValue<?> enumValue);
+	CtEnum<T> addEnumValue(CtEnumValue<?> enumValue);
 
 	/**
 	 * Removes en enum value.
@@ -77,16 +80,16 @@ public interface CtEnum<T extends Enum<?>> extends CtClass<T> {
 	 *Sets all enum values of the enum.
 	 */
 	@PropertySetter(role = VALUE)
-	<C extends CtEnum<T>> C setEnumValues(List<CtEnumValue<?>> enumValues);
+	CtEnum<T> setEnumValues(List<CtEnumValue<?>> enumValues);
 
 	@Override
 	CtEnum<T> clone();
 
 	@Override
 	@UnsettableProperty
-	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+	CtEnum<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
+	CtEnum<T> setSuperclass(CtTypeReference<?> superClass);
 }

--- a/src/main/java/spoon/reflect/declaration/CtEnumValue.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnumValue.java
@@ -16,9 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtRHSReceiver;
 import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * Corresponds to one enum value specified in an enumeration.
@@ -40,5 +43,5 @@ public interface CtEnumValue<T> extends CtField<T> {
 
 	@Override
 	@UnsettableProperty
-	<U extends CtRHSReceiver<T>> U setAssignment(CtExpression<T> assignment);
+	CtEnumValue<T> setAssignment(CtExpression<T> assignment);
 }

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -16,19 +16,22 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
+import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
-
-import java.util.List;
-import java.util.Set;
 
 import static spoon.reflect.path.CtRole.PARAMETER;
 import static spoon.reflect.path.CtRole.THROWN;
+
+
+
 
 /**
  * This element represents an executable element such as a method, a
@@ -66,7 +69,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	 * Sets the parameters.
 	 */
 	@PropertySetter(role = PARAMETER)
-	<T extends CtExecutable<R>> T setParameters(List<CtParameter<?>> parameters);
+	CtExecutable<R> setParameters(List<CtParameter<?>> parameters);
 
 	/**
 	 * Add a parameter for this executable
@@ -75,7 +78,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = PARAMETER)
-	<T extends CtExecutable<R>> T addParameter(CtParameter<?> parameter);
+	CtExecutable<R> addParameter(CtParameter<?> parameter);
 
 	/**
 	 * Remove a parameter for this executable
@@ -96,7 +99,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	 * Sets the thrown types.
 	 */
 	@PropertySetter(role = THROWN)
-	<T extends CtExecutable<R>> T setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
+	CtExecutable<R> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes);
 
 	/**
 	 * add a thrown type.
@@ -105,7 +108,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = THROWN)
-	<T extends CtExecutable<R>> T addThrownType(CtTypeReference<? extends Throwable> throwType);
+	CtExecutable<R> addThrownType(CtTypeReference<? extends Throwable> throwType);
 
 	/**
 	 * remove a thrown type.

--- a/src/main/java/spoon/reflect/declaration/CtField.java
+++ b/src/main/java/spoon/reflect/declaration/CtField.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtRHSReceiver;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This element defines a field declaration.
@@ -50,7 +54,7 @@ public interface CtField<T> extends CtVariable<T>, CtTypeMember, CtRHSReceiver<T
 
 	@Override
 	@UnsettableProperty
-	<U extends CtRHSReceiver<T>> U setAssignment(CtExpression<T> assignment);
+	CtField<T> setAssignment(CtExpression<T> assignment);
 
 	@Override
 	CtField<T> clone();

--- a/src/main/java/spoon/reflect/declaration/CtFormalTypeDeclarer.java
+++ b/src/main/java/spoon/reflect/declaration/CtFormalTypeDeclarer.java
@@ -16,12 +16,15 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.TYPE_PARAMETER;
+
+
+
 
 /**
  * This abstract element defines a declaration that accepts formal type
@@ -39,13 +42,13 @@ public interface CtFormalTypeDeclarer extends CtTypeMember {
 	 * Sets the type parameters of this generic element.
 	 */
 	@PropertySetter(role = TYPE_PARAMETER)
-	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+	CtFormalTypeDeclarer setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
 
 	/**
 	 * Add a type parameter to this generic element.
 	 */
 	@PropertySetter(role = TYPE_PARAMETER)
-	<T extends CtFormalTypeDeclarer> T addFormalCtTypeParameter(CtTypeParameter formalTypeParameter);
+	CtFormalTypeDeclarer addFormalCtTypeParameter(CtTypeParameter formalTypeParameter);
 
 	/**
 	 * Removes a type parameters from this generic element.

--- a/src/main/java/spoon/reflect/declaration/CtImport.java
+++ b/src/main/java/spoon/reflect/declaration/CtImport.java
@@ -16,12 +16,16 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.reference.CtReference;
 import spoon.support.DerivedProperty;
 
 import static spoon.reflect.path.CtRole.IMPORT_REFERENCE;
+
+
+
 
 /**
  * This element represents an import declaration.
@@ -58,7 +62,7 @@ public interface CtImport extends CtElement {
 	 * The import kind will be computed based on this reference.
 	 */
 	@PropertySetter(role = IMPORT_REFERENCE)
-	<T extends CtImport> T setReference(CtReference reference);
+	CtImport setReference(CtReference reference);
 
 	@Override
 	CtImport clone();

--- a/src/main/java/spoon/reflect/declaration/CtImportKind.java
+++ b/src/main/java/spoon/reflect/declaration/CtImportKind.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.declaration;
 
+
+
+
 public enum CtImportKind {
 	TYPE,
 	ALL_TYPES,

--- a/src/main/java/spoon/reflect/declaration/CtInterface.java
+++ b/src/main/java/spoon/reflect/declaration/CtInterface.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This element defines an interface declaration.
@@ -28,5 +32,5 @@ public interface CtInterface<T> extends CtType<T> {
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
+	CtInterface<T> setSuperclass(CtTypeReference<?> superClass);
 }

--- a/src/main/java/spoon/reflect/declaration/CtMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtMethod.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.Collection;
 import spoon.refactoring.Refactoring;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.Collection;
-
 import static spoon.reflect.path.CtRole.IS_DEFAULT;
+
+
+
 
 
 /**
@@ -49,7 +52,7 @@ public interface CtMethod<T> extends CtExecutable<T>, CtTypeMember, CtFormalType
 	 * Sets the default value state of a method.
 	 */
 	@PropertySetter(role = IS_DEFAULT)
-	<C extends CtMethod<T>> C setDefaultMethod(boolean defaultMethod);
+	CtMethod<T> setDefaultMethod(boolean defaultMethod);
 
 	@Override
 	CtMethod<T> clone();

--- a/src/main/java/spoon/reflect/declaration/CtModifiable.java
+++ b/src/main/java/spoon/reflect/declaration/CtModifiable.java
@@ -16,14 +16,17 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.support.DerivedProperty;
 import spoon.support.reflect.CtExtendedModifier;
 
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.MODIFIER;
+
+
+
 
 /**
  * This interface defines an element that accepts modifiers.
@@ -53,7 +56,7 @@ public interface CtModifiable extends CtElement {
 	 * Sets the modifiers.
 	 */
 	@PropertySetter(role = MODIFIER)
-	<T extends CtModifiable> T setModifiers(Set<ModifierKind> modifiers);
+	CtModifiable setModifiers(Set<ModifierKind> modifiers);
 
 	/**
 	 * add a modifier
@@ -61,7 +64,7 @@ public interface CtModifiable extends CtElement {
 	 * @param modifier
 	 */
 	@PropertySetter(role = MODIFIER)
-	<T extends CtModifiable> T addModifier(ModifierKind modifier);
+	CtModifiable addModifier(ModifierKind modifier);
 
 	/**
 	 * remove a modifier
@@ -69,13 +72,13 @@ public interface CtModifiable extends CtElement {
 	 * @param modifier
 	 */
 	@PropertySetter(role = MODIFIER)
-	<T extends CtModifiable> T removeModifier(ModifierKind modifier);
+	CtModifiable removeModifier(ModifierKind modifier);
 
 	/**
 	 * Sets the visibility of this modifiable element (replaces old visibility).
 	 */
 	@PropertySetter(role = MODIFIER)
-	<T extends CtModifiable> T setVisibility(ModifierKind visibility);
+	CtModifiable setVisibility(ModifierKind visibility);
 
 	/**
 	 * Gets the visibility of this modifiable element.
@@ -84,7 +87,7 @@ public interface CtModifiable extends CtElement {
 	ModifierKind getVisibility();
 
 	Set<CtExtendedModifier> getExtendedModifiers();
-	<T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers);
+	CtModifiable setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers);
 
 	/**
 	 * Returns true if it contains a public modifier (see {@link #hasModifier(ModifierKind)})

--- a/src/main/java/spoon/reflect/declaration/CtModule.java
+++ b/src/main/java/spoon/reflect/declaration/CtModule.java
@@ -16,12 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.support.DerivedProperty;
-
-import java.util.List;
 
 import static spoon.reflect.path.CtRole.EXPORTED_PACKAGE;
 import static spoon.reflect.path.CtRole.MODIFIER;
@@ -31,6 +31,9 @@ import static spoon.reflect.path.CtRole.PROVIDED_SERVICE;
 import static spoon.reflect.path.CtRole.REQUIRED_MODULE;
 import static spoon.reflect.path.CtRole.SERVICE_TYPE;
 import static spoon.reflect.path.CtRole.SUB_PACKAGE;
+
+
+
 
 /**
  * Represents a Java module as defined in Java 9.
@@ -69,22 +72,22 @@ public interface CtModule extends CtNamedElement {
 	boolean isOpenModule();
 
 	@PropertySetter(role = MODIFIER)
-	<T extends CtModule> T setIsOpenModule(boolean openModule);
+	CtModule setIsOpenModule(boolean openModule);
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
-	<T extends CtModule> T setModuleDirectives(List<CtModuleDirective> moduleDirectives);
+	CtModule setModuleDirectives(List<CtModuleDirective> moduleDirectives);
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
-	<T extends CtModule> T addModuleDirective(CtModuleDirective moduleDirective);
+	CtModule addModuleDirective(CtModuleDirective moduleDirective);
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
-	<T extends CtModule> T addModuleDirectiveAt(int position, CtModuleDirective moduleDirective);
+	CtModule addModuleDirectiveAt(int position, CtModuleDirective moduleDirective);
 
 	@PropertyGetter(role = MODULE_DIRECTIVE)
 	List<CtModuleDirective> getModuleDirectives();
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
-	<T extends CtModule> T removeModuleDirective(CtModuleDirective moduleDirective);
+	CtModule removeModuleDirective(CtModuleDirective moduleDirective);
 
 	@PropertyGetter(role = SERVICE_TYPE)
 	@DerivedProperty
@@ -92,15 +95,15 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = SERVICE_TYPE)
 	@DerivedProperty
-	<T extends CtModule> T setUsedServices(List<CtUsedService> usedServices);
+	CtModule setUsedServices(List<CtUsedService> usedServices);
 
 	@PropertySetter(role = SERVICE_TYPE)
 	@DerivedProperty
-	<T extends CtModule> T addUsedService(CtUsedService usedService);
+	CtModule addUsedService(CtUsedService usedService);
 
 	@PropertySetter(role = SERVICE_TYPE)
 	@DerivedProperty
-	<T extends CtModule> T removeUsedService(CtUsedService usedService);
+	CtModule removeUsedService(CtUsedService usedService);
 
 	@PropertyGetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
@@ -108,15 +111,15 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T setExportedPackages(List<CtPackageExport> exportedPackages);
+	CtModule setExportedPackages(List<CtPackageExport> exportedPackages);
 
 	@PropertySetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T addExportedPackage(CtPackageExport exportedPackage);
+	CtModule addExportedPackage(CtPackageExport exportedPackage);
 
 	@PropertySetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T removeExportedPackage(CtPackageExport exportedPackage);
+	CtModule removeExportedPackage(CtPackageExport exportedPackage);
 
 	@PropertyGetter(role = OPENED_PACKAGE)
 	@DerivedProperty
@@ -124,15 +127,15 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = OPENED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T setOpenedPackages(List<CtPackageExport> openedPackages);
+	CtModule setOpenedPackages(List<CtPackageExport> openedPackages);
 
 	@PropertySetter(role = OPENED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T addOpenedPackage(CtPackageExport openedPackage);
+	CtModule addOpenedPackage(CtPackageExport openedPackage);
 
 	@PropertySetter(role = OPENED_PACKAGE)
 	@DerivedProperty
-	<T extends CtModule> T removeOpenedPackage(CtPackageExport openedPackage);
+	CtModule removeOpenedPackage(CtPackageExport openedPackage);
 
 	@PropertyGetter(role = REQUIRED_MODULE)
 	@DerivedProperty
@@ -140,15 +143,15 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = REQUIRED_MODULE)
 	@DerivedProperty
-	<T extends CtModule> T setRequiredModules(List<CtModuleRequirement> requiredModules);
+	CtModule setRequiredModules(List<CtModuleRequirement> requiredModules);
 
 	@PropertySetter(role = REQUIRED_MODULE)
 	@DerivedProperty
-	<T extends CtModule> T addRequiredModule(CtModuleRequirement requiredModule);
+	CtModule addRequiredModule(CtModuleRequirement requiredModule);
 
 	@PropertySetter(role = REQUIRED_MODULE)
 	@DerivedProperty
-	<T extends CtModule> T removeRequiredModule(CtModuleRequirement requiredModule);
+	CtModule removeRequiredModule(CtModuleRequirement requiredModule);
 
 	@PropertyGetter(role = PROVIDED_SERVICE)
 	@DerivedProperty
@@ -156,15 +159,15 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = PROVIDED_SERVICE)
 	@DerivedProperty
-	<T extends CtModule> T setProvidedServices(List<CtProvidedService> providedServices);
+	CtModule setProvidedServices(List<CtProvidedService> providedServices);
 
 	@PropertySetter(role = PROVIDED_SERVICE)
 	@DerivedProperty
-	<T extends CtModule> T addProvidedService(CtProvidedService providedService);
+	CtModule addProvidedService(CtProvidedService providedService);
 
 	@PropertySetter(role = PROVIDED_SERVICE)
 	@DerivedProperty
-	<T extends CtModule> T removeProvidedService(CtProvidedService providedService);
+	CtModule removeProvidedService(CtProvidedService providedService);
 
 	/**
 	 * returns the root package of the unnamed module
@@ -174,7 +177,7 @@ public interface CtModule extends CtNamedElement {
 	CtPackage getRootPackage();
 
 	@PropertySetter(role = SUB_PACKAGE)
-	<T extends CtModule> T setRootPackage(CtPackage rootPackage);
+	CtModule setRootPackage(CtPackage rootPackage);
 
 	@DerivedProperty
 	@Override

--- a/src/main/java/spoon/reflect/declaration/CtModuleDirective.java
+++ b/src/main/java/spoon/reflect/declaration/CtModuleDirective.java
@@ -16,6 +16,9 @@
  */
 package spoon.reflect.declaration;
 
+
+
+
 /**
  * Represents a directive of a {@link CtModule}
  *

--- a/src/main/java/spoon/reflect/declaration/CtModuleRequirement.java
+++ b/src/main/java/spoon/reflect/declaration/CtModuleRequirement.java
@@ -16,12 +16,15 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtModuleReference;
 
-import java.util.Set;
+
+
 
 /**
  * Represents a require module in a Java module definition
@@ -49,13 +52,13 @@ public interface CtModuleRequirement extends CtModuleDirective {
 	Set<RequiresModifier> getRequiresModifiers();
 
 	@PropertySetter(role = CtRole.MODIFIER)
-	<T extends CtModuleRequirement> T setRequiresModifiers(Set<RequiresModifier> requiresModifiers);
+	CtModuleRequirement setRequiresModifiers(Set<RequiresModifier> requiresModifiers);
 
 	@PropertyGetter(role = CtRole.MODULE_REF)
 	CtModuleReference getModuleReference();
 
 	@PropertySetter(role = CtRole.MODULE_REF)
-	<T extends CtModuleRequirement> T setModuleReference(CtModuleReference moduleReference);
+	CtModuleRequirement setModuleReference(CtModuleReference moduleReference);
 
 	@Override
 	CtModuleRequirement clone();

--- a/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.List;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtTypeReference;
 
 import static spoon.reflect.path.CtRole.MULTI_TYPE;
+
+
+
 
 /**
  * Defined an element with several types.
@@ -32,7 +35,7 @@ public interface CtMultiTypedElement extends CtElement {
 	 * Adds a type for the element.
 	 */
 	@PropertySetter(role = MULTI_TYPE)
-	<T extends CtMultiTypedElement> T addMultiType(CtTypeReference<?> ref);
+	CtMultiTypedElement addMultiType(CtTypeReference<?> ref);
 
 	/**
 	 * Removes a type for the element.
@@ -50,5 +53,5 @@ public interface CtMultiTypedElement extends CtElement {
 	 * Adds a type for the element.
 	 */
 	@PropertySetter(role = MULTI_TYPE)
-	<T extends CtMultiTypedElement> T setMultiTypes(List<CtTypeReference<?>> types);
+	CtMultiTypedElement setMultiTypes(List<CtTypeReference<?>> types);
 }

--- a/src/main/java/spoon/reflect/declaration/CtNamedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtNamedElement.java
@@ -16,12 +16,16 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtReference;
-import spoon.support.DerivedProperty;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtReference;
+import spoon.support.DerivedProperty;
 
 import static spoon.reflect.path.CtRole.NAME;
+
+
+
 
 /**
  * Declares an element that has a name (a class, a method, a variable, etc).
@@ -40,7 +44,7 @@ public interface CtNamedElement extends CtElement {
 	 * Sets the simple (unqualified) name of this element.
 	 */
 	@PropertySetter(role = NAME)
-	<T extends CtNamedElement> T setSimpleName(String simpleName);
+	CtNamedElement setSimpleName(String simpleName);
 
 	/**
 	 * Returns the corresponding reference.

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -16,15 +16,18 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtPackageReference;
-import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtPackageReference;
+import spoon.support.DerivedProperty;
 
-import static spoon.reflect.path.CtRole.SUB_PACKAGE;
 import static spoon.reflect.path.CtRole.CONTAINED_TYPE;
+import static spoon.reflect.path.CtRole.SUB_PACKAGE;
+
+
+
 
 /**
  * This element defines a package declaration. The packages are represented by a
@@ -108,7 +111,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * Adds a type to this package.
 	 */
 	@PropertySetter(role = CONTAINED_TYPE)
-	<T extends CtPackage> T addType(CtType<?> type);
+	CtPackage addType(CtType<?> type);
 
 	/**
 	 * Removes a type from this package.
@@ -123,7 +126,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * 		new set of child packages
 	 */
 	@PropertySetter(role = SUB_PACKAGE)
-	<T extends CtPackage> T setPackages(Set<CtPackage> pack);
+	CtPackage setPackages(Set<CtPackage> pack);
 
 	/**
 	 * add a subpackage
@@ -132,7 +135,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = SUB_PACKAGE)
-	<T extends CtPackage> T addPackage(CtPackage pack);
+	CtPackage addPackage(CtPackage pack);
 
 	/**
 	 * remove a subpackage
@@ -150,7 +153,7 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * 		new Set of types
 	 */
 	@PropertySetter(role = CONTAINED_TYPE)
-	<T extends CtPackage> T setTypes(Set<CtType<?>> types);
+	CtPackage setTypes(Set<CtType<?>> types);
 
 	@Override
 	CtPackage clone();

--- a/src/main/java/spoon/reflect/declaration/CtPackageExport.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackageExport.java
@@ -16,15 +16,19 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtPackageReference;
 
-import java.util.List;
 
-/**
+
+
+
+public/**
  * Represents an exported or opened package in a Java module
  *
  * The exports directive specifies the name of a package to be exported by the current module.
@@ -49,10 +53,10 @@ import java.util.List;
  *     opens com.example.foo.quux;
  * </pre>
  */
-public interface CtPackageExport extends CtModuleDirective {
+interface CtPackageExport extends CtModuleDirective {
 
 	@PropertySetter(role = CtRole.OPENED_PACKAGE)
-	<T extends CtPackageExport> T setOpenedPackage(boolean openedPackage);
+	CtPackageExport setOpenedPackage(boolean openedPackage);
 
 	@PropertyGetter(role = CtRole.OPENED_PACKAGE)
 	boolean isOpenedPackage();
@@ -61,16 +65,16 @@ public interface CtPackageExport extends CtModuleDirective {
 	CtPackageReference getPackageReference();
 
 	@PropertySetter(role = CtRole.PACKAGE_REF)
-	<T extends CtPackageExport> T setPackageReference(CtPackageReference packageReference);
+	CtPackageExport setPackageReference(CtPackageReference packageReference);
 
 	@PropertyGetter(role = CtRole.MODULE_REF)
 	List<CtModuleReference> getTargetExport();
 
 	@PropertySetter(role = CtRole.MODULE_REF)
-	<T extends CtPackageExport> T setTargetExport(List<CtModuleReference> targetExport);
+	CtPackageExport setTargetExport(List<CtModuleReference> targetExport);
 
 	@PropertySetter(role = CtRole.MODULE_REF)
-	<T extends CtPackageExport> T addTargetExport(CtModuleReference targetExport);
+	CtPackageExport addTargetExport(CtModuleReference targetExport);
 
 	@Override
 	CtPackageExport clone();

--- a/src/main/java/spoon/reflect/declaration/CtParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtParameter.java
@@ -16,14 +16,18 @@
  */
 package spoon.reflect.declaration;
 
+
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.IS_VARARGS;
+
+
+
 
 /**
  * This element defines an executable parameter declaration.
@@ -54,7 +58,7 @@ public interface CtParameter<T> extends CtVariable<T>, CtShadowable {
 	 * Sets this parameter to have varargs.
 	 */
 	@PropertySetter(role = IS_VARARGS)
-	<C extends CtParameter<T>> C setVarArgs(boolean varArgs);
+	CtParameter<T> setVarArgs(boolean varArgs);
 
 	/** overriding the return type */
 	@Override
@@ -66,5 +70,5 @@ public interface CtParameter<T> extends CtVariable<T>, CtShadowable {
 
 	@Override
 	@UnsettableProperty
-	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
+	CtParameter<T> setDefaultExpression(CtExpression<T> assignedExpression);
 }

--- a/src/main/java/spoon/reflect/declaration/CtProvidedService.java
+++ b/src/main/java/spoon/reflect/declaration/CtProvidedService.java
@@ -16,14 +16,18 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 
-import java.util.List;
 
-/**
+
+
+
+public/**
  * Represents a provided service in a {@link CtModule}.
  * The provides directive specifies a service for which the with clause specifies one or more service providers to java.util.ServiceLoader.
  * The service must be a class type, an interface type, or an annotation type. It is a compile-time error if a provides directive specifies an enum type as the service.
@@ -40,22 +44,22 @@ import java.util.List;
  *     provides com.example.foo.spi.Itf with com.example.foo.Impl;
  * </pre>
  */
-public interface CtProvidedService extends CtModuleDirective {
+interface CtProvidedService extends CtModuleDirective {
 
 	@PropertyGetter(role = CtRole.SERVICE_TYPE)
 	CtTypeReference getServiceType();
 
 	@PropertySetter(role = CtRole.SERVICE_TYPE)
-	<T extends CtProvidedService> T setServiceType(CtTypeReference providingType);
+	CtProvidedService setServiceType(CtTypeReference providingType);
 
 	@PropertyGetter(role = CtRole.IMPLEMENTATION_TYPE)
 	List<CtTypeReference> getImplementationTypes();
 
 	@PropertySetter(role = CtRole.IMPLEMENTATION_TYPE)
-	<T extends CtProvidedService> T setImplementationTypes(List<CtTypeReference> usedTypes);
+	CtProvidedService setImplementationTypes(List<CtTypeReference> usedTypes);
 
 	@PropertySetter(role = CtRole.IMPLEMENTATION_TYPE)
-	<T extends CtProvidedService> T addImplementationType(CtTypeReference usedType);
+	CtProvidedService addImplementationType(CtTypeReference usedType);
 
 	@Override
 	CtProvidedService clone();

--- a/src/main/java/spoon/reflect/declaration/CtShadowable.java
+++ b/src/main/java/spoon/reflect/declaration/CtShadowable.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtTypeReference;
 
 import static spoon.reflect.path.CtRole.IS_SHADOW;
+
+
+
 
 /** A shadow element is an element that is in the Spoon model, but does not exist in the actual source code.
  * The goal of shadow elements is to simplify transformations.
@@ -42,5 +46,5 @@ public interface CtShadowable {
 	 * {@link #isShadow()}.
 	 */
 	@PropertySetter(role = IS_SHADOW)
-	<E extends CtShadowable> E setShadow(boolean isShadow);
+	CtShadowable setShadow(boolean isShadow);
 }

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -16,21 +16,24 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
-import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.DerivedProperty;
 
-import static spoon.reflect.path.CtRole.METHOD;
 import static spoon.reflect.path.CtRole.FIELD;
 import static spoon.reflect.path.CtRole.INTERFACE;
+import static spoon.reflect.path.CtRole.METHOD;
 import static spoon.reflect.path.CtRole.NAME;
 import static spoon.reflect.path.CtRole.NESTED_TYPE;
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
 import static spoon.reflect.path.CtRole.TYPE_MEMBER;
+
+
+
 
 /**
  * This abstract element defines a super-type for classes and interfaces, which
@@ -138,7 +141,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * @return <tt>true</tt> if the field is added.
 	 */
 	@PropertySetter(role = FIELD)
-	<F, C extends CtType<T>> C addFieldAtTop(CtField<F> field);
+	<F> CtType<T> addFieldAtTop(CtField<F> field);
 
 	/**
 	 * add a field at the end of the field list.
@@ -147,7 +150,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = FIELD)
-	<F, C extends CtType<T>> C addField(CtField<F> field);
+	<F> CtType<T> addField(CtField<F> field);
 
 	/**
 	 * add a field at a given position.
@@ -156,13 +159,13 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = FIELD)
-	<F, C extends CtType<T>> C addField(int index, CtField<F> field);
+	<F> CtType<T> addField(int index, CtField<F> field);
 
 	/**
 	 * Sets all fields in the type.
 	 */
 	@PropertySetter(role = FIELD)
-	<C extends CtType<T>> C setFields(List<CtField<?>> fields);
+	CtType<T> setFields(List<CtField<?>> fields);
 
 	/**
 	 * remove a Field
@@ -180,7 +183,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = NESTED_TYPE)
-	<N, C extends CtType<T>> C addNestedType(CtType<N> nestedType);
+	<N> CtType<T> addNestedType(CtType<N> nestedType);
 
 	/**
 	 * Remove a nested type.
@@ -195,7 +198,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Sets all nested types.
 	 */
 	@PropertySetter(role = NESTED_TYPE)
-	<C extends CtType<T>> C setNestedTypes(Set<CtType<?>> nestedTypes);
+	CtType<T> setNestedTypes(Set<CtType<?>> nestedTypes);
 
 	/**
 	 * Replace all the code snippets that are found in this type by the corresponding Spoon AST.
@@ -276,13 +279,13 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Sets the methods of this type.
 	 */
 	@PropertySetter(role = METHOD)
-	<C extends CtType<T>> C setMethods(Set<CtMethod<?>> methods);
+	CtType<T> setMethods(Set<CtMethod<?>> methods);
 
 	/**
 	 * Adds a method to this type.
 	 */
 	@PropertySetter(role = METHOD)
-	<M, C extends CtType<T>> C addMethod(CtMethod<M> method);
+	<M> CtType<T> addMethod(CtMethod<M> method);
 
 	/**
 	 * Removes a method from this type.
@@ -294,20 +297,20 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Sets the superclass type.
 	 */
 	@PropertySetter(role = SUPER_TYPE)
-	<C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass);
+	CtType<T> setSuperclass(CtTypeReference<?> superClass);
 
 	/**
 	 * Sets the super interfaces of this type.
 	 */
 	@PropertySetter(role = INTERFACE)
-	<C extends CtType<T>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
+	CtType<T> setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
 
 	/**
 	 * @param interfac
 	 * @return <tt>true</tt> if this element changed as a result of the call
 	 */
 	@PropertySetter(role = INTERFACE)
-	<S, C extends CtType<T>> C addSuperInterface(CtTypeReference<S> interfac);
+	<S> CtType<T> addSuperInterface(CtTypeReference<S> interfac);
 
 	/**
 	 * @param interfac
@@ -326,14 +329,14 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Adds a type member at the end of all type member of the type.
 	 */
 	@PropertySetter(role = TYPE_MEMBER)
-	<C extends CtType<T>> C addTypeMember(CtTypeMember member);
+	CtType<T> addTypeMember(CtTypeMember member);
 
 	/**
 	 * Adds a type member at a given position. Think to use this method if the order is
 	 * important for you.
 	 */
 	@PropertySetter(role = TYPE_MEMBER)
-	<C extends CtType<T>> C addTypeMemberAt(int position, CtTypeMember member);
+	CtType<T> addTypeMemberAt(int position, CtTypeMember member);
 
 	/**
 	 * Removes the type member.
@@ -345,7 +348,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * Removes all types members with these new members.
 	 */
 	@PropertySetter(role = TYPE_MEMBER)
-	<C extends CtType<T>> C setTypeMembers(List<CtTypeMember> members);
+	CtType<T> setTypeMembers(List<CtTypeMember> members);
 
 	@Override
 	CtType<T> clone();

--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -16,18 +16,21 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.Collection;
+import java.util.Set;
+import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-
-import java.util.Collection;
-import java.util.Set;
 
 import static spoon.reflect.path.CtRole.INTERFACE;
 import static spoon.reflect.path.CtRole.MODIFIER;
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
+
+
+
 
 /**
  * Returns information that can be obtained both at compile-time and run-time

--- a/src/main/java/spoon/reflect/declaration/CtTypeMember.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeMember.java
@@ -16,7 +16,11 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * This interface represents a member of a class (field, method,

--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
-import java.util.List;
-import java.util.Set;
+
+
 
 /**
  * This element defines a declaration of a type parameter (aka generics).
@@ -46,45 +49,45 @@ public interface CtTypeParameter extends CtType<Object> {
 
 	@Override
 	@UnsettableProperty
-	<T extends CtFormalTypeDeclarer> T setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
+	CtTypeParameter setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<Object>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
+	CtTypeParameter setSuperInterfaces(Set<CtTypeReference<?>> interfaces);
 
 	@Override
 	@UnsettableProperty
-	<S, C extends CtType<Object>> C addSuperInterface(CtTypeReference<S> interfac);
+	<S> CtTypeParameter addSuperInterface(CtTypeReference<S> interfac);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<Object>> C setTypeMembers(List<CtTypeMember> members);
+	CtTypeParameter setTypeMembers(List<CtTypeMember> members);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<Object>> C setFields(List<CtField<?>> fields);
+	CtTypeParameter setFields(List<CtField<?>> fields);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<Object>> C setMethods(Set<CtMethod<?>> methods);
+	CtTypeParameter setMethods(Set<CtMethod<?>> methods);
 
 	@Override
 	@UnsettableProperty
-	<M, C extends CtType<Object>> C addMethod(CtMethod<M> method);
+	<M> CtTypeParameter addMethod(CtMethod<M> method);
 
 	@Override
 	@UnsettableProperty
-	<C extends CtType<Object>> C setNestedTypes(Set<CtType<?>> nestedTypes);
+	CtTypeParameter setNestedTypes(Set<CtType<?>> nestedTypes);
 
 	@Override
 	@UnsettableProperty
-	<N, C extends CtType<Object>> C addNestedType(CtType<N> nestedType);
+	<N> CtTypeParameter addNestedType(CtType<N> nestedType);
 
 	@Override
 	@UnsettableProperty
-	<F, C extends CtType<Object>> C addFieldAtTop(CtField<F> field);
+	<F> CtTypeParameter addFieldAtTop(CtField<F> field);
 
 	@Override
 	@UnsettableProperty
-	<T extends CtModifiable> T setModifiers(Set<ModifierKind> modifiers);
+	CtTypeParameter setModifiers(Set<ModifierKind> modifiers);
 }

--- a/src/main/java/spoon/reflect/declaration/CtTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypedElement.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.declaration;
 
-import spoon.reflect.reference.CtTypeReference;
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.reference.CtTypeReference;
 
 import static spoon.reflect.path.CtRole.TYPE;
+
+
+
 
 /**
  * This abstract element defines a typed element.
@@ -36,5 +40,5 @@ public interface CtTypedElement<T> extends CtElement {
 	 * Sets this element's type.
 	 */
 	@PropertySetter(role = TYPE)
-	<C extends CtTypedElement> C setType(CtTypeReference<T> type);
+	CtTypedElement<T> setType(CtTypeReference<T> type);
 }

--- a/src/main/java/spoon/reflect/declaration/CtUsedService.java
+++ b/src/main/java/spoon/reflect/declaration/CtUsedService.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
+
+
+
 
 /**
  * Represents the declaration of a used service in a {@link CtModule}
@@ -40,7 +44,7 @@ public interface CtUsedService extends CtModuleDirective {
 	CtTypeReference getServiceType();
 
 	@PropertySetter(role = CtRole.SERVICE_TYPE)
-	<T extends CtUsedService> T setServiceType(CtTypeReference providingType);
+	CtUsedService setServiceType(CtTypeReference providingType);
 
 	@Override
 	CtUsedService clone();

--- a/src/main/java/spoon/reflect/declaration/CtVariable.java
+++ b/src/main/java/spoon/reflect/declaration/CtVariable.java
@@ -16,13 +16,17 @@
  */
 package spoon.reflect.declaration;
 
+
+import spoon.reflect.annotations.PropertyGetter;
+import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.DerivedProperty;
-import spoon.reflect.annotations.PropertyGetter;
-import spoon.reflect.annotations.PropertySetter;
 
 import static spoon.reflect.path.CtRole.DEFAULT_EXPRESSION;
+
+
+
 
 /**
  * This abstract element defines a variable declaration.
@@ -49,5 +53,5 @@ public interface CtVariable<T> extends CtNamedElement, CtTypedElement<T>, CtModi
 	 * declared.
 	 */
 	@PropertySetter(role = DEFAULT_EXPRESSION)
-	<C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> assignedExpression);
+	CtVariable<T> setDefaultExpression(CtExpression<T> assignedExpression);
 }

--- a/src/main/java/spoon/reflect/declaration/ModifierKind.java
+++ b/src/main/java/spoon/reflect/declaration/ModifierKind.java
@@ -16,6 +16,12 @@
  */
 package spoon.reflect.declaration;
 
+
+import java.util.Locale;
+
+
+
+
 /**
  * Represents a modifier on the declaration of a program element such as a
  * class, method, or field.

--- a/src/main/java/spoon/reflect/declaration/ParentNotInitializedException.java
+++ b/src/main/java/spoon/reflect/declaration/ParentNotInitializedException.java
@@ -16,7 +16,11 @@
  */
 package spoon.reflect.declaration;
 
+
 import spoon.SpoonException;
+
+
+
 
 /**
  * This exception is thrown when the parent of an element has not been correctly

--- a/src/main/java/spoon/reflect/reference/CtActualTypeContainer.java
+++ b/src/main/java/spoon/reflect/reference/CtActualTypeContainer.java
@@ -16,11 +16,14 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 
-import java.util.List;
+
+
 
 
 /**
@@ -37,12 +40,12 @@ public interface CtActualTypeContainer {
 	 * Sets the type arguments.
 	 */
 	@PropertySetter(role = CtRole.TYPE_ARGUMENT)
-	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
+	CtActualTypeContainer setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Adds a type argument.
 	 */
-	<T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
+	CtActualTypeContainer addActualTypeArgument(CtTypeReference<?> actualTypeArgument);
 
 	/**
 	 * Removes a type argument.

--- a/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
@@ -16,11 +16,15 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
+
+
+
 
 
 /**
@@ -42,13 +46,13 @@ public interface CtArrayTypeReference<T> extends CtTypeReference<T> {
 	 * this method returns a type reference to "int".
 	 */
 	@DerivedProperty
-	CtTypeReference<?> getArrayType();
+	CtArrayTypeReference<?> getArrayType();
 
 	/**
 	 * Sets the type of the elements contained in this array.
 	 */
 	@PropertySetter(role = CtRole.TYPE)
-	<C extends CtArrayTypeReference<T>> C setComponentType(CtTypeReference<?> componentType);
+	CtArrayTypeReference<T> setComponentType(CtTypeReference<?> componentType);
 
 	/**
 	 * Returns the number of dimensions of this array type. This corresponds to
@@ -71,7 +75,7 @@ public interface CtArrayTypeReference<T> extends CtTypeReference<T> {
 	 */
 	@UnsettableProperty
 	@Override
-	<T extends CtReference> T setSimpleName(String simpleName);
+	CtArrayTypeReference<T> setSimpleName(String simpleName);
 
 	@Override
 	CtArrayTypeReference<T> clone();

--- a/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.code.CtCatchVariable;
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * This interface defines a reference to {@link spoon.reflect.code.CtCatchVariable}.

--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -16,15 +16,18 @@
  */
 package spoon.reflect.reference;
 
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.List;
+
+
 
 
 /**
@@ -99,7 +102,7 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	 * Sets parameters of the executable.
 	 */
 	@PropertySetter(role = CtRole.ARGUMENT_TYPE)
-	<C extends CtExecutableReference<T>> C setParameters(List<CtTypeReference<?>> parameters);
+	CtExecutableReference<T> setParameters(List<CtTypeReference<?>> parameters);
 
 	/**
 	 * Returns <code>true</code> if this executable overrides the given
@@ -140,19 +143,19 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	 * Sets the declaring type.
 	 */
 	@PropertySetter(role = CtRole.DECLARING_TYPE)
-	<C extends CtExecutableReference<T>> C setDeclaringType(CtTypeReference<?> declaringType);
+	CtExecutableReference<T> setDeclaringType(CtTypeReference<?> declaringType);
 
 	/**
 	 * Sets this executable reference to be static or not.
 	 */
 	@PropertySetter(role = CtRole.IS_STATIC)
-	<C extends CtExecutableReference<T>> C setStatic(boolean b);
+	CtExecutableReference<T> setStatic(boolean b);
 
 	/**
 	 * Sets the type of the variable.
 	 */
 	@PropertySetter(role = CtRole.TYPE)
-	<C extends CtExecutableReference<T>> C setType(CtTypeReference<T> type);
+	CtExecutableReference<T> setType(CtTypeReference<T> type);
 
 	/**
 	 * Tells if the referenced executable is final.

--- a/src/main/java/spoon/reflect/reference/CtFieldReference.java
+++ b/src/main/java/spoon/reflect/reference/CtFieldReference.java
@@ -16,13 +16,16 @@
  */
 package spoon.reflect.reference;
 
+
+import java.lang.reflect.Member;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 
-import java.lang.reflect.Member;
+
+
 
 
 /**
@@ -78,19 +81,19 @@ public interface CtFieldReference<T> extends CtVariableReference<T> {
 	 * Sets the type in which the field is declared.
 	 */
 	@PropertySetter(role = CtRole.DECLARING_TYPE)
-	<C extends CtFieldReference<T>> C setDeclaringType(CtTypeReference<?> declaringType);
+	CtFieldReference<T> setDeclaringType(CtTypeReference<?> declaringType);
 
 	/**
 	 * Forces a reference to a final element.
 	 */
 	@PropertySetter(role = CtRole.IS_FINAL)
-	<C extends CtFieldReference<T>> C setFinal(boolean b);
+	CtFieldReference<T> setFinal(boolean b);
 
 	/**
 	 * Forces a reference to a static element.
 	 */
 	@PropertySetter(role = CtRole.IS_STATIC)
-	<C extends CtFieldReference<T>> C setStatic(boolean b);
+	CtFieldReference<T> setStatic(boolean b);
 
 	@Override
 	CtFieldReference<T> clone();

--- a/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
@@ -16,12 +16,15 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.BOUND;
+
+
+
 
 /**
  * This interface defines a reference to an intersection type in generics or in casts.
@@ -40,13 +43,13 @@ public interface CtIntersectionTypeReference<T> extends CtTypeReference<T> {
 	 * Sets the bounds of the intersection type.
 	 */
 	@PropertySetter(role = BOUND)
-	<C extends CtIntersectionTypeReference> C setBounds(List<CtTypeReference<?>> bounds);
+	CtIntersectionTypeReference<T> setBounds(List<CtTypeReference<?>> bounds);
 
 	/**
 	 * Adds a bound.
 	 */
 	@PropertySetter(role = BOUND)
-	<C extends CtIntersectionTypeReference> C addBound(CtTypeReference<?> bound);
+	CtIntersectionTypeReference<T> addBound(CtTypeReference<?> bound);
 
 	/**
 	 * Removes a bound.

--- a/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.code.CtLocalVariable;
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * This interface defines a reference to

--- a/src/main/java/spoon/reflect/reference/CtModuleReference.java
+++ b/src/main/java/spoon/reflect/reference/CtModuleReference.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.declaration.CtModule;
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * Represents a reference to a {@link CtModule}

--- a/src/main/java/spoon/reflect/reference/CtPackageReference.java
+++ b/src/main/java/spoon/reflect/reference/CtPackageReference.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.declaration.CtPackage;
 import spoon.support.DerivedProperty;
+
+
+
 
 /**
  * This interface defines a reference to a

--- a/src/main/java/spoon/reflect/reference/CtParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtParameterReference.java
@@ -16,8 +16,12 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.declaration.CtParameter;
 import spoon.support.DerivedProperty;
+
+
+
 
 
 /**

--- a/src/main/java/spoon/reflect/reference/CtReference.java
+++ b/src/main/java/spoon/reflect/reference/CtReference.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.List;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.code.CtComment;
@@ -24,7 +26,8 @@ import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
-import java.util.List;
+
+
 
 
 /**
@@ -48,7 +51,7 @@ public interface CtReference extends CtElement {
 	 * Sets the name of referenced element.
 	 */
 	@PropertySetter(role = CtRole.NAME)
-	<T extends CtReference> T setSimpleName(String simpleName);
+	CtReference setSimpleName(String simpleName);
 
 	/**
 	 * Returns the declaration that corresponds to the referenced element only
@@ -65,5 +68,5 @@ public interface CtReference extends CtElement {
 	/** comments are not possible for references */
 	@Override
 	@UnsettableProperty
-	<E extends CtElement> E setComments(List<CtComment> comments);
+	CtReference setComments(List<CtComment> comments);
 }

--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -16,11 +16,14 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.List;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
-import java.util.List;
+
+
 
 
 /**
@@ -56,7 +59,7 @@ public interface CtTypeParameterReference extends CtTypeReference<Object> {
 
 	@Override
 	@UnsettableProperty
-	<T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
+	CtTypeParameterReference setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments);
 
 	/**
 	 * Returns true if this has the default bounding type that is java.lang.Object (which basically means that there is no bound)

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtShadowable;
@@ -27,9 +29,8 @@ import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
 
-import java.util.Set;
 
-import static spoon.reflect.path.CtRole.PACKAGE_REF;
+
 
 /**
  * This interface defines a reference to a
@@ -122,13 +123,13 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * referenced type is not a inner type.
 	 */
 	@PropertySetter(role = CtRole.DECLARING_TYPE)
-	<C extends CtTypeReference<T>> C setDeclaringType(CtTypeReference<?> type);
+	CtTypeReference<T> setDeclaringType(CtTypeReference<?> type);
 
 	/**
 	 * Sets the reference to the declaring package.
 	 */
 	@PropertySetter(role = PACKAGE_REF)
-	<C extends CtTypeReference<T>> C setPackage(CtPackageReference pack);
+	CtTypeReference<T> setPackage(CtPackageReference pack);
 
 	/**
 	 * Casts the type reference in {@link CtIntersectionTypeReference}.

--- a/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
@@ -16,12 +16,14 @@
  */
 package spoon.reflect.reference;
 
-import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtElement;
-import spoon.support.UnsettableProperty;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * This interface defines a reference to an unbound
@@ -33,5 +35,5 @@ public interface CtUnboundVariableReference<T> extends CtVariableReference<T> {
 
 	@Override
 	@UnsettableProperty
-	<E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
+	CtUnboundVariableReference<T> setAnnotations(List<CtAnnotation<? extends Annotation>> annotation);
 }

--- a/src/main/java/spoon/reflect/reference/CtVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtVariableReference.java
@@ -16,6 +16,8 @@
  */
 package spoon.reflect.reference;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.declaration.CtVariable;
@@ -23,7 +25,8 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.support.DerivedProperty;
 
-import java.util.Set;
+
+
 
 
 /**
@@ -42,7 +45,7 @@ public interface CtVariableReference<T> extends CtReference {
 	 * Sets the type of the variable.
 	 */
 	@PropertySetter(role = CtRole.TYPE)
-	<C extends CtVariableReference<T>> C setType(CtTypeReference<T> type);
+	CtVariableReference<T> setType(CtTypeReference<T> type);
 
 	/**
 	 * Tries to get the declaration of the reference.

--- a/src/main/java/spoon/reflect/reference/CtWildcardReference.java
+++ b/src/main/java/spoon/reflect/reference/CtWildcardReference.java
@@ -16,10 +16,14 @@
  */
 package spoon.reflect.reference;
 
+
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.reflect.path.CtRole;
 import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * Represents a wildcard in generic type annotations, i.e. the "?" (e.g. the "?" in Collection&lt;?&gt; or Collection&lt;? extends List&gt;).
@@ -30,7 +34,7 @@ public interface CtWildcardReference extends CtTypeParameterReference {
 
 	@Override
 	@UnsettableProperty
-	<C extends CtReference> C setSimpleName(String simpleName);
+	CtWildcardReference setSimpleName(String simpleName);
 
 	/**
 	 * Returns {@code true} if the bounds are in <code>extends</code> clause.
@@ -43,7 +47,7 @@ public interface CtWildcardReference extends CtTypeParameterReference {
 	 * Set to {@code true} to write <code>extends</code> clause for bounds types.
 	 */
 	@PropertySetter(role = CtRole.IS_UPPER)
-	<T extends CtWildcardReference> T setUpper(boolean upper);
+	CtWildcardReference setUpper(boolean upper);
 
 	/**
 	 * A type parameter can have an <code>extends</code> clause which declare
@@ -63,5 +67,5 @@ public interface CtWildcardReference extends CtTypeParameterReference {
 	 * Sets the <code>extends</code> clause of the type parameter.
 	 */
 	@PropertySetter(role = CtRole.BOUNDING_TYPE)
-	<T extends CtWildcardReference> T setBoundingType(CtTypeReference<?> superType);
+	CtWildcardReference setBoundingType(CtTypeReference<?> superType);
 }

--- a/src/main/java/spoon/support/reflect/code/CtAnnotationFieldAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAnnotationFieldAccessImpl.java
@@ -16,8 +16,12 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtAnnotationFieldAccessImpl<T> extends CtFieldAccessImpl<T> implements CtAnnotationFieldAccess<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
@@ -16,11 +16,15 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtExpression;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public abstract class CtArrayAccessImpl<T, V extends CtExpression<?>> extends CtTargetedExpressionImpl<T, V> implements CtArrayAccess<T, V> {
 	private static final long serialVersionUID = 1L;
@@ -34,13 +38,13 @@ public abstract class CtArrayAccessImpl<T, V extends CtExpression<?>> extends Ct
 	}
 
 	@Override
-	public <C extends CtArrayAccess<T, V>> C setIndexExpression(CtExpression<Integer> expression) {
+	public CtArrayAccessImpl<T, V> setIndexExpression(CtExpression<Integer> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtArrayReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayReadImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtArrayRead;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtArrayReadImpl<T> extends CtArrayAccessImpl<T, CtExpression<?>> implements CtArrayRead<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtArrayWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayWriteImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtArrayWrite;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtArrayWriteImpl<T> extends CtArrayAccessImpl<T, CtExpression<?>> implements CtArrayWrite<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtAssert;
 import spoon.reflect.code.CtExpression;
@@ -23,6 +24,9 @@ import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	private static final long serialVersionUID = 1L;
@@ -44,13 +48,13 @@ public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	}
 
 	@Override
-	public <A extends CtAssert<T>> A setAssertExpression(CtExpression<Boolean> asserted) {
+	public CtAssertImpl<T> setAssertExpression(CtExpression<Boolean> asserted) {
 		if (asserted != null) {
 			asserted.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CONDITION, asserted, this.asserted);
 		this.asserted = asserted;
-		return (A) this;
+		return this;
 	}
 
 	@Override
@@ -59,13 +63,13 @@ public class CtAssertImpl<T> extends CtStatementImpl implements CtAssert<T> {
 	}
 
 	@Override
-	public <A extends CtAssert<T>> A setExpression(CtExpression<T> value) {
+	public CtAssertImpl<T> setExpression(CtExpression<T> value) {
 		if (value != null) {
 			value.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, value, this.value);
 		this.value = value;
-		return (A) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
@@ -16,23 +16,24 @@
  */
 package spoon.support.reflect.code;
 
-import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtAssignment;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtRHSReceiver;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
 import java.util.List;
+import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.reflect.declaration.CtElementImpl;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.CASTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.ASSIGNED;
 import static spoon.reflect.path.CtRole.ASSIGNMENT;
 import static spoon.reflect.path.CtRole.CAST;
 import static spoon.reflect.path.CtRole.TYPE;
+
+
+
 
 public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements CtAssignment<T, A> {
 	private static final long serialVersionUID = 1L;
@@ -75,40 +76,40 @@ public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements
 	}
 
 	@Override
-	public <C extends CtAssignment<T, A>> C setAssigned(CtExpression<T> assigned) {
+	public CtAssignmentImpl<T, A> setAssigned(CtExpression<T> assigned) {
 		if (assigned != null) {
 			assigned.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ASSIGNED, assigned, this.assigned);
 		this.assigned = assigned;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtRHSReceiver<A>> C setAssignment(CtExpression<A> assignment) {
+	public CtAssignmentImpl<T, A> setAssignment(CtExpression<A> assignment) {
 		if (assignment != null) {
 			assignment.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ASSIGNMENT, assignment, this.assignment);
 		this.assignment = assignment;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtAssignmentImpl<T, A> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExpression<T>> C setTypeCasts(List<CtTypeReference<?>> casts) {
+	public CtAssignmentImpl<T, A> setTypeCasts(List<CtTypeReference<?>> casts) {
 		if (casts == null || casts.isEmpty()) {
 			this.typeCasts = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.typeCasts == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.typeCasts = new ArrayList<>(CASTS_CONTAINER_DEFAULT_CAPACITY);
@@ -118,13 +119,13 @@ public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements
 		for (CtTypeReference<?> cast : casts) {
 			addTypeCast(cast);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExpression<T>> C addTypeCast(CtTypeReference<?> type) {
+	public CtAssignmentImpl<T, A> addTypeCast(CtTypeReference<?> type) {
 		if (type == null) {
-			return (C) this;
+			return this;
 		}
 		if (typeCasts == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			typeCasts = new ArrayList<>(CASTS_CONTAINER_DEFAULT_CAPACITY);
@@ -132,7 +133,7 @@ public class CtAssignmentImpl<T, A extends T> extends CtStatementImpl implements
 		type.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CAST, typeCasts, type);
 		typeCasts.add(type);
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
@@ -25,6 +26,9 @@ import spoon.reflect.visitor.CtVisitor;
 import static spoon.reflect.path.CtRole.LEFT_OPERAND;
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
 import static spoon.reflect.path.CtRole.RIGHT_OPERAND;
+
+
+
 
 public class CtBinaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtBinaryOperator<T> {
 	private static final long serialVersionUID = 1L;
@@ -54,30 +58,30 @@ public class CtBinaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtBi
 	}
 
 	@Override
-	public <C extends CtBinaryOperator<T>> C setLeftHandOperand(CtExpression<?> expression) {
+	public CtBinaryOperatorImpl<T> setLeftHandOperand(CtExpression<?> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, LEFT_OPERAND, expression, this.leftHandOperand);
 		leftHandOperand = expression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtBinaryOperator<T>> C setRightHandOperand(CtExpression<?> expression) {
+	public CtBinaryOperatorImpl<T> setRightHandOperand(CtExpression<?> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, RIGHT_OPERAND, expression, this.rightHandOperand);
 		rightHandOperand = expression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtBinaryOperator<T>> C setKind(BinaryOperatorKind kind) {
+	public CtBinaryOperatorImpl<T> setKind(BinaryOperatorKind kind) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, OPERATOR_KIND, kind, this.kind);
 		this.kind = kind;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -14,9 +14,12 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
-
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
@@ -32,9 +35,8 @@ import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.support.util.ModelList;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+
+
 
 public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	private static final long serialVersionUID = 1L;
@@ -99,91 +101,91 @@ public class CtBlockImpl<R> extends CtStatementImpl implements CtBlock<R> {
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatementList statements) {
+	public CtBlockImpl<R> insertBegin(CtStatementList statements) {
 		if (this.shouldInsertAfterSuper()) {
 			getStatements().get(0).insertAfter(statements);
-			return (T) this;
+			return this;
 		}
 		List<CtStatement> copy = new ArrayList<>(statements.getStatements());
 		statements.setStatements(null);
 		this.statements.addAll(0, copy);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatement statement) {
+	public CtBlockImpl<R> insertBegin(CtStatement statement) {
 		if (this.shouldInsertAfterSuper()) {
 			getStatements().get(0).insertAfter(statement);
-			return (T) this;
+			return this;
 		}
 		this.statements.add(0, statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatement statement) {
+	public CtBlockImpl<R> insertEnd(CtStatement statement) {
 		addStatement(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
+	public CtBlockImpl<R> insertEnd(CtStatementList statements) {
 		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
 		//remove statements from the `statementsToBeInserted` before they are added to spoon model
 		//note: one element MUST NOT be part of two models.
 		statements.setStatements(null);
 		this.statements.addAll(this.statements.size(), tobeInserted);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtBlockImpl<R> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtBlockImpl<R> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtBlockImpl<R> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtBlockImpl<R> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T setStatements(List<CtStatement> statements) {
+	public CtBlockImpl<R> setStatements(List<CtStatement> statements) {
 		this.statements.set(statements);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(CtStatement statement) {
+	public CtBlockImpl<R> addStatement(CtStatement statement) {
 		this.statements.add(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(int index, CtStatement statement) {
+	public CtBlockImpl<R> addStatement(int index, CtStatement statement) {
 		this.statements.add(index, statement);
-		return (T) this;
+		return this;
 	}
 
 

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -16,17 +16,19 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBreak;
-import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.ParentFunction;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.TARGET_LABEL;
+
+
+
 
 public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 	private static final long serialVersionUID = 1L;
@@ -45,10 +47,10 @@ public class CtBreakImpl extends CtStatementImpl implements CtBreak {
 	}
 
 	@Override
-	public <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel) {
+	public CtBreakImpl setTargetLabel(String targetLabel) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TARGET_LABEL, targetLabel, this.targetLabel);
 		this.targetLabel = targetLabel;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -16,6 +16,10 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCase;
@@ -28,9 +32,8 @@ import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
+
+
 
 public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 	private static final long serialVersionUID = 1L;
@@ -57,32 +60,32 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 	}
 
 	@Override
-	public <T extends CtCase<E>> T setCaseExpression(CtExpression<E> caseExpression) {
+	public CtCaseImpl<E> setCaseExpression(CtExpression<E> caseExpression) {
 		if (caseExpression != null) {
 			caseExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.CASE, caseExpression, this.caseExpression);
 		this.caseExpression = caseExpression;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T setStatements(List<CtStatement> statements) {
+	public CtCaseImpl<E> setStatements(List<CtStatement> statements) {
 		if (statements == null || statements.isEmpty()) {
 			this.statements = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.STATEMENT, this.statements, new ArrayList<>(this.statements));
 		this.statements.clear();
 		for (CtStatement stmt : statements) {
 			addStatement(stmt);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(CtStatement statement) {
-		return this.addStatement(this.statements.size(), statement);
+	public CtCaseImpl<E> addStatement(CtStatement statement) {
+		return ((CtCaseImpl<E>) (this.addStatement(this.statements.size(), statement)));
 	}
 
 	private void ensureModifiableStatementsList() {
@@ -92,19 +95,19 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(int index, CtStatement statement) {
+	public CtCaseImpl<E> addStatement(int index, CtStatement statement) {
 		if (statement == null) {
-			return (T) this;
+			return this;
 		}
 		this.ensureModifiableStatementsList();
 		statement.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.STATEMENT, this.statements, index, statement);
 		statements.add(index, statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatement statement) {
+	public CtCaseImpl<E> insertBegin(CtStatement statement) {
 		ensureModifiableStatementsList();
 		statement.setParent(this);
 		this.addStatement(0, statement);
@@ -112,11 +115,11 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatementList statements) {
+	public CtCaseImpl<E> insertBegin(CtStatementList statements) {
 		this.ensureModifiableStatementsList();
 		for (CtStatement statement : statements.getStatements()) {
 			statement.setParent(this);
@@ -125,18 +128,18 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatement statement) {
+	public CtCaseImpl<E> insertEnd(CtStatement statement) {
 		ensureModifiableStatementsList();
 		addStatement(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
+	public CtCaseImpl<E> insertEnd(CtStatementList statements) {
 		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
 		//remove statements from the `statementsToBeInserted` before they are added to spoon model
 		//note: one element MUST NOT be part of two models.
@@ -144,39 +147,39 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 		for (CtStatement s : tobeInserted) {
 			insertEnd(s);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtCaseImpl<E> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtCaseImpl<E> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtCaseImpl<E> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtCaseImpl<E> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
@@ -16,9 +16,9 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtStatement;
@@ -26,6 +26,9 @@ import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.PARAMETER;
+
+
+
 
 public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 	private static final long serialVersionUID = 1L;
@@ -52,7 +55,7 @@ public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 	}
 
 	@Override
-	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+	public CtCatchImpl setBody(CtStatement statement) {
 		if (statement != null) {
 			CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, body, this.body);
@@ -65,17 +68,17 @@ public class CtCatchImpl extends CtCodeElementImpl implements CtCatch {
 			this.body = null;
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtCatch> T setParameter(CtCatchVariable<? extends Throwable> parameter) {
+	public CtCatchImpl setParameter(CtCatchVariable<? extends Throwable> parameter) {
 		if (parameter != null) {
 			parameter.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, PARAMETER, parameter, this.parameter);
 		this.parameter = parameter;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -16,15 +16,15 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtMultiTypedElement;
-import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtCatchVariableReference;
@@ -37,10 +37,8 @@ import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+
+
 
 public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatchVariable<T> {
 	private static final long serialVersionUID = 1L;
@@ -111,28 +109,28 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> defaultExpression) {
+	public CtCatchVariableImpl<T> setDefaultExpression(CtExpression<T> defaultExpression) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
+	public CtCatchVariableImpl<T> setSimpleName(String simpleName) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.NAME, simpleName, this.name);
 		this.name = simpleName;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtCatchVariableImpl<T> setType(CtTypeReference<T> type) {
 		setMultiTypes(type == null ? emptyList() : Collections.singletonList(type));
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtMultiTypedElement> T addMultiType(CtTypeReference<?> type) {
+	public CtCatchVariableImpl<T> addMultiType(CtTypeReference<?> type) {
 		if (type == null) {
-			return (T) this;
+			return this;
 		}
 		if (types == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			types = new ArrayList<>(ModelElementContainerDefaultCapacities.CATCH_VARIABLE_MULTI_TYPES_CONTAINER_DEFAULT_CAPACITY);
@@ -140,7 +138,7 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 		type.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.MULTI_TYPE, this.types, type);
 		types.add(type);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -158,11 +156,11 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 	}
 
 	@Override
-	public <T extends CtMultiTypedElement> T setMultiTypes(List<CtTypeReference<?>> types) {
+	public CtCatchVariableImpl<T> setMultiTypes(List<CtTypeReference<?>> types) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.MULTI_TYPE, this.types, new ArrayList<>(this.types));
 		if (types == null || types.isEmpty()) {
 			this.types = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		if (this.types == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.types = new ArrayList<>();
@@ -171,7 +169,7 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 		for (CtTypeReference<?> t : types) {
 			addMultiType(t);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -185,27 +183,27 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtCatchVariableImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtCatchVariableImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtCatchVariableImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtCatchVariableImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -228,9 +226,9 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 	}
 
 	@Override
-	public <C extends CtModifiable> C setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtCatchVariableImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtCodeElement;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
+
+
+
 
 public abstract class CtCodeElementImpl extends CtElementImpl implements CtCodeElement {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
@@ -16,15 +16,18 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.SnippetCompilationError;
 import spoon.support.compiler.SnippetCompilationHelper;
 
 import static spoon.reflect.path.CtRole.SNIPPET;
+
+
+
 
 public class CtCodeSnippetExpressionImpl<T> extends CtExpressionImpl<T> implements CtCodeSnippetExpression<T> {
 
@@ -44,10 +47,10 @@ public class CtCodeSnippetExpressionImpl<T> extends CtExpressionImpl<T> implemen
 	}
 
 	@Override
-	public <C extends CtCodeSnippet> C setValue(String value) {
+	public CtCodeSnippetExpressionImpl<T> setValue(String value) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SNIPPET, value, this.value);
 		this.value = value;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
@@ -16,15 +16,18 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.SnippetCompilationError;
 import spoon.support.compiler.SnippetCompilationHelper;
 
 import static spoon.reflect.path.CtRole.SNIPPET;
+
+
+
 
 public class CtCodeSnippetStatementImpl extends CtStatementImpl implements CtCodeSnippetStatement {
 
@@ -44,10 +47,10 @@ public class CtCodeSnippetStatementImpl extends CtStatementImpl implements CtCod
 	}
 
 	@Override
-	public <C extends CtCodeSnippet> C setValue(String value) {
+	public CtCodeSnippetStatementImpl setValue(String value) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SNIPPET, value, this.value);
 		this.value = value;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
@@ -16,13 +16,16 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.Objects;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.util.Objects;
+
+
 
 public class CtCommentImpl extends CtStatementImpl implements CtComment {
 	private static final long serialVersionUID = 1L;
@@ -46,10 +49,10 @@ public class CtCommentImpl extends CtStatementImpl implements CtComment {
 	}
 
 	@Override
-	public <E extends CtComment> E setContent(String content) {
+	public CtCommentImpl setContent(String content) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.COMMENT_CONTENT, content, this.content);
 		this.content = content;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -58,10 +61,10 @@ public class CtCommentImpl extends CtStatementImpl implements CtComment {
 	}
 
 	@Override
-	public <E extends CtComment> E setCommentType(CommentType commentType) {
+	public CtCommentImpl setCommentType(CommentType commentType) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, commentType, this.type);
 		type = commentType;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -105,9 +108,9 @@ public class CtCommentImpl extends CtStatementImpl implements CtComment {
 	}
 
 	@Override
-	public CtJavaDoc asJavaDoc() {
+	public CtCommentImpl asJavaDoc() {
 		if (this instanceof CtJavaDoc) {
-			return (CtJavaDoc) this;
+			return this;
 		}
 		throw new IllegalStateException("not a javadoc comment");
 	}

--- a/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtExpression;
@@ -24,6 +25,9 @@ import spoon.reflect.visitor.CtVisitor;
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.ELSE;
 import static spoon.reflect.path.CtRole.THEN;
+
+
+
 
 public class CtConditionalImpl<T> extends CtExpressionImpl<T> implements CtConditional<T> {
 	private static final long serialVersionUID = 1L;
@@ -58,33 +62,33 @@ public class CtConditionalImpl<T> extends CtExpressionImpl<T> implements CtCondi
 	}
 
 	@Override
-	public <C extends CtConditional<T>> C setElseExpression(CtExpression<T> elseExpression) {
+	public CtConditionalImpl<T> setElseExpression(CtExpression<T> elseExpression) {
 		if (elseExpression != null) {
 			elseExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ELSE, elseExpression, this.elseExpression);
 		this.elseExpression = elseExpression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtConditional<T>> C setCondition(CtExpression<Boolean> condition) {
+	public CtConditionalImpl<T> setCondition(CtExpression<Boolean> condition) {
 		if (condition != null) {
 			condition.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CONDITION, condition, this.condition);
 		this.condition = condition;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtConditional<T>> C setThenExpression(CtExpression<T> thenExpression) {
+	public CtConditionalImpl<T> setThenExpression(CtExpression<T> thenExpression) {
 		if (thenExpression != null) {
 			thenExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, THEN, thenExpression, this.thenExpression);
 		this.thenExpression = thenExpression;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -16,27 +16,27 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.ARGUMENT;
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
 import static spoon.reflect.path.CtRole.LABEL;
+
+
+
 
 public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtConstructorCall<T> {
 	private static final long serialVersionUID = 1L;
@@ -74,34 +74,34 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatement statement) {
+	public CtConstructorCallImpl<T> insertAfter(CtStatement statement) {
 		CtStatementImpl.insertAfter(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatement statement) {
+	public CtConstructorCallImpl<T> insertBefore(CtStatement statement) {
 		CtStatementImpl.insertBefore(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatementList statements) {
+	public CtConstructorCallImpl<T> insertAfter(CtStatementList statements) {
 		CtStatementImpl.insertAfter(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatementList statements) {
+	public CtConstructorCallImpl<T> insertBefore(CtStatementList statements) {
 		CtStatementImpl.insertBefore(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C setArguments(List<CtExpression<?>> arguments) {
+	public CtConstructorCallImpl<T> setArguments(List<CtExpression<?>> arguments) {
 		if (arguments == null || arguments.isEmpty()) {
 			this.arguments = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			this.arguments = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -111,12 +111,12 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 		for (CtExpression<?> expr : arguments) {
 			addArgument(expr);
 		}
-		return (C) this;
+		return this;
 	}
 
-	private <C extends CtAbstractInvocation<T>> C addArgument(int position, CtExpression<?> argument) {
+	private CtConstructorCallImpl<T> addArgument(int position, CtExpression<?> argument) {
 		if (argument == null) {
-			return (C) this;
+			return this;
 		}
 		if (arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			arguments = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -124,12 +124,12 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 		argument.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, ARGUMENT, this.arguments, position, argument);
 		arguments.add(position, argument);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C addArgument(CtExpression<?> argument) {
-		return addArgument(arguments.size(), argument);
+	public CtConstructorCallImpl<T> addArgument(CtExpression<?> argument) {
+		return ((CtConstructorCallImpl<T>) (addArgument(arguments.size(), argument)));
 	}
 
 	@Override
@@ -142,20 +142,20 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C setExecutable(CtExecutableReference<T> executable) {
+	public CtConstructorCallImpl<T> setExecutable(CtExecutableReference<T> executable) {
 		if (executable != null) {
 			executable.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXECUTABLE_REF, executable, this.executable);
 		this.executable = executable;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C setLabel(String label) {
+	public CtConstructorCallImpl<T> setLabel(String label) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, LABEL, label, this.label);
 		this.label = label;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -166,20 +166,20 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 
 	@Override
 	@DerivedProperty
-	public <T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
+	public CtConstructorCallImpl<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
 		if (getExecutable() != null) {
 			getExecutable().setActualTypeArguments(actualTypeArguments);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
 	@DerivedProperty
-	public <T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+	public CtConstructorCallImpl<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
 		if (getExecutable() != null) {
 			getExecutable().addActualTypeArgument(actualTypeArgument);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -199,14 +199,14 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 
 	@Override
 	@DerivedProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtConstructorCallImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		if (getExecutable() != null) {
 			getExecutable().setType(type);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -16,17 +16,19 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtContinue;
-import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.ParentFunction;
 
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.TARGET_LABEL;
+
+
+
 
 public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	private static final long serialVersionUID = 1L;
@@ -45,10 +47,10 @@ public class CtContinueImpl extends CtStatementImpl implements CtContinue {
 	}
 
 	@Override
-	public <T extends CtLabelledFlowBreak> T setTargetLabel(String targetLabel) {
+	public CtContinueImpl setTargetLabel(String targetLabel) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TARGET_LABEL, targetLabel, this.targetLabel);
 		this.targetLabel = targetLabel;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtDoImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtDoImpl.java
@@ -16,12 +16,16 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtDo;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtDoImpl extends CtLoopImpl implements CtDo {
 	private static final long serialVersionUID = 1L;
@@ -40,13 +44,13 @@ public class CtDoImpl extends CtLoopImpl implements CtDo {
 	}
 
 	@Override
-	public <T extends CtDo> T setLoopingExpression(CtExpression<Boolean> expression) {
+	public CtDoImpl setLoopingExpression(CtExpression<Boolean> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
@@ -23,6 +24,9 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
+
+
+
 
 public class CtExecutableReferenceExpressionImpl<T, E extends CtExpression<?>> extends CtTargetedExpressionImpl<T, E> implements CtExecutableReferenceExpression<T, E> {
 	@MetamodelPropertyField(role = EXECUTABLE_REF)
@@ -39,13 +43,13 @@ public class CtExecutableReferenceExpressionImpl<T, E extends CtExpression<?>> e
 	}
 
 	@Override
-	public <C extends CtExecutableReferenceExpression<T, E>> C setExecutable(CtExecutableReference<T> executable) {
+	public CtExecutableReferenceExpressionImpl<T, E> setExecutable(CtExecutableReference<T> executable) {
 		if (executable != null) {
 			executable.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXECUTABLE_REF, executable, this.executable);
 		this.executable = executable;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
@@ -16,18 +16,20 @@
  */
 package spoon.support.reflect.code;
 
-import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.support.reflect.declaration.CtElementImpl;
 
 import java.util.ArrayList;
 import java.util.List;
+import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.reflect.declaration.CtElementImpl;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.CASTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.CAST;
 import static spoon.reflect.path.CtRole.TYPE;
+
+
+
 
 public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements CtExpression<T> {
 	private static final long serialVersionUID = 1L;
@@ -49,21 +51,21 @@ public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements C
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtExpressionImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExpression<T>> C setTypeCasts(List<CtTypeReference<?>> casts) {
+	public CtExpressionImpl<T> setTypeCasts(List<CtTypeReference<?>> casts) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CAST, this.typeCasts, new ArrayList<>(this.typeCasts));
 		if (casts == null || casts.isEmpty()) {
 			this.typeCasts = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.typeCasts == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.typeCasts = new ArrayList<>(CASTS_CONTAINER_DEFAULT_CAPACITY);
@@ -72,13 +74,13 @@ public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements C
 		for (CtTypeReference<?> cast : casts) {
 			addTypeCast(cast);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExpression<T>> C addTypeCast(CtTypeReference<?> type) {
+	public CtExpressionImpl<T> addTypeCast(CtTypeReference<?> type) {
 		if (type == null) {
-			return (C) this;
+			return this;
 		}
 		if (typeCasts == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			typeCasts = new ArrayList<>(CASTS_CONTAINER_DEFAULT_CAPACITY);
@@ -86,7 +88,7 @@ public abstract class CtExpressionImpl<T> extends CtCodeElementImpl implements C
 		type.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CAST, this.typeCasts, type);
 		typeCasts.add(type);
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -23,6 +24,9 @@ import spoon.reflect.code.CtTargetedExpression;
 import spoon.reflect.reference.CtFieldReference;
 
 import static spoon.reflect.path.CtRole.TARGET;
+
+
+
 
 public abstract class CtFieldAccessImpl<T> extends CtVariableAccessImpl<T> implements CtFieldAccess<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtFieldReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldReadImpl.java
@@ -16,8 +16,12 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtFieldReadImpl<T> extends CtFieldAccessImpl<T> implements CtFieldRead<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtFieldWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldWriteImpl.java
@@ -16,8 +16,12 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtFieldWriteImpl<T> extends CtFieldAccessImpl<T> implements CtFieldWrite<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtForEach;
@@ -24,6 +25,9 @@ import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.FOREACH_VARIABLE;
+
+
+
 
 public class CtForEachImpl extends CtLoopImpl implements CtForEach {
 	private static final long serialVersionUID = 1L;
@@ -50,23 +54,23 @@ public class CtForEachImpl extends CtLoopImpl implements CtForEach {
 	}
 
 	@Override
-	public <T extends CtForEach> T setExpression(CtExpression<?> expression) {
+	public CtForEachImpl setExpression(CtExpression<?> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtForEach> T setVariable(CtLocalVariable<?> variable) {
+	public CtForEachImpl setVariable(CtLocalVariable<?> variable) {
 		if (variable != null) {
 			variable.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, FOREACH_VARIABLE, variable, this.variable);
 		this.variable = variable;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -16,6 +16,9 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFor;
@@ -23,14 +26,14 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.FOR_INIT_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.ModelElementContainerDefaultCapacities.FOR_UPDATE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.FOR_INIT;
 import static spoon.reflect.path.CtRole.FOR_UPDATE;
+
+
+
 
 public class CtForImpl extends CtLoopImpl implements CtFor {
 	private static final long serialVersionUID = 1L;
@@ -55,13 +58,13 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 	}
 
 	@Override
-	public <T extends CtFor> T setExpression(CtExpression<Boolean> expression) {
+	public CtForImpl setExpression(CtExpression<Boolean> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -70,9 +73,9 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 	}
 
 	@Override
-	public <T extends CtFor> T addForInit(CtStatement statement) {
+	public CtForImpl addForInit(CtStatement statement) {
 		if (statement == null) {
-			return (T) this;
+			return this;
 		}
 		if (forInit == CtElementImpl.<CtStatement>emptyList()) {
 			forInit = new ArrayList<>(FOR_INIT_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
@@ -80,21 +83,21 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 		statement.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, FOR_INIT, this.forInit, statement);
 		forInit.add(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtFor> T setForInit(List<CtStatement> statements) {
+	public CtForImpl setForInit(List<CtStatement> statements) {
 		if (statements == null || statements.isEmpty()) {
 			this.forInit = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_INIT, this.forInit, new ArrayList<>(this.forInit));
 		this.forInit.clear();
 		for (CtStatement stmt : statements) {
 			addForInit(stmt);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -112,9 +115,9 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 	}
 
 	@Override
-	public <T extends CtFor> T addForUpdate(CtStatement statement) {
+	public CtForImpl addForUpdate(CtStatement statement) {
 		if (statement == null) {
-			return (T) this;
+			return this;
 		}
 		if (forUpdate == CtElementImpl.<CtStatement>emptyList()) {
 			forUpdate = new ArrayList<>(FOR_UPDATE_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
@@ -122,21 +125,21 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 		statement.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, FOR_UPDATE, this.forUpdate, statement);
 		forUpdate.add(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtFor> T setForUpdate(List<CtStatement> statements) {
+	public CtForImpl setForUpdate(List<CtStatement> statements) {
 		if (statements == null || statements.isEmpty()) {
 			this.forUpdate = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_UPDATE, this.forUpdate, new ArrayList<>(this.forUpdate));
 		this.forUpdate.clear();
 		for (CtStatement stmt : statements) {
 			addForUpdate(stmt);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtIfImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtIfImpl.java
@@ -16,8 +16,8 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
@@ -27,6 +27,9 @@ import spoon.reflect.visitor.CtVisitor;
 import static spoon.reflect.path.CtRole.CONDITION;
 import static spoon.reflect.path.CtRole.ELSE;
 import static spoon.reflect.path.CtRole.THEN;
+
+
+
 
 public class CtIfImpl extends CtStatementImpl implements CtIf {
 	private static final long serialVersionUID = 1L;
@@ -63,34 +66,34 @@ public class CtIfImpl extends CtStatementImpl implements CtIf {
 	}
 
 	@Override
-	public <T extends CtIf> T setCondition(CtExpression<Boolean> condition) {
+	public CtIfImpl setCondition(CtExpression<Boolean> condition) {
 		if (condition != null) {
 			condition.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CONDITION, condition, this.condition);
 		this.condition = condition;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtIf> T setElseStatement(CtStatement elseStatement) {
+	public CtIfImpl setElseStatement(CtStatement elseStatement) {
 		if (elseStatement != null) {
 			elseStatement.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ELSE, elseStatement, this.elseStatement);
 		this.elseStatement = elseStatement;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtIf> T setThenStatement(CtStatement thenStatement) {
+	public CtIfImpl setThenStatement(CtStatement thenStatement) {
 		// then branch might be null: `if (condition) ;`
 		if (thenStatement != null) {
 			thenStatement.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, THEN, thenStatement, this.thenStatement);
 		this.thenStatement = thenStatement;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -103,7 +106,7 @@ public class CtIfImpl extends CtStatementImpl implements CtIf {
 		return null;
 	}
 
-	public CtCodeElement getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtIfImpl getSubstitution(CtType<?> targetType) {
+		return ((CtIfImpl) (clone()));
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -16,27 +16,27 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.ARGUMENT;
 import static spoon.reflect.path.CtRole.EXECUTABLE_REF;
 import static spoon.reflect.path.CtRole.LABEL;
+
+
+
 
 public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtInvocation<T> {
 	private static final long serialVersionUID = 1L;
@@ -60,9 +60,9 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 		return arguments;
 	}
 
-	private <C extends CtAbstractInvocation<T>> C addArgument(int position, CtExpression<?> argument) {
+	private CtInvocationImpl<T> addArgument(int position, CtExpression<?> argument) {
 		if (argument == null) {
-			return (C) this;
+			return this;
 		}
 		if (arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			arguments = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -70,12 +70,12 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 		argument.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, ARGUMENT, this.arguments, position, argument);
 		arguments.add(position, argument);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C addArgument(CtExpression<?> argument) {
-		return addArgument(arguments.size(), argument);
+	public CtInvocationImpl<T> addArgument(CtExpression<?> argument) {
+		return ((CtInvocationImpl<T>) (addArgument(arguments.size(), argument)));
 	}
 
 	@Override
@@ -98,34 +98,34 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatement statement) {
+	public CtInvocationImpl<T> insertAfter(CtStatement statement) {
 		CtStatementImpl.insertAfter(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatement statement) {
+	public CtInvocationImpl<T> insertBefore(CtStatement statement) {
 		CtStatementImpl.insertBefore(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatementList statements) {
+	public CtInvocationImpl<T> insertAfter(CtStatementList statements) {
 		CtStatementImpl.insertAfter(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatementList statements) {
+	public CtInvocationImpl<T> insertBefore(CtStatementList statements) {
 		CtStatementImpl.insertBefore(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C setArguments(List<CtExpression<?>> arguments) {
+	public CtInvocationImpl<T> setArguments(List<CtExpression<?>> arguments) {
 		if (arguments == null || arguments.isEmpty()) {
 			this.arguments = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			this.arguments = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -135,17 +135,17 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 		for (CtExpression<?> expr : arguments) {
 			addArgument(expr);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtAbstractInvocation<T>> C setExecutable(CtExecutableReference<T> executable) {
+	public CtInvocationImpl<T> setExecutable(CtExecutableReference<T> executable) {
 		if (executable != null) {
 			executable.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXECUTABLE_REF, executable, this.executable);
 		this.executable = executable;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -154,10 +154,10 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 	}
 
 	@Override
-	public <C extends CtStatement> C setLabel(String label) {
+	public CtInvocationImpl<T> setLabel(String label) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, LABEL, label, this.label);
 		this.label = label;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -168,14 +168,14 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 
 	@Override
 	@DerivedProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtInvocationImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		if (getExecutable() != null) {
 			getExecutable().setType(type);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -184,19 +184,19 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 	}
 
 	@Override
-	public <T extends CtActualTypeContainer> T setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
+	public CtInvocationImpl<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
 		if (getExecutable() != null) {
 			getExecutable().setActualTypeArguments(actualTypeArguments);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtActualTypeContainer> T addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+	public CtInvocationImpl<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
 		if (getExecutable() != null) {
 			getExecutable().addActualTypeArgument(actualTypeArgument);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
@@ -16,7 +16,10 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
 import spoon.reflect.declaration.CtElement;
@@ -24,7 +27,10 @@ import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.util.ModelList;
 
-import java.util.List;
+import static spoon.reflect.code.CtComment.CommentType.JAVADOC;
+
+
+
 
 public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 
@@ -54,33 +60,33 @@ public class CtJavaDocImpl extends CtCommentImpl implements CtJavaDoc {
 	}
 
 	@Override
-	public <E extends CtJavaDoc> E setTags(List<CtJavaDocTag> tags) {
+	public CtJavaDocImpl setTags(List<CtJavaDocTag> tags) {
 		this.tags.set(tags);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtJavaDoc> E addTag(CtJavaDocTag tag) {
+	public CtJavaDocImpl addTag(CtJavaDocTag tag) {
 		this.tags.add(tag);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtJavaDoc> E addTag(int index, CtJavaDocTag tag) {
+	public CtJavaDocImpl addTag(int index, CtJavaDocTag tag) {
 		this.tags.add(index, tag);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtJavaDoc> E removeTag(int index) {
+	public CtJavaDocImpl removeTag(int index) {
 		this.tags.remove(index);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtJavaDoc> E removeTag(CtJavaDocTag tag) {
+	public CtJavaDocImpl removeTag(CtJavaDocTag tag) {
 		this.tags.remove(tag);
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
@@ -16,14 +16,19 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtJavaDocTag;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
+import static spoon.reflect.code.CtJavaDocTag.TagType.tagFromName;
 import static spoon.reflect.path.CtRole.COMMENT_CONTENT;
-import static spoon.reflect.path.CtRole.JAVADOC_TAG_VALUE;
 import static spoon.reflect.path.CtRole.DOCUMENTATION_TYPE;
+import static spoon.reflect.path.CtRole.JAVADOC_TAG_VALUE;
+
+
+
 
 public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 
@@ -40,16 +45,16 @@ public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 	}
 
 	@Override
-	public <E extends CtJavaDocTag> E setType(String type) {
+	public CtJavaDocTagImpl setType(String type) {
 		this.setType(CtJavaDocTag.TagType.tagFromName(type));
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtJavaDocTag> E setType(TagType type) {
+	public CtJavaDocTagImpl setType(TagType type) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DOCUMENTATION_TYPE, type, this.type);
 		this.type = type;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -58,10 +63,10 @@ public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 	}
 
 	@Override
-	public <E extends CtJavaDocTag> E setContent(String content) {
+	public CtJavaDocTagImpl setContent(String content) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, COMMENT_CONTENT, content, this.content);
 		this.content = content;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -70,10 +75,10 @@ public class CtJavaDocTagImpl extends CtElementImpl implements CtJavaDocTag {
 	}
 
 	@Override
-	public <E extends CtJavaDocTag> E setParam(String param) {
+	public CtJavaDocTagImpl setParam(String param) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, JAVADOC_TAG_VALUE, param, this.param);
 		this.param = param;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -16,19 +16,22 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.MethodFactory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -37,16 +40,15 @@ import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.visitor.SignaturePrinter;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.NAME;
 import static spoon.reflect.path.CtRole.PARAMETER;
 import static spoon.reflect.path.CtRole.THROWN;
+
+
+
 
 public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> {
 	@MetamodelPropertyField(role = NAME)
@@ -71,10 +73,10 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	}
 
 	@Override
-	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
+	public CtLambdaImpl<T> setSimpleName(String simpleName) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simpleName, this.simpleName);
 		this.simpleName = simpleName;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -84,7 +86,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	}
 
 	@Override
-	public <C extends CtBodyHolder> C setBody(CtStatement statement) {
+	public CtLambdaImpl<T> setBody(CtStatement statement) {
 		if (statement != null) {
 			CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, body, this.body);
@@ -100,7 +102,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 			this.body = null;
 		}
 
-		return (C) this;
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -147,10 +149,10 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	}
 
 	@Override
-	public <C extends CtExecutable<T>> C setParameters(List<CtParameter<?>> params) {
+	public CtLambdaImpl<T> setParameters(List<CtParameter<?>> params) {
 		if (params == null || params.isEmpty()) {
 			this.parameters = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.parameters == CtElementImpl.<CtParameter<?>>emptyList()) {
 			this.parameters = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -160,13 +162,13 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		for (CtParameter<?> p : params) {
 			addParameter(p);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExecutable<T>> C addParameter(CtParameter<?> parameter) {
+	public CtLambdaImpl<T> addParameter(CtParameter<?> parameter) {
 		if (parameter == null) {
-			return (C) this;
+			return this;
 		}
 		if (parameters == CtElementImpl.<CtParameter<?>>emptyList()) {
 			parameters = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -174,7 +176,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		parameter.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, PARAMETER, this.parameters, parameter);
 		parameters.add(parameter);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -193,14 +195,14 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtExecutable<T>> C setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
-		return (C) this;
+	public CtLambdaImpl<T> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
+		return this;
 	}
 
 	@Override
-	public <C extends CtExecutable<T>> C addThrownType(CtTypeReference<? extends Throwable> throwType) {
+	public CtLambdaImpl<T> addThrownType(CtTypeReference<? extends Throwable> throwType) {
 		if (throwType == null) {
-			return (C) this;
+			return this;
 		}
 		if (thrownTypes == CtElementImpl.<CtTypeReference<? extends Throwable>>emptySet()) {
 			thrownTypes = new QualifiedNameBasedSortedSet<>();
@@ -208,7 +210,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		throwType.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, THROWN, this.thrownTypes, throwType);
 		thrownTypes.add(throwType);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -238,7 +240,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	}
 
 	@Override
-	public <C extends CtLambda<T>> C setExpression(CtExpression<T> expression) {
+	public CtLambdaImpl<T> setExpression(CtExpression<T> expression) {
 		if (body != null && expression != null) {
 			throw new SpoonException("A lambda can't have two bodies.");
 		} else {
@@ -248,7 +250,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 			this.expression = expression;
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
@@ -16,13 +16,15 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtVisitor;
 
-import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
 
 public class CtLiteralImpl<T extends Object> extends CtExpressionImpl<T> implements CtLiteral<T> {
 	private static final long serialVersionUID = 1L;
@@ -41,13 +43,13 @@ public class CtLiteralImpl<T extends Object> extends CtExpressionImpl<T> impleme
 	}
 
 	@Override
-	public <C extends CtLiteral<T>> C setValue(T value) {
+	public CtLiteralImpl<T> setValue(T value) {
 		if (this.value instanceof CtElement) {
 			((CtElement) this.value).setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, value, this.value);
 		this.value = value;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
@@ -16,14 +16,11 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtRHSReceiver;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtLocalVariableReference;
@@ -34,7 +31,8 @@ import spoon.support.UnsettableProperty;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 
-import java.util.Set;
+
+
 
 public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVariable<T> {
 	private static final long serialVersionUID = 1L;
@@ -80,30 +78,30 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 	}
 
 	@Override
-	public <C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> defaultExpression) {
+	public CtLocalVariableImpl<T> setDefaultExpression(CtExpression<T> defaultExpression) {
 		if (defaultExpression != null) {
 			defaultExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
 		this.defaultExpression = defaultExpression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
+	public CtLocalVariableImpl<T> setSimpleName(String simpleName) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.NAME, simpleName, this.name);
 		this.name = simpleName;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtLocalVariableImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -117,27 +115,27 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtLocalVariableImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtLocalVariableImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtLocalVariableImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtLocalVariableImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -160,9 +158,9 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 	}
 
 	@Override
-	public <T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtLocalVariableImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -173,9 +171,9 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtRHSReceiver<T>> C setAssignment(CtExpression<T> assignment) {
+	public CtLocalVariableImpl<T> setAssignment(CtExpression<T> assignment) {
 		setDefaultExpression(assignment);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -184,10 +182,10 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 	}
 
 	@Override
-	public <U extends CtLocalVariable<T>> U setInferred(boolean inferred) {
+	public CtLocalVariableImpl<T> setInferred(boolean inferred) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_INFERRED, inferred, this.inferred);
 		this.inferred = inferred;
-		return (U) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -16,15 +16,17 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
-import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtType;
 
 import static spoon.reflect.path.CtRole.BODY;
+
+
+
 
 public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 	private static final long serialVersionUID = 1L;
@@ -39,7 +41,7 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+	public CtLoopImpl setBody(CtStatement statement) {
 		if (statement != null) {
 			CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, body, this.body);
@@ -51,7 +53,7 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 			getFactory().getEnvironment().getModelChangeListener().onObjectDelete(this, BODY, this.body);
 			this.body = null;
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -64,7 +66,7 @@ public abstract class CtLoopImpl extends CtStatementImpl implements CtLoop {
 		return null;
 	}
 
-	public CtCodeElement getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtLoopImpl getSubstitution(CtType<?> targetType) {
+		return ((CtLoopImpl) (clone()));
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
@@ -16,18 +16,21 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.NEW_ARRAY_DEFAULT_EXPRESSIONS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.DIMENSION;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray<T> {
 	private static final long serialVersionUID = 1L;
@@ -54,23 +57,23 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray
 	}
 
 	@Override
-	public <C extends CtNewArray<T>> C setDimensionExpressions(List<CtExpression<Integer>> dimensionExpressions) {
+	public CtNewArrayImpl<T> setDimensionExpressions(List<CtExpression<Integer>> dimensionExpressions) {
 		if (dimensionExpressions == null || dimensionExpressions.isEmpty()) {
 			this.dimensionExpressions = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, DIMENSION, this.dimensionExpressions, new ArrayList<>(this.dimensionExpressions));
 		this.dimensionExpressions.clear();
 		for (CtExpression<Integer> expr : dimensionExpressions) {
 			addDimensionExpression(expr);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtNewArray<T>> C addDimensionExpression(CtExpression<Integer> dimension) {
+	public CtNewArrayImpl<T> addDimensionExpression(CtExpression<Integer> dimension) {
 		if (dimension == null) {
-			return (C) this;
+			return this;
 		}
 		if (dimensionExpressions == CtElementImpl.<CtExpression<Integer>>emptyList()) {
 			dimensionExpressions = new ArrayList<>(NEW_ARRAY_DEFAULT_EXPRESSIONS_CONTAINER_DEFAULT_CAPACITY);
@@ -78,7 +81,7 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray
 		dimension.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, DIMENSION, this.dimensionExpressions, dimension);
 		dimensionExpressions.add(dimension);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -91,23 +94,23 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray
 	}
 
 	@Override
-	public <C extends CtNewArray<T>> C setElements(List<CtExpression<?>> expressions) {
+	public CtNewArrayImpl<T> setElements(List<CtExpression<?>> expressions) {
 		if (expressions == null || expressions.isEmpty()) {
 			this.expressions = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, EXPRESSION, this.expressions, new ArrayList<>(this.expressions));
 		this.expressions.clear();
 		for (CtExpression<?> expr : expressions) {
 			addElement(expr);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtNewArray<T>> C addElement(CtExpression<?> expression) {
+	public CtNewArrayImpl<T> addElement(CtExpression<?> expression) {
 		if (expression == null) {
-			return (C) this;
+			return this;
 		}
 		if (expressions == CtElementImpl.<CtExpression<?>>emptyList()) {
 			this.expressions = new ArrayList<>();
@@ -115,7 +118,7 @@ public class CtNewArrayImpl<T> extends CtExpressionImpl<T> implements CtNewArray
 		expression.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, EXPRESSION, this.expressions, expression);
 		expressions.add(expression);
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
@@ -16,12 +16,16 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.NESTED_TYPE;
+
+
+
 
 public class CtNewClassImpl<T> extends CtConstructorCallImpl<T> implements CtNewClass<T> {
 	private static final long serialVersionUID = 1L;
@@ -40,13 +44,13 @@ public class CtNewClassImpl<T> extends CtConstructorCallImpl<T> implements CtNew
 	}
 
 	@Override
-	public <N extends CtNewClass> N setAnonymousClass(CtClass<?> anonymousClass) {
+	public CtNewClassImpl<T> setAnonymousClass(CtClass<?> anonymousClass) {
 		if (anonymousClass != null) {
 			anonymousClass.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NESTED_TYPE, anonymousClass, this.anonymousClass);
 		this.anonymousClass = anonymousClass;
-		return (N) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
@@ -16,12 +16,16 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
+
+
+
 
 public class CtOperatorAssignmentImpl<T, A extends T> extends CtAssignmentImpl<T, A> implements CtOperatorAssignment<T, A> {
 	private static final long serialVersionUID = 1L;
@@ -40,10 +44,10 @@ public class CtOperatorAssignmentImpl<T, A extends T> extends CtAssignmentImpl<T
 	}
 
 	@Override
-	public <C extends CtOperatorAssignment<T, A>> C setKind(BinaryOperatorKind kind) {
+	public CtOperatorAssignmentImpl<T, A> setKind(BinaryOperatorKind kind) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, OPERATOR_KIND, kind, this.kind);
 		this.kind = kind;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
@@ -16,14 +16,17 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtReturnImpl<R> extends CtStatementImpl implements CtReturn<R> {
 	private static final long serialVersionUID = 1L;
@@ -42,13 +45,13 @@ public class CtReturnImpl<R> extends CtStatementImpl implements CtReturn<R> {
 	}
 
 	@Override
-	public <T extends CtReturn<R>> T setReturnedExpression(CtExpression<R> expression) {
+	public CtReturnImpl<R> setReturnedExpression(CtExpression<R> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.returnedExpression);
 		this.returnedExpression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -61,7 +64,7 @@ public class CtReturnImpl<R> extends CtStatementImpl implements CtReturn<R> {
 		return null;
 	}
 
-	public CtCodeElement getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtReturnImpl<R> getSubstitution(CtType<?> targetType) {
+		return ((CtReturnImpl<R>) (clone()));
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -16,6 +16,9 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
@@ -33,10 +36,10 @@ import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.LABEL;
+
+
+
 
 public abstract class CtStatementImpl extends CtCodeElementImpl implements CtStatement {
 	private static final long serialVersionUID = 1L;
@@ -254,27 +257,27 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 	}
 
 	@Override
-	public <T extends CtStatement> T insertBefore(CtStatement statement) throws ParentNotInitializedException {
+	public CtStatementImpl insertBefore(CtStatement statement) throws ParentNotInitializedException {
 		insertBefore(this, statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatement> T insertBefore(CtStatementList statements) throws ParentNotInitializedException {
+	public CtStatementImpl insertBefore(CtStatementList statements) throws ParentNotInitializedException {
 		insertBefore(this, statements);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatement> T insertAfter(CtStatement statement) throws ParentNotInitializedException {
+	public CtStatementImpl insertAfter(CtStatement statement) throws ParentNotInitializedException {
 		insertAfter(this, statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatement> T insertAfter(CtStatementList statements) throws ParentNotInitializedException {
+	public CtStatementImpl insertAfter(CtStatementList statements) throws ParentNotInitializedException {
 		insertAfter(this, statements);
-		return (T) this;
+		return this;
 	}
 
 	@MetamodelPropertyField(role = LABEL)
@@ -286,10 +289,10 @@ public abstract class CtStatementImpl extends CtCodeElementImpl implements CtSta
 	}
 
 	@Override
-	public <T extends CtStatement> T setLabel(String label) {
+	public CtStatementImpl setLabel(String label) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, LABEL, label, this.label);
 		this.label = label;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -16,23 +16,25 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.cu.SourcePosition;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.Query;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.STATEMENT;
+
+
+
 
 public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtStatementList {
 	private static final long serialVersionUID = 1L;
@@ -51,28 +53,28 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 	}
 
 	@Override
-	public <T extends CtStatementList> T setStatements(List<CtStatement> stmts) {
+	public CtStatementListImpl<R> setStatements(List<CtStatement> stmts) {
 		if (stmts == null || stmts.isEmpty()) {
 			this.statements = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, STATEMENT, this.statements, new ArrayList<>(this.statements));
 		this.statements.clear();
 		for (CtStatement stmt : stmts) {
 			addStatement(stmt);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(CtStatement statement) {
-		return this.addStatement(this.statements.size(), statement);
+	public CtStatementListImpl<R> addStatement(CtStatement statement) {
+		return ((CtStatementListImpl<R>) (this.addStatement(this.statements.size(), statement)));
 	}
 
 	@Override
-	public <T extends CtStatementList> T addStatement(int index, CtStatement statement) {
+	public CtStatementListImpl<R> addStatement(int index, CtStatement statement) {
 		if (statement == null) {
-			return (T) this;
+			return this;
 		}
 		if (this.statements == CtElementImpl.<CtStatement>emptyList()) {
 			this.statements = new ArrayList<>(BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY);
@@ -80,7 +82,7 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 		statement.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, STATEMENT, this.statements, index, statement);
 		this.statements.add(index, statement);
-		return (T) this;
+		return this;
 	}
 
 	private void ensureModifiableStatementsList() {
@@ -90,7 +92,7 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatementList statements) {
+	public CtStatementListImpl<R> insertBegin(CtStatementList statements) {
 		ensureModifiableStatementsList();
 		for (CtStatement statement : statements.getStatements()) {
 			statement.setParent(this);
@@ -99,11 +101,11 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBegin(CtStatement statement) {
+	public CtStatementListImpl<R> insertBegin(CtStatement statement) {
 		ensureModifiableStatementsList();
 		statement.setParent(this);
 		this.addStatement(0, statement);
@@ -111,18 +113,18 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatement statement) {
+	public CtStatementListImpl<R> insertEnd(CtStatement statement) {
 		ensureModifiableStatementsList();
 		addStatement(statement);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertEnd(CtStatementList statements) {
+	public CtStatementListImpl<R> insertEnd(CtStatementList statements) {
 		List<CtStatement> tobeInserted = new ArrayList<>(statements.getStatements());
 		//remove statements from the `statementsToBeInserted` before they are added to spoon model
 		//note: one element MUST NOT be part of two models.
@@ -130,39 +132,39 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 		for (CtStatement s : tobeInserted) {
 			insertEnd(s);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtStatementListImpl<R> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtStatementListImpl<R> insertAfter(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertAfter(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
+	public CtStatementListImpl<R> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatement statement) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtStatementList> T insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
+	public CtStatementListImpl<R> insertBefore(Filter<? extends CtStatement> insertionPoints, CtStatementList statements) {
 		for (CtStatement e : Query.getElements(this, insertionPoints)) {
 			e.insertBefore(statements);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -185,11 +187,11 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 	}
 
 	@Override
-	public <E extends CtElement> E setPosition(SourcePosition position) {
+	public CtStatementListImpl<R> setPosition(SourcePosition position) {
 		for (CtStatement s : statements) {
 			s.setPosition(position);
 		}
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -202,7 +204,7 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 		return (CtStatementList) super.clone();
 	}
 
-	public CtStatementList getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtStatementListImpl<R> getSubstitution(CtType<?> targetType) {
+		return ((CtStatementListImpl<R>) (clone()));
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtSuperAccess;
@@ -23,6 +24,9 @@ import spoon.reflect.code.CtTargetedExpression;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.TARGET;
+
+
+
 
 public class CtSuperAccessImpl<T> extends CtVariableReadImpl<T> implements CtSuperAccess<T> {
 

--- a/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
@@ -16,6 +16,9 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
@@ -23,12 +26,12 @@ import spoon.reflect.code.CtSwitch;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.SWITCH_CASES_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.CASE;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 	private static final long serialVersionUID = 1L;
@@ -55,33 +58,33 @@ public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 	}
 
 	@Override
-	public <T extends CtSwitch<S>> T setCases(List<CtCase<? super S>> cases) {
+	public CtSwitchImpl<S> setCases(List<CtCase<? super S>> cases) {
 		if (cases == null || cases.isEmpty()) {
 			this.cases = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CASE, this.cases, new ArrayList<>(this.cases));
 		this.cases.clear();
 		for (CtCase<? super S> aCase : cases) {
 			addCase(aCase);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtSwitch<S>> T setSelector(CtExpression<S> selector) {
+	public CtSwitchImpl<S> setSelector(CtExpression<S> selector) {
 		if (selector != null) {
 			selector.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, selector, this.expression);
 		this.expression = selector;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtSwitch<S>> T addCase(CtCase<? super S> c) {
+	public CtSwitchImpl<S> addCase(CtCase<? super S> c) {
 		if (c == null) {
-			return (T) this;
+			return this;
 		}
 		if (cases == CtElementImpl.<CtCase<? super S>>emptyList()) {
 			cases = new ArrayList<>(SWITCH_CASES_CONTAINER_DEFAULT_CAPACITY);
@@ -89,7 +92,7 @@ public class CtSwitchImpl<S> extends CtStatementImpl implements CtSwitch<S> {
 		c.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CASE, this.cases, c);
 		cases.add(c);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
@@ -24,6 +25,9 @@ import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtSynchronizedImpl extends CtStatementImpl implements CtSynchronized {
 	private static final long serialVersionUID = 1L;
@@ -50,23 +54,23 @@ public class CtSynchronizedImpl extends CtStatementImpl implements CtSynchronize
 	}
 
 	@Override
-	public <T extends CtSynchronized> T setBlock(CtBlock<?> block) {
+	public CtSynchronizedImpl setBlock(CtBlock<?> block) {
 		if (block != null) {
 			block.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, block, this.block);
 		this.block = block;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtSynchronized> T setExpression(CtExpression<?> expression) {
+	public CtSynchronizedImpl setExpression(CtExpression<?> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
@@ -16,11 +16,15 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtTargetedExpression;
 
 import static spoon.reflect.path.CtRole.TARGET;
+
+
+
 
 public abstract class CtTargetedExpressionImpl<E, T extends CtExpression<?>> extends CtExpressionImpl<E> implements CtTargetedExpression<E, T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtThisAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtThisAccessImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtThisAccessImpl<T> extends CtTargetedExpressionImpl<T, CtExpression<?>> implements CtThisAccess<T> {
 

--- a/src/main/java/spoon/support/reflect/code/CtThrowImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtThrowImpl.java
@@ -16,14 +16,17 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtThrow;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtThrowImpl extends CtStatementImpl implements CtThrow {
 	private static final long serialVersionUID = 1L;
@@ -42,13 +45,13 @@ public class CtThrowImpl extends CtStatementImpl implements CtThrow {
 	}
 
 	@Override
-	public <T extends CtThrow> T setThrownExpression(CtExpression<? extends Throwable> expression) {
+	public CtThrowImpl setThrownExpression(CtExpression<? extends Throwable> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.throwExpression);
 		this.throwExpression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -61,8 +64,8 @@ public class CtThrowImpl extends CtStatementImpl implements CtThrow {
 		return null;
 	}
 
-	public CtCodeElement getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtThrowImpl getSubstitution(CtType<?> targetType) {
+		return ((CtThrowImpl) (clone()));
 	}
 
 }

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -16,24 +16,25 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtCatch;
-import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.CATCH_CASES_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.CATCH;
 import static spoon.reflect.path.CtRole.FINALIZER;
+
+
+
 
 public class CtTryImpl extends CtStatementImpl implements CtTry {
 	private static final long serialVersionUID = 1L;
@@ -58,23 +59,23 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	@Override
-	public <T extends CtTry> T setCatchers(List<CtCatch> catchers) {
+	public CtTryImpl setCatchers(List<CtCatch> catchers) {
 		if (catchers == null || catchers.isEmpty()) {
 			this.catchers = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CATCH, this.catchers, new ArrayList<>(this.catchers));
 		this.catchers.clear();
 		for (CtCatch c : catchers) {
 			addCatcher(c);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtTry> T addCatcher(CtCatch catcher) {
+	public CtTryImpl addCatcher(CtCatch catcher) {
 		if (catcher == null) {
-			return (T) this;
+			return this;
 		}
 		if (catchers == CtElementImpl.<CtCatch>emptyList()) {
 			catchers = new ArrayList<>(CATCH_CASES_CONTAINER_DEFAULT_CAPACITY);
@@ -82,7 +83,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 		catcher.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CATCH, this.catchers, catcher);
 		catchers.add(catcher);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -100,13 +101,13 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	@Override
-	public <T extends CtTry> T setFinalizer(CtBlock<?> finalizer) {
+	public CtTryImpl setFinalizer(CtBlock<?> finalizer) {
 		if (finalizer != null) {
 			finalizer.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, FINALIZER, finalizer, this.finalizer);
 		this.finalizer = finalizer;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -115,7 +116,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	@Override
-	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+	public CtTryImpl setBody(CtStatement statement) {
 		if (statement != null) {
 			CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, body, this.body);
@@ -128,7 +129,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 			this.body = null;
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -141,8 +142,8 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 		return null;
 	}
 
-	public CtCodeElement getSubstitution(CtType<?> targetType) {
-		return clone();
+	public CtTryImpl getSubstitution(CtType<?> targetType) {
+		return ((CtTryImpl) (clone()));
 	}
 
 }

--- a/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
@@ -16,17 +16,20 @@
  */
 package spoon.support.reflect.code;
 
+
+import java.util.ArrayList;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.RESOURCES_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.TRY_RESOURCE;
+
+
+
 
 public class CtTryWithResourceImpl extends CtTryImpl implements CtTryWithResource {
 	private static final long serialVersionUID = 1L;
@@ -45,23 +48,23 @@ public class CtTryWithResourceImpl extends CtTryImpl implements CtTryWithResourc
 	}
 
 	@Override
-	public <T extends CtTryWithResource> T setResources(List<CtLocalVariable<?>> resources) {
+	public CtTryWithResourceImpl setResources(List<CtLocalVariable<?>> resources) {
 		if (resources == null || resources.isEmpty()) {
 			this.resources = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, TRY_RESOURCE, this.resources, new ArrayList<>(this.resources));
 		this.resources.clear();
 		for (CtLocalVariable<?> l : resources) {
 			addResource(l);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtTryWithResource> T addResource(CtLocalVariable<?> resource) {
+	public CtTryWithResourceImpl addResource(CtLocalVariable<?> resource) {
 		if (resource == null) {
-			return (T) this;
+			return this;
 		}
 		if (resources == CtElementImpl.<CtLocalVariable<?>>emptyList()) {
 			resources = new ArrayList<>(RESOURCES_CONTAINER_DEFAULT_CAPACITY);
@@ -69,7 +72,7 @@ public class CtTryWithResourceImpl extends CtTryImpl implements CtTryWithResourc
 		resource.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TRY_RESOURCE, this.resources, resource);
 		resources.add(resource);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -16,14 +16,18 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.declaration.CtTypedElement;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.ACCESSED_TYPE;
+
+
+
 
 public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTypeAccess<A> {
 
@@ -41,13 +45,13 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 	}
 
 	@Override
-	public <C extends CtTypeAccess<A>> C setAccessedType(CtTypeReference<A> accessedType) {
+	public CtTypeAccessImpl<A> setAccessedType(CtTypeReference<A> accessedType) {
 		if (accessedType != null) {
 			accessedType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, ACCESSED_TYPE, accessedType, this.type);
 		type = accessedType;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -57,9 +61,9 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<Void> type) {
+	public CtTypeAccessImpl<A> setType(CtTypeReference<Void> type) {
 		// type is used in setAccessedType now.
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
@@ -27,6 +28,9 @@ import spoon.reflect.visitor.CtVisitor;
 import static spoon.reflect.path.CtRole.EXPRESSION;
 import static spoon.reflect.path.CtRole.LABEL;
 import static spoon.reflect.path.CtRole.OPERATOR_KIND;
+
+
+
 
 public class CtUnaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtUnaryOperator<T> {
 	private static final long serialVersionUID = 1L;
@@ -61,51 +65,51 @@ public class CtUnaryOperatorImpl<T> extends CtExpressionImpl<T> implements CtUna
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatement statement) {
+	public CtUnaryOperatorImpl<T> insertAfter(CtStatement statement) {
 		CtStatementImpl.insertAfter(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatement statement) {
+	public CtUnaryOperatorImpl<T> insertBefore(CtStatement statement) {
 		CtStatementImpl.insertBefore(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatementList statements) {
+	public CtUnaryOperatorImpl<T> insertAfter(CtStatementList statements) {
 		CtStatementImpl.insertAfter(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatementList statements) {
+	public CtUnaryOperatorImpl<T> insertBefore(CtStatementList statements) {
 		CtStatementImpl.insertBefore(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtUnaryOperator> C setOperand(CtExpression<T> expression) {
+	public CtUnaryOperatorImpl<T> setOperand(CtExpression<T> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.operand);
 		this.operand = expression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtUnaryOperator> C setKind(UnaryOperatorKind kind) {
+	public CtUnaryOperatorImpl<T> setKind(UnaryOperatorKind kind) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, OPERATOR_KIND, kind, this.kind);
 		this.kind = kind;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C setLabel(String label) {
+	public CtUnaryOperatorImpl<T> setLabel(String label) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, LABEL, label, this.label);
 		this.label = label;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
@@ -16,14 +16,17 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtVariableAccess;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.DerivedProperty;
 
 import static spoon.reflect.path.CtRole.VARIABLE;
+
+
+
 
 public abstract class CtVariableAccessImpl<T> extends CtExpressionImpl<T> implements CtVariableAccess<T> {
 	private static final long serialVersionUID = 1L;
@@ -41,13 +44,13 @@ public abstract class CtVariableAccessImpl<T> extends CtExpressionImpl<T> implem
 	}
 
 	@Override
-	public <C extends CtVariableAccess<T>> C setVariable(CtVariableReference<T> variable) {
+	public CtVariableAccessImpl<T> setVariable(CtVariableReference<T> variable) {
 		if (variable != null) {
 			variable.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, VARIABLE, variable, this.variable);
 		this.variable = variable;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -58,14 +61,14 @@ public abstract class CtVariableAccessImpl<T> extends CtExpressionImpl<T> implem
 
 	@Override
 	@DerivedProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtVariableAccessImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		if (type != null) {
 			getVariable().setType(type);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtVariableReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableReadImpl.java
@@ -16,8 +16,12 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtVariableReadImpl<T> extends CtVariableAccessImpl<T> implements CtVariableRead<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtVariableWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableWriteImpl.java
@@ -16,8 +16,12 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtVariableWriteImpl<T> extends CtVariableAccessImpl<T> implements CtVariableWrite<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
@@ -16,12 +16,16 @@
  */
 package spoon.support.reflect.code;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
+
+
+
 
 public class CtWhileImpl extends CtLoopImpl implements CtWhile {
 	private static final long serialVersionUID = 1L;
@@ -40,13 +44,13 @@ public class CtWhileImpl extends CtLoopImpl implements CtWhile {
 	}
 
 	@Override
-	public <T extends CtWhile> T setLoopingExpression(CtExpression<Boolean> expression) {
+	public CtWhileImpl setLoopingExpression(CtExpression<Boolean> expression) {
 		if (expression != null) {
 			expression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, expression, this.expression);
 		this.expression = expression;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -16,35 +16,6 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.Launcher;
-import spoon.SpoonException;
-import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtCodeElement;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtFieldAccess;
-import spoon.reflect.code.CtFieldRead;
-import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtNewArray;
-import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.declaration.CtAnnotatedElementType;
-import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtAnnotationMethod;
-import spoon.reflect.declaration.CtAnnotationType;
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtShadowable;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.eval.PartialEvaluator;
-import spoon.reflect.path.CtRole;
-import spoon.reflect.reference.CtArrayTypeReference;
-import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.DerivedProperty;
-import spoon.support.UnsettableProperty;
-import spoon.support.comparator.CtLineElementComparator;
-import spoon.support.reflect.code.CtExpressionImpl;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
@@ -62,6 +33,37 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import spoon.Launcher;
+import spoon.SpoonException;
+import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.code.CtCodeElement;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtNewArray;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtAnnotatedElementType;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtAnnotationMethod;
+import spoon.reflect.declaration.CtAnnotationType;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.eval.PartialEvaluator;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtArrayTypeReference;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+import spoon.support.comparator.CtLineElementComparator;
+import spoon.support.reflect.code.CtExpressionImpl;
+
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotation}.
@@ -101,11 +103,11 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T addValue(String elementName, Object value) {
+	public CtAnnotationImpl<A> addValue(String elementName, Object value) {
 		if (value instanceof CtExpression) {
-			return addValueExpression(elementName, (CtExpression<?>) value);
+			return ((CtAnnotationImpl<A>) (addValueExpression(elementName, ((CtExpression<?>) (value)))));
 		}
-		return this.addValueExpression(elementName, convertValueToExpression(value));
+		return ((CtAnnotationImpl<A>) (this.addValueExpression(elementName, convertValueToExpression(value))));
 	}
 
 	private CtExpression convertValueToExpression(Object value) {
@@ -162,7 +164,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 		return c.isPrimitive() || c == Byte.class || c == Short.class || c == Integer.class || c == Long.class || c == Float.class || c == Double.class || c == Boolean.class || c == Character.class;
 	}
 
-	private <T extends CtAnnotation<A>> T addValueExpression(String elementName, CtExpression<?> expression) {
+	private CtAnnotationImpl<A> addValueExpression(String elementName, CtExpression<?> expression) {
 		if (elementValues.containsKey(elementName)) {
 			// Update value of the existing one.
 			final CtExpression ctExpression = elementValues.get(elementName);
@@ -191,27 +193,27 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 			getFactory().getEnvironment().getModelChangeListener().onMapAdd(this, CtRole.VALUE, this.elementValues, elementName, expression);
 			elementValues.put(elementName, expression);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T addValue(String elementName, CtLiteral<?> value) {
-		return addValueExpression(elementName, value);
+	public CtAnnotationImpl<A> addValue(String elementName, CtLiteral<?> value) {
+		return ((CtAnnotationImpl<A>) (addValueExpression(elementName, value)));
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T addValue(String elementName, CtNewArray<? extends CtExpression> value) {
-		return addValueExpression(elementName, value);
+	public CtAnnotationImpl<A> addValue(String elementName, CtNewArray<? extends CtExpression> value) {
+		return ((CtAnnotationImpl<A>) (addValueExpression(elementName, value)));
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T addValue(String elementName, CtFieldAccess<?> value) {
-		return addValueExpression(elementName, value);
+	public CtAnnotationImpl<A> addValue(String elementName, CtFieldAccess<?> value) {
+		return ((CtAnnotationImpl<A>) (addValueExpression(elementName, value)));
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T addValue(String elementName, CtAnnotation<?> value) {
-		return addValueExpression(elementName, value);
+	public CtAnnotationImpl<A> addValue(String elementName, CtAnnotation<?> value) {
+		return ((CtAnnotationImpl<A>) (addValueExpression(elementName, value)));
 	}
 
 	/**
@@ -306,8 +308,8 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T extends CtExpression> T getValue(String key) {
-		return (T) getValueAsExpression(key);
+	public CtAnnotationImpl<A> getValue(String key) {
+		return ((CtAnnotationImpl<A>) (getValueAsExpression(key)));
 	}
 
 	@Override
@@ -456,38 +458,38 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public <T extends CtAnnotation<A>> T setAnnotationType(CtTypeReference<? extends Annotation> annotationType) {
+	public CtAnnotationImpl<A> setAnnotationType(CtTypeReference<? extends Annotation> annotationType) {
 		if (annotationType != null) {
 			annotationType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, annotationType, this.annotationType);
 		this.annotationType = (CtTypeReference<A>) annotationType;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T setElementValues(Map<String, Object> values) {
+	public CtAnnotationImpl<A> setElementValues(Map<String, Object> values) {
 		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, CtRole.VALUE, this.elementValues, new HashMap<>(elementValues));
 		this.elementValues.clear();
 		for (Entry<String, Object> e : values.entrySet()) {
 			addValue(e.getKey(), e.getValue());
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtAnnotation<A>> T setValues(Map<String, CtExpression> values) {
+	public CtAnnotationImpl<A> setValues(Map<String, CtExpression> values) {
 		getFactory().getEnvironment().getModelChangeListener().onMapDeleteAll(this, CtRole.VALUE, this.elementValues, new HashMap<>(elementValues));
 		this.elementValues.clear();
 		for (Entry<String, CtExpression> e : values.entrySet()) {
 			addValue(e.getKey(), e.getValue());
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public CtElement getAnnotatedElement() {
-		return this.getParent();
+	public CtAnnotationImpl<A> getAnnotatedElement() {
+		return ((CtAnnotationImpl<A>) (this.getParent()));
 	}
 
 	@Override
@@ -530,10 +532,10 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtAnnotationImpl<A> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -549,7 +551,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtExpression<A>> C setTypeCasts(List<CtTypeReference<?>> casts) {
-		return (C) this;
+	public CtAnnotationImpl<A> setTypeCasts(List<CtTypeReference<?>> casts) {
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
@@ -16,14 +16,14 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtAnnotationMethod;
-import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtTypeReference;
@@ -33,8 +33,8 @@ import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.DEFAULT_EXPRESSION;
 
-import java.util.List;
-import java.util.Set;
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotationMethod}.
@@ -54,13 +54,13 @@ public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnno
 	}
 
 	@Override
-	public <C extends CtAnnotationMethod<T>> C setDefaultExpression(CtExpression<T> assignedExpression) {
+	public CtAnnotationMethodImpl<T> setDefaultExpression(CtExpression<T> assignedExpression) {
 		if (assignedExpression != null) {
 			assignedExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DEFAULT_EXPRESSION, assignedExpression, this.defaultExpression);
 		this.defaultExpression = assignedExpression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -71,8 +71,8 @@ public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnno
 
 	@Override
 	@UnsettableProperty
-	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
-		return (T) this;
+	public CtAnnotationMethodImpl<T> setBody(CtStatement statement) {
+		return this;
 	}
 
 	@Override
@@ -83,8 +83,8 @@ public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnno
 
 	@Override
 	@UnsettableProperty
-	public <U extends CtExecutable<T>> U setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
-		return (U) this;
+	public CtAnnotationMethodImpl<T> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
+		return this;
 	}
 
 	@Override
@@ -95,8 +95,8 @@ public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnno
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		return (C) this;
+	public CtAnnotationMethodImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+		return this;
 	}
 
 	@Override
@@ -107,8 +107,8 @@ public class CtAnnotationMethodImpl<T> extends CtMethodImpl<T> implements CtAnno
 
 	@Override
 	@UnsettableProperty
-	public <U extends CtExecutable<T>> U setParameters(List<CtParameter<?>> parameters) {
-		return (U) this;
+	public CtAnnotationMethodImpl<T> setParameters(List<CtParameter<?>> parameters) {
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
@@ -16,22 +16,23 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.reflect.declaration.CtAnnotationMethod;
-import spoon.reflect.declaration.CtAnnotationType;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.DerivedProperty;
-import spoon.support.UnsettableProperty;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.declaration.CtAnnotationMethod;
+import spoon.reflect.declaration.CtAnnotationType;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.DerivedProperty;
+import spoon.support.UnsettableProperty;
+
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtAnnotationType}.
@@ -65,14 +66,14 @@ public class CtAnnotationTypeImpl<T extends Annotation> extends CtTypeImpl<T> im
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass) {
-		return (C) this;
+	public CtAnnotationTypeImpl<T> setSuperclass(CtTypeReference<?> superClass) {
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<T>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
-		return (C) this;
+	public CtAnnotationTypeImpl<T> setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
+		return this;
 	}
 
 	@Override
@@ -83,8 +84,8 @@ public class CtAnnotationTypeImpl<T extends Annotation> extends CtTypeImpl<T> im
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		return (C) this;
+	public CtAnnotationTypeImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+		return this;
 	}
 
 	@Override
@@ -107,10 +108,10 @@ public class CtAnnotationTypeImpl<T extends Annotation> extends CtTypeImpl<T> im
 	}
 
 	@Override
-	public <M, C extends CtType<T>> C addMethod(CtMethod<M> method) {
+	public <M> CtAnnotationTypeImpl<T> addMethod(CtMethod<M> method) {
 		if (method != null && !(method instanceof CtAnnotationMethod)) {
 			throw new IllegalArgumentException("The method " + method.getSignature() + " should be a " + CtAnnotationMethod.class.getName());
 		}
-		return super.addMethod(method);
+		return ((CtAnnotationTypeImpl<T>) (super.addMethod(method)));
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -16,14 +16,14 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtAnonymousExecutable;
-import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
@@ -32,8 +32,8 @@ import spoon.support.UnsettableProperty;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 
-import java.util.List;
-import java.util.Set;
+
+
 
 public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements CtAnonymousExecutable {
 	private static final long serialVersionUID = 1L;
@@ -47,15 +47,15 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	}
 
 	@Override
-	public <T extends CtModifiable> T addModifier(ModifierKind modifier) {
+	public CtAnonymousExecutableImpl addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModifiable> T removeModifier(ModifierKind modifier) {
+	public CtAnonymousExecutableImpl removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -83,15 +83,15 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	}
 
 	@Override
-	public <T extends CtModifiable> T setModifiers(Set<ModifierKind> modifiers) {
+	public CtAnonymousExecutableImpl setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModifiable> T setVisibility(ModifierKind visibility) {
+	public CtAnonymousExecutableImpl setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -100,9 +100,9 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	}
 
 	@Override
-	public <T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtAnonymousExecutableImpl setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -113,14 +113,14 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 
 	@Override
 	@UnsettableProperty
-	public CtExecutable setParameters(List list) {
+	public CtAnonymousExecutableImpl setParameters(List list) {
 		// unsettable property
 		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public CtExecutable addParameter(CtParameter parameter) {
+	public CtAnonymousExecutableImpl addParameter(CtParameter parameter) {
 		// unsettable property
 		return this;
 	}
@@ -139,14 +139,14 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 
 	@Override
 	@UnsettableProperty
-	public CtExecutable setThrownTypes(Set thrownTypes) {
+	public CtAnonymousExecutableImpl setThrownTypes(Set thrownTypes) {
 		// unsettable property
 		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public CtExecutable addThrownType(CtTypeReference throwType) {
+	public CtAnonymousExecutableImpl addThrownType(CtTypeReference throwType) {
 		// unsettable property
 		return this;
 	}
@@ -165,9 +165,9 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 
 	@Override
 	@UnsettableProperty
-	public <T extends CtNamedElement> T setSimpleName(String simpleName) {
+	public CtAnonymousExecutableImpl setSimpleName(String simpleName) {
 		// unsettable property
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -178,9 +178,9 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<Void> type) {
+	public CtAnonymousExecutableImpl setType(CtTypeReference<Void> type) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -16,26 +16,6 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.SpoonException;
-import spoon.SpoonModelBuilder.InputType;
-import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtCodeElement;
-import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtStatementList;
-import spoon.reflect.declaration.CtAnonymousExecutable;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtConstructor;
-import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeMember;
-import spoon.reflect.reference.CtExecutableReference;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.UnsettableProperty;
-import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
-import spoon.support.reflect.code.CtStatementImpl;
-import spoon.support.reflect.eval.VisitorPartialEvaluator;
-import spoon.support.util.SignatureBasedSortedSet;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -46,10 +26,33 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import spoon.SpoonException;
+import spoon.SpoonModelBuilder;
+import spoon.SpoonModelBuilder.InputType;
+import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.code.CtCodeElement;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtStatementList;
+import spoon.reflect.declaration.CtAnonymousExecutable;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.UnsettableProperty;
+import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
+import spoon.support.reflect.code.CtStatementImpl;
+import spoon.support.reflect.eval.VisitorPartialEvaluator;
+import spoon.support.util.SignatureBasedSortedSet;
 
-import static spoon.reflect.path.CtRole.CONSTRUCTOR;
 import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
+import static spoon.reflect.path.CtRole.CONSTRUCTOR;
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
+
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtClass}.
@@ -104,13 +107,13 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public <C extends CtClass<T>> C addAnonymousExecutable(CtAnonymousExecutable e) {
+	public CtClassImpl<T> addAnonymousExecutable(CtAnonymousExecutable e) {
 		if (e == null) {
-			return (C) this;
+			return this;
 		}
 		e.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, ANNONYMOUS_EXECUTABLE, typeMembers, e);
-		return addTypeMember(e);
+		return ((CtClassImpl<T>) (addTypeMember(e)));
 	}
 
 	@Override
@@ -125,38 +128,38 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public <C extends CtClass<T>> C setAnonymousExecutables(List<CtAnonymousExecutable> anonymousExecutables) {
+	public CtClassImpl<T> setAnonymousExecutables(List<CtAnonymousExecutable> anonymousExecutables) {
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, ANNONYMOUS_EXECUTABLE, typeMembers, new ArrayList<>(getAnonymousExecutables()));
 		if (anonymousExecutables == null || anonymousExecutables.isEmpty()) {
 			this.typeMembers.removeAll(getAnonymousExecutables());
-			return (C) this;
+			return this;
 		}
 		typeMembers.removeAll(getAnonymousExecutables());
 		for (CtAnonymousExecutable exec : anonymousExecutables) {
 			addAnonymousExecutable(exec);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtClass<T>> C setConstructors(Set<CtConstructor<T>> constructors) {
+	public CtClassImpl<T> setConstructors(Set<CtConstructor<T>> constructors) {
 		Set<CtConstructor<T>> oldConstructor = getConstructors();
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CONSTRUCTOR, typeMembers, oldConstructor);
 		if (constructors == null || constructors.isEmpty()) {
 			this.typeMembers.removeAll(oldConstructor);
-			return (C) this;
+			return this;
 		}
 		typeMembers.removeAll(oldConstructor);
 		for (CtConstructor<T> constructor : constructors) {
 			addConstructor(constructor);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtClass<T>> C addConstructor(CtConstructor<T> constructor) {
+	public CtClassImpl<T> addConstructor(CtConstructor<T> constructor) {
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CONSTRUCTOR, typeMembers, constructor);
-		return addTypeMember(constructor);
+		return ((CtClassImpl<T>) (addTypeMember(constructor)));
 	}
 
 	@Override
@@ -165,13 +168,13 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public <C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass) {
+	public CtClassImpl<T> setSuperclass(CtTypeReference<?> superClass) {
 		if (superClass != null) {
 			superClass.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SUPER_TYPE, superClass, this.superClass);
 		this.superClass = superClass;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -195,27 +198,27 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatement statement) {
+	public CtClassImpl<T> insertAfter(CtStatement statement) {
 		CtStatementImpl.insertAfter(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertAfter(CtStatementList statements) {
+	public CtClassImpl<T> insertAfter(CtStatementList statements) {
 		CtStatementImpl.insertAfter(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatement statement) {
+	public CtClassImpl<T> insertBefore(CtStatement statement) {
 		CtStatementImpl.insertBefore(this, statement);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtStatement> C insertBefore(CtStatementList statements) {
+	public CtClassImpl<T> insertBefore(CtStatementList statements) {
 		CtStatementImpl.insertBefore(this, statements);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -225,8 +228,8 @@ public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtCl
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtStatement> C setLabel(String label) {
-		return (C) this;
+	public CtClassImpl<T> setLabel(String label) {
+		return this;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -16,15 +16,14 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtConstructor;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
@@ -35,11 +34,10 @@ import spoon.support.UnsettableProperty;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
+
+
+
 
 public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConstructor<T> {
 	private static final long serialVersionUID = 1L;
@@ -57,8 +55,8 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtNamedElement> C setSimpleName(String simpleName) {
-		return (C) this;
+	public CtConstructorImpl<T> setSimpleName(String simpleName) {
+		return this;
 	}
 
 	@Override
@@ -83,9 +81,9 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtConstructorImpl<T> setType(CtTypeReference<T> type) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -94,10 +92,10 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+	public CtConstructorImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
 		if (formalTypeParameters == null || formalTypeParameters.isEmpty()) {
 			this.formalCtTypeParameters = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			this.formalCtTypeParameters = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -107,13 +105,13 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
 			addFormalCtTypeParameter(formalTypeParameter);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
+	public CtConstructorImpl<T> addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
 		if (formalTypeParameter == null) {
-			return (C) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
@@ -121,7 +119,7 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 		}
 		formalTypeParameter.setParent(this);
 		formalCtTypeParameters.add(formalTypeParameter);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -144,27 +142,27 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtConstructorImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtConstructorImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtConstructorImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtConstructorImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -178,9 +176,9 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
-	public <T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtConstructorImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (T) this;
+		return this;
 	}
 
 
@@ -193,10 +191,10 @@ public class CtConstructorImpl<T> extends CtExecutableImpl<T> implements CtConst
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtConstructorImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -16,6 +16,17 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.log4j.Logger;
 import spoon.Launcher;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
@@ -64,16 +75,10 @@ import spoon.support.visitor.equals.CloneHelper;
 import spoon.support.visitor.equals.EqualsVisitor;
 import spoon.support.visitor.replace.ReplacementVisitor;
 
-import java.io.Serializable;
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import static spoon.reflect.code.CtComment.CommentType.JAVADOC;
+
+
+
 
 /**
  * Contains the default implementation of most CtElement methods.
@@ -213,17 +218,17 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
+	public CtElementImpl setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
 		if (annotations == null || annotations.isEmpty()) {
 			this.annotations = emptyList();
-			return (E) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
 		this.annotations.clear();
 		for (CtAnnotation<? extends Annotation> annot : annotations) {
 			addAnnotation(annot);
 		}
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -233,9 +238,9 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E addAnnotation(CtAnnotation<? extends Annotation> annotation) {
+	public CtElementImpl addAnnotation(CtAnnotation<? extends Annotation> annotation) {
 		if (annotation == null) {
-			return (E) this;
+			return this;
 		}
 		if (this.annotations == CtElementImpl.<CtAnnotation<? extends Annotation>>emptyList()) {
 			this.annotations = new ArrayList<>(ModelElementContainerDefaultCapacities.ANNOTATIONS_CONTAINER_DEFAULT_CAPACITY);
@@ -243,7 +248,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		annotation.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.ANNOTATION, this.annotations, annotation);
 		this.annotations.add(annotation);
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -256,36 +261,36 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setDocComment(String docComment) {
+	public CtElementImpl setDocComment(String docComment) {
 		for (CtComment ctComment : comments) {
 			if (ctComment.getCommentType() == CtComment.CommentType.JAVADOC) {
 				ctComment.setContent(docComment);
-				return (E) this;
+				return this;
 			}
 		}
 		this.addComment(factory.Code().createComment(docComment, CtComment.CommentType.JAVADOC));
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtElement> E setPosition(SourcePosition position) {
+	public CtElementImpl setPosition(SourcePosition position) {
 		if (position == null) {
 			position = SourcePosition.NOPOSITION;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.POSITION, position, this.position);
 		this.position = position;
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtElement> E setPositions(final SourcePosition position) {
+	public CtElementImpl setPositions(final SourcePosition position) {
 		accept(new CtScanner() {
 			@Override
 			public void enter(CtElement e) {
 				e.setPosition(position);
 			}
 		});
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -323,10 +328,10 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setImplicit(boolean implicit) {
+	public CtElementImpl setImplicit(boolean implicit) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_IMPLICIT, implicit, this.implicit);
 		this.implicit = implicit;
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -480,10 +485,10 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setAllMetadata(Map<String, Object> metadata) {
+	public CtElementImpl setAllMetadata(Map<String, Object> metadata) {
 		if (metadata == null || metadata.isEmpty()) {
 			this.metadata = null;
-			return (E) this;
+			return this;
 		}
 		if (this.metadata == null) {
 			this.metadata = new HashMap<>();
@@ -491,16 +496,16 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			this.metadata.clear();
 		}
 		this.metadata.putAll(metadata);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtElement> E putMetadata(String key, Object val) {
+	public CtElementImpl putMetadata(String key, Object val) {
 		if (metadata == null) {
 			metadata = new HashMap<>();
 		}
 		metadata.put(key, val);
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -533,9 +538,9 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E addComment(CtComment comment) {
+	public CtElementImpl addComment(CtComment comment) {
 		if (comment == null) {
-			return (E) this;
+			return this;
 		}
 		if (this.comments == CtElementImpl.<CtComment>emptyList()) {
 			comments = new ArrayList<>(ModelElementContainerDefaultCapacities.COMMENT_CONTAINER_DEFAULT_CAPACITY);
@@ -543,31 +548,31 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		comment.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.COMMENT, this.comments, comment);
 		comments.add(comment);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtElement> E removeComment(CtComment comment) {
+	public CtElementImpl removeComment(CtComment comment) {
 		if (this.comments == CtElementImpl.<CtComment>emptyList()) {
-			return (E) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.COMMENT, comments, comments.indexOf(comment), comment);
 		this.comments.remove(comment);
-		return (E) this;
+		return this;
 	}
 
 	@Override
-	public <E extends CtElement> E setComments(List<CtComment> comments) {
+	public CtElementImpl setComments(List<CtComment> comments) {
 		if (comments == null || comments.isEmpty()) {
 			this.comments = emptyList();
-			return (E) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.COMMENT, this.comments, new ArrayList<>(this.comments));
 		this.comments.clear();
 		for (CtComment comment : comments) {
 			addComment(comment);
 		}
-		return (E) this;
+		return this;
 	}
 
 	@Override
@@ -582,10 +587,10 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement, T> E setValueByRole(CtRole role, T value) {
+	public < T> CtElementImpl setValueByRole(CtRole role, T value) {
 		RoleHandler rh = RoleHandlerHelper.getRoleHandler(this.getClass(), role);
 		rh.setValue(this, value);
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -16,27 +16,29 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 import spoon.support.util.SignatureBasedSortedSet;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.VALUE;
+
+
+
 
 public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtEnum<T> {
 	private static final long serialVersionUID = 1L;
@@ -70,9 +72,9 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 	}
 
 	@Override
-	public <C extends CtEnum<T>> C addEnumValue(CtEnumValue<?> enumValue) {
+	public CtEnumImpl<T> addEnumValue(CtEnumValue<?> enumValue) {
 		if (enumValue == null) {
-			return (C) this;
+			return this;
 		}
 		if (enumValues == CtElementImpl.<CtEnumValue<?>>emptyList()) {
 			enumValues = new ArrayList<>();
@@ -84,7 +86,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 		}
 
 		// enum value already exists.
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -112,21 +114,21 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 	}
 
 	@Override
-	public <C extends CtEnum<T>> C setEnumValues(List<CtEnumValue<?>> enumValues) {
+	public CtEnumImpl<T> setEnumValues(List<CtEnumValue<?>> enumValues) {
 		if (enumValues == null) {
 			this.enumValues = emptyList();
-			return (C) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, VALUE, this.enumValues, new ArrayList<>(enumValues));
 		if (enumValues.isEmpty()) {
 			this.enumValues = emptyList();
-			return (C) this;
+			return this;
 		}
 		this.enumValues.clear();
 		for (CtEnumValue<?> enumValue : enumValues) {
 			addEnumValue(enumValue);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -160,8 +162,8 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass) {
-		return (C) this;
+	public CtEnumImpl<T> setSuperclass(CtTypeReference<?> superClass) {
+		return this;
 	}
 
 	private CtMethod valuesMethod() {
@@ -238,7 +240,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		return (C) this;
+	public CtEnumImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumValueImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumValueImpl.java
@@ -16,10 +16,14 @@
  */
 package spoon.support.reflect.declaration;
 
+
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
+
+
+
 
 public class CtEnumValueImpl<T> extends CtFieldImpl<T> implements CtEnumValue<T> {
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
@@ -28,15 +32,13 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.visitor.SignaturePrinter;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.BODY;
 import static spoon.reflect.path.CtRole.PARAMETER;
 import static spoon.reflect.path.CtRole.THROWN;
+
+
+
 
 
 /**
@@ -74,7 +76,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 	}
 
 	@Override
-	public <T extends CtBodyHolder> T setBody(CtStatement statement) {
+	public CtExecutableImpl<R> setBody(CtStatement statement) {
 		if (statement != null) {
 			CtBlock<?> body = getFactory().Code().getOrCreateCtBlock(statement);
 			getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BODY, body, this.body);
@@ -86,7 +88,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 			getFactory().getEnvironment().getModelChangeListener().onObjectDelete(this, BODY, this.body);
 			this.body = null;
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -95,10 +97,10 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 	}
 
 	@Override
-	public <T extends CtExecutable<R>> T setParameters(List<CtParameter<?>> parameters) {
+	public CtExecutableImpl<R> setParameters(List<CtParameter<?>> parameters) {
 		if (parameters == null || parameters.isEmpty()) {
 			this.parameters = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		if (this.parameters == CtElementImpl.<CtParameter<?>>emptyList()) {
 			this.parameters = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -108,13 +110,13 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		for (CtParameter<?> p : parameters) {
 			addParameter(p);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtExecutable<R>> T addParameter(CtParameter<?> parameter) {
+	public CtExecutableImpl<R> addParameter(CtParameter<?> parameter) {
 		if (parameter == null) {
-			return (T) this;
+			return this;
 		}
 		if (parameters == CtElementImpl.<CtParameter<?>>emptyList()) {
 			parameters = new ArrayList<>(PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -122,7 +124,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		parameter.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, PARAMETER, this.parameters, parameter);
 		parameters.add(parameter);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -140,10 +142,10 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 	}
 
 	@Override
-	public <T extends CtExecutable<R>> T setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
+	public CtExecutableImpl<R> setThrownTypes(Set<CtTypeReference<? extends Throwable>> thrownTypes) {
 		if (thrownTypes == null || thrownTypes.isEmpty()) {
 			this.thrownTypes = CtElementImpl.emptySet();
-			return (T) this;
+			return this;
 		}
 		if (this.thrownTypes == CtElementImpl.<CtTypeReference<? extends Throwable>>emptySet()) {
 			this.thrownTypes = new QualifiedNameBasedSortedSet<>();
@@ -153,13 +155,13 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		for (CtTypeReference<? extends Throwable> thrownType : thrownTypes) {
 			addThrownType(thrownType);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtExecutable<R>> T addThrownType(CtTypeReference<? extends Throwable> throwType) {
+	public CtExecutableImpl<R> addThrownType(CtTypeReference<? extends Throwable> throwType) {
 		if (throwType == null) {
-			return (T) this;
+			return this;
 		}
 		if (thrownTypes == CtElementImpl.<CtTypeReference<? extends Throwable>>emptySet()) {
 			thrownTypes = new QualifiedNameBasedSortedSet<>();
@@ -167,7 +169,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		throwType.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, THROWN, this.thrownTypes, throwType);
 		thrownTypes.add(throwType);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -16,15 +16,12 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtRHSReceiver;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtFieldReference;
@@ -34,7 +31,8 @@ import spoon.support.DerivedProperty;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 
-import java.util.Set;
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtField}.
@@ -87,23 +85,23 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
-	public <C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> defaultExpression) {
+	public CtFieldImpl<T> setDefaultExpression(CtExpression<T> defaultExpression) {
 		if (defaultExpression != null) {
 			defaultExpression.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.DEFAULT_EXPRESSION, defaultExpression, this.defaultExpression);
 		this.defaultExpression = defaultExpression;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtFieldImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -117,21 +115,21 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtFieldImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtFieldImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtFieldImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -140,16 +138,16 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
-	public <C extends CtModifiable> C setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtFieldImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (C) this;
+		return this;
 	}
 
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtFieldImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -164,9 +162,9 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
-	public <C extends CtRHSReceiver<T>> C setAssignment(CtExpression<T> assignment) {
+	public CtFieldImpl<T> setAssignment(CtExpression<T> assignment) {
 		setDefaultExpression(assignment);
-		return (C) this;
+		return this;
 	}
 
 	@MetamodelPropertyField(role = CtRole.IS_SHADOW)
@@ -178,10 +176,10 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtFieldImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
@@ -16,18 +16,22 @@
  */
 package spoon.support.reflect.declaration;
 
+
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.declaration.CtImport;
+import spoon.reflect.declaration.CtImportKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.declaration.CtImport;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtReference;
-import spoon.reflect.declaration.CtImportKind;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.reference.CtWildcardStaticTypeMemberReferenceImpl;
+
+
+
 
 public class CtImportImpl extends CtElementImpl implements CtImport {
 	@MetamodelPropertyField(role = CtRole.IMPORT_REFERENCE)
@@ -58,13 +62,13 @@ public class CtImportImpl extends CtElementImpl implements CtImport {
 	}
 
 	@Override
-	public <T extends CtImport> T setReference(CtReference reference) {
+	public CtImportImpl setReference(CtReference reference) {
 		if (reference != null) {
 			reference.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IMPORT_REFERENCE, reference, this.localReference);
 		this.localReference = reference;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -16,18 +16,20 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.reflect.declaration.CtInterface;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.reference.CtExecutableReference;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.support.UnsettableProperty;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import spoon.reflect.declaration.CtInterface;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.support.UnsettableProperty;
+
+
+
 
 public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> {
 	private static final long serialVersionUID = 1L;
@@ -67,8 +69,8 @@ public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> 
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass) {
+	public CtInterfaceImpl<T> setSuperclass(CtTypeReference<?> superClass) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -16,28 +16,28 @@
  */
 package spoon.support.reflect.declaration;
 
-import spoon.refactoring.Refactoring;
-import spoon.reflect.ModelElementContainerDefaultCapacities;
-import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtShadowable;
-import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.path.CtRole;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
-import spoon.reflect.visitor.filter.AllTypeMembersFunction;
-import spoon.support.reflect.CtExtendedModifier;
-import spoon.support.reflect.CtModifierHandler;
-import spoon.support.visitor.ClassTypingContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import spoon.refactoring.Refactoring;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
+import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.chain.CtConsumer;
+import spoon.reflect.visitor.filter.AllTypeMembersFunction;
+import spoon.support.reflect.CtExtendedModifier;
+import spoon.support.reflect.CtModifierHandler;
+import spoon.support.visitor.ClassTypingContext;
+
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtMethod}.
@@ -73,13 +73,13 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtMethodImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.returnType);
 		this.returnType = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -88,10 +88,10 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <C extends CtMethod<T>> C setDefaultMethod(boolean defaultMethod) {
+	public CtMethodImpl<T> setDefaultMethod(boolean defaultMethod) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_DEFAULT, defaultMethod, this.defaultMethod);
 		this.defaultMethod = defaultMethod;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -100,11 +100,11 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+	public CtMethodImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, new ArrayList<>(this.formalCtTypeParameters));
 		if (formalTypeParameters == null || formalTypeParameters.isEmpty()) {
 			this.formalCtTypeParameters = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			this.formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -113,13 +113,13 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
 			addFormalCtTypeParameter(formalTypeParameter);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
+	public CtMethodImpl<T> addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
 		if (formalTypeParameter == null) {
-			return (C) this;
+			return this;
 		}
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -127,7 +127,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		formalTypeParameter.setParent(this);
 		formalCtTypeParameters.add(formalTypeParameter);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -150,27 +150,27 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtMethodImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtMethodImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtMethodImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtMethodImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -184,9 +184,9 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <C extends CtModifiable> C setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtMethodImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return  (C) this;
+		return  this;
 	}
 
 	@Override
@@ -203,10 +203,10 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtMethodImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -16,14 +16,18 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtModuleDirective;
+import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtProvidedService;
-import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtModuleReference;
@@ -32,9 +36,8 @@ import spoon.support.DerivedProperty;
 import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.util.SortedList;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+
 
 public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	@MetamodelPropertyField(role = CtRole.MODIFIER)
@@ -60,11 +63,11 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setModuleDirectives(List<CtModuleDirective> moduleDirectives) {
+	public CtModuleImpl setModuleDirectives(List<CtModuleDirective> moduleDirectives) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.MODULE_DIRECTIVE, this.moduleDirectives, new ArrayList<>(this.moduleDirectives));
 		if (moduleDirectives == null || moduleDirectives.isEmpty()) {
 			this.moduleDirectives = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 		if (this.moduleDirectives == CtElementImpl.<CtModuleDirective>emptyList()) {
 			this.moduleDirectives = new SortedList<>(new CtLineElementComparator());
@@ -75,13 +78,13 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.addModuleDirective(moduleDirective);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addModuleDirective(CtModuleDirective moduleDirective) {
+	public CtModuleImpl addModuleDirective(CtModuleDirective moduleDirective) {
 		if (moduleDirective == null) {
-			return (T) this;
+			return this;
 		}
 
 		if (this.moduleDirectives == CtElementImpl.<CtModuleDirective>emptyList()) {
@@ -95,13 +98,13 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.moduleDirectives.add(moduleDirective);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addModuleDirectiveAt(int position, CtModuleDirective moduleDirective) {
+	public CtModuleImpl addModuleDirectiveAt(int position, CtModuleDirective moduleDirective) {
 		if (moduleDirective == null) {
-			return (T) this;
+			return this;
 		}
 
 		if (this.moduleDirectives == CtElementImpl.<CtModuleDirective>emptyList()) {
@@ -115,7 +118,7 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.moduleDirectives.add(position, moduleDirective);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -124,9 +127,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T removeModuleDirective(CtModuleDirective moduleDirective) {
+	public CtModuleImpl removeModuleDirective(CtModuleDirective moduleDirective) {
 		if (moduleDirective == null || this.moduleDirectives.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 		if (this.moduleDirectives.contains(moduleDirective)) {
 			getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.MODULE_DIRECTIVE.getMatchingSubRoleFor(moduleDirective), this.moduleDirectives, this.moduleDirectives.indexOf(moduleDirective), moduleDirective);
@@ -137,14 +140,14 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			}
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T setIsOpenModule(boolean openModule) {
+	public CtModuleImpl setIsOpenModule(boolean openModule) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.MODIFIER, openModule, this.openModule);
 		this.openModule = openModule;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -163,9 +166,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setUsedServices(List<CtUsedService> consumedServices) {
+	public CtModuleImpl setUsedServices(List<CtUsedService> consumedServices) {
 		if (consumedServices == null || consumedServices.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 		List<CtUsedService> usedServices = getUsedServices();
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.SERVICE_TYPE, this.moduleDirectives, new ArrayList<>(usedServices));
@@ -174,25 +177,25 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 		for (CtUsedService consumedService : consumedServices) {
 			this.addModuleDirective(consumedService);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addUsedService(CtUsedService consumedService) {
+	public CtModuleImpl addUsedService(CtUsedService consumedService) {
 		if (consumedService == null) {
-			return (T) this;
+			return this;
 		}
 
 		this.addModuleDirective(consumedService);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T removeUsedService(CtUsedService usedService) {
+	public CtModuleImpl removeUsedService(CtUsedService usedService) {
 		if (usedService == null) {
-			return (T) this;
+			return this;
 		}
-		return this.removeModuleDirective(usedService);
+		return ((CtModuleImpl) (this.removeModuleDirective(usedService)));
 	}
 
 	@Override
@@ -214,9 +217,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setExportedPackages(List<CtPackageExport> exportedPackages) {
+	public CtModuleImpl setExportedPackages(List<CtPackageExport> exportedPackages) {
 		if (exportedPackages == null || exportedPackages.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 
 		List<CtPackageExport> oldExportedPackages = getExportedPackages();
@@ -228,25 +231,25 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.addModuleDirective(exportedPackage);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addExportedPackage(CtPackageExport exportedPackage) {
+	public CtModuleImpl addExportedPackage(CtPackageExport exportedPackage) {
 		if (exportedPackage == null) {
-			return (T) this;
+			return this;
 		}
 		exportedPackage.setOpenedPackage(false);
 		this.addModuleDirective(exportedPackage);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T removeExportedPackage(CtPackageExport exportedPackage) {
+	public CtModuleImpl removeExportedPackage(CtPackageExport exportedPackage) {
 		if (exportedPackage == null) {
-			return (T) this;
+			return this;
 		}
-		return this.removeModuleDirective(exportedPackage);
+		return ((CtModuleImpl) (this.removeModuleDirective(exportedPackage)));
 	}
 
 	@Override
@@ -268,9 +271,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setOpenedPackages(List<CtPackageExport> openedPackages) {
+	public CtModuleImpl setOpenedPackages(List<CtPackageExport> openedPackages) {
 		if (openedPackages == null || openedPackages.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 
 		List<CtPackageExport> oldOpenedPackages = getOpenedPackages();
@@ -282,25 +285,25 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.addModuleDirective(exportedPackage);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addOpenedPackage(CtPackageExport openedPackage) {
+	public CtModuleImpl addOpenedPackage(CtPackageExport openedPackage) {
 		if (openedPackage == null) {
-			return (T) this;
+			return this;
 		}
 		openedPackage.setOpenedPackage(true);
 		this.addModuleDirective(openedPackage);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T removeOpenedPackage(CtPackageExport openedPackage) {
+	public CtModuleImpl removeOpenedPackage(CtPackageExport openedPackage) {
 		if (openedPackage == null) {
-			return (T) this;
+			return this;
 		}
-		return this.removeModuleDirective(openedPackage);
+		return ((CtModuleImpl) (this.removeModuleDirective(openedPackage)));
 	}
 
 	@Override
@@ -319,9 +322,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setRequiredModules(List<CtModuleRequirement> requiredModules) {
+	public CtModuleImpl setRequiredModules(List<CtModuleRequirement> requiredModules) {
 		if (requiredModules == null || requiredModules.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 
 		List<CtModuleRequirement> oldRequiredModules = getRequiredModules();
@@ -331,25 +334,25 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 		for (CtModuleRequirement moduleRequirement : requiredModules) {
 			this.addModuleDirective(moduleRequirement);
 		}
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addRequiredModule(CtModuleRequirement requiredModule) {
+	public CtModuleImpl addRequiredModule(CtModuleRequirement requiredModule) {
 		if (requiredModule == null) {
-			return (T) this;
+			return this;
 		}
 
 		this.addModuleDirective(requiredModule);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T removeRequiredModule(CtModuleRequirement requiredModule) {
+	public CtModuleImpl removeRequiredModule(CtModuleRequirement requiredModule) {
 		if (requiredModule == null) {
-			return (T) this;
+			return this;
 		}
-		return this.removeModuleDirective(requiredModule);
+		return ((CtModuleImpl) (this.removeModuleDirective(requiredModule)));
 	}
 
 	@Override
@@ -368,9 +371,9 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setProvidedServices(List<CtProvidedService> providedServices) {
+	public CtModuleImpl setProvidedServices(List<CtProvidedService> providedServices) {
 		if (providedServices == null || providedServices.isEmpty()) {
-			return (T) this;
+			return this;
 		}
 
 		List<CtProvidedService> oldProvidedServices = getProvidedServices();
@@ -381,25 +384,25 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 			this.addModuleDirective(providedService);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T addProvidedService(CtProvidedService providedService) {
+	public CtModuleImpl addProvidedService(CtProvidedService providedService) {
 		if (providedService == null) {
-			return (T) this;
+			return this;
 		}
 
 		this.addModuleDirective(providedService);
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtModule> T removeProvidedService(CtProvidedService providedService) {
+	public CtModuleImpl removeProvidedService(CtProvidedService providedService) {
 		if (providedService == null) {
-			return (T) this;
+			return this;
 		}
-		return this.removeModuleDirective(providedService);
+		return ((CtModuleImpl) (this.removeModuleDirective(providedService)));
 	}
 
 	@Override
@@ -408,13 +411,13 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 	}
 
 	@Override
-	public <T extends CtModule> T setRootPackage(CtPackage rootPackage) {
+	public CtModuleImpl setRootPackage(CtPackage rootPackage) {
 		if (rootPackage != null) {
 			rootPackage.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.SUB_PACKAGE, rootPackage, this.rootPackage);
 		this.rootPackage = rootPackage;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
@@ -16,14 +16,17 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.HashSet;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.util.HashSet;
-import java.util.Set;
+
+
 
 public class CtModuleRequirementImpl extends CtElementImpl implements CtModuleRequirement {
 	@MetamodelPropertyField(role = CtRole.MODIFIER)
@@ -41,11 +44,11 @@ public class CtModuleRequirementImpl extends CtElementImpl implements CtModuleRe
 	}
 
 	@Override
-	public <T extends CtModuleRequirement> T setRequiresModifiers(Set<RequiresModifier> requiresModifiers) {
+	public CtModuleRequirementImpl setRequiresModifiers(Set<RequiresModifier> requiresModifiers) {
 		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(this, CtRole.MODIFIER, this.requiresModifiers, new HashSet<>(requiresModifiers));
 		if (requiresModifiers == null || requiresModifiers.isEmpty()) {
 			this.requiresModifiers = CtElementImpl.emptySet();
-			return (T) this;
+			return this;
 		}
 
 		if (this.requiresModifiers == CtElementImpl.<RequiresModifier>emptySet()) {
@@ -57,7 +60,7 @@ public class CtModuleRequirementImpl extends CtElementImpl implements CtModuleRe
 			this.requiresModifiers.add(requiresModifier);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -66,13 +69,13 @@ public class CtModuleRequirementImpl extends CtElementImpl implements CtModuleRe
 	}
 
 	@Override
-	public <T extends CtModuleRequirement> T setModuleReference(CtModuleReference moduleReference) {
+	public CtModuleRequirementImpl setModuleReference(CtModuleReference moduleReference) {
 		if (moduleReference != null) {
 			moduleReference.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.MODULE_REF, moduleReference, this.moduleReference);
 		this.moduleReference = moduleReference;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.declaration;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.factory.Factory;
@@ -23,6 +24,9 @@ import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.reference.CtReference;
 
 import static spoon.reflect.path.CtRole.NAME;
+
+
+
 
 public abstract class CtNamedElementImpl extends CtElementImpl implements CtNamedElement {
 
@@ -42,18 +46,18 @@ public abstract class CtNamedElementImpl extends CtElementImpl implements CtName
 	}
 
 	@Override
-	public <T extends CtNamedElement> T setSimpleName(String simpleName) {
+	public CtNamedElementImpl setSimpleName(String simpleName) {
 		Factory factory = getFactory();
 		if (factory == null) {
 			this.simpleName = simpleName;
-			return (T) this;
+			return this;
 		}
 		if (factory instanceof FactoryImpl) {
 			simpleName = ((FactoryImpl) factory).dedup(simpleName);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simpleName, this.simpleName);
 		this.simpleName = simpleName;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
@@ -16,6 +16,10 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.path.CtRole;
@@ -23,9 +27,8 @@ import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+
 
 public class CtPackageExportImpl extends CtElementImpl implements CtPackageExport {
 	@MetamodelPropertyField(role = CtRole.PACKAGE_REF)
@@ -41,10 +44,10 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 	}
 
 	@Override
-	public <T extends CtPackageExport> T setOpenedPackage(boolean openedPackage) {
+	public CtPackageExportImpl setOpenedPackage(boolean openedPackage) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.OPENED_PACKAGE, openedPackage, this.isOpen);
 		this.isOpen = openedPackage;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -58,13 +61,13 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 	}
 
 	@Override
-	public <T extends CtPackageExport> T setPackageReference(CtPackageReference packageReference) {
+	public CtPackageExportImpl setPackageReference(CtPackageReference packageReference) {
 		if (packageReference != null) {
 			packageReference.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.PACKAGE_REF, packageReference, this.packageReference);
 		this.packageReference = packageReference;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -73,11 +76,11 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 	}
 
 	@Override
-	public <T extends CtPackageExport> T setTargetExport(List<CtModuleReference> targetExports) {
+	public CtPackageExportImpl setTargetExport(List<CtModuleReference> targetExports) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.MODULE_REF, this.targets, new ArrayList<>(this.targets));
 		if (targetExports == null || targetExports.isEmpty()) {
 			this.targets = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 
 		if (this.targets == CtElementImpl.<CtModuleReference>emptyList()) {
@@ -88,13 +91,13 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 			this.addTargetExport(targetExport);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtPackageExport> T addTargetExport(CtModuleReference targetExport) {
+	public CtPackageExportImpl addTargetExport(CtModuleReference targetExport) {
 		if (targetExport == null) {
-			return (T) this;
+			return this;
 		}
 		if (this.targets == CtElementImpl.<CtModuleReference>emptyList()) {
 			this.targets = new ArrayList<>();
@@ -102,7 +105,7 @@ public class CtPackageExportImpl extends CtElementImpl implements CtPackageExpor
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.MODULE_REF, this.targets, targetExport);
 		targetExport.setParent(this);
 		this.targets.add(targetExport);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -16,11 +16,13 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.Comparator;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.path.CtRole;
@@ -29,7 +31,8 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.comparator.QualifiedNameComparator;
 import spoon.support.util.ModelSet;
 
-import java.util.Set;
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtPackage}.
@@ -98,9 +101,9 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	@Override
-	public <T extends CtPackage> T addPackage(CtPackage pack) {
+	public CtPackageImpl addPackage(CtPackage pack) {
 		this.packs.add(pack);
-		return (T) this;
+		return this;
 	}
 
 	/** add all types of "from" in "to" */
@@ -186,15 +189,15 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	@Override
-	public <T extends CtPackage> T setPackages(Set<CtPackage> packs) {
+	public CtPackageImpl setPackages(Set<CtPackage> packs) {
 		this.packs.set(packs);
-			return (T) this;
+			return this;
 		}
 
 	@Override
-	public <T extends CtPackage> T setTypes(Set<CtType<?>> types) {
+	public CtPackageImpl setTypes(Set<CtType<?>> types) {
 		this.types.set(types);
-			return (T) this;
+			return this;
 		}
 
 	@Override
@@ -203,9 +206,9 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	@Override
-	public <T extends CtPackage> T addType(CtType<?> type) {
+	public CtPackageImpl addType(CtType<?> type) {
 		types.add(type);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -227,10 +230,10 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtPackageImpl setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -16,14 +16,12 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtParameter;
-import spoon.reflect.declaration.CtShadowable;
-import spoon.reflect.declaration.CtTypedElement;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtParameterReference;
@@ -34,7 +32,8 @@ import spoon.support.UnsettableProperty;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.CtModifierHandler;
 
-import java.util.Set;
+
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtParameter}.
@@ -79,19 +78,19 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtVariable<T>> C setDefaultExpression(CtExpression<T> defaultExpression) {
+	public CtParameterImpl<T> setDefaultExpression(CtExpression<T> defaultExpression) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public CtParameterImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -100,10 +99,10 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	@Override
-	public <C extends CtParameter<T>> C setVarArgs(boolean varArgs) {
+	public CtParameterImpl<T> setVarArgs(boolean varArgs) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_VARARGS, varArgs, this.varArgs);
 		this.varArgs = varArgs;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -117,27 +116,27 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtParameterImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtParameterImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtParameterImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtParameterImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -157,9 +156,9 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	@Override
-	public <T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtParameterImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (T) this;
+		return this;
 	}
 
 
@@ -172,10 +171,10 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtParameterImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
@@ -16,15 +16,18 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+
+
 
 public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedService {
 	@MetamodelPropertyField(role = CtRole.SERVICE_TYPE)
@@ -42,13 +45,13 @@ public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedSe
 	}
 
 	@Override
-	public <T extends CtProvidedService> T setServiceType(CtTypeReference providingType) {
+	public CtProvidedServiceImpl setServiceType(CtTypeReference providingType) {
 		if (providingType != null) {
 			providingType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.SERVICE_TYPE, providingType, this.serviceType);
 		this.serviceType = providingType;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -57,11 +60,11 @@ public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedSe
 	}
 
 	@Override
-	public <T extends CtProvidedService> T setImplementationTypes(List<CtTypeReference> usedTypes) {
+	public CtProvidedServiceImpl setImplementationTypes(List<CtTypeReference> usedTypes) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.IMPLEMENTATION_TYPE, this.implementationTypes, new ArrayList<>(this.implementationTypes));
 		if (usedTypes == null || usedTypes.isEmpty()) {
 			this.implementationTypes = CtElementImpl.emptyList();
-			return (T) this;
+			return this;
 		}
 
 		if (this.implementationTypes == CtElementImpl.<CtTypeReference>emptyList()) {
@@ -72,13 +75,13 @@ public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedSe
 			this.addImplementationType(usedType);
 		}
 
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtProvidedService> T addImplementationType(CtTypeReference usedType) {
+	public CtProvidedServiceImpl addImplementationType(CtTypeReference usedType) {
 		if (usedType == null) {
-			return (T) this;
+			return this;
 		}
 		if (this.implementationTypes == CtElementImpl.<CtTypeReference>emptyList()) {
 			this.implementationTypes = new ArrayList<>();
@@ -87,7 +90,7 @@ public class CtProvidedServiceImpl extends CtElementImpl implements CtProvidedSe
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.IMPLEMENTATION_TYPE, this.implementationTypes, usedType);
 		usedType.setParent(this);
 		this.implementationTypes.add(usedType);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -16,20 +16,32 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
 import spoon.SpoonException;
 import spoon.refactoring.Refactoring;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnnotationType;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
@@ -57,17 +69,8 @@ import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.util.SignatureBasedSortedSet;
 import spoon.support.visitor.ClassTypingContext;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
-import spoon.reflect.ModelElementContainerDefaultCapacities;
+
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtType}.
@@ -102,14 +105,14 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	 * Otherwise, adds it at the end.
 	 */
 	@Override
-	public <C extends CtType<T>> C addTypeMember(CtTypeMember member) {
+	public CtTypeImpl<T> addTypeMember(CtTypeMember member) {
 		if (member == null) {
-			return (C) this;
+			return this;
 		}
 		Comparator c = new CtLineElementComparator();
 
 		if (member.isImplicit()) {
-			return addTypeMemberAt(0, member);
+			return ((CtTypeImpl<T>) (addTypeMemberAt(0, member)));
 		}
 
 		// by default, inserting at the end
@@ -126,13 +129,13 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				insertionPosition--;
 			}
 		}
-		return addTypeMemberAt(insertionPosition, member);
+		return ((CtTypeImpl<T>) (addTypeMemberAt(insertionPosition, member)));
 	}
 
 	@Override
-	public <C extends CtType<T>> C addTypeMemberAt(int position, CtTypeMember member) {
+	public CtTypeImpl<T> addTypeMemberAt(int position, CtTypeMember member) {
 		if (member == null) {
-			return (C) this;
+			return this;
 		}
 		if (this.typeMembers == CtElementImpl.<CtTypeMember>emptyList()) {
 			this.typeMembers = new ArrayList<>();
@@ -147,7 +150,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				this.typeMembers.add(member);
 			}
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -170,49 +173,49 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <C extends CtType<T>> C setTypeMembers(List<CtTypeMember> members) {
+	public CtTypeImpl<T> setTypeMembers(List<CtTypeMember> members) {
 		for (CtTypeMember typeMember : new ArrayList<>(typeMembers)) {
 			removeTypeMember(typeMember);
 		}
 		if (members == null || members.isEmpty()) {
 			this.typeMembers = emptyList();
-			return (C) this;
+			return this;
 		}
 		typeMembers.clear();
 		for (CtTypeMember typeMember : members) {
 			addTypeMember(typeMember);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <F, C extends CtType<T>> C addFieldAtTop(CtField<F> field) {
-		return addTypeMemberAt(0, field);
+	public <F> CtTypeImpl<T> addFieldAtTop(CtField<F> field) {
+		return ((CtTypeImpl<T>) (addTypeMemberAt(0, field)));
 	}
 
 	@Override
-	public <F, C extends CtType<T>> C addField(CtField<F> field) {
-		return addTypeMember(field);
+	public <F> CtTypeImpl<T> addField(CtField<F> field) {
+		return ((CtTypeImpl<T>) (addTypeMember(field)));
 	}
 
 	@Override
-	public <F, C extends CtType<T>> C addField(int index, CtField<F> field) {
-		return addTypeMemberAt(index, field);
+	public <F> CtTypeImpl<T> addField(int index, CtField<F> field) {
+		return ((CtTypeImpl<T>) (addTypeMemberAt(index, field)));
 	}
 
 	@Override
-	public <C extends CtType<T>> C setFields(List<CtField<?>> fields) {
+	public CtTypeImpl<T> setFields(List<CtField<?>> fields) {
 		List<CtField<?>> oldFields = getFields();
 		if (fields == null || fields.isEmpty()) {
 			this.typeMembers.removeAll(oldFields);
-			return (C) this;
+			return this;
 		}
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.FIELD, this.typeMembers, new ArrayList<>(oldFields));
 		typeMembers.removeAll(oldFields);
 		for (CtField<?> field : fields) {
 			addField(field);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -255,8 +258,8 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <N, C extends CtType<T>> C addNestedType(CtType<N> nestedType) {
-		return addTypeMember(nestedType);
+	public <N> CtTypeImpl<T> addNestedType(CtType<N> nestedType) {
+		return ((CtTypeImpl<T>) (addTypeMember(nestedType)));
 	}
 
 	@Override
@@ -265,18 +268,18 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <C extends CtType<T>> C setNestedTypes(Set<CtType<?>> nestedTypes) {
+	public CtTypeImpl<T> setNestedTypes(Set<CtType<?>> nestedTypes) {
 		Set<CtType<?>> oldNestedTypes = getNestedTypes();
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.NESTED_TYPE, typeMembers, oldNestedTypes);
 		if (nestedTypes == null || nestedTypes.isEmpty()) {
 			this.typeMembers.removeAll(oldNestedTypes);
-			return (C) this;
+			return this;
 		}
 		typeMembers.removeAll(oldNestedTypes);
 		for (CtType<?> nestedType : nestedTypes) {
 			addNestedType(nestedType);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -463,27 +466,27 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtTypeImpl<T> setModifiers(Set<ModifierKind> modifiers) {
 		modifierHandler.setModifiers(modifiers);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtTypeImpl<T> addModifier(ModifierKind modifier) {
 		modifierHandler.addModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtTypeImpl<T> removeModifier(ModifierKind modifier) {
 		modifierHandler.removeModifier(modifier);
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtTypeImpl<T> setVisibility(ModifierKind visibility) {
 		modifierHandler.setVisibility(visibility);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -497,9 +500,9 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <T extends CtModifiable> T setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
+	public CtTypeImpl<T> setExtendedModifiers(Set<CtExtendedModifier> extendedModifiers) {
 		this.modifierHandler.setExtendedModifiers(extendedModifiers);
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -576,7 +579,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <M, C extends CtType<T>> C addMethod(CtMethod<M> method) {
+	public <M> CtTypeImpl<T> addMethod(CtMethod<M> method) {
 		if (method != null) {
 			for (CtTypeMember typeMember : new ArrayList<>(typeMembers)) {
 				if (!(typeMember instanceof CtMethod)) {
@@ -590,7 +593,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 				}
 			}
 		}
-		return addTypeMember(method);
+		return ((CtTypeImpl<T>) (addTypeMember(method)));
 	}
 
 	@Override
@@ -599,9 +602,9 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <S, C extends CtType<T>> C addSuperInterface(CtTypeReference<S> interfac) {
+	public <S> CtTypeImpl<T> addSuperInterface(CtTypeReference<S> interfac) {
 		if (interfac == null) {
-			return (C) this;
+			return this;
 		}
 		if (interfaces == CtElementImpl.<CtTypeReference<?>>emptySet()) {
 			interfaces = new QualifiedNameBasedSortedSet<>();
@@ -609,7 +612,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		interfac.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onSetAdd(this, CtRole.INTERFACE, this.interfaces, interfac);
 		interfaces.add(interfac);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -636,11 +639,11 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+	public CtTypeImpl<T> setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.TYPE_PARAMETER, formalCtTypeParameters, new ArrayList<>(formalCtTypeParameters));
 		if (formalTypeParameters == null || formalTypeParameters.isEmpty()) {
 			this.formalCtTypeParameters = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			this.formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -649,13 +652,13 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		for (CtTypeParameter formalTypeParameter : formalTypeParameters) {
 			addFormalCtTypeParameter(formalTypeParameter);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtFormalTypeDeclarer> C addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
+	public CtTypeImpl<T> addFormalCtTypeParameter(CtTypeParameter formalTypeParameter) {
 		if (formalTypeParameter == null) {
-			return (C) this;
+			return this;
 		}
 		if (formalCtTypeParameters == CtElementImpl.<CtTypeParameter>emptyList()) {
 			formalCtTypeParameters = new ArrayList<>(ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -663,7 +666,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		formalTypeParameter.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CtRole.TYPE_PARAMETER, this.formalCtTypeParameters, formalTypeParameter);
 		formalCtTypeParameters.add(formalTypeParameter);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -847,31 +850,31 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <C extends CtType<T>> C setMethods(Set<CtMethod<?>> methods) {
+	public CtTypeImpl<T> setMethods(Set<CtMethod<?>> methods) {
 		Set<CtMethod<?>> allMethods = getMethods();
 		getFactory().getEnvironment().getModelChangeListener().onListDelete(this, CtRole.METHOD, this.typeMembers, new ArrayList(allMethods));
 		typeMembers.removeAll(allMethods);
 		if (methods == null || methods.isEmpty()) {
-			return (C) this;
+			return this;
 		}
 		for (CtMethod<?> meth : methods) {
 			addMethod(meth);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<T>> C setSuperclass(CtTypeReference<?> superClass) {
+	public CtTypeImpl<T> setSuperclass(CtTypeReference<?> superClass) {
 		// overridden in subclasses.
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtType<T>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
+	public CtTypeImpl<T> setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
 		if (interfaces == null || interfaces.isEmpty()) {
 			this.interfaces = CtElementImpl.emptySet();
-			return (C) this;
+			return this;
 		}
 		if (this.interfaces == CtElementImpl.<CtTypeReference<?>>emptySet()) {
 			this.interfaces = new QualifiedNameBasedSortedSet<>();
@@ -881,7 +884,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		for (CtTypeReference<?> anInterface : interfaces) {
 			addSuperInterface(anInterface);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -938,10 +941,10 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtTypeImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -16,17 +16,22 @@
  */
 package spoon.support.reflect.declaration;
 
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -36,12 +41,10 @@ import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 import spoon.support.visitor.GenericTypeAdapter;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
+
+
+
 
 public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypeParameter {
 	@MetamodelPropertyField(role = SUPER_TYPE)
@@ -58,13 +61,13 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	}
 
 	@Override
-	public <C extends CtType<Object>> C setSuperclass(CtTypeReference<?> superClass) {
+	public CtTypeParameterImpl setSuperclass(CtTypeReference<?> superClass) {
 		if (superClass != null) {
 			superClass.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, SUPER_TYPE, superClass, this.superClass);
 		this.superClass = superClass;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -98,30 +101,30 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <F, C extends CtType<Object>> C addFieldAtTop(CtField<F> field) {
+	public <F> CtTypeParameterImpl addFieldAtTop(CtField<F> field) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <F, C extends CtType<Object>> C addField(CtField<F> field) {
+	public <F> CtTypeParameterImpl addField(CtField<F> field) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <F, C extends CtType<Object>> C addField(int index, CtField<F> field) {
+	public <F> CtTypeParameterImpl addField(int index, CtField<F> field) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<Object>> C setFields(List<CtField<?>> fields) {
+	public CtTypeParameterImpl setFields(List<CtField<?>> fields) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -144,9 +147,9 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <N, C extends CtType<Object>> C addNestedType(CtType<N> nestedType) {
+	public <N> CtTypeParameterImpl addNestedType(CtType<N> nestedType) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -158,9 +161,9 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<Object>> C setNestedTypes(Set<CtType<?>> nestedTypes) {
+	public CtTypeParameterImpl setNestedTypes(Set<CtType<?>> nestedTypes) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -197,30 +200,30 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtModifiable> C setModifiers(Set<ModifierKind> modifiers) {
+	public CtTypeParameterImpl setModifiers(Set<ModifierKind> modifiers) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtModifiable> C addModifier(ModifierKind modifier) {
+	public CtTypeParameterImpl addModifier(ModifierKind modifier) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtModifiable> C removeModifier(ModifierKind modifier) {
+	public CtTypeParameterImpl removeModifier(ModifierKind modifier) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtModifiable> C setVisibility(ModifierKind visibility) {
+	public CtTypeParameterImpl setVisibility(ModifierKind visibility) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -314,9 +317,9 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <M, C extends CtType<Object>> C addMethod(CtMethod<M> method) {
+	public <M> CtTypeParameterImpl addMethod(CtMethod<M> method) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -328,9 +331,9 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <S, C extends CtType<Object>> C addSuperInterface(CtTypeReference<S> interfac) {
+	public <S> CtTypeParameterImpl addSuperInterface(CtTypeReference<S> interfac) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -374,16 +377,16 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<Object>> C setMethods(Set<CtMethod<?>> methods) {
+	public CtTypeParameterImpl setMethods(Set<CtMethod<?>> methods) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<Object>> C setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
+	public CtTypeParameterImpl setSuperInterfaces(Set<CtTypeReference<?>> interfaces) {
 		// unsettable property
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -412,8 +415,8 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtFormalTypeDeclarer> C setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
-		return (C) this;
+	public CtTypeParameterImpl setFormalCtTypeParameters(List<CtTypeParameter> formalTypeParameters) {
+		return this;
 	}
 
 	@Override
@@ -424,7 +427,7 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtType<Object>> C setTypeMembers(List<CtTypeMember> members) {
-		return (C) this;
+	public CtTypeParameterImpl setTypeMembers(List<CtTypeMember> members) {
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtUsedServiceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtUsedServiceImpl.java
@@ -16,11 +16,15 @@
  */
 package spoon.support.reflect.declaration;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtUsedServiceImpl extends CtElementImpl implements CtUsedService {
 	@MetamodelPropertyField(role = CtRole.SERVICE_TYPE)
@@ -32,14 +36,14 @@ public class CtUsedServiceImpl extends CtElementImpl implements CtUsedService {
 	}
 
 	@Override
-	public <T extends CtUsedService> T setServiceType(CtTypeReference usedService) {
+	public CtUsedServiceImpl setServiceType(CtTypeReference usedService) {
 		if (usedService != null) {
 			usedService.setParent(this);
 		}
 
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.SERVICE_TYPE, usedService, this.serviceType);
 		this.serviceType = usedService;
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/InvisibleArrayConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/InvisibleArrayConstructorImpl.java
@@ -16,11 +16,14 @@
  */
 package spoon.support.reflect.declaration;
 
+
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
+
+
+
 
 
 /**
@@ -43,13 +46,13 @@ public class InvisibleArrayConstructorImpl<T> extends CtConstructorImpl<T> {
 	}
 
 	@Override
-	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+	public InvisibleArrayConstructorImpl<T> setType(CtTypeReference<T> type) {
 		if (type == null) {
-			return (C) this;
+			return this;
 		}
 
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -16,16 +16,18 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.Array;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.reference.CtArrayTypeReference;
-import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.SpoonClassNotFoundException;
 
-import java.lang.reflect.Array;
-
 import static spoon.reflect.path.CtRole.TYPE;
+
+
+
 
 public class
 CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTypeReference<T> {
@@ -53,8 +55,8 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	}
 
 	@Override
-	public CtTypeReference<?> getArrayType() {
-		return getLastComponentTypeReference(componentType);
+	public CtArrayTypeReferenceImpl<?> getArrayType() {
+		return ((CtArrayTypeReferenceImpl<T>) (getLastComponentTypeReference(componentType)));
 	}
 
 	private CtTypeReference<?> getLastComponentTypeReference(CtTypeReference<?> component) {
@@ -62,13 +64,13 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	}
 
 	@Override
-	public <C extends CtArrayTypeReference<T>> C setComponentType(CtTypeReference<?> componentType) {
+	public CtArrayTypeReferenceImpl<T> setComponentType(CtTypeReference<?> componentType) {
 		if (componentType != null) {
 			componentType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, componentType, this.componentType);
 		this.componentType = componentType;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -77,8 +79,8 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	}
 
 	@Override
-	public <T extends CtReference> T setSimpleName(String simplename) {
-		return (T) this;
+	public CtArrayTypeReferenceImpl<T> setSimpleName(String simplename) {
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
@@ -16,12 +16,16 @@
  */
 package spoon.support.reflect.reference;
 
+
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.visitor.CtVisitor;
+
+
+
 
 public class CtCatchVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtCatchVariableReference<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -16,6 +16,15 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -27,7 +36,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.reference.CtActualTypeContainer;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
@@ -40,21 +49,15 @@ import spoon.support.util.RtHelper;
 import spoon.support.visitor.ClassTypingContext;
 import spoon.support.visitor.SignaturePrinter;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.METHOD_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
+import static spoon.reflect.path.CtRole.ARGUMENT_TYPE;
 import static spoon.reflect.path.CtRole.DECLARING_TYPE;
 import static spoon.reflect.path.CtRole.IS_STATIC;
-import static spoon.reflect.path.CtRole.ARGUMENT_TYPE;
 import static spoon.reflect.path.CtRole.TYPE;
 import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
+
+
+
 
 public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtExecutableReference<T> {
 	private static final long serialVersionUID = 1L;
@@ -162,10 +165,10 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	}
 
 	@Override
-	public <C extends CtExecutableReference<T>> C setParameters(List<CtTypeReference<?>> parameters) {
+	public CtExecutableReferenceImpl<T> setParameters(List<CtTypeReference<?>> parameters) {
 		if (parameters == null || parameters.isEmpty()) {
 			this.parameters = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.parameters == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.parameters = new ArrayList<>();
@@ -175,7 +178,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		for (CtTypeReference<?> parameter : parameters) {
 			addParameter(parameter);
 		}
-		return (C) this;
+		return this;
 	}
 
 	private boolean addParameter(CtTypeReference<?> parameter) {
@@ -241,10 +244,10 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	}
 
 	@Override
-	public <C extends CtActualTypeContainer> C setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
+	public CtExecutableReferenceImpl<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
 		if (actualTypeArguments == null || actualTypeArguments.isEmpty()) {
 			this.actualTypeArguments = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.actualTypeArguments = new ArrayList<>();
@@ -254,27 +257,27 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		for (CtTypeReference<?> actualTypeArgument : actualTypeArguments) {
 			addActualTypeArgument(actualTypeArgument);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExecutableReference<T>> C setDeclaringType(CtTypeReference<?> declaringType) {
+	public CtExecutableReferenceImpl<T> setDeclaringType(CtTypeReference<?> declaringType) {
 		if (declaringType != null) {
 			declaringType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DECLARING_TYPE, declaringType, this.declaringType);
 		this.declaringType = declaringType;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtExecutableReference<T>> C setType(CtTypeReference<T> type) {
+	public CtExecutableReferenceImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -347,10 +350,10 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	}
 
 	@Override
-	public <C extends CtExecutableReference<T>> C setStatic(boolean stat) {
+	public CtExecutableReferenceImpl<T> setStatic(boolean stat) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_STATIC, stat, this.stat);
 		this.stat = stat;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -390,17 +393,17 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	}
 
 	@Override
-	public CtExecutableReference<?> getOverridingExecutable() {
+	public CtExecutableReferenceImpl<?> getOverridingExecutable() {
 		CtTypeReference<Object> objectType = getFactory().Type().OBJECT;
 		CtTypeReference<?> declaringType = getDeclaringType();
 		if (declaringType == null) {
-			return getOverloadedExecutable(objectType, objectType);
+			return ((CtExecutableReferenceImpl<T>) (getOverloadedExecutable(objectType, objectType)));
 		}
 		CtTypeReference<?> st = declaringType.getSuperclass();
 		if (st == null) {
-			return getOverloadedExecutable(objectType, objectType);
+			return ((CtExecutableReferenceImpl<T>) (getOverloadedExecutable(objectType, objectType)));
 		}
-		return getOverloadedExecutable(st, objectType);
+		return ((CtExecutableReferenceImpl<T>) (getOverloadedExecutable(st, objectType)));
 	}
 
 	private CtExecutableReference<?> getOverloadedExecutable(CtTypeReference<?> t, CtTypeReference<Object> objectType) {
@@ -423,9 +426,9 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	}
 
 	@Override
-	public <C extends CtActualTypeContainer> C addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+	public CtExecutableReferenceImpl<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
 		if (actualTypeArgument == null) {
-			return (C) this;
+			return this;
 		}
 		if (actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			actualTypeArguments = new ArrayList<>(METHOD_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -433,7 +436,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 		actualTypeArgument.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TYPE_ARGUMENT, this.actualTypeArguments, actualTypeArgument);
 		actualTypeArguments.add(actualTypeArgument);
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -16,6 +16,11 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Member;
+import java.util.Collections;
+import java.util.Set;
 import spoon.Launcher;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtEnum;
@@ -28,14 +33,12 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.util.RtHelper;
 
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Member;
-import java.util.Collections;
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.DECLARING_TYPE;
 import static spoon.reflect.path.CtRole.IS_FINAL;
 import static spoon.reflect.path.CtRole.IS_STATIC;
+
+
+
 
 public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtFieldReference<T> {
 	private static final long serialVersionUID = 1L;
@@ -195,27 +198,27 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 	}
 
 	@Override
-	public <C extends CtFieldReference<T>> C setDeclaringType(CtTypeReference<?> declaringType) {
+	public CtFieldReferenceImpl<T> setDeclaringType(CtTypeReference<?> declaringType) {
 		if (declaringType != null) {
 			declaringType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DECLARING_TYPE, declaringType, this.declaringType);
 		this.declaringType = declaringType;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtFieldReference<T>> C setFinal(boolean fina) {
+	public CtFieldReferenceImpl<T> setFinal(boolean fina) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_FINAL, fina, this.fina);
 		this.fina = fina;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtFieldReference<T>> C setStatic(boolean stat) {
+	public CtFieldReferenceImpl<T> setStatic(boolean stat) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_STATIC, stat, this.stat);
 		this.stat = stat;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -16,17 +16,21 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import spoon.reflect.annotations.MetamodelPropertyField;
+import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import static spoon.reflect.path.CtRole.BOUND;
+
+
+
 
 
 public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtIntersectionTypeReference<T> {
@@ -44,10 +48,10 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	}
 
 	@Override
-	public <C extends CtIntersectionTypeReference> C setBounds(List<CtTypeReference<?>> bounds) {
+	public CtIntersectionTypeReferenceImpl<T> setBounds(List<CtTypeReference<?>> bounds) {
 		if (bounds == null || bounds.isEmpty()) {
 			this.bounds = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.bounds == CtElementImpl.<CtTypeReference<?>>emptySet()) {
 			this.bounds = new ArrayList<>();
@@ -57,13 +61,13 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 		for (CtTypeReference<?> bound : bounds) {
 			addBound(bound);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtIntersectionTypeReference> C addBound(CtTypeReference<?> bound) {
+	public CtIntersectionTypeReferenceImpl<T> addBound(CtTypeReference<?> bound) {
 		if (bound == null) {
-			return (C) this;
+			return this;
 		}
 		if (bounds == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			bounds = new ArrayList<>();
@@ -73,7 +77,7 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 			getFactory().getEnvironment().getModelChangeListener().onListAdd(this, BOUND, this.bounds, bound);
 			bounds.add(bound);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -16,6 +16,7 @@
  */
 package spoon.support.reflect.reference;
 
+
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ParentNotInitializedException;
@@ -23,6 +24,10 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
+import spoon.support.reflect.declaration.CtElementImpl;
+
+
+
 
 /**
  * An implementation for {@link CtLocalVariableReference}.

--- a/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
@@ -16,11 +16,14 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.lang.reflect.AnnotatedElement;
+
+
 
 public class CtModuleReferenceImpl extends CtReferenceImpl implements CtModuleReference {
 

--- a/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
@@ -16,11 +16,14 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.lang.reflect.AnnotatedElement;
+
+
 
 public class CtPackageReferenceImpl extends CtReferenceImpl implements CtPackageReference {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
@@ -16,6 +16,8 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.util.List;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
@@ -24,7 +26,8 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.util.List;
+
+
 
 public class CtParameterReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtParameterReference<T> {
 	private static final long serialVersionUID = 1L;

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -16,9 +16,13 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.io.Serializable;
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Objects;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.reference.CtReference;
@@ -26,12 +30,10 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.io.Serializable;
-import java.lang.reflect.AnnotatedElement;
-import java.util.List;
-import java.util.Objects;
-
 import static spoon.reflect.path.CtRole.NAME;
+
+
+
 
 public abstract class CtReferenceImpl extends CtElementImpl implements CtReference, Serializable {
 
@@ -51,24 +53,24 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 	}
 
 	@Override
-	public <T extends CtReference> T setSimpleName(String simplename) {
+	public CtReferenceImpl setSimpleName(String simplename) {
 		Factory factory = getFactory();
 		if (factory == null) {
 			this.simplename = simplename;
-			return (T) this;
+			return this;
 		}
 		if (factory instanceof FactoryImpl) {
 			simplename = ((FactoryImpl) factory).dedup(simplename);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simplename, this.simplename);
 		this.simplename = simplename;
-		return (T) this;
+		return this;
 	}
 
 	@UnsettableProperty
 	@Override
-	public <E extends CtElement> E setComments(List<CtComment> comments) {
-		return (E) this;
+	public CtReferenceImpl setComments(List<CtComment> comments) {
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -16,23 +16,26 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.List;
+import java.util.Objects;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
+import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.lang.reflect.AnnotatedElement;
-import java.util.List;
-import java.util.Objects;
+
+
 
 public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> implements CtTypeParameterReference {
 	private static final long serialVersionUID = 1L;
@@ -70,14 +73,14 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtActualTypeContainer> C setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
-		return (C) this;
+	public CtTypeParameterReferenceImpl setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
+		return this;
 	}
 
 	@Override
 	@UnsettableProperty
-	public <C extends CtActualTypeContainer> C addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
-		return (C) this;
+	public CtTypeParameterReferenceImpl addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -16,6 +16,15 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -25,11 +34,9 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
@@ -42,20 +49,14 @@ import spoon.support.SpoonClassNotFoundException;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.visitor.ClassTypingContext;
 
-import java.lang.reflect.AnnotatedElement;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.DECLARING_TYPE;
 import static spoon.reflect.path.CtRole.IS_SHADOW;
 import static spoon.reflect.path.CtRole.PACKAGE_REF;
 import static spoon.reflect.path.CtRole.TYPE_ARGUMENT;
+
+
+
 
 public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeReference<T> {
 	private static final long serialVersionUID = 1L;
@@ -254,10 +255,10 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	}
 
 	@Override
-	public <C extends CtActualTypeContainer> C setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
+	public CtTypeReferenceImpl<T> setActualTypeArguments(List<? extends CtTypeReference<?>> actualTypeArguments) {
 		if (actualTypeArguments == null || actualTypeArguments.isEmpty()) {
 			this.actualTypeArguments = CtElementImpl.emptyList();
-			return (C) this;
+			return this;
 		}
 		if (this.actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			this.actualTypeArguments = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -267,27 +268,27 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		for (CtTypeReference<?> actualTypeArgument : actualTypeArguments) {
 			addActualTypeArgument(actualTypeArgument);
 		}
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypeReference<T>> C setDeclaringType(CtTypeReference<?> declaringType) {
+	public CtTypeReferenceImpl<T> setDeclaringType(CtTypeReference<?> declaringType) {
 		if (declaringType != null) {
 			declaringType.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, DECLARING_TYPE, declaringType, this.declaringType);
 		this.declaringType = declaringType;
-		return (C) this;
+		return this;
 	}
 
 	@Override
-	public <C extends CtTypeReference<T>> C setPackage(CtPackageReference pack) {
+	public CtTypeReferenceImpl<T> setPackage(CtPackageReference pack) {
 		if (pack != null) {
 			pack.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, PACKAGE_REF, pack, this.pack);
 		this.pack = pack;
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -471,9 +472,9 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	}
 
 	@Override
-	public <C extends CtActualTypeContainer> C addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
+	public CtTypeReferenceImpl<T> addActualTypeArgument(CtTypeReference<?> actualTypeArgument) {
 		if (actualTypeArgument == null) {
-			return (C) this;
+			return this;
 		}
 		if (actualTypeArguments == CtElementImpl.<CtTypeReference<?>>emptyList()) {
 			actualTypeArguments = new ArrayList<>(TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY);
@@ -481,7 +482,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		actualTypeArgument.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, TYPE_ARGUMENT, this.actualTypeArguments, actualTypeArgument);
 		actualTypeArguments.add(actualTypeArgument);
-		return (C) this;
+		return this;
 	}
 
 	@Override
@@ -718,10 +719,10 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	}
 
 	@Override
-	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+	public CtTypeReferenceImpl<T> setShadow(boolean isShadow) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_SHADOW, isShadow, this.isShadow);
 		this.isShadow = isShadow;
-		return (E) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
@@ -16,15 +16,18 @@
  */
 package spoon.support.reflect.reference;
 
+
 import java.lang.annotation.Annotation;
 import java.util.List;
-
 import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtElement;
 import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
+import spoon.support.reflect.declaration.CtElementImpl;
+
+
+
 
 /** represents a reference to an unbound field (used when no full classpath is available */
 public class CtUnboundVariableReferenceImpl<T> extends CtVariableReferenceImpl<T> implements CtUnboundVariableReference<T> {
@@ -48,7 +51,7 @@ public class CtUnboundVariableReferenceImpl<T> extends CtVariableReferenceImpl<T
 
 	@Override
 	@UnsettableProperty
-	public <E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
-		return (E) this;
+	public CtUnboundVariableReferenceImpl<T> setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
@@ -16,6 +16,10 @@
  */
 package spoon.support.reflect.reference;
 
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collections;
+import java.util.Set;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
@@ -23,11 +27,10 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtVisitor;
 
-import java.lang.reflect.AnnotatedElement;
-import java.util.Collections;
-import java.util.Set;
-
 import static spoon.reflect.path.CtRole.TYPE;
+
+
+
 
 public abstract class CtVariableReferenceImpl<T> extends CtReferenceImpl implements CtVariableReference<T> {
 	private static final long serialVersionUID = 1L;
@@ -49,13 +52,13 @@ public abstract class CtVariableReferenceImpl<T> extends CtReferenceImpl impleme
 	}
 
 	@Override
-	public <C extends CtVariableReference<T>> C setType(CtTypeReference<T> type) {
+	public CtVariableReferenceImpl<T> setType(CtTypeReference<T> type) {
 		if (type != null) {
 			type.setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, TYPE, type, this.type);
 		this.type = type;
-		return (C) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
@@ -16,16 +16,19 @@
  */
 package spoon.support.reflect.reference;
 
-import static spoon.reflect.path.CtRole.BOUNDING_TYPE;
-import static spoon.reflect.path.CtRole.IS_UPPER;
 
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
+
+import static spoon.reflect.path.CtRole.BOUNDING_TYPE;
+import static spoon.reflect.path.CtRole.IS_UPPER;
+
+
+
 
 public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implements CtWildcardReference {
 
@@ -51,14 +54,14 @@ public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implem
 	}
 
 	@Override
-	public <T extends CtWildcardReference> T setUpper(boolean upper) {
+	public CtWildcardReferenceImpl setUpper(boolean upper) {
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, IS_UPPER, upper, this.upper);
 		this.upper = upper;
-		return (T) this;
+		return this;
 	}
 
 	@Override
-	public <T extends CtWildcardReference> T setBoundingType(CtTypeReference<?> superType) {
+	public CtWildcardReferenceImpl setBoundingType(CtTypeReference<?> superType) {
 		if (superType != null) {
 			superType.setParent(this);
 		}
@@ -72,7 +75,7 @@ public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implem
 
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, BOUNDING_TYPE, superType, this.superType);
 		this.superType = superType;
-		return (T) this;
+		return this;
 	}
 
 	@Override
@@ -82,8 +85,8 @@ public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implem
 
 	@Override
 	@UnsettableProperty
-	public <T extends CtReference> T setSimpleName(String simplename) {
-		return (T) this;
+	public CtWildcardReferenceImpl setSimpleName(String simplename) {
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardStaticTypeMemberReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardStaticTypeMemberReferenceImpl.java
@@ -16,7 +16,8 @@
  */
 package spoon.support.reflect.reference;
 
-import spoon.reflect.reference.CtReference;
+
+
 
 /**
  * This class intends to be used only to represent the reference of a
@@ -30,11 +31,11 @@ public class CtWildcardStaticTypeMemberReferenceImpl extends CtTypeReferenceImpl
 	}
 
 	@Override
-	public <T extends CtReference> T setSimpleName(String newName) {
+	public CtWildcardStaticTypeMemberReferenceImpl setSimpleName(String newName) {
 		if (!newName.endsWith(".*")) {
 			newName += ".*";
 		}
-		return super.setSimpleName(newName);
+		return ((CtWildcardStaticTypeMemberReferenceImpl) (super.setSimpleName(newName)));
 	}
 
 	@Override


### PR DESCRIPTION
Alternative of #1852 as fix of #1846
The code of this PR was generated by SniperPrinter. The sources of generator are in this [branch](https://github.com/pvojtechovsky/spoon/tree/refReturnTypeMM).

There are following problems, which has to be solved before we can merge it:
* the order of imports is changed by printer (see # #2638). Note: it is not using sniper mode for imports. @surli do you think we can modify import printer by way it keeps the order from origin sources?
* each file contains extra spaces between imports and class definition. I will try to fix that in Sniper printer.
* ImportScanner still adds 20 unwanted imports.
![image](https://user-images.githubusercontent.com/23107345/46374665-8ba1e280-c691-11e8-987e-164dc0b1e963.png)
I can remove them manually before commit. Or it needs a fix in import scanner.
* 41 problems caused by change in return types. See this [discussion](https://github.com/INRIA/spoon/pull/1852#issuecomment-426072727) in #1852 