### PR TITLE
refactor: add loggers to SpoonClassFileTransformer.java (fix SonarQube)

### DIFF
--- a/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
+++ b/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
@@ -16,7 +16,6 @@
  */
 package spoon.decompiler;
 
-import org.apache.log4j.Logger;
 import org.benf.cfr.reader.Main;
 import spoon.IncrementalLauncher;
 import spoon.SpoonModelBuilder;
@@ -37,8 +36,6 @@ import java.util.function.Predicate;
 
 @Experimental
 public class SpoonClassFileTransformer implements ClassFileTransformer {
-
-	private static final Logger LOGGER = Logger.getLogger(SpoonClassFileTransformer.class);
 
 	protected String pathToDecompiled;
 	//protected String pathToRecompile;
@@ -136,6 +133,7 @@ public class SpoonClassFileTransformer implements ClassFileTransformer {
 			ProtectionDomain protectionDomain,
 			byte[] classfileBuffer
 	) throws IllegalClassFormatException {
+		IncrementalLauncher launcher = new IncrementalLauncher(inputSources, classPath, cache);
 		try {
 
 			//If the class is not matched by user's filter, resume unmodified loading
@@ -147,7 +145,6 @@ public class SpoonClassFileTransformer implements ClassFileTransformer {
 			String pathToClassFile = loader.getResource(className + ".class").getPath();
 			decompiler.decompile(pathToClassFile);
 
-			IncrementalLauncher launcher = new IncrementalLauncher(inputSources, classPath, cache);
 			launcher.addInputResource(pathToDecompiled);
 
 			//Get updated model
@@ -178,10 +175,10 @@ public class SpoonClassFileTransformer implements ClassFileTransformer {
 				return fileContent;
 			} catch (IOException e) {
 				launcher.getEnvironment().debugMessage("[ERROR][Agent] while loading transformed " + className);
-				LOGGER.error(e.getMessage(), e);
+				launcher.getEnvironment().debugMessage(e.toString());
 			}
 		} catch (Exception e) {
-			LOGGER.error(e.getMessage(), e);
+			launcher.getEnvironment().debugMessage(e.toString());
 		}
 		return classfileBuffer;
 	}

--- a/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
+++ b/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
@@ -16,6 +16,7 @@
  */
 package spoon.decompiler;
 
+import org.apache.log4j.Logger;
 import org.benf.cfr.reader.Main;
 import spoon.IncrementalLauncher;
 import spoon.SpoonModelBuilder;
@@ -36,6 +37,8 @@ import java.util.function.Predicate;
 
 @Experimental
 public class SpoonClassFileTransformer implements ClassFileTransformer {
+
+	private static final Logger LOGGER = Logger.getLogger(SpoonClassFileTransformer.class);
 
 	protected String pathToDecompiled;
 	//protected String pathToRecompile;
@@ -175,10 +178,10 @@ public class SpoonClassFileTransformer implements ClassFileTransformer {
 				return fileContent;
 			} catch (IOException e) {
 				launcher.getEnvironment().debugMessage("[ERROR][Agent] while loading transformed " + className);
-				e.printStackTrace();
+				LOGGER.error(e.getMessage(), e);
 			}
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOGGER.error(e.getMessage(), e);
 		}
 		return classfileBuffer;
 	}


### PR DESCRIPTION
SonarQube: *Use a logger to log this exception.*

@pvojtechovsky 
Please tell me if I used logging correctly (according to Spoon rules and according to Java best practices).