### PR TITLE
refactor: split multiple variables in VariableReferencesModelTest.java

### DIFF
--- a/src/test/java/spoon/test/query_function/testclasses/VariableReferencesModelTest.java
+++ b/src/test/java/spoon/test/query_function/testclasses/VariableReferencesModelTest.java
@@ -26,7 +26,11 @@ public class VariableReferencesModelTest {
 				int field = 1;
 				assertTrue(field == 1);
 			}
-			int f1,f2,f3,field = 2,f4;
+			int f1;
+			int f2;
+			int f3;
+			int field = 2;
+			int f4;
 			assertTrue(field == 2);
 		}
 		int field = 3;


### PR DESCRIPTION
*Reports multiple variables being declared in a single declaration. Some coding standards prohibit such declarations.*

Multiple variables in one line are hard to read, and easy to overlook. Thing to avoid.