### PR TITLE
WIP fix: detection and print of enum field with implicit access

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -855,7 +855,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 						if (field != null) {
 							final String fieldName = field.getSimpleName();
 							CtVariable<?> var = f.getVariable().map(new PotentialVariableDeclarationFunction(fieldName)).first();
-							if (var != field) {
+							if (var != null && var != field) {
 								//another variable declaration was found which is hiding the field declaration for this field access. Make the field access explicit
 								target.setImplicit(false);
 							}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -346,7 +346,11 @@ public class JDTTreeBuilderHelper {
 		if (va.getVariable() != null) {
 			final CtFieldReference<T> ref = va.getVariable();
 			if (ref.isStatic() && !ref.getDeclaringType().isAnonymous()) {
-				va.setTarget(jdtTreeBuilder.getFactory().Code().createTypeAccess(ref.getDeclaringType()));
+				CtTypeAccess<?> typeAccess = jdtTreeBuilder.getFactory().Code().createTypeAccess(ref.getDeclaringType());
+				//the field reference made from `SingleNameReference` is always implicit
+				//the non implicit one is created from `QualifiedNameReference`
+				typeAccess.setImplicit(true);
+				va.setTarget(typeAccess);
 			} else if (!ref.isStatic()) {
 				va.setTarget(jdtTreeBuilder.getFactory().Code().createThisAccess(jdtTreeBuilder.getReferencesBuilder().getTypeReference(singleNameReference.actualReceiverType), true));
 			}

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1013,7 +1013,7 @@ public class AnnotationTest {
 		assertEquals("java.lang.String value = \"\";", fieldValue.toString());
 		final CtMethod<Object> methodValue = aTypeAnnotation.getMethod("value");
 		assertTrue(methodValue instanceof CtAnnotationMethod);
-		assertEquals("java.lang.String value() default spoon.test.annotation.testclasses.SuperAnnotation.value;", methodValue.toString());
+		assertEquals("java.lang.String value() default value;", methodValue.toString());
 		final CtMethod<Object> methodNoDefault = aTypeAnnotation.getMethod("value1");
 		assertTrue(methodNoDefault instanceof CtAnnotationMethod);
 		assertEquals("java.lang.String value1();", methodNoDefault.toString());

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -203,7 +203,7 @@ public class FieldAccessTest {
 		assertEquals("LOG", logFieldAccess.getVariable().getSimpleName());
 		assertSame(MyClass.class, logFieldAccess.getVariable().getDeclaringType().getActualClass());
 
-		String expectedLambda = "() -> {" + System.lineSeparator() + "    spoon.test.fieldaccesses.testclasses.MyClass.LOG.info(\"bla\");" + System.lineSeparator() + "}";
+		String expectedLambda = "() -> {" + System.lineSeparator() + "    LOG.info(\"bla\");" + System.lineSeparator() + "}";
 		assertEquals(expectedLambda, logFieldAccess.getParent(CtLambda.class).toString());
 	}
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -40,6 +40,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtPathStringBuilder;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
@@ -1472,4 +1473,19 @@ launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/JavaLo
 				"}", launcher.getFactory().Type().get("spoon.test.imports.testclasses.JavaLongUse").toString());
 	}
 
+	@Test
+	public void testImplicitEnumField() {
+		//contract: distinguish between `CtRole.NAME` and `NAME` enum field
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(true);
+		String outputDir = "./target/spooned";
+		launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/Vopice.java");
+		launcher.setSourceOutputDirectory(outputDir);
+		launcher.run();
+
+		CtType element = launcher.getFactory().Class().getAll().get(0);
+		List<CtElement> statements = new CtPathStringBuilder().fromString("#typeMember#body#statement").evaluateOn(element);
+		assertEquals("NAME.toString()", statements.get(1).toString());
+		assertEquals("CtRole.NAME.toString()", statements.get(2).toString());
+	}
 }

--- a/src/test/java/spoon/test/imports/testclasses/Vopice.java
+++ b/src/test/java/spoon/test/imports/testclasses/Vopice.java
@@ -1,0 +1,12 @@
+package spoon.test.imports.testclasses;
+
+import static spoon.reflect.path.CtRole.NAME;
+
+import spoon.reflect.path.CtRole;
+
+public class Vopice {
+	{
+		NAME.toString();
+		CtRole.NAME.toString();
+	}
+}

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -178,14 +178,14 @@ public class TargetedExpressionTest {
 		assertEquals(10, elements.size());
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedType).target(expectedThisAccess).result("this.k"), elements.get(0));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedType).target(expectedTypeAccess).result("spoon.test.targeted.testclasses.Foo.k"), elements.get(1));
-		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedType).target(expectedTypeAccess).result("spoon.test.targeted.testclasses.Foo.k"), elements.get(2));
+		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedType).target(expectedTypeAccess).result("k"), elements.get(2));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedThisAccess).result("this.k"), elements.get(3));
-		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedTypeAccess).result("spoon.test.targeted.testclasses.Foo.k"), elements.get(4));
+		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedTypeAccess).result("k"), elements.get(4));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedType).target(expectedTypeAccess).result("spoon.test.targeted.testclasses.Foo.k"), elements.get(5));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("spoon.test.targeted.testclasses.Bar.FIELD"), elements.get(6));
-		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("spoon.test.targeted.testclasses.Bar.FIELD"), elements.get(7));
+		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldRead.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("FIELD"), elements.get(7));
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("spoon.test.targeted.testclasses.Bar.FIELD"), elements.get(8));
-		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("spoon.test.targeted.testclasses.Bar.FIELD"), elements.get(9));
+		assertEqualsFieldAccess(new ExpectedTargetedExpression().type(CtFieldWrite.class).declaringType(expectedBarType).target(expectedBarTypeAccess).result("FIELD"), elements.get(9));
 
 		final CtAnonymousExecutable staticInit = type.getAnonymousExecutables().get(0);
 		final List<CtFieldAccess<?>> staticElements = staticInit.getElements(new TypeFilter<>(CtFieldAccess.class));

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -125,7 +125,7 @@ public class PatternTest {
 			Match match = matches.get(1);
 			assertEquals(Arrays.asList(
 					"java.lang.System.out.println(\"a\")",
-					"java.lang.System.out.println(\"Xxxx\")",
+					"out.println(\"Xxxx\")",
 					"java.lang.System.out.println(((java.lang.String) (null)))",
 					"java.lang.System.out.println(java.lang.Long.class.toString())"), toListOfStrings(match.getMatchingElements()));
 			assertEquals(Arrays.asList(
@@ -164,7 +164,7 @@ public class PatternTest {
 			Match match = matches.get(1);
 			assertEquals(Arrays.asList(
 					"int cc = 0",
-					"java.lang.System.out.println(\"Xxxx\")",
+					"out.println(\"Xxxx\")",
 					"cc++",
 					"java.lang.System.out.println(((java.lang.String) (null)))",
 					"cc++"), toListOfStrings(match.getMatchingElements()));
@@ -216,7 +216,7 @@ public class PatternTest {
 		}
 		{
 			Match match = matches.get(1);
-			assertEquals(Arrays.asList("java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+			assertEquals(Arrays.asList("out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 			assertEquals(true, match.getParameters().getValue("option"));
 			assertEquals("\"Xxxx\"", match.getParameters().getValue("value").toString());
 		}
@@ -318,7 +318,7 @@ public class PatternTest {
 				"int i = 0",
 				"i++",
 				"java.lang.System.out.println(i)",
-				"java.lang.System.out.println(\"Xxxx\")",
+				"out.println(\"Xxxx\")",
 				"java.lang.System.out.println(((java.lang.String) (null)))",
 				"java.lang.System.out.println(\"last one\")"), toListOfStrings(match.getMatchingElements()));
 
@@ -327,7 +327,7 @@ public class PatternTest {
 				"int i = 0",
 				"i++",
 				"java.lang.System.out.println(i)",
-				"java.lang.System.out.println(\"Xxxx\")",
+				"out.println(\"Xxxx\")",
 				"java.lang.System.out.println(((java.lang.String) (null)))"), toListOfStrings((List) match.getParameters().getValue("statements")));
 
 		//last statement is matched by last template, which saves printed value
@@ -354,7 +354,7 @@ public class PatternTest {
 					"int i = 0",
 					"i++",
 					"java.lang.System.out.println(i)",
-					"java.lang.System.out.println(\"Xxxx\")"
+					"out.println(\"Xxxx\")"
 			), toListOfStrings(match.getMatchingElements()));
 
 			//check 3 statements are stored as value of "statements" parameter
@@ -399,7 +399,7 @@ public class PatternTest {
 					"int i = 0",
 					"i++",
 					"java.lang.System.out.println(i)",	//this is println(int), but last temple matches println(String) - it is question if it is wanted or not ...
-					"java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+					"out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 
 			//check all statements excluding last are stored as value of "statements" parameter
 			assertEquals(Arrays.asList(
@@ -453,7 +453,7 @@ public class PatternTest {
 					"int i = 0",
 					"i++",
 					"java.lang.System.out.println(i)",	//this is println(int), but last temple matches println(String) - it is question if it is wanted or not ...
-					"java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+					"out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 
 			//check all statements excluding last are stored as value of "statements" parameter
 			assertEquals(Arrays.asList(
@@ -496,7 +496,7 @@ public class PatternTest {
 			assertEquals(Arrays.asList(
 					"i++",
 					"java.lang.System.out.println(i)",	//this is println(int), but last temple matches println(String) - it is question if it is wanted or not ...
-					"java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+					"out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 
 			//check 2 statements excluding last are stored as value of "statements" parameter
 			assertEquals(Arrays.asList(
@@ -548,7 +548,7 @@ public class PatternTest {
 				"int i = 0",
 				"i++",
 				"java.lang.System.out.println(i)",
-				"java.lang.System.out.println(\"Xxxx\")",
+				"out.println(\"Xxxx\")",
 				"java.lang.System.out.println(((java.lang.String) (null)))"), toListOfStrings(match.getMatchingElements()));
 
 		//check 4 statements excluding last are stored as value of "statements" parameter
@@ -556,7 +556,7 @@ public class PatternTest {
 				"int i = 0",
 				"i++",
 				"java.lang.System.out.println(i)",
-				"java.lang.System.out.println(\"Xxxx\")"), toListOfStrings((List) match.getParameters().getValue("statements")));
+				"out.println(\"Xxxx\")"), toListOfStrings((List) match.getParameters().getValue("statements")));
 		//last statement is matched by last template, which saves printed value
 		assertTrue(match.getParameters().getValue("printedValue") instanceof CtLiteral);
 		assertEquals("((java.lang.String) (null))", match.getParameters().getValue("printedValue").toString());
@@ -755,7 +755,7 @@ public class PatternTest {
 			}
 			{
 				Match match = matches.get(1);
-				assertEquals(Arrays.asList("java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+				assertEquals(Arrays.asList("out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 				assertTrue(match.getParameters().getValue("value") instanceof CtLiteral);
 				assertEquals("\"Xxxx\"", match.getParameters().getValue("value").toString());
 			}
@@ -814,7 +814,7 @@ public class PatternTest {
 			}
 			{
 				Match match = matches.get(1);
-				assertEquals(Arrays.asList("java.lang.System.out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
+				assertEquals(Arrays.asList("out.println(\"Xxxx\")"), toListOfStrings(match.getMatchingElements()));
 				assertTrue(match.getParameters().getValue("value") instanceof CtLiteral);
 				assertEquals("\"Xxxx\"", match.getParameters().getValue("value").toString());
 			}


### PR DESCRIPTION
Spoon now detects and correctly prints these two cases
```java
import static spoon.reflect.path.CtRole.NAME;
import spoon.reflect.path.CtRole;
...
NAME.toString();
CtRole.NAME.toString();
```