### PR TITLE
refactor: remove redundant cast - InlinedStatementConfigurator.java

### DIFF
--- a/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
+++ b/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
@@ -235,9 +235,6 @@ public class InlinedStatementConfigurator {
 				}
 			}
 		}
-		if (elseStmt instanceof CtIf) {
-			return (CtIf) elseStmt;
-		}
 		return elseStmt;
 	}
 


### PR DESCRIPTION
Remove cast from CtIf to CtIf.

Checker: Redundant type cast
*Reports unnecessary cast expressions.*