### PR TITLE
fix: use correct classloader during shadow type building

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -58,8 +58,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-import static spoon.testing.utils.ModelUtils.createFactory;
-
 /**
  * The {@link CtType} sub-factory.
  */
@@ -579,6 +577,11 @@ public class TypeFactory extends SubFactory {
 			}
 		}
 		return aType;
+	}
+
+	private Factory createFactory() {
+		//use existing environment to use correct class loader
+		return new FactoryImpl(new DefaultCoreFactory(), factory.getEnvironment());
 	}
 
 	/**

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -395,8 +395,9 @@ public class CompilationTest {
 				} catch (SpoonClassNotFoundException ignore) { }
 			}
 		});
-
-		assertEquals(3, l.size());
+		
+		//JDK 9 has implicit constructor, while JDK 8 has not
+		assertTrue(l.size()>=3);
 		assertTrue(l.contains("KJHKY"));
 		assertSame(MyClassLoader.class, launcher.getEnvironment().getInputClassLoader().getClass());
 	}


### PR DESCRIPTION
JavaReflectionTreeBuilder used factory with default environment instead of current environment, therefore it used wrong class loader - it was not possible to define the class loaded of JavaReflectionTreeBuilder