### PR TITLE
refactor: don't print a scary stack trace when it's not meaningful

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -67,7 +67,8 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 			return getDeclaringType().getActualClass().getDeclaredField(
 					getSimpleName());
 		} catch (Exception e) {
-			Launcher.LOGGER.error(e.getMessage(), e);
+			// it's ok, this can happen in noclasspath, we don't have to print a scary stacktrace
+			Launcher.LOGGER.error("getActualField returns nothing, it's OK if you're in noclasspath");
 		}
 		return null;
 	}


### PR DESCRIPTION
we all crawled through this stack trace in Travis logs.

that's over now.

```
spoon.support.SpoonClassNotFoundException: cannot load class: daikon.Runtime
	at spoon.support.reflect.reference.CtTypeReferenceImpl.lambda$findClass$9(CtTypeReferenceImpl.java:170)
	at spoon.support.util.internal.MapUtils.getOrCreate(MapUtils.java:43)
	at spoon.support.util.internal.MapUtils.getOrCreate(MapUtils.java:33)
	at spoon.support.reflect.reference.CtTypeReferenceImpl.findClass(CtTypeReferenceImpl.java:163)
	at spoon.support.reflect.reference.CtTypeReferenceImpl.getActualClass(CtTypeReferenceImpl.java:143)
	at spoon.support.reflect.reference.CtFieldReferenceImpl.getActualField(CtFieldReferenceImpl.java:63)
	at spoon.support.reflect.reference.CtFieldReferenceImpl.getModifiers(CtFieldReferenceImpl.java:227)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.isInitializeStaticFinalField(DefaultJavaPrettyPrinter.java:896)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.printCtFieldAccess(DefaultJavaPrettyPrinter.java:843)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.visitCtFieldWrite(DefaultJavaPrettyPrinter.java:802)
	at spoon.support.reflect.code.CtFieldWriteImpl.accept(CtFieldWriteImpl.java:27)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.scan(DefaultJavaPrettyPrinter.java:363)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.visitCtAssignment(DefaultJavaPrettyPrinter.java:511)
	at spoon.support.reflect.code.CtAssignmentImpl.accept(CtAssignmentImpl.java:54)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.scan(DefaultJavaPrettyPrinter.java:363)
	at spoon.reflect.visitor.ElementPrinterHelper.writeStatement(ElementPrinterHelper.java:178)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.visitCtBlock(DefaultJavaPrettyPrinter.java:544)
	at spoon.support.reflect.code.CtBlockImpl.accept(CtBlockImpl.java:67)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.scan(DefaultJavaPrettyPrinter.java:363)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.visitCtAnonymousExecutable(DefaultJavaPrettyPrinter.java:462)
	at spoon.support.reflect.declaration.CtAnonymousExecutableImpl.accept(CtAnonymousExecutableImpl.java:46)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.scan(DefaultJavaPrettyPrinter.java:363)
	at spoon.reflect.visitor.ElementPrinterHelper.writeElementList(ElementPrinterHelper.java:188)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.visitCtClass(DefaultJavaPrettyPrinter.java:638)
	at spoon.support.reflect.declaration.CtClassImpl.accept(CtClassImpl.java:67)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.scan(DefaultJavaPrettyPrinter.java:363)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.printTypes(DefaultJavaPrettyPrinter.java:2017)
	at spoon.reflect.visitor.DefaultJavaPrettyPrinter.calculate(DefaultJavaPrettyPrinter.java:2012)
	at spoon.support.JavaOutputProcessor.createJavaFile(JavaOutputProcessor.java:120)
	at spoon.support.JavaOutputProcessor.process(JavaOutputProcessor.java:156)
	at spoon.support.JavaOutputProcessor.process(JavaOutputProcessor.java:46)
	at spoon.support.visitor.ProcessingVisitor.scan(ProcessingVisitor.java:74)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:176)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:150)
	at spoon.reflect.visitor.CtScanner.visitCtPackage(CtScanner.java:652)
	at spoon.support.reflect.declaration.CtPackageImpl.accept(CtPackageImpl.java:97)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:184)
	at spoon.support.visitor.ProcessingVisitor.scan(ProcessingVisitor.java:77)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:176)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:150)
	at spoon.reflect.visitor.CtScanner.visitCtPackage(CtScanner.java:651)
	at spoon.support.reflect.declaration.CtPackageImpl.accept(CtPackageImpl.java:97)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:184)
	at spoon.support.visitor.ProcessingVisitor.scan(ProcessingVisitor.java:77)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:176)
	at spoon.reflect.visitor.CtScanner.visitCtModule(CtScanner.java:926)
	at spoon.reflect.factory.ModuleFactory$CtUnnamedModule.accept(ModuleFactory.java:105)
	at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:184)
	at spoon.support.visitor.ProcessingVisitor.scan(ProcessingVisitor.java:77)
	at spoon.support.QueueProcessingManager.process(QueueProcessingManager.java:129)
	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.generateProcessedSourceFilesUsingTypes(JDTBasedSpoonCompiler.java:484)
	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.generateProcessedSourceFiles(JDTBasedSpoonCompiler.java:210)
	at spoon.Launcher.prettyprint(Launcher.java:784)
	at spoon.Launcher.run(Launcher.java:722)
	at spoon.test.ctClass.CtClassTest.testParentOfTheEnclosingClassOfStaticClass(CtClassTest.java:115)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:379)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:340)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:125)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:413)
Caused by: java.lang.ClassNotFoundException: daikon.Runtime
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at spoon.support.reflect.reference.CtTypeReferenceImpl.lambda$findClass$9(CtTypeReferenceImpl.java:168)
	... 79 more

```