### PR TITLE
fix: CtImportScanner shouldn't import type when static field is imported

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -423,6 +423,7 @@ public class ImportScannerImpl extends CtScanner implements ImportScanner {
 										}
 									}
 								}
+								return false;
 							}
 						}
 					}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -764,7 +764,7 @@ public class ImportTest {
 		//contract: static import of enum field doesn't cause import of enum
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(true);
-		String outputDir = "./target/spooned";
+		String outputDir = "./target/spooned-enumField";
 		launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/Kun.java");
 		launcher.setSourceOutputDirectory(outputDir);
 		launcher.run();

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -760,6 +760,28 @@ public class ImportTest {
 	}
 
 	@Test
+	public void testStaticImportOfEnumField() {
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(true);
+		String outputDir = "./target/spooned";
+		launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/Kun.java");
+		launcher.setSourceOutputDirectory(outputDir);
+		launcher.run();
+		PrettyPrinter prettyPrinter = launcher.createPrettyPrinter();
+
+		CtType element = launcher.getFactory().Class().getAll().get(0);
+		List<CtType<?>> toPrint = new ArrayList<>();
+		toPrint.add(element);
+
+		prettyPrinter.calculate(element.getPosition().getCompilationUnit(), toPrint);
+		String output = prettyPrinter.getResult();
+
+		assertTrue("The file should not contain the import of enum",!output.contains("import spoon.reflect.path.CtRole;"));
+		assertTrue("The file should contain the static import of enum field",!output.contains("import spoon.reflect.path.CtRole.NAME;"));
+		canBeBuilt(outputDir, 7);
+	}
+
+	@Test
 	public void testShouldNotCreateAutoreference() {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(false);

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -761,6 +761,7 @@ public class ImportTest {
 
 	@Test
 	public void testStaticImportOfEnumField() {
+		//contract: static import of enum field doesn't cause import of enum
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(true);
 		String outputDir = "./target/spooned";

--- a/src/test/java/spoon/test/imports/testclasses/Kun.java
+++ b/src/test/java/spoon/test/imports/testclasses/Kun.java
@@ -1,0 +1,7 @@
+package spoon.test.imports.testclasses;
+
+import static spoon.reflect.path.CtRole.NAME;
+
+public class Kun {
+	String field = NAME.toString();
+}


### PR DESCRIPTION
When printer prints the code like
```java
import static spoon.reflect.path.CtRole.NAME;
...
String field = NAME.toString();
```
then it shouldn't add `import spoon.reflect.path.CtRole;`