### PR TITLE
fix: CompilationUnit has lineSeparatorPositions even for empty class

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -96,7 +96,7 @@ public class JDTCommentBuilder {
 		this.sourceUnit = declarationUnit.compilationResult.compilationUnit;
 		this.contents = sourceUnit.getContents();
 		this.filePath = CharOperation.charToString(sourceUnit.getFileName());
-		this.spoonUnit = factory.CompilationUnit().getOrCreate(filePath);
+		this.spoonUnit = JDTTreeBuilder.getOrCreateCompilationUnit(declarationUnit, factory);
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -52,7 +52,7 @@ class JDTImportBuilder {
 		this.sourceUnit = declarationUnit.compilationResult.compilationUnit;
 		this.filePath = CharOperation.charToString(sourceUnit.getFileName());
 		// get the CU: it has already been built during model building in JDTBasedSpoonCompiler
-		this.spoonUnit = factory.CompilationUnit().getOrCreate(filePath);
+		this.spoonUnit = JDTTreeBuilder.getOrCreateCompilationUnit(declarationUnit, factory);
 		this.imports = new HashSet<>();
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -138,6 +138,7 @@ import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
+import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotationMethod;
 import spoon.reflect.declaration.CtAnonymousExecutable;
@@ -775,10 +776,20 @@ public class JDTTreeBuilder extends ASTVisitor {
 		return false;
 	}
 
+	static CompilationUnit getOrCreateCompilationUnit(CompilationUnitDeclaration compilationUnitDeclaration, Factory factory) {
+		CompilationUnit compilationUnitSpoon = factory.CompilationUnit().getOrCreate(new String(compilationUnitDeclaration.getFileName()));
+		if (compilationUnitSpoon.getLineSeparatorPositions() == null) {
+			compilationUnitSpoon.setLineSeparatorPositions(compilationUnitDeclaration.compilationResult.lineSeparatorPositions);
+		} else if (compilationUnitSpoon.getLineSeparatorPositions() != compilationUnitDeclaration.compilationResult.lineSeparatorPositions) {
+			throw new SpoonException("Unexpected CompilationUnit lineSeparatorPositions");
+		}
+		return compilationUnitSpoon;
+	}
+
 	@Override
 	public boolean visit(CompilationUnitDeclaration compilationUnitDeclaration, CompilationUnitScope scope) {
 		context.compilationunitdeclaration = scope.referenceContext;
-		context.compilationUnitSpoon = getFactory().CompilationUnit().getOrCreate(new String(context.compilationunitdeclaration.getFileName()));
+		context.compilationUnitSpoon = getOrCreateCompilationUnit(context.compilationunitdeclaration, getFactory());
 		ModuleBinding enclosingModule = scope.fPackage.enclosingModule;
 
 		CtModule module;

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -82,14 +82,16 @@ class JDTTreeBuilderQuery {
 			return null;
 		}
 		for (CompilationUnitDeclaration unitToProcess : unitsToProcess) {
-			for (TypeDeclaration type : unitToProcess.types) {
-				if (qualifiedName.equals(CharOperation.toString(type.binding.compoundName))) {
-					return type.binding;
-				}
-				if (type.memberTypes != null) {
-					for (TypeDeclaration memberType : type.memberTypes) {
-						if (qualifiedName.equals(CharOperation.toString(memberType.binding.compoundName))) {
-							return type.binding;
+			if (unitToProcess.types != null) {
+				for (TypeDeclaration type : unitToProcess.types) {
+					if (qualifiedName.equals(CharOperation.toString(type.binding.compoundName))) {
+						return type.binding;
+					}
+					if (type.memberTypes != null) {
+						for (TypeDeclaration memberType : type.memberTypes) {
+							if (qualifiedName.equals(CharOperation.toString(memberType.binding.compoundName))) {
+								return type.binding;
+							}
 						}
 					}
 				}

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -86,10 +86,9 @@ public class PositionBuilder {
 			return SourcePosition.NOPOSITION;
 		}
 		CoreFactory cf = this.jdtTreeBuilder.getFactory().Core();
-		CompilationUnit cu = this.jdtTreeBuilder.getFactory().CompilationUnit().getOrCreate(new String(this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.getFileName()));
+		CompilationUnit cu = this.jdtTreeBuilder.getContextBuilder().compilationUnitSpoon;
 		CompilationResult cr = this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.compilationResult;
 		int[] lineSeparatorPositions = cr.lineSeparatorPositions;
-		cu.setLineSeparatorPositions(lineSeparatorPositions);
 		char[] contents = cr.compilationUnit.getContents();
 
 		int sourceStart = node.sourceStart;
@@ -509,7 +508,7 @@ public class PositionBuilder {
 
 	private void setModifiersPosition(CtModifiable e, int start, int end) {
 		CoreFactory cf = this.jdtTreeBuilder.getFactory().Core();
-		CompilationUnit cu = this.jdtTreeBuilder.getFactory().CompilationUnit().getOrCreate(new String(this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.getFileName()));
+		CompilationUnit cu = this.jdtTreeBuilder.getContextBuilder().compilationUnitSpoon;
 		CompilationResult cr = this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.compilationResult;
 		char[] contents = cr.compilationUnit.getContents();
 

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1201,6 +1201,7 @@ public class PositionTest {
 			assertEquals("label2: while(true);", contentAtPosition(classContent, stmt3.getPosition()));
 		}
 	}
+
 	@Test
 	public void testPackageDeclaration() throws Exception {
 		//contract: check position of package declaration
@@ -1250,5 +1251,13 @@ public class PositionTest {
 		
 		assertEquals("/* package declaration comments*/\n" + 
 				"package spoon.test.position.testclasses;", contentAtPosition(classContent, packageDecl.getPosition()));
+	}
+
+	@Test
+	public void testCommentedOutClass() {
+		//contract: commented out class should not fail model build
+		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/TestCommentedOutClass.java"));
+		CtType<?> type = build.Type().get("spoon.test.position.testclasses.TestCommentedOutClass");
+		assertNull(type);
 	}
 }

--- a/src/test/java/spoon/test/position/testclasses/TestCommentedOutClass.java
+++ b/src/test/java/spoon/test/position/testclasses/TestCommentedOutClass.java
@@ -1,0 +1,4 @@
+package spoon.test.position.testclasses;
+
+//public class TestCommentedOutClass {
+//}


### PR DESCRIPTION
This is alternative to #2823

Thank You Egor for the failing test. I added it as part of this PR.

Then I fixed it by way the compilation unit has correct lineSeparatorPositions even when it is empty.