### PR TITLE
fix: CtPackageDeclaration position doesn't include top file comment

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -578,13 +578,16 @@ public class PositionBuilder {
 	 * Note: all kinds of java comments are understood as whitespace too.
 	 * The search must start out of comment or on the first character of the comment
 	 */
-	private int findNextNonWhitespace(char[] content, int maxOff, int off) {
+	static int findNextNonWhitespace(char[] content, int maxOff, int off) {
+		return findNextNonWhitespace(true, content, maxOff, off);
+	}
+	static int findNextNonWhitespace(boolean commentIsWhiteSpace, char[] content, int maxOff, int off) {
 		maxOff = Math.min(maxOff, content.length - 1);
 		while (off >= 0 && off <= maxOff) {
 			char c = content[off];
 			if (Character.isWhitespace(c) == false) {
 				//non whitespace found
-				int endOfCommentOff = getEndOfComment(content, maxOff, off);
+				int endOfCommentOff = commentIsWhiteSpace ? getEndOfComment(content, maxOff, off) : -1;
 				if (endOfCommentOff == -1) {
 					//it is not a comment. Finish
 					return off;
@@ -603,7 +606,7 @@ public class PositionBuilder {
 	 * Can return `off` if it is already a non whitespace.
 	 * Note: all kinds of java comments are understood as whitespace too. Then it returns offset of the first character of the comment
 	 */
-	private int findNextWhitespace(char[] content, int maxOff, int off) {
+	static int findNextWhitespace(char[] content, int maxOff, int off) {
 		maxOff = Math.min(maxOff, content.length - 1);
 		while (off >= 0 && off <= maxOff) {
 			char c = content[off];
@@ -620,7 +623,7 @@ public class PositionBuilder {
 	 * @return index of first non whitespace char, searching backward. Can return `off` if it is already a non whitespace.
 	 * Note: all kinds of java comments are understood as whitespace too. Then it returns offset of the first non whitespace character before the comment
 	 */
-	int findPrevNonWhitespace(char[] content, int minOff, int off) {
+	static int findPrevNonWhitespace(char[] content, int minOff, int off) {
 		minOff = Math.max(0, minOff);
 		while (off >= minOff) {
 			char c = content[off];
@@ -644,7 +647,7 @@ public class PositionBuilder {
 	 * Note: all kinds of java comments are understood as whitespace too. Then it returns offset of the last comment character.
 	 * in case of line comment it returns last character of EOL which ends the comment
 	 */
-	private int findPrevWhitespace(char[] content, int minOff, int off) {
+	static int findPrevWhitespace(char[] content, int minOff, int off) {
 		minOff = Math.max(0, minOff);
 		while (off >= minOff) {
 			char c = content[off];
@@ -660,7 +663,7 @@ public class PositionBuilder {
 	 * @return if the off points at start of comment then it returns offset which points on last character of the comment
 	 * if the off does not point at start of comment then it returns -1
 	 */
-	private int getEndOfComment(char[] content, int maxOff, int off) {
+	static int getEndOfComment(char[] content, int maxOff, int off) {
 		maxOff = Math.min(maxOff, content.length - 1);
 		if (off + 1 <= maxOff) {
 			if (content[off] == '/' && content[off + 1] == '*') {
@@ -707,7 +710,7 @@ public class PositionBuilder {
 	 * @return if the off points at end of comment then it returns offset which points on first character of the comment
 	 * if the off does not point at the end of comment then it returns -1
 	 */
-	private int getStartOfComment(char[] content, int minOff, int off) {
+	static int getStartOfComment(char[] content, int minOff, int off) {
 		if (off < 2) {
 			//there cannot start comment
 			return -1;

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -54,6 +54,7 @@ import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.comment.testclasses.BlockComment;
 import spoon.test.comment.testclasses.Comment1;
 import spoon.test.position.testclasses.AnnonymousClassNewIface;
 import spoon.test.position.testclasses.ArrayArgParameter;
@@ -1205,5 +1206,14 @@ public class PositionTest {
 		String classContent = getClassContent(foo);
 		CtPackageDeclaration packDecl = foo.getPosition().getCompilationUnit().getPackageDeclaration();
 		assertEquals("package spoon.test.position.testclasses;", contentAtPosition(classContent, packDecl.getPosition()));
+	}
+	@Test
+	public void testPackageDeclarationPosition() throws Exception {
+		//contract: check position of package declaration after file comment
+		final Factory build = build(BlockComment.class);
+		final CtType<?> type = build.Type().get(BlockComment.class);
+		String classContent = getClassContent(type);
+		final CtPackageDeclaration packDecl = type.getPosition().getCompilationUnit().getPackageDeclaration();
+		assertEquals("package spoon.test.comment.testclasses;", contentAtPosition(classContent, packDecl.getPosition()));
 	}
 }


### PR DESCRIPTION
The position of CtPackageDeclaration never contains top comment of file. Next comments belongs to package declaration
```java
/* file comment, belongs to compilation unit */
/* every other comment belongs to package declaration */
package a.b.C;
```
