### PR TITLE
refactor: unify test utils

### DIFF
--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -70,7 +70,7 @@ public class AnnotationValuesTest {
 
 	@Test
 	public void testCtAnnotationAPI() throws Exception {
-		Factory factory = ModelUtils.createFactory();
+		Factory factory = createFactory();
 		CtAnnotation<Annotation> annotation = factory.Core().createAnnotation();
 		annotation.addValue("integers", 7);
 

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -338,7 +338,7 @@ public class FieldAccessTest {
 
 	@Test
 	public void testTypeOfFieldAccess() throws Exception {
-		CtType<Panini> aPanini = ModelUtils.buildClass(Panini.class);
+		CtType<Panini> aPanini = buildClass(Panini.class);
 		List<CtFieldAccess> fieldAccesses = aPanini.getMethod("prepare").getElements(new TypeFilter<>(CtFieldAccess.class));
 		assertEquals(1, fieldAccesses.size());
 		assertNotNull(fieldAccesses.get(0).getType());
@@ -402,7 +402,7 @@ public class FieldAccessTest {
 	}
 	@Test
 	public void testFieldAccessAutoExplicit() throws Exception {
-		CtClass mouse = (CtClass)ModelUtils.buildClass(Mouse.class);
+		CtClass mouse = (CtClass) buildClass(Mouse.class);
 		CtMethod method = mouse.filterChildren((CtMethod m)->"meth1".equals(m.getSimpleName())).first();
 		
 		CtFieldReference ageFR = method.filterChildren((CtFieldReference fr)->"age".equals(fr.getSimpleName())).first();

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -88,7 +88,7 @@ public class FilterTest {
 
 	@Before
 	public void setup() throws Exception {
-		factory = ModelUtils.build(Foo.class);
+		factory = build(Foo.class);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -888,7 +888,7 @@ public class GenericsTest {
 	@Test
 	public void testTypeAdapted() throws Exception {
 		// contract: one can get the actual value of a generic type in a given context
-		CtClass<?> ctModel = (CtClass<?>) ModelUtils.buildClass(ErasureModelA.class);
+		CtClass<?> ctModel = (CtClass<?>) buildClass(ErasureModelA.class);
 		CtTypeParameter tpA = ctModel.getFormalCtTypeParameters().get(0);
 		CtTypeParameter tpB = ctModel.getFormalCtTypeParameters().get(1);
 		CtTypeParameter tpC = ctModel.getFormalCtTypeParameters().get(2);
@@ -1425,7 +1425,7 @@ public class GenericsTest {
 	@Test
 	public void testCannotAdaptTypeOfNonTypeScope() throws Exception {
 		//contract: ClassTypingContext doesn't fail on type parameters, which are defined out of the scope of ClassTypingContext
-		CtType<?> ctClass = ModelUtils.buildClass(OuterTypeParameter.class);
+		CtType<?> ctClass = buildClass(OuterTypeParameter.class);
 		//the method defines type parameter, which is used in super of local class
 		CtReturn<?> retStmt = (CtReturn<?>) ctClass.getMethodsByName("method").get(0).getBody().getStatements().get(0);
 		CtNewClass<?> newClassExpr = (CtNewClass<?>) retStmt.getReturnedExpression();

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -25,7 +25,7 @@ public class LoopTest {
 
 	@Test
 	public void testAnnotationInForLoop() {
-		CtType<?> aFoo = ModelUtils.build(new File("./src/test/resources/spoon/test/loop/testclasses/")).Type().get("spoon.test.loop.testclasses.Foo");
+		CtType<?> aFoo = build(new File("./src/test/resources/spoon/test/loop/testclasses/")).Type().get("spoon.test.loop.testclasses.Foo");
 
 		CtFor aFor = aFoo.getMethod("m").getElements(new TypeFilter<>(CtFor.class)).get(0);
 		assertEquals(1, ((CtLocalVariable) aFor.getForInit().get(0)).getType().getAnnotations().size());

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -672,7 +672,7 @@ public class PositionTest {
 	public void testPositionMethodTypeParameter() throws Exception {
 		//contract: the Method TypeParameter T extends List<?> has simple source position
 		//the previous used DeclarationSourcePosition had incorrect details
-		final CtType<?> foo = ModelUtils.buildClass(TypeParameter.class);
+		final CtType<?> foo = buildClass(TypeParameter.class);
 		String classContent = getClassContent(foo);
 
 		CtTypeParameter typeParam = foo.getMethodsByName("m").get(0).getFormalCtTypeParameters().get(0);
@@ -683,7 +683,7 @@ public class PositionTest {
 	@Test
 	public void testPositionOfAnnonymousType() throws Exception {
 		//contract: the annonymous type has consistent position
-		final CtEnum foo = (CtEnum) ModelUtils.buildClass(SomeEnum.class);
+		final CtEnum foo = (CtEnum) buildClass(SomeEnum.class);
 		String classContent = getClassContent(foo);
 
 		CtNewClass<?> newClass = (CtNewClass<?>) foo.getEnumValue("X").getDefaultExpression();
@@ -709,7 +709,7 @@ public class PositionTest {
 	@Test
 	public void testPositionOfAnnonymousTypeByNewInterface() throws Exception {
 		//contract: the annonymous type has consistent position
-		final CtType<?> foo = ModelUtils.buildClass(AnnonymousClassNewIface.class);
+		final CtType<?> foo = buildClass(AnnonymousClassNewIface.class);
 		String classContent = getClassContent(foo);
 
 		CtLocalVariable<?> localVar = (CtLocalVariable<?>) foo.getMethodsByName("m").get(0).getBody().getStatement(0);
@@ -741,7 +741,7 @@ public class PositionTest {
 	@Test
 	public void testPositionOfCtImport() throws Exception {
 		//contract: the CtImport has position
-		final CtType<?> foo = ModelUtils.buildClass(
+		final CtType<?> foo = buildClass(
 			launcher ->	launcher.getEnvironment().setAutoImports(true), 
 			AnnonymousClassNewIface.class);
 		String originSources = foo.getPosition().getCompilationUnit().getOriginalSourceCode();
@@ -762,7 +762,7 @@ public class PositionTest {
 	@Test
 	public void testEmptyModifiersOfMethod() throws Exception {
 		//contract: the modifiers of Method without modifiers are empty and have correct start
-		final CtType<?> foo = ModelUtils.buildClass(NoMethodModifiers.class);
+		final CtType<?> foo = buildClass(NoMethodModifiers.class);
 		String classContent = getClassContent(foo);
 
 		BodyHolderSourcePosition bhsp = (BodyHolderSourcePosition) foo.getMethodsByName("m").get(0).getPosition();
@@ -779,7 +779,7 @@ public class PositionTest {
 	@Test
 	public void testPositionTryCatch() throws Exception {
 		//contract: check that the variable in the catch has a correct position
-		CtType<?> foo = ModelUtils.buildClass(PositionTry.class);
+		CtType<?> foo = buildClass(PositionTry.class);
 		String classContent = getClassContent(foo);
 
 		List<CtCatchVariable> elements = foo.getElements(new TypeFilter<>(CtCatchVariable.class));
@@ -851,7 +851,7 @@ public class PositionTest {
 	@Test
 	public void testArrayArgParameter() throws Exception {
 		//contract: the parameter declared like `String arg[]`, `String[] arg` and `String []arg` has correct positions
-		final CtType<?> foo = ModelUtils.buildClass(ArrayArgParameter.class);
+		final CtType<?> foo = buildClass(ArrayArgParameter.class);
 		String classContent = getClassContent(foo);
 
 		{
@@ -901,7 +901,7 @@ public class PositionTest {
 	@Test
 	public void testExpressions() throws Exception {
 		//contract: the expression including type casts has correct position which includes all brackets too
-		final CtType<?> foo = ModelUtils.buildClass(Expressions.class);
+		final CtType<?> foo = buildClass(Expressions.class);
 		String classContent = getClassContent(foo);
 		List<CtInvocation<?>> statements = (List) foo.getMethodsByName("method").get(0).getBody().getStatements();
 
@@ -947,7 +947,7 @@ public class PositionTest {
 	@Test
 	public void testCatchPosition() throws Exception {
 		//contract: check the catch position
-		final CtType<?> foo = ModelUtils.buildClass(CatchPosition.class);
+		final CtType<?> foo = buildClass(CatchPosition.class);
 		String classContent = getClassContent(foo);
 		CtTry tryStatement = (CtTry) foo.getMethodsByName("method").get(0).getBody().getStatement(0);
 		{
@@ -1009,7 +1009,7 @@ public class PositionTest {
 	@Test
 	public void testEnumConstructorCallComment() throws Exception {
 		//contract: check position the enum constructor call 
-		final CtType<?> foo = ModelUtils.buildClass(FooEnum.class);
+		final CtType<?> foo = buildClass(FooEnum.class);
 		
 		String classContent = getClassContent(foo);
 		CtField<?> field = foo.getField("GET");
@@ -1026,7 +1026,7 @@ public class PositionTest {
 	@Test
 	public void testSwitchCase() throws Exception {
 		//contract: check position of the statements of the case of switch
-		final CtType<?> foo = ModelUtils.buildClass(FooSwitch.class);
+		final CtType<?> foo = buildClass(FooSwitch.class);
 		
 		String classContent = getClassContent(foo);
 		CtSwitch<?> switchStatement = foo.getMethodsByName("m1").get(0).getBody().getStatement(0);
@@ -1063,7 +1063,7 @@ public class PositionTest {
 	@Test
 	public void testFooForEach() throws Exception {
 		//contract: check position of the for each position
-		final CtType<?> foo = ModelUtils.buildClass(FooForEach.class);
+		final CtType<?> foo = buildClass(FooForEach.class);
 		
 		String classContent = getClassContent(foo);
 		List<CtForEach> stmts = (List) foo.getMethodsByName("m").get(0).getBody().getStatements();

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -491,8 +491,8 @@ public class TypeReferenceTest {
 	@Test
 	public void testShortTypeReference() {
 
-		CtTypeReference<Short> aShort = ModelUtils.createFactory().Type().SHORT;
-		CtTypeReference<Short> shortPrimitive = ModelUtils.createFactory().Type().SHORT_PRIMITIVE;
+		CtTypeReference<Short> aShort = createFactory().Type().SHORT;
+		CtTypeReference<Short> shortPrimitive = createFactory().Type().SHORT_PRIMITIVE;
 
 		assertSame(Short.class, aShort.getActualClass());
 		assertSame(short.class, shortPrimitive.getActualClass());

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -58,7 +58,7 @@ public class VariableAccessTest {
 
 	@Test
 	public void testDeclarationArray() throws Exception {
-		final CtType<Pozole> aPozole = ModelUtils.buildClass(Pozole.class);
+		final CtType<Pozole> aPozole = buildClass(Pozole.class);
 		final CtMethod<Object> m2 = aPozole.getMethod("m2");
 		final CtArrayWrite<?> ctArrayWrite = m2.getElements(new TypeFilter<CtArrayWrite<?>>(CtArrayWrite.class)).get(0);
 		final CtLocalVariable expected = m2.getElements(new TypeFilter<>(CtLocalVariable.class)).get(0);


### PR DESCRIPTION
The problem:
- there is statically imported test util e.g.  import static spoon.testing.utils.ModelUtils.createFactory;
- we use it as qualified entity: Factory factory = ModelUtils.createFactory();

Solution:
Remove (obvious) redundant class prefix: **ModelUtils.** createFactory();

General remark - what to import statically:
- assertions
- common Spoon utils like: build, buildClass, createFactory()

IDEA Code Inspection: Unnecessarily qualified statically imported element

*Reports any references to static members which are statically imported and also qualified with their containing class name. Because the elements are already statically imported such qualification is unnecessary and can be removed.*