### PR TITLE
refactor: remove useless condition (always true)

### DIFF
--- a/src/main/java/spoon/testing/AbstractCtPackageAssert.java
+++ b/src/main/java/spoon/testing/AbstractCtPackageAssert.java
@@ -47,7 +47,7 @@ public abstract class AbstractCtPackageAssert<T extends AbstractCtPackageAssert<
 			throw new AssertionError(String.format("The actual package named %1$s isn't equals to the expected package named %2$s", actual.getSimpleName(), expected.getSimpleName()));
 		}
 
-		if (processors != null && !processors.isEmpty()) {
+		if (!processors.isEmpty()) {
 			process(actual.getFactory(), processors);
 		}
 


### PR DESCRIPTION
Field *processors* is never null. Condition is always true. Should be removed.
```
public abstract class AbstractAssert<T extends AbstractAssert<T, A>, A> {
	protected final LinkedList<Processor<?>> processors = new LinkedList<>();
```

**Constant conditions & exceptions inspection**
*This inspection analyzes method control and data flow to report possible conditions that are always true or false, expressions whose value is statically proven to be constant, and situations that can lead to nullability contract violations.
Variables, method parameters and return values marked as @Nullable or @NotNull are treated as nullable (or not-null, respectively) and used during the analysis to check nullability contracts, e.g. report NullPointerException (NPE) errors that might be produced.
More complex contracts can be defined using @Contract annotation, for example:
@Contract("_, null -> null") — method returns null if its second argument is null @Contract("_, null -> null; _, !null -> !null") — method returns null if its second argument is null and not-null otherwise @Contract("true -> fail") — a typical assertFalse method which throws an exception if true is passed to it 
The inspection can be configured to use custom @Nullable
@NotNull annotations (by default the ones from annotations.jar will be used)*