### PR TITLE
fix: check style doesn't check left curly on lambda

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -53,7 +53,9 @@
 
     <!-- Checks for blocks. You know, those {}'s         -->
     <!-- See http://checkstyle.sf.net/config_blocks.html -->
-    <module name="LeftCurly" />
+    <module name="LeftCurly" >
+    	<property name="tokens" value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF, INTERFACE_DEF, LITERAL_CASE, LITERAL_CATCH, LITERAL_DEFAULT, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF, OBJBLOCK, STATIC_INIT"/>
+    </module>
     <module name="RightCurly" />
     <module name="NeedBraces"/>
 


### PR DESCRIPTION
I installed latest checkstyle plugin and I get this checkstyle error
![image](https://user-images.githubusercontent.com/23107345/49206757-5543c380-f3b3-11e8-8470-31640f33fab2.png)

I guess this PR is correct solution for that. The `LAMBDA` was removed from the list of tokens.

WDYT?