### PR TITLE
fix: java version not starting with "1." in pom.xml

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -286,7 +286,7 @@ public class SpoonPom implements SpoonResource {
 		return environment.getComplianceLevel();
 	}
 
-	private int correctJavaVersion(String javaVersion){
+	private int correctJavaVersion(String javaVersion) {
 		String version = extractVariable(javaVersion);
 		return Integer.parseInt((version.contains(".") ? version.substring(2) : version));
 	}

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -256,7 +256,8 @@ public class SpoonPom implements SpoonResource {
 			javaVersion = getSourceVersion(model.getBuild());
 		}
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			String version = extractVariable(javaVersion);
+			return Integer.parseInt((version.contains(".") ? version.substring(2) : version));
 		}
 		for (Profile profile: model.getProfiles()) {
 			if (profile.getActivation() != null && profile.getActivation().isActiveByDefault()) {

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -256,8 +256,7 @@ public class SpoonPom implements SpoonResource {
 			javaVersion = getSourceVersion(model.getBuild());
 		}
 		if (javaVersion != null) {
-			String version = extractVariable(javaVersion);
-			return Integer.parseInt((version.contains(".") ? version.substring(2) : version));
+			return correctJavaVersion(javaVersion);
 		}
 		for (Profile profile: model.getProfiles()) {
 			if (profile.getActivation() != null && profile.getActivation().isActiveByDefault()) {
@@ -265,26 +264,31 @@ public class SpoonPom implements SpoonResource {
 			}
 		}
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			return correctJavaVersion(javaVersion);
 		}
 		javaVersion = getProperty("java.version");
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			return correctJavaVersion(javaVersion);
 		}
 		javaVersion = getProperty("java.src.version");
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			return correctJavaVersion(javaVersion);
 		}
 		javaVersion = getProperty("maven.compiler.source");
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			return correctJavaVersion(javaVersion);
 		}
 		javaVersion = getProperty("maven.compile.source");
 		if (javaVersion != null) {
-			return Integer.parseInt(extractVariable(javaVersion).substring(2));
+			return correctJavaVersion(javaVersion);
 		}
 		// return the current compliance level of spoon
 		return environment.getComplianceLevel();
+	}
+
+	private int correctJavaVersion(String javaVersion){
+		String version = extractVariable(javaVersion);
+		return Integer.parseInt((version.contains(".") ? version.substring(2) : version));
 	}
 
 	private String getSourceVersion(BuildBase build) {

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -107,6 +107,10 @@ public class MavenLauncherTest {
 		launcher = new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
 		assertEquals(8, launcher.getEnvironment().getComplianceLevel());
 
+		// specify the pom.xml
+		launcher = new MavenLauncher("./src/test/resources/maven-launcher/java-11/pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
+		assertEquals(11, launcher.getEnvironment().getComplianceLevel());
+
 		// without calling maven to generate classpath
 		launcher = new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE, new String[]{});
 		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);

--- a/src/test/resources/maven-launcher/java-11/pom.xml
+++ b/src/test/resources/maven-launcher/java-11/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+
+    <properties>
+        <java.version>11</java.version>
+    </properties>
+</project>


### PR DESCRIPTION
If the java version does not start with `1.` in pom.xml, a `NumberFormatException` is thrown when creating a new `MavenLauncher`. (issue #2714)
We check if the java version number contains a `.` before removing it.

I added an Assert in `MavenLauncherTest`. 

I haven't done many PRs so feel free to tell me if I did anything wrong.