### PR TITLE
fix: PatternMatcher ignores isImplicit

### DIFF
--- a/doc/pattern.md
+++ b/doc/pattern.md
@@ -4,6 +4,39 @@ title: Spoon Patterns
 
 Spoon patterns enables you to find code elements. A Spoon pattern is based on a one or several AST nodes, which represent the code to match, where some parts of the AST are pattern parameters. When a pattern is matched, one can access to the code matched in each pattern parameter.
 
+The unique feature of Spoon pattern matching is that we are matching on AST tree of sources. Not on text of java sources. It means that:
+* source code formating is ignored. For example:
+
+```java
+void m() {}
+//matches with
+void	m(){
+}
+```
+* comments are ignored. For example:
+
+```java
+void m() {}
+//matches with
+/**
+ javadoc is ignored
+*/
+/* was public before */ void m(/*this is ignored too*/) {
+	//and line comments are ignored too
+}
+```
+
+* implicit and explicit elements are understood as same. For example:
+
+```java
+if (something) 
+	list = (List<String>) new ArrayList<>(FIELD_COUNT);
+//matches with
+if (something) {
+	OuterType.this.list = (java.util.List<java.lang.String>) new java.util.ArrayList<java.lang.String>(Constants.FIELD_COUNT);
+}
+```
+
 The main classes of Spoon patterns are those in package `spoon.pattern`:
 
 * classes: PatternBuilder, Pattern, Match, PatternBuilderHelper, PatternParameterConfigurator, InlinedStatementConfigurator 

--- a/doc/pattern.md
+++ b/doc/pattern.md
@@ -4,7 +4,7 @@ title: Spoon Patterns
 
 Spoon patterns enables you to find code elements. A Spoon pattern is based on a one or several AST nodes, which represent the code to match, where some parts of the AST are pattern parameters. When a pattern is matched, one can access to the code matched in each pattern parameter.
 
-The unique feature of Spoon pattern matching is that we are matching on AST tree of sources. Not on text of java sources. It means that:
+The unique feature of Spoon pattern matching is that we are matching on AST trees and not source code text. It means that:
 * source code formating is ignored. For example:
 
 ```java
@@ -26,7 +26,7 @@ void m() {}
 }
 ```
 
-* implicit and explicit elements are understood as same. For example:
+* implicit and explicit elements are considered the same. For example:
 
 ```java
 if (something) 

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -347,6 +347,7 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 	static {
 		roleToSkippedClass.put(CtRole.COMMENT, new Class[]{Object.class});
 		roleToSkippedClass.put(CtRole.POSITION, new Class[]{Object.class});
+		roleToSkippedClass.put(CtRole.IS_IMPLICIT, new Class[]{Object.class});
 		roleToSkippedClass.put(CtRole.TYPE, new Class[]{CtExecutableReference.class});
 		roleToSkippedClass.put(CtRole.DECLARING_TYPE, new Class[]{CtExecutableReference.class});
 	}

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -468,10 +468,11 @@ public class TemplateTest {
 			CtClass<?> klass = factory.Class().get(CheckBound.class);
 			CtIf templateRoot = (CtIf) ((CtMethod) templateKlass.getElements(new NamedElementFilter<>(CtMethod.class,"matcher2")).get(0)).getBody().getStatement(0);
 			TemplateMatcher matcher = new TemplateMatcher(templateRoot);
-			assertEquals(1, matcher.find(klass).size());
-			assertThat(asList("bov"), is(klass.filterChildren(matcher).map((CtElement e)->getMethodName(e)).list())) ;
+			assertEquals(2, matcher.find(klass).size());
+			assertThat(asList("bou", "bov"), is(klass.filterChildren(matcher).map((CtElement e)->getMethodName(e)).list())) ;
 			matcher.forEachMatch(klass, (match) -> {
-				assertTrue(checkParameters("bov", match, "_col_", "new java.util.ArrayList<>()"));
+				assertTrue(checkParameters("bov", match, "_col_", "new java.util.ArrayList<>()")
+						|| checkParameters("bou", match, "_col_", "new java.util.ArrayList<>()"));
 			});
 		}
 
@@ -553,15 +554,31 @@ public class TemplateTest {
 			CtClass<?> klass = factory.Class().get(CheckBound.class);
 			CtIf templateRoot = (CtIf) ((CtMethod) templateKlass.getElements(new NamedElementFilter<>(CtMethod.class,"matcher6")).get(0)).getBody().getStatement(0);
 			TemplateMatcher matcher = new TemplateMatcher(templateRoot);
-			assertEquals(2, matcher.find(klass).size());
-			assertThat(asList("baz","bou"), is(klass.filterChildren(matcher).map((CtElement e)->getMethodName(e)).list())) ;
+			assertEquals(6, matcher.find(klass).size());
+			assertThat(asList("foo","foo2","fbar","baz","bou","bov"), is(klass.filterChildren(matcher).map((CtElement e)->getMethodName(e)).list())) ;
 			matcher.forEachMatch(klass, (match) -> {
 				assertTrue(
-						checkParameters("baz", match,
+						checkParameters("foo", match,
+								"_x_", "(new java.util.ArrayList<>().size())",
+								"_y_", "10",
+								"_stmt_", "throw new java.lang.IndexOutOfBoundsException()")
+						||checkParameters("foo2", match, 
+								"_x_", "(new java.util.ArrayList<>().size())",
+								"_y_", "11",
+								"_stmt_", "throw new java.lang.IndexOutOfBoundsException()")
+						||checkParameters("fbar", match,
+								"_x_", "(l.size())",
+								"_y_", "10",
+								"_stmt_", "throw new java.lang.IndexOutOfBoundsException()")
+						||checkParameters("baz", match,
 								"_x_", "(new java.util.ArrayList<>().size())",
 								"_y_", "10",
 								"_stmt_", "null")
 						||checkParameters("bou", match,
+								"_x_", "(new java.util.ArrayList<>().size())",
+								"_y_", "10",
+								"_stmt_", "java.lang.System.out.println()")
+						||checkParameters("bov", match,
 								"_x_", "(new java.util.ArrayList<>().size())",
 								"_y_", "10",
 								"_stmt_", "java.lang.System.out.println()")
@@ -626,7 +643,7 @@ public class TemplateTest {
 				String key = keyValues[i * 2];
 				String expectedValue = keyValues[i * 2 + 1];
 				Object realValue = allParams.remove(key);
-				assertEquals(expectedValue, getOptimizedString(realValue));
+				assertEquals("parameter " + key, expectedValue, getOptimizedString(realValue));
 			}
 			assertTrue("Unexpected parameter values: " + allParams, allParams.isEmpty());
 			return true;


### PR DESCRIPTION
The `isImplicit` attribute is ignored by pattern matcher now. It means that these two lines:
```java
java.lang.String x;
String x;
```
are same from pattern matcher point of view.

It will be tested by #2683 which correctly sets isImplicit attributes and therefore two lines above has different values. Actually the values are same so it is not easily testable.