### PR TITLE
Add encoding detection callback

### DIFF
--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -18,6 +18,7 @@ package spoon.compiler;
 
 import org.apache.log4j.Level;
 import spoon.OutputType;
+import spoon.compiler.builder.EncodingProvider;
 import spoon.support.modelobs.FineModelChangeListener;
 import spoon.processing.FileGenerator;
 import spoon.processing.ProblemFixer;
@@ -34,7 +35,6 @@ import spoon.support.sniper.SniperJavaPrettyPrinter;
 
 import java.io.File;
 import java.nio.charset.Charset;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -380,9 +380,9 @@ public interface Environment {
 	Charset getEncoding();
 
 	/**
-	 * Get callback, which is used to detect encoding for each file separately
+	 * Get encoding provider, which is used to detect encoding for each file separately
 	 */
-	Function<byte[], Charset> getEncodingDetectionCallback();
+	EncodingProvider getEncodingProvider();
 
 	/**
 	 * Set the encoding to use for parsing source code
@@ -390,9 +390,9 @@ public interface Environment {
 	void setEncoding(Charset encoding);
 
 	/**
-	 * Set callback, which is used to detect encoding for each file separately
+	 * Set encoding provider, which is used to detect encoding for each file separately
 	 */
-	void setEncodingDetectionCallback(Function<byte[], Charset> callback);
+	void setEncodingProvider(EncodingProvider encodingProvider);
 
 	/**
 	 * Set the output type used for processing files

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -34,6 +34,7 @@ import spoon.support.sniper.SniperJavaPrettyPrinter;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -379,9 +380,19 @@ public interface Environment {
 	Charset getEncoding();
 
 	/**
+	 * Get callback, which is used to detect encoding for each file separately
+	 */
+	Function<byte[], Charset> getEncodingDetectionCallback();
+
+	/**
 	 * Set the encoding to use for parsing source code
 	 */
 	void setEncoding(Charset encoding);
+
+	/**
+	 * Set callback, which is used to detect encoding for each file separately
+	 */
+	void setEncodingDetectionCallback(Function<byte[], Charset> callback);
 
 	/**
 	 * Set the output type used for processing files

--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -16,8 +16,10 @@
  */
 package spoon.compiler;
 
+import org.apache.commons.io.IOUtils;
 import spoon.SpoonException;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -54,8 +56,9 @@ public interface SpoonFile extends SpoonResource {
 		byte[] bytes;
 		try {
 			InputStream contentStream = getContent();
-			bytes = new byte[contentStream.available()];
-			contentStream.read(bytes);
+			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+			IOUtils.copy(contentStream, outputStream);
+			bytes = outputStream.toByteArray();
 		} catch (IOException e) {
 			throw new SpoonException(e);
 		}

--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -54,8 +54,7 @@ public interface SpoonFile extends SpoonResource {
 	 */
 	default char[] getContentChars(Environment env) {
 		byte[] bytes;
-		try {
-			InputStream contentStream = getContent();
+		try (InputStream contentStream = getContent()) {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 			IOUtils.copy(contentStream, outputStream);
 			bytes = outputStream.toByteArray();

--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -16,7 +16,11 @@
  */
 package spoon.compiler;
 
+import spoon.SpoonException;
+
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 /**
  * This interface represents files that can be used as resources for the Spoon
@@ -41,4 +45,25 @@ public interface SpoonFile extends SpoonResource {
 	 * @return
 	 */
 	boolean isActualFile();
+
+	/**
+	 * Gets the file content as a char array, considering encoding or encoding
+	 * provider.
+	 */
+	default char[] getContentChars(Environment env) {
+		byte[] bytes;
+		try {
+			InputStream contentStream = getContent();
+			bytes = new byte[contentStream.available()];
+			contentStream.read(bytes);
+		} catch (IOException e) {
+			throw new SpoonException(e);
+		}
+		if (env.getEncodingProvider() == null) {
+			return new String(bytes, env.getEncoding()).toCharArray();
+		} else {
+			Charset encoding = env.getEncodingProvider().detectEncoding(this, bytes);
+			return new String(bytes, encoding).toCharArray();
+		}
+	}
 }

--- a/src/main/java/spoon/compiler/builder/EncodingProvider.java
+++ b/src/main/java/spoon/compiler/builder/EncodingProvider.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.compiler.builder;
+
+import spoon.compiler.SpoonFile;
+import java.nio.charset.Charset;
+
+public interface EncodingProvider {
+
+	/**
+	* User-defined function, which is used to detect encoding for each file
+	*/
+	Charset detectEncoding(SpoonFile file, byte[] fileBytes);
+}

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -26,6 +26,7 @@ import spoon.compiler.Environment;
 import spoon.compiler.InvalidClassPathException;
 import spoon.compiler.SpoonFile;
 import spoon.compiler.SpoonFolder;
+import spoon.compiler.builder.EncodingProvider;
 import spoon.processing.FileGenerator;
 import spoon.processing.ProblemFixer;
 import spoon.processing.ProcessingManager;
@@ -55,7 +56,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.function.Function;
 import java.util.function.Supplier;
 
 
@@ -101,7 +101,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private transient Charset encoding = Charset.defaultCharset();
 
-	private transient Function<byte[], Charset> encodingDetectionCallback;
+	private transient EncodingProvider encodingProvider;
 
 	private int complianceLevel = DEFAULT_CODE_COMPLIANCE_LEVEL;
 
@@ -586,8 +586,8 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public Function<byte[], Charset> getEncodingDetectionCallback() {
-		return encodingDetectionCallback;
+	public EncodingProvider getEncodingProvider() {
+		return encodingProvider;
 	}
 
 	@Override
@@ -596,8 +596,8 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public void setEncodingDetectionCallback(Function<byte[], Charset> encodingDetectionCallback) {
-		this.encodingDetectionCallback = encodingDetectionCallback;
+	public void setEncodingProvider(EncodingProvider encodingProvider) {
+		this.encodingProvider = encodingProvider;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -55,6 +55,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 
@@ -99,6 +100,8 @@ public class StandardEnvironment implements Serializable, Environment {
 	private transient FineModelChangeListener modelChangeListener = new EmptyModelChangeListener();
 
 	private transient Charset encoding = Charset.defaultCharset();
+
+	private transient Function<byte[], Charset> encodingDetectionCallback;
 
 	private int complianceLevel = DEFAULT_CODE_COMPLIANCE_LEVEL;
 
@@ -583,8 +586,18 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
+	public Function<byte[], Charset> getEncodingDetectionCallback() {
+		return encodingDetectionCallback;
+	}
+
+	@Override
 	public void setEncoding(Charset encoding) {
 		this.encoding = encoding;
+	}
+
+	@Override
+	public void setEncodingDetectionCallback(Function<byte[], Charset> encodingDetectionCallback) {
+		this.encodingDetectionCallback = encodingDetectionCallback;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/VirtualFile.java
+++ b/src/main/java/spoon/support/compiler/VirtualFile.java
@@ -23,7 +23,6 @@ import spoon.compiler.SpoonFolder;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 
 public class VirtualFile implements SpoonFile {
 	public static final String VIRTUAL_FILE_NAME = "virtual_file";
@@ -48,13 +47,7 @@ public class VirtualFile implements SpoonFile {
 
 	@Override
 	public char[] getContentChars(Environment env) {
-		byte[] bytes = content.getBytes();
-		if (env.getEncodingProvider() == null) {
-			return new String(bytes, env.getEncoding()).toCharArray();
-		} else {
-			Charset encoding = env.getEncodingProvider().detectEncoding(this, bytes);
-			return new String(bytes, encoding).toCharArray();
-		}
+		return content.toCharArray();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/VirtualFile.java
+++ b/src/main/java/spoon/support/compiler/VirtualFile.java
@@ -16,12 +16,14 @@
  */
 package spoon.support.compiler;
 
+import spoon.compiler.Environment;
 import spoon.compiler.SpoonFile;
 import spoon.compiler.SpoonFolder;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 public class VirtualFile implements SpoonFile {
 	public static final String VIRTUAL_FILE_NAME = "virtual_file";
@@ -42,6 +44,17 @@ public class VirtualFile implements SpoonFile {
 	@Override
 	public InputStream getContent() {
 		return new ByteArrayInputStream(content.getBytes());
+	}
+
+	@Override
+	public char[] getContentChars(Environment env) {
+		byte[] bytes = content.getBytes();
+		if (env.getEncodingProvider() == null) {
+			return new String(bytes, env.getEncoding()).toCharArray();
+		} else {
+			Charset encoding = env.getEncodingProvider().detectEncoding(this, bytes);
+			return new String(bytes, encoding).toCharArray();
+		}
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -16,16 +16,13 @@
  */
 package spoon.support.compiler.jdt;
 
-import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
-import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
+import spoon.compiler.Environment;
 import spoon.compiler.SpoonFile;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
 
 public class FileCompilerConfig implements SpoonModelBuilder.InputType {
@@ -54,31 +51,16 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 	public void initializeCompiler(JDTBatchCompiler compiler) {
 		JDTBasedSpoonCompiler jdtCompiler = compiler.getJdtCompiler();
 		List<CompilationUnit> cuList = new ArrayList<>();
-		InputStream inputStream = null;
 
-		try {
-			for (SpoonFile f : getFiles(compiler)) {
+		for (SpoonFile f : getFiles(compiler)) {
 
-				if (compiler.filesToBeIgnored.contains(f.getPath())) {
-					continue;
-				}
-
-				String fName = f.isActualFile() ? f.getPath() : f.getName();
-				inputStream = f.getContent();
-				if (jdtCompiler.getEnvironment().getEncodingDetectionCallback() == null) {
-					char[] content = IOUtils.toCharArray(inputStream, jdtCompiler.getEnvironment().getEncoding());
-					cuList.add(new CompilationUnit(content, fName, jdtCompiler.getEnvironment().getEncoding().displayName()));
-				} else {
-					byte[] bytes = IOUtils.toByteArray(inputStream);
-					Charset encoding = jdtCompiler.getEnvironment().getEncodingDetectionCallback().apply(bytes);
-					char[] content = new String(bytes, encoding).toCharArray();
-					cuList.add(new CompilationUnit(content, fName, encoding.displayName()));
-				}
-				IOUtils.closeQuietly(inputStream);
+			if (compiler.filesToBeIgnored.contains(f.getPath())) {
+				continue;
 			}
-		} catch (Exception e) {
-			IOUtils.closeQuietly(inputStream);
-			throw new SpoonException(e);
+
+			String fName = f.isActualFile() ? f.getPath() : f.getName();
+			Environment env = jdtCompiler.getEnvironment();
+			cuList.add(new CompilationUnit(f.getContentChars(env), fName, env.getEncoding().displayName()));
 		}
 
 		compiler.setCompilationUnits(cuList.toArray(new CompilationUnit[0]));

--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -17,6 +17,7 @@
 package spoon.support.compiler.jdt;
 
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -64,8 +65,15 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 
 				String fName = f.isActualFile() ? f.getPath() : f.getName();
 				inputStream = f.getContent();
-				char[] content = IOUtils.toCharArray(inputStream, jdtCompiler.getEnvironment().getEncoding());
-				cuList.add(new CompilationUnit(content, fName, jdtCompiler.getEnvironment().getEncoding().displayName()));
+				if (jdtCompiler.getEnvironment().getEncodingDetectionCallback() == null) {
+					char[] content = IOUtils.toCharArray(inputStream, jdtCompiler.getEnvironment().getEncoding());
+					cuList.add(new CompilationUnit(content, fName, jdtCompiler.getEnvironment().getEncoding().displayName()));
+				} else {
+					byte[] bytes = IOUtils.toByteArray(inputStream);
+					Charset encoding = jdtCompiler.getEnvironment().getEncodingDetectionCallback().apply(bytes);
+					char[] content = new String(bytes, encoding).toCharArray();
+					cuList.add(new CompilationUnit(content, fName, encoding.displayName()));
+				}
 				IOUtils.closeQuietly(inputStream);
 			}
 		} catch (Exception e) {

--- a/src/test/java/spoon/test/api/FileSystemFolderTest.java
+++ b/src/test/java/spoon/test/api/FileSystemFolderTest.java
@@ -46,7 +46,7 @@ public class FileSystemFolderTest {
 		try {
 			spoon.buildModel();
 		} catch (SpoonException spe) {
-			Throwable containedException = spe.getCause().getCause();
+			Throwable containedException = spe.getCause();
 			assertTrue(containedException instanceof FileNotFoundException);
 		}
 	}

--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
+import spoon.compiler.SpoonFile;
 import spoon.reflect.CtModel;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
@@ -272,7 +273,7 @@ public class TestCompilationUnit {
 		}.scan(type.getFactory().getModel().getRootPackage());
 	}
 
-	private Charset detectEncodingDummy(byte[] fileBytes) {
+	private Charset detectEncodingDummy(SpoonFile unused, byte[] fileBytes) {
 		if (fileBytes.length == 76) {
 			return Charset.forName("Cp1251");
 		} else if (fileBytes.length == 86) {
@@ -287,7 +288,7 @@ public class TestCompilationUnit {
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/resources/encodings/Cp1251.java");
 		launcher.addInputResource("./src/test/resources/encodings/Utf8.java");
-		launcher.getEnvironment().setEncodingDetectionCallback(this::detectEncodingDummy);
+		launcher.getEnvironment().setEncodingProvider(this::detectEncodingDummy);
 		CtModel model = launcher.buildModel();
 
 		CtType<?> utf8Type = model.getAllTypes()

--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -19,6 +19,8 @@ package spoon.test.compilationunit;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.SpoonException;
+import spoon.reflect.CtModel;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.position.BodyHolderSourcePosition;
@@ -42,11 +44,13 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 
 /**
  * Created by urli on 18/08/2017.
@@ -266,5 +270,41 @@ public class TestCompilationUnit {
 				fail("CtCompilation unit must not be scanned when started from model root package");
 			}
 		}.scan(type.getFactory().getModel().getRootPackage());
+	}
+
+	private Charset detectEncodingDummy(byte[] fileBytes) {
+		if (fileBytes.length == 76) {
+			return Charset.forName("Cp1251");
+		} else if (fileBytes.length == 86) {
+			return Charset.forName("UTF-8");
+		}
+		throw new SpoonException("unexpected length");
+	}
+
+	@Test
+	public void testDifferentEncodings() throws Exception {
+		//contract: both utf-8 and cp1251 files in the same project should be handled properly
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/encodings/Cp1251.java");
+		launcher.addInputResource("./src/test/resources/encodings/Utf8.java");
+		launcher.getEnvironment().setEncodingDetectionCallback(this::detectEncodingDummy);
+		CtModel model = launcher.buildModel();
+
+		CtType<?> utf8Type = model.getAllTypes()
+				.stream()
+				.filter(t -> "Utf8".equals(t.getSimpleName()))
+				.findFirst()
+				.get();
+
+		CtType<?> cp1251Type = model.getAllTypes()
+				.stream()
+				.filter(t -> "Cp1251".equals(t.getSimpleName()))
+				.findFirst()
+				.get();
+
+		assertEquals("\"Привет мир\"", utf8Type.getField("s1").getAssignment().toString());
+		assertEquals("\"Привет мир\"", cp1251Type.getField("s1").getAssignment().toString());
+		assertEquals(utf8Type.getField("s1"), cp1251Type.getField("s1"));
+		assertNotEquals(utf8Type.getField("s2"), cp1251Type.getField("s2"));
 	}
 }

--- a/src/test/resources/encodings/Cp1251.java
+++ b/src/test/resources/encodings/Cp1251.java
@@ -1,0 +1,4 @@
+public class Cp1251 {
+    String s1 = "Привет мир";
+    String s2 = "АБВ"
+}

--- a/src/test/resources/encodings/Utf8.java
+++ b/src/test/resources/encodings/Utf8.java
@@ -1,0 +1,4 @@
+public class Utf8 {
+    String s1 = "Привет мир";
+    String s2 = "ГДЕ"
+}


### PR DESCRIPTION
This PR provides ability to specify user-defined callback, which could be used to detect encoding for each file separately. See #2781.

For example I use juniversalchardet lib:
```
private Charset detectEncoding(byte[] fileBytes) {
   final int maxLength = 4096;
   UniversalDetector detector = new UniversalDetector(null);
   detector.handleData(fileBytes, 0, Math.min(fileBytes.length, maxLength));
   detector.dataEnd();
   String encoding = detector.getDetectedCharset();
   detector.reset();
   if (encoding != null) {
       return Charset.forName(encoding);
   }
   return Charset.forName("UTF-8");
}
```
Spoon api:
```
final Launcher launcher = new Launcher();
launcher.getEnvironment().setEncodingDetectionCallback(bytes -> detectEncoding(bytes));
// ...
CtModel model = launcher.buildModel();
```
It helps to have correct AST in projects with mixed encodings.