### PR TITLE
refactor: flip order of comparison - put literal first to lower risk of NPE

### DIFF
--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -196,7 +196,7 @@ public class EnumsTest {
 		CtModel model = factory.getModel();
 
 		CtField lenField = model.getElements(new TypeFilter<>(CtField.class)).stream()
-				.filter(p -> p.getSimpleName().equals("len"))
+				.filter(p -> "len".equals(p.getSimpleName()))
 				.findFirst().get();
 
 		assertTrue(lenField.isPrivate());

--- a/src/test/java/spoon/test/jar/JarTest.java
+++ b/src/test/java/spoon/test/jar/JarTest.java
@@ -47,14 +47,14 @@ public class JarTest {
 		ZipFolder folder = (ZipFolder) resources.get(0);
 		List<SpoonFile> files = folder.getAllFiles();
 		assertEquals(5, files.size());
-		assertEquals("Manifest-Version: 1.0\r\n\r\n", readFileString(files.stream().filter(f -> f.getName().equals("META-INF/MANIFEST.MF")).findFirst().get(), "ISO-8859-1"));
+		assertEquals("Manifest-Version: 1.0\r\n\r\n", readFileString(files.stream().filter(f -> "META-INF/MANIFEST.MF".equals(f.getName())).findFirst().get(), "ISO-8859-1"));
 		assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
 				"<classpath>\n" + 
 				"	<classpathentry kind=\"con\" path=\"org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8\"/>\n" + 
 				"	<classpathentry kind=\"src\" path=\"src\"/>\n" + 
 				"	<classpathentry kind=\"output\" path=\"bin\"/>\n" + 
 				"</classpath>\n" + 
-				"", readFileString(files.stream().filter(f -> f.getName().equals(".classpath")).findFirst().get(), "ISO-8859-1"));
+				"", readFileString(files.stream().filter(f -> ".classpath".equals(f.getName())).findFirst().get(), "ISO-8859-1"));
 	}
 	
 	private byte[] readFileBytes(SpoonFile file) {

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -504,7 +504,7 @@ public class MainTest {
 			SourcePosition sp = type.getPosition();
 			totalCount += assertSourcePositionTreeIsCorrectlyOrder(sp.getCompilationUnit().getOriginalSourceFragment(), 0, sp.getCompilationUnit().getOriginalSourceCode().length());
 			hasComment = hasComment || type.getComments().size() > 0; 
-		};
+		}
 		assertTrue(totalCount > 1000);
 		assertTrue(hasComment);
 	}


### PR DESCRIPTION
Code inspection
- 'expression.equals("literal")' rather than 'literal.equals("expression")'

*Reports calls to .equals() whose arguments are String literals. Some coding standards specify that String literals should be the target of .equals(), rather than argument, thus minimizing NullPointerExceptions.*