### PR TITLE
refactor: add missing braces to tests

### DIFF
--- a/src/test/java/spoon/JarLauncherTest.java
+++ b/src/test/java/spoon/JarLauncherTest.java
@@ -38,7 +38,9 @@ public class JarLauncherTest {
 		File jar = new File(baseDir, "helloworld-1.0-SNAPSHOT.jar");
 
 		File pathToDecompiledRoot = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "spoon-tmp");
-		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		if(pathToDecompiledRoot.exists()) {
+			pathToDecompiledRoot.delete();
+		}
 		File pathToDecompile = new File(pathToDecompiledRoot,"src/main/java");
 		pathToDecompile.mkdirs();
 
@@ -53,7 +55,9 @@ public class JarLauncherTest {
 		assertNotNull(var.getType().getTypeDeclaration());
 
 
-		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		if(pathToDecompiledRoot.exists()) {
+			pathToDecompiledRoot.delete();
+		}
 	}
 
 
@@ -64,7 +68,9 @@ public class JarLauncherTest {
 		File jar = new File(baseDir, "helloworld-1.0-SNAPSHOT.jar");
 
 		File pathToDecompiledRoot = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator") + "spoon-tmp");
-		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		if(pathToDecompiledRoot.exists()) {
+			pathToDecompiledRoot.delete();
+		}
 		File pathToDecompile = new File(pathToDecompiledRoot,"src/main/java");
 		pathToDecompile.mkdirs();
 
@@ -79,7 +85,9 @@ public class JarLauncherTest {
 		assertNotNull(var.getType().getTypeDeclaration());
 
 
-		if(pathToDecompiledRoot.exists()) pathToDecompiledRoot.delete();
+		if(pathToDecompiledRoot.exists()) {
+			pathToDecompiledRoot.delete();
+		}
 	}
 
 	@Test

--- a/src/test/java/spoon/test/refactoring/CtRenameLocalVariableRefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/CtRenameLocalVariableRefactoringTest.java
@@ -85,7 +85,9 @@ public class CtRenameLocalVariableRefactoringTest
 		
 		varRenameClass.getMethods().forEach(method->{
 			//debugging support
-			if(DEBUG.length==3 && DEBUG[0].equals(method.getSimpleName())==false) return;
+			if(DEBUG.length==3 && DEBUG[0].equals(method.getSimpleName())==false) {
+				return;
+			}
 			method.filterChildren((CtVariable var)->true)
 				.map((CtVariable var)->var.getAnnotation(tryRename))
 				.forEach((CtAnnotation<TestTryRename> annotation)->{


### PR DESCRIPTION
Code inspection
- Control flow statement without braces inspection

*Reports any if, while or for statements without braces. Braces make the code easier to read and help prevent errors when modifying the code.*