### PR TITLE
bug: Invalid enum members modifiers

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1140,7 +1140,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		field.setSimpleName(CharOperation.charToString(fieldDeclaration.name));
 		if (fieldDeclaration.binding != null) {
-			if (fieldDeclaration.binding.declaringClass != null && fieldDeclaration.binding.declaringClass.isEnum()) {
+			if (fieldDeclaration.binding.declaringClass != null &&
+				fieldDeclaration.binding.declaringClass.isEnum() &&
+				field instanceof CtEnumValue) {
 				//enum values take over visibility from enum type
 				//JDT compiler has a bug that enum values are always public static final, even for private enum
 				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.declaringClass.modifiers, true, false));

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1140,9 +1140,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		field.setSimpleName(CharOperation.charToString(fieldDeclaration.name));
 		if (fieldDeclaration.binding != null) {
-			if (fieldDeclaration.binding.declaringClass != null &&
-				fieldDeclaration.binding.declaringClass.isEnum() &&
-				field instanceof CtEnumValue) {
+			if (fieldDeclaration.binding.declaringClass != null
+				&& fieldDeclaration.binding.declaringClass.isEnum()
+				&& field instanceof CtEnumValue) {
 				//enum values take over visibility from enum type
 				//JDT compiler has a bug that enum values are always public static final, even for private enum
 				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.declaringClass.modifiers, true, false));

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -9,6 +9,7 @@ import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
@@ -18,6 +19,7 @@ import spoon.test.enums.testclasses.Burritos;
 import spoon.test.enums.testclasses.Foo;
 import spoon.test.enums.testclasses.NestedEnums;
 import spoon.test.enums.testclasses.Regular;
+import spoon.test.enums.testclasses.EnumWithMembers;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.Assert.assertEquals;
@@ -169,5 +171,22 @@ public class EnumsTest {
 				assertFalse(defaultExpression.isImplicit());
 			}
 		}
+	}
+
+	@Test
+	public void testEnumMembersModifiers() throws Exception {
+		// contract: enum members should have correct modifiers
+		final Factory factory = build(EnumWithMembers.class);
+		CtModel model = factory.getModel();
+
+		CtField lenField = model.getElements(new TypeFilter<>(CtField.class)).stream()
+				.filter(p -> p.getSimpleName().equals("len"))
+				.findFirst().get();
+
+		assertTrue(lenField.isPrivate());
+		assertTrue(lenField.isStatic());
+		assertFalse(lenField.isFinal());
+		assertFalse(lenField.isPublic());
+		assertFalse(lenField.isProtected());
 	}
 }

--- a/src/test/java/spoon/test/enums/testclasses/EnumWithMembers.java
+++ b/src/test/java/spoon/test/enums/testclasses/EnumWithMembers.java
@@ -1,0 +1,13 @@
+package spoon.test.enums.testclasses;
+
+public enum EnumWithMembers {
+    ONE,
+    TWO,
+    THREE;
+
+    private static int len = -1;
+
+    public static void f() {
+        len = 44;
+    }
+}


### PR DESCRIPTION
Hi. I found out that Spoon is probably wrong about the 'final' and 'public' modifiers of enum members.
Consider the following code:
```
public enum MyEnum {
    ONE,
    TWO,
    THREE;

    private static int len = -1; // Spoon says that len is final and public, but it is not!

    public static void f() {
        len = 44;
    }
}
```
BTW, If I do the same in a class it works fine:
```
public class MyClass {

    private static int len = -1; // len is not final and is not public (as expected)

    public static void f() {
        len = 44;
    }
}
```

This PR contains failing test cases (see `lenField.isFinal()` and `lenField.isPublic()`).
Any ideas how to fix this?
Thanks.