### PR TITLE
refactor: getDocComment uses the same implementation as pretty-printer

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -74,7 +74,7 @@ public class CommentHelper {
 				break;
 			default:
 				// per line suffix
-				printCommentContent(printer, comment, s -> { return (" * " + s).replaceAll(" *$",""); });
+				printCommentContent(printer, comment, s -> { return (" * " + s).replaceAll(" *$", ""); });
 		}
 		// suffix
 		switch (commentType) {

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -980,7 +980,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		 * E.g. from CtJavaDocTag#toString
 		 * Write directly to PrinterHelper, because java doc tag is not a java token. Normally it is part of COMMENT token.
 		 */
-		CommentHelper.printJavaDocTag(printer.getPrinterHelper(), docTag);
+		CommentHelper.printJavaDocTag(printer.getPrinterHelper(), docTag, x -> { return x; });
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -21,8 +21,6 @@ import spoon.Launcher;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
-import spoon.reflect.code.CtJavaDoc;
-import spoon.reflect.code.CtJavaDocTag;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
@@ -74,6 +72,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static spoon.reflect.visitor.CommentHelper.printComment;
 
 /**
  * Contains the default implementation of most CtElement methods.
@@ -186,12 +186,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	public String getDocComment() {
 		for (CtComment ctComment : comments) {
 			if (ctComment.getCommentType() == CtComment.CommentType.JAVADOC) {
-				StringBuilder result = new StringBuilder();
-				result.append(ctComment.getContent() + System.lineSeparator());
-				for (CtJavaDocTag tag: ((CtJavaDoc) ctComment).getTags()) {
-					result.append(tag.toString()); // the tag already contains a new line
-				}
-				return result.toString();
+				return printComment(ctComment);
 			}
 		}
 		return "";

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -68,7 +68,7 @@ public class JavaDocTest {
 
 		// contract: getDocComment returns the comment content together with the tag content
 		CtMethod<?> method = aClass.getMethodsByName("create").get(0);
-		assertEquals("Creates an annotation type." + System.lineSeparator()
+		assertEquals("Creates an annotation type." + System.lineSeparator() + System.lineSeparator()
 				+ "@param owner" + System.lineSeparator()
 				+ "\t\tthe package of the annotation type" + System.lineSeparator()
 				+ "@param simpleName" + System.lineSeparator()


### PR DESCRIPTION
(reduce code duplication)