### PR TITLE
refactor: remove redundant cast - CtRolePathElement.java

### DIFF
--- a/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
@@ -103,7 +103,7 @@ public class CtRolePathElement extends AbstractPathElement<CtElement, CtElement>
 						if (getArguments().containsKey("index")) {
 							int index = Integer.parseInt(getArguments().get("index"));
 							if (index < subMatches.size()) {
-								matchs.add((CtElement) new ArrayList<>(subMatches).get(index));
+								matchs.add(new ArrayList<>(subMatches).get(index));
 							}
 						} else {
 							matchs.addAll(subMatches);


### PR DESCRIPTION
Remove redundant cast from *CtElement* to *CtElement*.

Checker: Redundant type cast
*Reports unnecessary cast expressions.*

This is also SonarQube fix - Remove this unnecessary cast to "CtIf".