### PR TITLE
feat: CtScannerListener knows role of scanned element

### DIFF
--- a/src/main/java/spoon/reflect/visitor/EarlyTerminatingScanner.java
+++ b/src/main/java/spoon/reflect/visitor/EarlyTerminatingScanner.java
@@ -128,12 +128,12 @@ public class EarlyTerminatingScanner<T> extends CtScanner {
 			doScan(scannedRole, element, ScanningMode.NORMAL);
 		} else {
 			//the listener is defined, call it's enter method first
-			ScanningMode mode = listener.enter(element);
+			ScanningMode mode = listener.enter(scannedRole, element);
 			if (mode != ScanningMode.SKIP_ALL) {
 				//the listener decided to visit this element and may be children
 				doScan(scannedRole, element, mode);
 				//then call exit, only if enter returned true
-				listener.exit(element);
+				listener.exit(scannedRole, element);
 			} //else the listener decided to skip this element and all children. Do not call exit.
 		}
 	}

--- a/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
@@ -17,6 +17,7 @@
 package spoon.reflect.visitor.chain;
 
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
 
 /**
  * Responsible for performing an action when a scanner enters/exits a node while scanning the AST.
@@ -29,7 +30,21 @@ public interface CtScannerListener {
 	 * @return a {@link ScanningMode} that drives how the scanner processes this element and its children.
 	 * For instance, returning {@link ScanningMode#SKIP_ALL} causes that element and all children to be skipped and {@link #exit(CtElement)} are be NOT called for that element.
 	 */
-	ScanningMode enter(CtElement element);
+	default ScanningMode enter(CtElement element) {
+		return ScanningMode.NORMAL;
+	}
+
+	/**
+	 * Called before the scanner enters an element
+	 *
+	 * @param role the {@link CtRole}, which `element` has in it's parent. It is null for the first scanned element
+	 * @param element the element about to be scanned.
+	 * @return a {@link ScanningMode} that drives how the scanner processes this element and its children.
+	 * For instance, returning {@link ScanningMode#SKIP_ALL} causes that element and all children to be skipped and {@link #exit(CtElement)} are be NOT called for that element.
+	 */
+	default ScanningMode enter(CtRole role, CtElement element) {
+		return enter(element);
+	}
 
 	/**
 	 * This method is called after the element and all its children have been visited.
@@ -38,5 +53,17 @@ public interface CtScannerListener {
 	 *
 	 * @param element the element that has just been scanned.
 	 */
-	void exit(CtElement element);
+	default void exit(CtElement element) {
+	}
+	/**
+	 * This method is called after the element and all its children have been visited.
+	 * This method is NOT called if an exception is thrown in {@link #enter(CtElement)} or during the scanning of the element or any of its children element.
+	 * This method is NOT called for an element for which {@link #enter(CtElement)} returned {@link ScanningMode#SKIP_ALL}.
+	 *
+	 * @param role the {@link CtRole}, which `element` has in it's parent. It is null for the first scanned element
+	 * @param element the element that has just been scanned.
+	 */
+	default void exit(CtRole role, CtElement element) {
+		exit(element);
+	}
 }

--- a/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
@@ -37,7 +37,7 @@ public interface CtScannerListener {
 	/**
 	 * Called before the scanner enters an element
 	 *
-	 * @param role the {@link CtRole}, which `element` has in it's parent. It is null for the first scanned element
+	 * @param role the {@link CtRole}, which `element` has in its parent. It is null for the first scanned element
 	 * @param element the element about to be scanned.
 	 * @return a {@link ScanningMode} that drives how the scanner processes this element and its children.
 	 * For instance, returning {@link ScanningMode#SKIP_ALL} causes that element and all children to be skipped and {@link #exit(CtElement)} are be NOT called for that element.
@@ -60,7 +60,7 @@ public interface CtScannerListener {
 	 * This method is NOT called if an exception is thrown in {@link #enter(CtElement)} or during the scanning of the element or any of its children element.
 	 * This method is NOT called for an element for which {@link #enter(CtElement)} returned {@link ScanningMode#SKIP_ALL}.
 	 *
-	 * @param role the {@link CtRole}, which `element` has in it's parent. It is null for the first scanned element
+	 * @param role the {@link CtRole}, which `element` has in its parent. It is null for the first scanned element
 	 * @param element the element that has just been scanned.
 	 */
 	default void exit(CtRole role, CtElement element) {


### PR DESCRIPTION
Information about role of the scanned element is now available in `CtScannerListener`.

It makes algorithms of import validators easier and faster.