### PR TITLE
doc: fix javadoc in MetamodelPropertyField.java

### DIFF
--- a/src/main/java/spoon/reflect/annotations/MetamodelPropertyField.java
+++ b/src/main/java/spoon/reflect/annotations/MetamodelPropertyField.java
@@ -18,7 +18,6 @@ package spoon.reflect.annotations;
 
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.path.CtRole;
-import spoon.support.reflect.declaration.CtClassImpl;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,8 +26,7 @@ import java.lang.annotation.Target;
 
 /**
  * Tells that a field is a property of the metamodel
- * For instance {@link CtClassImpl#simpleName} is the property name of {@link CtNamedElement}
- *
+ * For instance {@link spoon.support.reflect.declaration.CtNamedElementImpl#getSimpleName} is the property name of {@link CtNamedElement}
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD })


### PR DESCRIPTION
Code inspection
- Declaration has problems in Javadoc references inspection

*Symbol 'simpleName' is inacessible from here*

```
/**
 * Tells that a field is a property of the metamodel
 * For instance {@link CtClassImpl#simpleName} is the property name of {@link CtNamedElement}
 *
 */
@Retention(RetentionPolicy.RUNTIME)
@Target({ ElementType.FIELD })
public @interface MetamodelPropertyField {
	CtRole[] role();
}
```

Maybe a correct solution is reference to:
{@link spoon.support.reflect.declaration.CtNamedElementImpl#getSimpleName}
?

@pvojtechovsky 
Could you take a look on WHOLE comment? ;-)