### PR TITLE
fix(FieldAccessTest): adapt FieldAccessTest to oracle jdk 11/jdt changes

### DIFF
--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -32,6 +32,7 @@ import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.UnaryOperatorKind;
+import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
@@ -388,7 +389,7 @@ public class FieldAccessTest {
 			@Override
 			public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
 				visited++;
-				assertEquals("array", ((CtVariableWrite) fieldWrite.getTarget()).getVariable().getSimpleName());
+				assertEquals("array", ((CtVariableAccess) fieldWrite.getTarget()).getVariable().getSimpleName());
 				assertEquals("length", fieldWrite.getVariable().getSimpleName());
 			}
 		}


### PR DESCRIPTION
Related to adding a travis build with jdk 11 See #2782 

`CtFieldWrite.getTarget()` on `array.length` used to return a `CtVariableWrite` for some reasons... But with jdk 11 now returns  a `CtVariableRead`...

`FieldAccessTest#testFieldAccessOnUnknownType()` has been changed to handle both... by expecting a `CtVariableAccess`.

This fixes tests for jdk 11 as can be seen here ( https://travis-ci.org/INRIA/spoon/jobs/460289160 ).
Wether this is satisfaying or not, is up to debate. WDYT?