### PR TITLE
feature: AllTypeMembersFunction mode=[All, SKIP_PRIVATE]

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
@@ -19,9 +19,11 @@ package spoon.reflect.visitor.filter;
 import java.util.HashSet;
 import java.util.Set;
 
+import spoon.SpoonException;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.CtQuery;
@@ -31,13 +33,27 @@ import spoon.reflect.visitor.chain.CtQueryable;
 /**
  * Expects {@link CtType} as input
  * and produces all {@link CtTypeMember}s declared in input class
- * or any super class or super interface
+ * or any super class or super interface.
+ * It first returns own type members, then type members of superclass, etc.
  */
 public class AllTypeMembersFunction implements CtConsumableFunction<CtTypeInformation>, CtQueryAware {
+
+	public enum Mode {
+		/**
+		 * Returns all type members - including private
+		 */
+		ALL,
+		/**
+		 * Returns only type members, which are accessible from the input `type`.
+		 * It means that inherited private type members are skipped
+		 */
+		INERNALLY_ACCESSIBLE
+	}
 
 	private CtQuery query;
 	private final Class<?> memberClass;
 	private Set<String> distinctSet;
+	private Mode mode = Mode.ALL;
 
 	/**
 	 * returns all type members
@@ -69,12 +85,25 @@ public class AllTypeMembersFunction implements CtConsumableFunction<CtTypeInform
 
 	@Override
 	public void apply(CtTypeInformation input, final CtConsumer<Object> outputConsumer) {
+		String inputQName = input.getQualifiedName();
 		final CtQuery q = ((CtQueryable) input).map(new SuperInheritanceHierarchyFunction(distinctSet == null ? new HashSet<>() : distinctSet).includingSelf(true));
 		q.forEach(new CtConsumer<CtType<?>>() {
 			@Override
 			public void accept(CtType<?> type) {
-				for (CtTypeMember typeMember : type.getTypeMembers()) {
+				boolean isInputType = inputQName.equals(type.getQualifiedName());
+				loop: for (CtTypeMember typeMember : type.getTypeMembers()) {
 					if (memberClass == null || memberClass.isInstance(typeMember)) {
+						switch (mode) {
+						case ALL:
+							break;
+						case INERNALLY_ACCESSIBLE:
+							if (typeMember.hasModifier(ModifierKind.PRIVATE) && !isInputType) {
+								continue loop;
+							}
+							break;
+						default:
+							throw new SpoonException("Unexpected mode " + mode);
+						}
 						outputConsumer.accept(typeMember);
 					}
 					if (query.isTerminated()) {
@@ -88,5 +117,13 @@ public class AllTypeMembersFunction implements CtConsumableFunction<CtTypeInform
 	@Override
 	public void setQuery(CtQuery query) {
 		this.query = query;
+	}
+
+	/**
+	 * @param mode defines how whether type members with limited visibility are returned
+	 */
+	public AllTypeMembersFunction setMode(Mode mode) {
+		this.mode = mode;
+		return this;
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
@@ -47,7 +47,7 @@ public class AllTypeMembersFunction implements CtConsumableFunction<CtTypeInform
 		 * Returns only type members, which are accessible from the input `type`.
 		 * It means that inherited private type members are skipped
 		 */
-		INERNALLY_ACCESSIBLE
+		SKIP_PRIVATE
 	}
 
 	private CtQuery query;
@@ -96,7 +96,7 @@ public class AllTypeMembersFunction implements CtConsumableFunction<CtTypeInform
 						switch (mode) {
 						case ALL:
 							break;
-						case INERNALLY_ACCESSIBLE:
+						case SKIP_PRIVATE:
 							if (typeMember.hasModifier(ModifierKind.PRIVATE) && !isInputType) {
 								continue loop;
 							}

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -18,14 +18,17 @@ package spoon.test.model;
 
 import org.junit.Test;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.AllTypeMembersFunction;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -50,6 +53,19 @@ public class TypeTest {
 		// we have 3  methods in Foo + 2 in Baz - 1 common in Foo.bar (m) + 12 in Object + 1 explicit constructor in Foo
 		Collection<CtExecutableReference<?>> allExecutables = type.getAllExecutables();
 		assertEquals(17, allExecutables.size());
+	}
+
+	@Test
+	public void testAllTypeMembersFunctionMode() throws Exception {
+		// contract: AllTypeMembersFunction can be configured to return all members or only internally visible members
+		CtClass<?> type = build("spoon.test.model", "Foo");
+		List<CtMethod> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.INERNALLY_ACCESSIBLE)).list();
+		List<CtMethod> allMethods = type.map(new AllTypeMembersFunction(CtMethod.class)).list();
+		assertEquals(16, internallyAccessibleMethods.size());
+		assertEquals(17, allMethods.size());
+		allMethods.removeAll(internallyAccessibleMethods);
+		assertEquals(1, allMethods.size());
+		assertEquals("registerNatives()", allMethods.get(0).getSignature());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -59,7 +59,7 @@ public class TypeTest {
 	public void testAllTypeMembersFunctionMode() throws Exception {
 		// contract: AllTypeMembersFunction can be configured to return all members or only internally visible members
 		CtClass<?> type = build("spoon.test.model", "Foo");
-		List<CtMethod> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.INERNALLY_ACCESSIBLE)).list();
+		List<CtMethod> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.SKIP_PRIVATE)).list();
 		List<CtMethod> allMethods = type.map(new AllTypeMembersFunction(CtMethod.class)).list();
 		assertEquals(16, internallyAccessibleMethods.size());
 		assertEquals(17, allMethods.size());


### PR DESCRIPTION
AllTypeMembersFunction can now return
A) all type members
B) only these type members which are visible in input type. It means inherited private type members are not returned