### PR TITLE
fix: NPE in JDTCommentBuilder

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1235,10 +1235,12 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (ifElement.getElseStatement() != null) {
 			List<CtComment> comments = elementPrinterHelper.getComments(ifElement, CommentOffset.INSIDE);
 			for (CtComment comment : comments) {
-				SourcePosition thenPosition =
-						ifElement.getThenStatement().getPosition().isValidPosition() ? ifElement.getThenStatement().getPosition() : ((CtBlock) ifElement.getThenStatement()).getStatement(0).getPosition();
-				if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd()) {
-					elementPrinterHelper.writeComment(comment);
+				if (ifElement.getThenStatement() != null) {
+					SourcePosition thenPosition =
+							ifElement.getThenStatement().getPosition().isValidPosition() ? ifElement.getThenStatement().getPosition() : ((CtBlock) ifElement.getThenStatement()).getStatement(0).getPosition();
+					if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd()) {
+						elementPrinterHelper.writeComment(comment);
+					}
 				}
 			}
 			if (thenStmt instanceof CtBlock && !thenStmt.isImplicit()) {

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1231,13 +1231,17 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		scan(ifElement.getCondition());
 		printer.writeSeparator(")");
 		CtStatement thenStmt = ifElement.getThenStatement();
+		CtStatement elseStmt = ifElement.getElseStatement();
 		elementPrinterHelper.writeIfOrLoopBlock(thenStmt);
-		if (ifElement.getElseStatement() != null) {
+		if (elseStmt != null) {
 			List<CtComment> comments = elementPrinterHelper.getComments(ifElement, CommentOffset.INSIDE);
-			for (CtComment comment : comments) {
-				if (ifElement.getThenStatement() != null) {
-					SourcePosition thenPosition =
-							ifElement.getThenStatement().getPosition().isValidPosition() ? ifElement.getThenStatement().getPosition() : ((CtBlock) ifElement.getThenStatement()).getStatement(0).getPosition();
+			if (thenStmt != null) {
+				SourcePosition thenPosition = thenStmt.getPosition();
+				if (!thenPosition.isValidPosition()) {
+					CtStatement thenExpression = ((CtBlock) thenStmt).getStatement(0);
+					thenPosition = thenExpression.getPosition();
+				}
+				for (CtComment comment : comments) {
 					if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd()) {
 						elementPrinterHelper.writeComment(comment);
 					}
@@ -1248,7 +1252,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				printer.writeSpace();
 			}
 			printer.writeKeyword("else");
-			elementPrinterHelper.writeIfOrLoopBlock(ifElement.getElseStatement());
+			elementPrinterHelper.writeIfOrLoopBlock(elseStmt);
 		}
 		exitCtStatement(ifElement);
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -373,10 +373,12 @@ public class JDTCommentBuilder {
 					}
 				}
 				if (e.getElseStatement() != null) {
-					SourcePosition thenPosition = e.getThenStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getThenStatement()).getStatement(0).getPosition() : e.getThenStatement().getPosition();
-					SourcePosition elsePosition = e.getElseStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getElseStatement()).getStatement(0).getPosition() : e.getElseStatement().getPosition();
-					if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd() && comment.getPosition().getSourceEnd() < elsePosition.getSourceStart()) {
-						e.getElseStatement().addComment(comment);
+					if (e.getThenStatement() != null) {
+						SourcePosition thenPosition = e.getThenStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getThenStatement()).getStatement(0).getPosition() : e.getThenStatement().getPosition();
+						SourcePosition elsePosition = e.getElseStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getElseStatement()).getStatement(0).getPosition() : e.getElseStatement().getPosition();
+						if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd() && comment.getPosition().getSourceEnd() < elsePosition.getSourceStart()) {
+							e.getElseStatement().addComment(comment);
+						}
 					}
 				}
 				try {

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -364,21 +364,23 @@ public class JDTCommentBuilder {
 
 			@Override
 			public void visitCtIf(CtIf e) {
-				if (e.getThenStatement() != null) {
-					if (!(e.getThenStatement() instanceof CtBlock)) {
-						if (comment.getPosition().getSourceEnd() <= e.getThenStatement().getPosition().getSourceStart()) {
-							e.getThenStatement().addComment(comment);
+				CtStatement thenStatement = e.getThenStatement();
+				if (thenStatement != null) {
+					if (!(thenStatement instanceof CtBlock)) {
+						if (comment.getPosition().getSourceEnd() <= thenStatement.getPosition().getSourceStart()) {
+							thenStatement.addComment(comment);
 							return;
 						}
 					}
 				}
-				if (e.getElseStatement() != null) {
-					if (e.getThenStatement() != null) {
-						SourcePosition thenPosition = e.getThenStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getThenStatement()).getStatement(0).getPosition() : e.getThenStatement().getPosition();
-						SourcePosition elsePosition = e.getElseStatement().getPosition().isValidPosition() == false ? ((CtBlock) e.getElseStatement()).getStatement(0).getPosition() : e.getElseStatement().getPosition();
-						if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd() && comment.getPosition().getSourceEnd() < elsePosition.getSourceStart()) {
-							e.getElseStatement().addComment(comment);
-						}
+				CtStatement elseStatement = e.getElseStatement();
+				if (elseStatement != null && thenStatement != null) {
+					CtStatement thenExpression = ((CtBlock) thenStatement).getStatement(0);
+					CtStatement elseExpression = ((CtBlock) thenStatement).getStatement(0);
+					SourcePosition thenPosition = thenStatement.getPosition().isValidPosition() ? thenStatement.getPosition() : thenExpression.getPosition();
+					SourcePosition elsePosition = elseStatement.getPosition().isValidPosition() ? elseStatement.getPosition() : elseExpression.getPosition();
+					if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd() && comment.getPosition().getSourceEnd() < elsePosition.getSourceStart()) {
+						elseStatement.addComment(comment);
 					}
 				}
 				try {

--- a/src/test/java/spoon/test/condition/testclasses/Foo2.java
+++ b/src/test/java/spoon/test/condition/testclasses/Foo2.java
@@ -7,4 +7,13 @@ public class Foo2 {
 		if (false);
 		else System.out.println();
 	}
+
+	void bug2() {
+		if (false)
+			System.out.println("valid");
+		else if (false);
+			// Do nothing...
+		else
+			System.out.println("invalid");
+	}
 }


### PR DESCRIPTION
Hello.
I was trying to migrate from spoon 7.0 to 7.2, and encountered some mode build failures due to the recent changes. (We have a large test base with ~80 open-source projects).

Spoon 7.2 failed to build a model with NPE for the following code (it's from [sakai](https://github.com/sakaiproject/sakai) open-source project):

```
if (itemGrading.getAttemptsRemaining() == null){
    // this is not possible unless the question is submitted without the
    // attempt set correctly
    if ((item.getTriesAllowed()).intValue() >= 9999)
      attemptsRemaining = 9999;  
} else{
  if ((item.getTriesAllowed()).intValue() >= 9999 )
    attemptsRemaining = 9999;
  else if (itemGrading.getAttemptsRemaining().intValue() > 0);
  // We're now getting the applet to tell us how many attempts remain
  // attemptsRemaining = itemGrading.getAttemptsRemaining().intValue() - 1;
  else
    throw new Exception("This page must have been reached by mistake. Our record shows that no more attempt for this question is allowed.");
}
```

Stacktrace:

```
[INFO] java.lang.NullPointerException
[INFO] 	at spoon.support.compiler.jdt.JDTCommentBuilder$1.visitCtIf(JDTCommentBuilder.java:376)
[INFO] 	at spoon.support.reflect.code.CtIfImpl.accept(CtIfImpl.java:45)
[INFO] 	at spoon.reflect.visitor.CtInheritanceScanner.scan(CtInheritanceScanner.java:184)
[INFO] 	at spoon.support.compiler.jdt.JDTCommentBuilder$1.scan(JDTCommentBuilder.java:233)
[INFO] 	at spoon.support.compiler.jdt.JDTCommentBuilder.insertCommentInAST(JDTCommentBuilder.java:433)
[INFO] 	at spoon.support.compiler.jdt.JDTCommentBuilder.buildComment(JDTCommentBuilder.java:147)
[INFO] 	at spoon.support.compiler.jdt.JDTCommentBuilder.build(JDTCommentBuilder.java:111)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.lambda$buildModel$2(JDTBasedSpoonCompiler.java:443)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.forEachCompilationUnit(JDTBasedSpoonCompiler.java:457)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildModel(JDTBasedSpoonCompiler.java:442)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildUnitsAndModel(JDTBasedSpoonCompiler.java:375)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildSources(JDTBasedSpoonCompiler.java:340)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.build(JDTBasedSpoonCompiler.java:123)
[INFO] 	at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.build(JDTBasedSpoonCompiler.java:106)
[INFO] 	at spoon.Launcher.buildModel(Launcher.java:772)
[INFO] 	at com.pvsstudio.projects.Module.build(Module.java:283)
[INFO] 	at com.pvsstudio.runner.ModuleWorker.run(ModuleWorker.java:41)
[INFO] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[INFO] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[INFO] 	at java.lang.Thread.run(Thread.java:748)
```

In general spoon 7.2 fails to build model for the following code:

```
if (false)
    System.out.println("hello");
else if (false);
    // Do nothing...
else
    System.out.println("world");
```

I think this issue is related to that commit: https://github.com/INRIA/spoon/commit/7f29a8188b2a975760bdb27edfd0a15bcc5b2956

So in this PR I provide failing test case and a possible solution (we need to check if then part is null, even if the else part is not null).