### PR TITLE
refactor: remove unused private method (fix SonarQube waraning)

### DIFF
--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -186,13 +186,4 @@ public class CtPathStringBuilder {
 			}
 		}
 	}
-
-	private String getNextToken(StringTokenizer tokenizer, String newDelimeters) {
-		try {
-			return tokenizer.nextToken(newDelimeters);
-		} catch (NoSuchElementException e) {
-			return null;
-		}
-	}
-
 }


### PR DESCRIPTION
SonarQube fix.

Private method is unused and may be removed - *private String getNextToken()*.
There is a package level method that is used - *String getNextToken(String delimiters)*.
```