### PR TITLE
refactor: use isEmpty() - fix sonarqube

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -496,7 +496,7 @@ public class TypeFactory extends SubFactory {
 	}
 
 	private boolean isNumber(String str) {
-		if (str == null || str.length() == 0) {
+		if (str == null || str.isEmpty()) {
 			return false;
 		}
 		int len = str.length();


### PR DESCRIPTION
I remember not to use isEmpty in more complex cases (that produce negation etc.).