### PR TITLE
refactor: remove redundant transient keyword (SonarQube fix)

### DIFF
--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -41,7 +41,7 @@ public class CompilationUnitFactory extends SubFactory {
 		super(factory);
 	}
 
-	private transient Map<String, CompilationUnit> cachedCompilationUnits = new TreeMap<>();
+	private Map<String, CompilationUnit> cachedCompilationUnits = new TreeMap<>();
 
 	/**
 	 * Gets the compilation unit map.
@@ -166,5 +166,4 @@ public class CompilationUnitFactory extends SubFactory {
 	public CompilationUnit removeFromCache(String filePath) {
 		return cachedCompilationUnits.remove(filePath);
 	}
-
 }


### PR DESCRIPTION
Fix SonarQube warning: *Remove the "transient" modifier from this field.*

*transient is used to mark fields in a Serializable class which will not be written out to file (or stream). In a class that does not implement Serializable, this modifier is simply wasted keystrokes, and should be removed.*