### PR TITLE
refactor: simplify logic in CtNamedPathElement.java (SonarQube fix)

### DIFF
--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -110,7 +110,7 @@ public class CtNamedPathElement extends AbstractPathElement<CtElement, CtElement
 				e instanceof CtNamedElement && matchPattern(((CtNamedElement) e).getSimpleName()) ||
 				e instanceof CtReference && matchPattern(((CtReference) e).getSimpleName())) {
 					results.add(e);
-			}
+				}
 		}
 
 		private boolean matchPattern(String str) {

--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -105,12 +105,11 @@ public class CtNamedPathElement extends AbstractPathElement<CtElement, CtElement
 		public void scanCtElement(CtElement e) {
 			if (WILDCARD.equals(pattern) || RECURSIVE_WILDCARD.equals(pattern)) {
 				results.add(e);
-			} else if (e instanceof CtExecutable && matchPattern(getSignature((CtExecutable) e))) {
-				results.add(e);
-			} else if (e instanceof CtNamedElement && matchPattern(((CtNamedElement) e).getSimpleName())) {
-				results.add(e);
-			} else if (e instanceof CtReference && matchPattern(((CtReference) e).getSimpleName())) {
-				results.add(e);
+			} else if (
+				e instanceof CtExecutable && matchPattern(getSignature((CtExecutable) e)) ||
+				e instanceof CtNamedElement && matchPattern(((CtNamedElement) e).getSimpleName()) ||
+				e instanceof CtReference && matchPattern(((CtReference) e).getSimpleName())) {
+					results.add(e);
 			}
 		}
 

--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -106,9 +106,9 @@ public class CtNamedPathElement extends AbstractPathElement<CtElement, CtElement
 			if (WILDCARD.equals(pattern) || RECURSIVE_WILDCARD.equals(pattern)) {
 				results.add(e);
 			} else if (
-				e instanceof CtExecutable && matchPattern(getSignature((CtExecutable) e)) ||
-				e instanceof CtNamedElement && matchPattern(((CtNamedElement) e).getSimpleName()) ||
-				e instanceof CtReference && matchPattern(((CtReference) e).getSimpleName())) {
+				e instanceof CtExecutable && matchPattern(getSignature((CtExecutable) e))
+				|| e instanceof CtNamedElement && matchPattern(((CtNamedElement) e).getSimpleName())
+				|| e instanceof CtReference && matchPattern(((CtReference) e).getSimpleName())) {
 					results.add(e);
 				}
 		}


### PR DESCRIPTION
SonarQube fix: *Remove this conditional structure or edit its code blocks so that they're not all the same.*

*Having all branches in a switch or if chain with the same implementation is an error. Either a copy-paste error was made and something different should be executed, or there shouldn't be a switch/if chain at all. Note that this rule does not apply to if chains without else-s, or to switch-es without default clauses.*