### PR TITLE
fix(MaintTest): quickfix of ci timeout issues

### DIFF
--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -533,31 +533,40 @@ public class MainTest {
 
 	@Test
 	public void testElementToPathToElementEquivalency() {
+		System.out.println("Start testElementToPathToElementEquivalency...");
+		System.out.flush();
+		for (CtPackage ctPackage: rootPackage.getPackage("spoon").getPackages()) {
+			long startTime = System.currentTimeMillis();
 
-		rootPackage.accept(new CtScanner() {
-			@Override
-			public void scan(CtElement element) {
-				if (element != null) {
-					CtPath path = element.getPath();
-					String pathStr = path.toString();
-					try {
-						CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
-						assertEquals(pathStr, pathRead.toString());
-						Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
-						//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
-						assertEquals(1, returnedElements.size());
-						CtElement actualElement = (CtElement) returnedElements.toArray()[0];
-						//contract: Element -> Path -> String -> Path -> Element leads to the original element
-						assertSame(element, actualElement);
-					} catch (CtPathException e) {
-						throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
-					} catch (AssertionError e) {
-						throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
+			ctPackage.accept(new CtScanner() {
+				@Override
+				public void scan(CtElement element) {
+					if (element != null) {
+						CtPath path = element.getPath();
+						String pathStr = path.toString();
+						try {
+							CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
+							assertEquals(pathStr, pathRead.toString());
+							Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
+							//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
+							assertEquals(1, returnedElements.size());
+							CtElement actualElement = (CtElement) returnedElements.toArray()[0];
+							//contract: Element -> Path -> String -> Path -> Element leads to the original element
+							assertSame(element, actualElement);
+						} catch (CtPathException e) {
+							throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
+						} catch (AssertionError e) {
+							throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
+						}
 					}
+					super.scan(element);
 				}
-				super.scan(element);
-			}
-		});
+			});
+			System.out.println("Package: " + ctPackage.getQualifiedName() + " " + (System.currentTimeMillis() - startTime) + " ms");
+			System.out.flush();
+		}
+		System.out.println("Done");
+		System.out.flush();
 	}
 
 	@Test


### PR DESCRIPTION
This should fix timout issues on travis. It is only a quick fix that print and flush() a message after each package testing for the one test that takes a long time.

The offending test is `MainTest#testElementToPathToElementEquivalency()` and we might want to rework it. _(Keeping in mind that we should not blame whoever wrote it... :innocent:)_

I suggest that we select a meaningful subset of the sources on which it runs. (So far it runs on the complete spoon AST).