### PR TITLE
test: remove long logs fof CtGenerationTest which makes CI log unreadable

### DIFF
--- a/src/test/java/spoon/processing/CtGenerationTest.java
+++ b/src/test/java/spoon/processing/CtGenerationTest.java
@@ -88,11 +88,7 @@ public class CtGenerationTest {
 		// cp ./target/generated/spoon/support/visitor/replace/ReplacementVisitor.java ./src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
 		CtClass<Object> actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/support/visitor/replace/ReplacementVisitor.java")).Class().get("spoon.support.visitor.replace.ReplacementVisitor");
 		CtClass<Object> expected = build(new File("./src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java")).Class().get("spoon.support.visitor.replace.ReplacementVisitor");
-		try {
-			assertThat(actual).isEqualTo(expected);
-		} catch (AssertionError e) {
-			throw new ComparisonFailure("ReplacementVisitor different", expected.toString(), actual.toString());
-		}
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	@Test
@@ -153,22 +149,12 @@ public class CtGenerationTest {
 		// cp ./target/generated/spoon/support/visitor/clone/CloneBuilder.java  ./src/main/java/spoon/support/visitor/clone/CloneBuilder.java
 		CtClass<Object> actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/support/visitor/clone/CloneBuilder.java")).Class().get("spoon.support.visitor.clone.CloneBuilder");
 		CtClass<Object> expected = build(new File("./src/main/java/spoon/support/visitor/clone/CloneBuilder.java")).Class().get("spoon.support.visitor.clone.CloneBuilder");
-		try {
-			assertThat(actual)
-					.isEqualTo(expected);
-		} catch (AssertionError e) {
-			throw new ComparisonFailure("CloneBuilder different", expected.toString(), actual.toString());
-		}
+		assertThat(actual).isEqualTo(expected);
 
 		// cp ./target/generated/spoon/support/visitor/clone/CloneVisitor.java  ./src/main/java/spoon/support/visitor/clone/CloneVisitor.java
 		actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/support/visitor/clone/CloneVisitor.java")).Class().get("spoon.support.visitor.clone.CloneVisitor");
 		expected = build(new File("./src/main/java/spoon/support/visitor/clone/CloneVisitor.java")).Class().get("spoon.support.visitor.clone.CloneVisitor");
-		try {
-			assertThat(actual)
-					.isEqualTo(expected);
-		} catch (AssertionError e) {
-			throw new ComparisonFailure("CloneVisitor different", expected.toString(), actual.toString());
-		}
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	@Test
@@ -204,11 +190,7 @@ public class CtGenerationTest {
 		// cp ./target/generated/spoon/reflect/meta/impl/ModelRoleHandlers.java ./src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java
 		CtClass<Object> actual = build(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/reflect/meta/impl/ModelRoleHandlers.java")).Class().get("spoon.reflect.meta.impl.ModelRoleHandlers");
 		CtClass<Object> expected = build(new File("./src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java")).Class().get("spoon.reflect.meta.impl.ModelRoleHandlers");
-		try {
-			assertThat(actual).isEqualTo(expected);
-		} catch (AssertionError e) {
-			throw new ComparisonFailure("ModelRoleHandlers different", expected.toString(), actual.toString());
-		}
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	private class RegexFilter implements Filter<CtType<?>> {


### PR DESCRIPTION
Surefire displays ComparisonFailure ... which is not bad for short strings, but completely breaks the output if CtGenerationTest fails eg https://travis-ci.org/INRIA/spoon/jobs/452050077

