### PR TITLE
refactor: remove static import from CommentTest.java

### DIFF
--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -90,7 +90,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.io.IOUtils.write;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -867,7 +866,7 @@ public class CommentTest {
 		try {
 			assertEquals("doc outdated, please commit doc/code_elements.md", IOUtils.toString(new FileReader("doc/code_elements.md")), codeElementsDocumentationPage.toString());
 		} finally {
-			write(codeElementsDocumentationPage.toString(), new FileOutputStream("doc/code_elements.md"));
+			IOUtils.write(codeElementsDocumentationPage.toString(), new FileOutputStream("doc/code_elements.md"));
 		}
 	}
 

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -286,7 +286,7 @@ public class CommentTest {
 		// verify that the number of comment present in the AST is correct
 		assertEquals(69, comments.size());
 
-		// verify that all comments present in the AST is printed
+		// verify that all comments present in the AST are printed
 		for (CtComment comment : comments) {
 			if (comment.getCommentType() == CtComment.CommentType.FILE) {
 				// the header of the file is not printed with the toString
@@ -484,7 +484,7 @@ public class CommentTest {
 		// verify that the number of comment present in the AST is correct
 		assertEquals(52, comments.size());
 
-		// verify that all comments present in the AST is printed
+		// verify that all comments present in the AST are printed
 		for (CtComment comment : comments) {
 			if (comment.getCommentType() == CtComment.CommentType.FILE) {
 				// the header of the file is not printed with the toString
@@ -948,7 +948,7 @@ public class CommentTest {
 		List<CtLiteral<String>> literals = (List) ((CtNewArray<?>) type.getField("comments").getDefaultExpression()).getElements();
 		assertTrue(literals.size() > 10);
 		/*
-		 * each string literal has a comment and string value, which defines expected value of it's comment
+		 * each string literal has a comment and string value, which defines expected value of its comment
 		 */
 		for (CtLiteral<String> literal : literals) {
 			assertEquals(1, literal.getComments().size());


### PR DESCRIPTION
Make clear what exactly is called.
Fix few grammar errors.

https://carlosbecker.com/posts/avoid-static-imports/