### PR TITLE
refactor: CtTypeAccess#implicit is derived now

### DIFF
--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -18,6 +18,7 @@ package spoon.reflect.code;
 
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DerivedProperty;
@@ -83,6 +84,20 @@ public interface CtTypeAccess<A> extends CtExpression<Void> {
 	@Override
 	@UnsettableProperty
 	<C extends CtTypedElement> C setType(CtTypeReference<Void> type);
+
+	/**
+	 * @return {@link #getAccessedType()}.isImplicit()
+	 */
+	@Override
+	@DerivedProperty
+	boolean isImplicit();
+
+	/**
+	 * Calls {@link #getAccessedType()}.setImplicit()
+	 */
+	@Override
+	@DerivedProperty
+	<E extends CtElement> E setImplicit(boolean implicit);
 
 	@Override
 	CtTypeAccess<A> clone();

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -18,9 +18,11 @@ package spoon.support.reflect.code;
 
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
 import static spoon.reflect.path.CtRole.ACCESSED_TYPE;
@@ -60,6 +62,24 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 	public <C extends CtTypedElement> C setType(CtTypeReference<Void> type) {
 		// type is used in setAccessedType now.
 		return (C) this;
+	}
+
+	@Override
+	@DerivedProperty
+	public boolean isImplicit() {
+		if (type != null) {
+			return type.isImplicit();
+		}
+		return false;
+	}
+
+	@Override
+	@DerivedProperty
+	public <E extends CtElement> E setImplicit(boolean implicit) {
+		if (type != null) {
+			type.setImplicit(implicit);
+		}
+		return (E) this;
 	}
 
 	@Override

--- a/src/test/java/spoon/test/api/Metamodel.java
+++ b/src/test/java/spoon/test/api/Metamodel.java
@@ -1132,7 +1132,7 @@ public class Metamodel {
 
 			types.add(new Type("CtTypeAccess", spoon.reflect.code.CtTypeAccess.class, spoon.support.reflect.code.CtTypeAccessImpl.class, fm -> fm
 				.field(CtRole.TYPE, true, true)
-				.field(CtRole.IS_IMPLICIT, false, false)
+				.field(CtRole.IS_IMPLICIT, true, false)
 				.field(CtRole.POSITION, false, false)
 				.field(CtRole.ANNOTATION, false, false)
 				.field(CtRole.CAST, false, false)

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -41,6 +41,7 @@ import spoon.support.SpoonClassNotFoundException;
 import spoon.test.type.testclasses.Mole;
 import spoon.test.type.testclasses.Pozole;
 import spoon.test.type.testclasses.TypeMembersOrder;
+import spoon.testing.utils.ModelUtils;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -159,6 +160,25 @@ public class TypeTest {
 		assertEquals("a instanceof java.lang.Object[]", typeAccesses.get(1).getParent().toString());
 
 		canBeBuilt(target, 8, true);
+	}
+
+	@Test
+	public void testTypeAccessImplicitIsDerived() throws Exception {
+		// contract: A CtTypeAccess#implicit is derived
+		CtType<?> aPozole = ModelUtils.buildClass(Pozole.class);
+		final CtMethod<?> season = aPozole.getMethodsByName("season").get(0);
+
+		CtTypeAccess<?> typeAccesses = season.getElements(new TypeFilter<>(CtTypeAccess.class)).get(0);
+		assertFalse(typeAccesses.isImplicit());
+		assertFalse(typeAccesses.getAccessedType().isImplicit());
+		//contract: setting the value on accessed type influences value on type access too
+		typeAccesses.getAccessedType().setImplicit(true);
+		assertTrue(typeAccesses.isImplicit());
+		assertTrue(typeAccesses.getAccessedType().isImplicit());
+		//contract: setting the value on type access influences value on type too
+		typeAccesses.setImplicit(false);
+		assertFalse(typeAccesses.isImplicit());
+		assertFalse(typeAccesses.getAccessedType().isImplicit());
 	}
 
 	@Test


### PR DESCRIPTION
`CtTypeAccess` derives value of property `implict` from it's type.
It makes no sense that `CtTypeAccess` would have different value then it's `type`.