### PR TITLE
fix: MetamodelProperty#containerKindOf knows Collection now

### DIFF
--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -22,6 +22,7 @@ import static spoon.metamodel.Metamodel.getOrCreate;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -600,7 +601,7 @@ public class MetamodelProperty {
 		if (Map.class.isAssignableFrom(valueClass)) {
 			return ContainerKind.MAP;
 		}
-		if (Set.class.isAssignableFrom(valueClass)) {
+		if (Set.class.isAssignableFrom(valueClass) || Collection.class.isAssignableFrom(valueClass)) {
 			return ContainerKind.SET;
 		}
 		return ContainerKind.SINGLE;


### PR DESCRIPTION
Little change needed by #2702

There is no way how to test it. The "test" comes with #2702 after spoon model starts use `Collection` in some API methods.