### PR TITLE
refactor: remove redundant type (extending Object)

### DIFF
--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -540,7 +540,7 @@ public class Metamodel {
 		col.add(o);
 		return true;
 	}
-	static boolean containsObject(Iterable<? extends Object> iter, Object o) {
+	static boolean containsObject(Iterable<?> iter, Object o) {
 		for (Object object : iter) {
 			if (object == o) {
 				return true;

--- a/src/main/java/spoon/pattern/Match.java
+++ b/src/main/java/spoon/pattern/Match.java
@@ -27,10 +27,10 @@ import spoon.support.util.ImmutableMap;
  * Represents a single match of {@link Pattern}
  */
 public class Match {
-	private final List<? extends Object> matchingElements;
+	private final List<?> matchingElements;
 	private final ImmutableMap parameters;
 
-	public Match(List<? extends Object> matches, ImmutableMap parameters) {
+	public Match(List<?> matches, ImmutableMap parameters) {
 		this.parameters = parameters;
 		this.matchingElements = matches;
 	}

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -40,7 +40,7 @@ import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
  * </pre>
  * @author Renaud Pawlak
  */
-public interface CtClass<T extends Object> extends CtType<T>, CtStatement {
+public interface CtClass<T> extends CtType<T>, CtStatement {
 	/**
 	 * Returns the anonymous blocks of this class.
 	 * Derived from {@link #getTypeMembers()}

--- a/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
@@ -109,7 +109,7 @@ public interface CtQuery extends CtQueryable {
 	 * @return the list of elements collected by the query.
 	 * @see #forEach(CtConsumer) for an efficient way of manipulating the elements without creating an intermediate list.
 	 */
-	<R extends Object> List<R> list();
+	<R> List<R> list();
 
 	/**
 	 * Same as {@link CtQuery#list()}, but with static typing on the return type
@@ -127,7 +127,7 @@ public interface CtQuery extends CtQueryable {
 	 * otherwise the ClassCastException will be thrown.
 	 * @return the first element found by the query.
 	 */
-	<R extends Object> R first();
+	<R> R first();
 
 	/**
 	 * Same as {@link CtQuery#first()}, but with static typing on the return type

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -107,7 +107,7 @@ public class CtQueryImpl implements CtQuery {
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public <R extends Object> List<R> list() {
+	public <R> List<R> list() {
 		return (List<R>) list(Object.class);
 	}
 

--- a/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
@@ -24,7 +24,7 @@ import spoon.reflect.visitor.CtVisitor;
 
 import static spoon.reflect.path.CtRole.EXPRESSION;
 
-public class CtLiteralImpl<T extends Object> extends CtExpressionImpl<T> implements CtLiteral<T> {
+public class CtLiteralImpl<T> extends CtExpressionImpl<T> implements CtLiteral<T> {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = CtRole.VALUE)

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -56,7 +56,7 @@ import static spoon.reflect.path.CtRole.SUPER_TYPE;
  *
  * @author Renaud Pawlak
  */
-public class CtClassImpl<T extends Object> extends CtTypeImpl<T> implements CtClass<T> {
+public class CtClassImpl<T> extends CtTypeImpl<T> implements CtClass<T> {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = SUPER_TYPE)


### PR DESCRIPTION
Code inspection
- Type parameter explicitely extends 'java.lang.Object' inspection

Every Java class extends Object class OR another class.
Extending Object does not provide any value (it is like invoking "super()" in ctr) and makes code longer.