### PR TITLE
perf(MainTest): parallelize 

### DIFF
--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -533,45 +533,28 @@ public class MainTest {
 
 	@Test
 	public void testElementToPathToElementEquivalency() {
-		System.out.println("Start testElementToPathToElementEquivalency...");
-		System.out.flush();
-		for (CtPackage ctPackage: rootPackage.getPackage("spoon").getPackages()) {
-			long startTime = System.currentTimeMillis();
-
-			ctPackage.accept(new CtScanner() {
-				@Override
-				public void scan(CtElement element) {
-					if (element != null) {
-						CtPath path = element.getPath();
-						String pathStr = path.toString();
-						try {
-							CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
-							assertEquals(pathStr, pathRead.toString());
-							Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
-							//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
-							assertEquals(1, returnedElements.size());
-							CtElement actualElement = (CtElement) returnedElements.toArray()[0];
-							//contract: Element -> Path -> String -> Path -> Element leads to the original element
-							assertSame(element, actualElement);
-						} catch (CtPathException e) {
-							throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
-						} catch (AssertionError e) {
-							throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
-						}
-					}
-					super.scan(element);
-				}
-			});
-			System.out.println("Package: " + ctPackage.getQualifiedName() + " " + (System.currentTimeMillis() - startTime) + " ms");
-			System.out.flush();
-		}
-		System.out.println("Done");
-		System.out.flush();
+		rootPackage.getPackage("spoon").getElements(e->true).parallelStream().forEach(element -> {
+			CtPath path = element.getPath();
+			String pathStr = path.toString();
+			try {
+				CtPath pathRead = new CtPathStringBuilder().fromString(pathStr);
+				assertEquals(pathStr, pathRead.toString());
+				Collection<CtElement> returnedElements = pathRead.evaluateOn(rootPackage);
+				//contract: CtUniqueRolePathElement.evaluateOn() returns a unique elements if provided only a list of one inputs
+				assertEquals(1, returnedElements.size());
+				CtElement actualElement = (CtElement) returnedElements.toArray()[0];
+				//contract: Element -> Path -> String -> Path -> Element leads to the original element
+				assertSame(element, actualElement);
+			} catch (CtPathException e) {
+				throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
+			} catch (AssertionError e) {
+				throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
+			}
+		});
 	}
 
 	@Test
-	public void testElementIsContainedInAttributeOfItsParent() {
-		rootPackage.accept(new CtScanner() {
+	public void testElementIsContainedInAttributeOfItsParent() {rootPackage.accept(new CtScanner() {
 			@Override
 			public void scan(CtRole role, CtElement element) {
 				if (element != null) {

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -554,7 +554,8 @@ public class MainTest {
 	}
 
 	@Test
-	public void testElementIsContainedInAttributeOfItsParent() {rootPackage.accept(new CtScanner() {
+	public void testElementIsContainedInAttributeOfItsParent() {
+		rootPackage.accept(new CtScanner() {
 			@Override
 			public void scan(CtRole role, CtElement element) {
 				if (element != null) {


### PR DESCRIPTION
Alternative solution to #2681 following @pvojtechovsky 's idea.
This actually works well on my machine. The offending test goes from 3min 30s to a bit more than 1min.
Let's see if it helps with travis!

Whatever direction we choose, I think we could apply this to other tests.
It also make me think about something that might be silly (or at least uninformed) but does spoon provides some sort of parallel visitor/scanner that visit brother nodes in a parallel way?