### PR TITLE
feature: new property CtTypeReference#implicitParent

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -213,5 +213,17 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	@DerivedProperty
 	CtTypeParameter getTypeParameterDeclaration();
 
+	/**
+	 * @param parentIsImplicit false then fully qualified name is printed.
+	 * 		true then type simple name is printed.
+	 */
+	@DerivedProperty
+	CtTypeReference<T> setImplicitParent(boolean parentIsImplicit);
 
+	/**
+	 * @return false then fully qualified name is printed.
+	 * 		true then type simple name is printed.
+	 */
+	@DerivedProperty
+	boolean isImplicitParent();
 }

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -27,8 +27,7 @@ import java.lang.reflect.Array;
 
 import static spoon.reflect.path.CtRole.TYPE;
 
-public class
-CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTypeReference<T> {
+public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTypeReference<T> {
 	private static final long serialVersionUID = 1L;
 
 	@MetamodelPropertyField(role = TYPE)
@@ -119,5 +118,21 @@ CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implements CtArrayTyp
 	@Override
 	public CtArrayTypeReference<T> clone() {
 		return (CtArrayTypeReference<T>) super.clone();
+	}
+
+	@Override
+	public boolean isImplicitParent() {
+		if (componentType != null) {
+			return componentType.isImplicitParent();
+		}
+		return false;
+	}
+
+	@Override
+	public CtArrayTypeReferenceImpl<T> setImplicitParent(boolean packageIsImplicit) {
+		if (componentType != null) {
+			componentType.setImplicitParent(packageIsImplicit);
+		}
+		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -97,4 +97,20 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	public CtIntersectionTypeReference<T> clone() {
 		return (CtIntersectionTypeReference<T>) super.clone();
 	}
+
+	@Override
+	public boolean isImplicitParent() {
+		if (bounds != null && bounds.size() > 0) {
+			return bounds.get(0).isImplicitParent();
+		}
+		return false;
+	}
+
+	@Override
+	public CtIntersectionTypeReferenceImpl<T> setImplicitParent(boolean packageIsImplicit) {
+		if (bounds != null && bounds.size() > 0) {
+			bounds.get(0).setImplicitParent(packageIsImplicit);
+		}
+		return this;
+	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -212,4 +212,15 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	protected boolean isWildcard() {
 		return false;
 	}
+
+	@Override
+	public boolean isImplicitParent() {
+		return false;
+	}
+
+	@Override
+	@UnsettableProperty
+	public CtTypeParameterReferenceImpl setImplicitParent(boolean packageIsImplicit) {
+		return this;
+	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -38,6 +38,7 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.support.DerivedProperty;
 import spoon.support.SpoonClassNotFoundException;
 import spoon.support.reflect.declaration.CtElementImpl;
 import spoon.support.util.internal.MapUtils;
@@ -800,5 +801,27 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		CtTypeReference<?> erasedRef = clone();
 		erasedRef.getActualTypeArguments().clear();
 		return erasedRef;
+	}
+
+	@Override
+	@DerivedProperty
+	public boolean isImplicitParent() {
+		if (pack != null) {
+			return pack.isImplicit();
+		} else if (declaringType != null) {
+			return declaringType.isImplicit();
+		}
+		return false;
+	}
+
+	@Override
+	@DerivedProperty
+	public CtTypeReferenceImpl<T> setImplicitParent(boolean parentIsImplicit) {
+		if (pack != null) {
+			pack.setImplicit(parentIsImplicit);
+		} else if (declaringType != null) {
+			declaringType.setImplicit(parentIsImplicit);
+		}
+		return this;
 	}
 }

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -51,6 +51,8 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.reference.testclasses.EnumValue;
 import spoon.test.reference.testclasses.Panini;
 import spoon.test.reference.testclasses.ParamRefs;
+import spoon.test.reference.testclasses.SuperAccess;
+import spoon.testing.utils.ModelUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -655,5 +657,24 @@ public class TypeReferenceTest {
 
 		assertEquals("spoon.test.imports.testclasses.withgenerics.Target", fieldTypeRef.getQualifiedName());
 		assertEquals(2, fieldTypeRef.getActualTypeArguments().size());
+	}
+	
+	@Test
+	public void testTypeReferenceImplicitParent() throws Exception {
+		// contract: CtTypeReference#isImplicitParent can be used read / write implicit value of the parent
+		CtType<?> type = ModelUtils.buildClass(SuperAccess.class);
+		CtTypeReference<?> typeRef = type.getSuperclass();
+		assertFalse(typeRef.isImplicitParent());
+		assertFalse(typeRef.getPackage().isImplicit());
+		
+		//calling of setImplicitParent influences implicitnes of parent
+		typeRef.setImplicitParent(true);
+		assertTrue(typeRef.isImplicitParent());
+		assertTrue(typeRef.getPackage().isImplicit());
+
+		//calling of setImplicit on parent influences return value of isImplicitParent
+		typeRef.getPackage().setImplicit(false);
+		assertFalse(typeRef.isImplicitParent());
+		assertFalse(typeRef.getPackage().isImplicit());
 	}
 }


### PR DESCRIPTION
During refactoring of import handling #2683, I often needed to know whether type reference 
A) shows only simple name and it's parent is implicit
B) shows fully qualified name (it's parent is not implicit)
Therefore I found useful these two new API methods.

WDYT?