### PR TITLE
feat(FernflowerDecompiler)

### DIFF
--- a/doc/launcher.md
+++ b/doc/launcher.md
@@ -113,6 +113,11 @@ JarLauncher launcher = new JarLauncher("<path_to_jar>", "<path_to_output_src_dir
 });
 ```
 
+Spoon provides two out of the shelf decompilers, CFR by default, and Fernflower. You can use the later like this:
+```java
+JarLauncher launcher = new JarLauncher("<path_to_jar>", "<path_to_output_src_dir>", "<path_to_pom>", new FernflowerDecompiler(new File("<path_to_output_src_dir>/src/main/java")));
+```
+
 ## About the classpath
 
 Spoon analyzes source code. However, this source code may refer to libraries (as a field, parameter, or method return type). There are two cases:

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jboss.windup.decompiler.fernflower/fernflower -->
+    <dependency>
+      <groupId>org.jboss.windup.decompiler.fernflower</groupId>
+      <artifactId>fernflower</artifactId>
+      <version>2.5.0.Final</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>

--- a/src/main/java/spoon/decompiler/FernflowerDecompiler.java
+++ b/src/main/java/spoon/decompiler/FernflowerDecompiler.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
 package spoon.decompiler;
 
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;

--- a/src/main/java/spoon/decompiler/FernflowerDecompiler.java
+++ b/src/main/java/spoon/decompiler/FernflowerDecompiler.java
@@ -1,0 +1,19 @@
+package spoon.decompiler;
+
+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
+
+import java.io.File;
+
+public class FernflowerDecompiler implements Decompiler {
+
+	File outputDir;
+
+	public FernflowerDecompiler(File outputDir) {
+		this.outputDir = outputDir;
+	}
+
+	@Override
+	public void decompile(String jarPath) {
+		ConsoleDecompiler.main(new String[]{jarPath, outputDir.getPath()});
+	}
+}

--- a/src/test/java/spoon/JarLauncherTest.java
+++ b/src/test/java/spoon/JarLauncherTest.java
@@ -17,6 +17,8 @@
 package spoon;
 
 import org.junit.Test;
+import spoon.decompiler.CFRDecompiler;
+import spoon.decompiler.FernflowerDecompiler;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtTry;
@@ -34,7 +36,13 @@ public class JarLauncherTest {
 		File baseDir = new File("src/test/resources/jarLauncher");
 		File pom = new File(baseDir, "pom.xml");
 		File jar = new File(baseDir, "helloworld-1.0-SNAPSHOT.jar");
-		JarLauncher launcher = new JarLauncher(jar.getAbsolutePath(), null, pom.getAbsolutePath());
+
+		File pathToDecompiledRoot = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "spoon-tmp");
+		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		File pathToDecompile = new File(pathToDecompiledRoot,"src/main/java");
+		pathToDecompile.mkdirs();
+
+		JarLauncher launcher = new JarLauncher(jar.getAbsolutePath(), pathToDecompiledRoot.getPath(), pom.getAbsolutePath(), new CFRDecompiler(pathToDecompile));
 		launcher.getEnvironment().setAutoImports(true);
 		launcher.buildModel();
 		CtModel model = launcher.getModel();
@@ -43,6 +51,35 @@ public class JarLauncherTest {
 		CtTry tryStmt = (CtTry) constructor.getBody().getStatement(1);
 		CtLocalVariable var = (CtLocalVariable) tryStmt.getBody().getStatement(0);
 		assertNotNull(var.getType().getTypeDeclaration());
+
+
+		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+	}
+
+
+	@Test
+	public void testJarLauncherFernflower() {
+		File baseDir = new File("src/test/resources/jarLauncher");
+		File pom = new File(baseDir, "pom.xml");
+		File jar = new File(baseDir, "helloworld-1.0-SNAPSHOT.jar");
+
+		File pathToDecompiledRoot = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "spoon-tmp");
+		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		File pathToDecompile = new File(pathToDecompiledRoot,"src/main/java");
+		pathToDecompile.mkdirs();
+
+		JarLauncher launcher = new JarLauncher(jar.getAbsolutePath(), pathToDecompiledRoot.getPath(), pom.getAbsolutePath(), new FernflowerDecompiler(pathToDecompile));
+		launcher.getEnvironment().setAutoImports(true);
+		launcher.buildModel();
+		CtModel model = launcher.getModel();
+		assertEquals(model.getAllTypes().size(), 5);
+		CtConstructor constructor = (CtConstructor) model.getRootPackage().getFactory().Type().get("se.kth.castor.UseJson").getTypeMembers().get(0);
+		CtTry tryStmt = (CtTry) constructor.getBody().getStatement(1);
+		CtLocalVariable var = (CtLocalVariable) tryStmt.getBody().getStatement(0);
+		assertNotNull(var.getType().getTypeDeclaration());
+
+
+		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
 	}
 
 	@Test


### PR DESCRIPTION
As I am unsure how reliable is `CFRDecompiler`, and that it might make `SpoonClassFileTransformer` a little tricky to use, I suggest to add at least a second option. [Fernflower](https://github.com/JetBrains/intellij-community/tree/master/plugins/java-decompiler/engine) is IntelliJ's decompiler, which is open source (Apache v2) but not distributed as a standalone project. But JBoss is distributing it as a Maven dependency.

This change only increase slightly the jar-with-dependencies (16M -> 17M).