### PR TITLE
fix(doc): change link to javadoc to adapt the new module organization

### DIFF
--- a/doc/code_elements.md
+++ b/doc/code_elements.md
@@ -6,22 +6,22 @@ keywords: code, elements, ast, meta, model
 
 Figure at the end of this page shows the meta model for Java executable code. 
 There are two main kinds of code elements. 
-First, statements `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
+First, statements `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
 are untyped top-level instructions that can be used directly in a block of code. 
-Second, expressions `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
-are used inside the statements. For instance, a `CtLoop` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtLoop.html)) 
+Second, expressions `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
+are used inside the statements. For instance, a `CtLoop` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtLoop.html)) 
 (which is a statement) points to `CtExpression` which expresses its boolean condition.
 
 Some code elements such as invocations and assignments are both statements 
 and expressions (multiple inheritance links). Concretely, this is translated as an 
-interface `CtInvocation` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)) 
+interface `CtInvocation` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)) 
 inheriting from both interfaces `CtStatement` and `CtExpression`. 
 The generic type of `CtExpression` is used to add static type-checking when transforming programs.
 
 ![Code part of the Spoon Java 8 metamodel]({{ "/images/code-elements.png" | prepend: site.baseurl }})
 
 ### CtArrayRead
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtArrayRead.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtArrayRead.html)
 
 ```java
 
@@ -32,7 +32,7 @@ The generic type of `CtExpression` is used to add static type-checking when tran
 
 ```
 ### CtArrayWrite
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtArrayWrite.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtArrayWrite.html)
 
 ```java
 
@@ -42,13 +42,13 @@ The generic type of `CtExpression` is used to add static type-checking when tran
 
 ```
 ### CtAssert
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtAssert.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtAssert.html)
 
 ```java
 assert 1+1==2
 ```
 ### CtAssignment
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtAssignment.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtAssignment.html)
 
 ```java
 
@@ -57,7 +57,7 @@ assert 1+1==2
 
 ```
 ### CtBinaryOperator
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtBinaryOperator.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtBinaryOperator.html)
 
 ```java
 
@@ -66,7 +66,7 @@ assert 1+1==2
 
 ```
 ### CtBlock
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtBlock.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtBlock.html)
 
 ```java
 
@@ -76,7 +76,7 @@ assert 1+1==2
 	
 ```
 ### CtBreak
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtBreak.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtBreak.html)
 
 ```java
 
@@ -88,7 +88,7 @@ assert 1+1==2
 
 ```
 ### CtCase
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtCase.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtCase.html)
 
 ```java
 
@@ -99,7 +99,7 @@ switch(x) {
 }
 ```
 ### CtConditional
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtConditional.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtConditional.html)
 
 ```java
 
@@ -109,7 +109,7 @@ switch(x) {
 
 ```
 ### CtConstructorCall
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtConstructorCall.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtConstructorCall.html)
 
 ```java
 
@@ -117,7 +117,7 @@ switch(x) {
 
 ```
 ### CtContinue
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtContinue.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtContinue.html)
 
 ```java
 
@@ -129,7 +129,7 @@ switch(x) {
 
 ```
 ### CtDo
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtDo.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtDo.html)
 
 ```java
 
@@ -140,7 +140,7 @@ switch(x) {
 
 ```
 ### CtExecutableReferenceExpression
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtExecutableReferenceExpression.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtExecutableReferenceExpression.html)
 
 ```java
 
@@ -149,7 +149,7 @@ switch(x) {
 
 ```
 ### CtFieldRead
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtFieldRead.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtFieldRead.html)
 
 ```java
 
@@ -159,7 +159,7 @@ switch(x) {
 
 ```
 ### CtFieldWrite
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtFieldWrite.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtFieldWrite.html)
 
 ```java
 
@@ -169,7 +169,7 @@ switch(x) {
 
 ```
 ### CtFor
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtFor.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtFor.html)
 
 ```java
 
@@ -180,7 +180,7 @@ switch(x) {
 
 ```
 ### CtForEach
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtForEach.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtForEach.html)
 
 ```java
 
@@ -191,7 +191,7 @@ switch(x) {
 
 ```
 ### CtIf
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtIf.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtIf.html)
 
 ```java
 
@@ -203,7 +203,7 @@ switch(x) {
 
 ```
 ### CtInvocation
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)
 
 ```java
 
@@ -213,7 +213,7 @@ switch(x) {
 
 ```
 ### CtJavaDoc
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtJavaDoc.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtJavaDoc.html)
 
 ```java
 
@@ -224,7 +224,7 @@ switch(x) {
 
 ```
 ### CtLambda
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtLambda.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtLambda.html)
 
 ```java
 
@@ -235,7 +235,7 @@ switch(x) {
 
 ```
 ### CtLiteral
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtLiteral.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtLiteral.html)
 
 ```java
 
@@ -243,7 +243,7 @@ switch(x) {
 
 ```
 ### CtLocalVariable
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtLocalVariable.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtLocalVariable.html)
 
 ```java
 
@@ -256,7 +256,7 @@ switch(x) {
 
 ```
 ### CtNewArray
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtNewArray.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtNewArray.html)
 
 ```java
 
@@ -265,7 +265,7 @@ switch(x) {
 
 ```
 ### CtNewClass
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtNewClass.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtNewClass.html)
 
 ```java
 
@@ -279,7 +279,7 @@ switch(x) {
 
 ```
 ### CtOperatorAssignment
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtOperatorAssignment.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtOperatorAssignment.html)
 
 ```java
 
@@ -288,7 +288,7 @@ switch(x) {
 
 ```
 ### CtReturn
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtReturn.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtReturn.html)
 
 ```java
 
@@ -301,7 +301,7 @@ switch(x) {
 
 ```
 ### CtSuperAccess
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtSuperAccess.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtSuperAccess.html)
 
 ```java
 
@@ -314,7 +314,7 @@ switch(x) {
 
 ```
 ### CtSwitch
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtSwitch.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtSwitch.html)
 
 ```java
 
@@ -325,7 +325,7 @@ switch(x) { // <-- switch statement
 }
 ```
 ### CtSynchronized
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtSynchronized.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtSynchronized.html)
 
 ```java
 
@@ -336,7 +336,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtThisAccess
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtThisAccess.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtThisAccess.html)
 
 ```java
 
@@ -350,7 +350,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtThrow
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtThrow.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtThrow.html)
 
 ```java
 
@@ -358,7 +358,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtTry
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtTry.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtTry.html)
 
 ```java
 
@@ -368,7 +368,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtTryWithResource
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtTryWithResource.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtTryWithResource.html)
 
 ```java
 
@@ -379,7 +379,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtTypeAccess
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtTypeAccess.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtTypeAccess.html)
 
 ```java
 
@@ -405,7 +405,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtUnaryOperator
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtUnaryOperator.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtUnaryOperator.html)
 
 ```java
 
@@ -414,7 +414,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtVariableRead
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtVariableRead.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtVariableRead.html)
 
 ```java
 
@@ -425,7 +425,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtVariableWrite
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtVariableWrite.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtVariableWrite.html)
 
 ```java
 
@@ -438,7 +438,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtWhile
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtWhile.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtWhile.html)
 
 ```java
 
@@ -449,7 +449,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtAnnotation
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtAnnotation.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtAnnotation.html)
 
 ```java
 
@@ -459,7 +459,7 @@ switch(x) { // <-- switch statement
 
 ```
 ### CtClass
-[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtClass.html)
+[(javadoc)](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtClass.html)
 
 ```java
 

--- a/doc/code_elements_header.md
+++ b/doc/code_elements_header.md
@@ -6,15 +6,15 @@ keywords: code, elements, ast, meta, model
 
 Figure at the end of this page shows the meta model for Java executable code. 
 There are two main kinds of code elements. 
-First, statements `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
+First, statements `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
 are untyped top-level instructions that can be used directly in a block of code. 
-Second, expressions `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
-are used inside the statements. For instance, a `CtLoop` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtLoop.html)) 
+Second, expressions `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
+are used inside the statements. For instance, a `CtLoop` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtLoop.html)) 
 (which is a statement) points to `CtExpression` which expresses its boolean condition.
 
 Some code elements such as invocations and assignments are both statements 
 and expressions (multiple inheritance links). Concretely, this is translated as an 
-interface `CtInvocation` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)) 
+interface `CtInvocation` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtInvocation.html)) 
 inheriting from both interfaces `CtStatement` and `CtExpression`. 
 The generic type of `CtExpression` is used to add static type-checking when transforming programs.
 

--- a/doc/comments.md
+++ b/doc/comments.md
@@ -12,7 +12,7 @@ In Spoon there are four different kinds of comments:
 * Block comments (from /* to */) `CtComment.CommentType.BLOCK`
 * Javadoc comments (from /** to */) `CtComment.CommentType.JAVADOC`
 
-The comments are represented in Spoon with a `CtComment` class ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtComment.html)). 
+The comments are represented in Spoon with a `CtComment` class ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtComment.html)). 
 This class exposes an API to get the content `CtComment.getContent()`, the type `CtComment.getCommentType()` and the position `CtComment.getPosition()` of an comment.
 
 We also try to understand to which element they are attached.
@@ -96,11 +96,11 @@ public class CtCommentProcessor extends AbstractProcessor<CtComment> {
 
 # Source Position
 
-`SourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/cu/SourcePosition.html)) defines the position of the `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) in the original source file. 
+`SourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/cu/SourcePosition.html)) defines the position of the `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) in the original source file. 
 SourcePosition is extended by three specialized positions:
 
-- `DeclarationSourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/cu/position/DeclarationSourcePosition.html)) 
-- `BodyHolderSourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/cu/position/BodyHolderSourcePosition.html)).
+- `DeclarationSourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/cu/position/DeclarationSourcePosition.html)) 
+- `BodyHolderSourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/cu/position/BodyHolderSourcePosition.html)).
 
 These three specializations are used to define the position of specific CtElement.
 For example DeclarationSourcePosition is used to define the position of all declarations (variable, type, method, ...).

--- a/doc/factories.md
+++ b/doc/factories.md
@@ -8,37 +8,37 @@ When you design and implement transformations, with processors
 or templates, you need to create new elements, fill their data and add 
 them in the AST built by Spoon.
 
-To do that, use `Factory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/Factory.html)). 
+To do that, use `Factory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/Factory.html)). 
 `Factory` is the entry point for all factories of Spoon. Each factory 
 have a goal specific and help you in the creation of a new AST.
 
-- `CoreFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/CoreFactory.html)) 
+- `CoreFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/CoreFactory.html)) 
 allows the creation of any element in the meta model. To set up the objects, there are setters to initialize the object.
-- `CodeFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/CodeFactory.html)) 
+- `CodeFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/CodeFactory.html)) 
 contains utility methods to create code elements and asks minimal information
 to create a valid object.
-- `PackageFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/PackageFactory.html)) 
+- `PackageFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/PackageFactory.html)) 
 contains utility methods to create and get package reference.
-- `TypeFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/TypeFactory.html)) 
-contains utility methods with a link to `CtType` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtType.html)). 
+- `TypeFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/TypeFactory.html)) 
+contains utility methods with a link to `CtType` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtType.html)). 
 You can get any type from its fully qualified name or a .class invocation  
-and create all typed references like `CtTypeReference` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html)).
-- `ClassFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/ClassFactory.html)) 
-is a sub class of `TypeFactory` but specialized for `CtClass` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtClass.html)).
-- `EnumFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/EnumFactory.html)) 
-is a sub class of `TypeFactory` but specialized for `CtEnum` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtEnum.html)).
-- `InterfaceFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/InterfaceFactory.html)) 
-is a sub class of `TypeFactory` but specialized for `CtInterface` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtInterface.html)).
-- `ExecutableFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/ExecutableFactory.html)) 
-contains utility methods with a link to `CtExecutable` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtExecutable.html)). 
+and create all typed references like `CtTypeReference` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html)).
+- `ClassFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/ClassFactory.html)) 
+is a sub class of `TypeFactory` but specialized for `CtClass` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtClass.html)).
+- `EnumFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/EnumFactory.html)) 
+is a sub class of `TypeFactory` but specialized for `CtEnum` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtEnum.html)).
+- `InterfaceFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/InterfaceFactory.html)) 
+is a sub class of `TypeFactory` but specialized for `CtInterface` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtInterface.html)).
+- `ExecutableFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/ExecutableFactory.html)) 
+contains utility methods with a link to `CtExecutable` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtExecutable.html)). 
 You can create executable objects and their parameters.
-- `ConstructorFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/ConstructorFactory.html)) 
-is a sub class of `ExecutableFactory` but specialized for `CtConstructor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtConstructor.html)).
-- `MethodFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/MethodFactory.html)) 
-is a sub class of `ExecutableFactory` but specialized for `CtMethod` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtMethod.html)).
-- `FieldFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/FieldFactory.html)) 
+- `ConstructorFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/ConstructorFactory.html)) 
+is a sub class of `ExecutableFactory` but specialized for `CtConstructor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtConstructor.html)).
+- `MethodFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/MethodFactory.html)) 
+is a sub class of `ExecutableFactory` but specialized for `CtMethod` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtMethod.html)).
+- `FieldFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/FieldFactory.html)) 
 contains utility methods to create a valid field or a field reference.
-- `AnnotationFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/AnnotationFactory.html)) 
+- `AnnotationFactory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/AnnotationFactory.html)) 
 contains utility methods to annotate any elements or create a new one.
 
 All these factories contribute to facilitate the creation of elements. 

--- a/doc/first_analysis_processor.md
+++ b/doc/first_analysis_processor.md
@@ -26,18 +26,18 @@ catch can be considered bad practice. That could be a great information to know 
 many and where are these catches in a project to fill them with some code, 
 e.g. throws a runtime exception or logs the exception.
 
-To implement this analysis, create a new Java class which extends `AbstractProcessor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/processing/AbstractProcessor.html)). 
+To implement this analysis, create a new Java class which extends `AbstractProcessor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/processing/AbstractProcessor.html)). 
 This super class takes a generic type parameter to know what type you want inspect in a AST. 
-For this tutorial, we inspect a catch, a `CtCatch` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtCatch.html)).
+For this tutorial, we inspect a catch, a `CtCatch` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtCatch.html)).
 
 {{site.data.alerts.note}} 
 You can view the complete meta model of Spoon at <http://spoon.gforge.inria.fr/structural_elements.html> and <http://spoon.gforge.inria.fr/code_elements.html>. 
 It is a simple way to know what you can inspect with processors.
 {{site.data.alerts.end}}
 
-When the class `AbstractProcessor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/processing/AbstractProcessor.html))
+When the class `AbstractProcessor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/processing/AbstractProcessor.html))
 is extended, implement the method `void process(E element)`where `E` is a generic type for 
-any elements of the AST (all classes in the Spoon meta model which extends `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html))). It is in this method that you can access all information you want of the the current `CtCatch` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtCatch.html)). 
+any elements of the AST (all classes in the Spoon meta model which extends `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html))). It is in this method that you can access all information you want of the the current `CtCatch` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtCatch.html)). 
 A first implementation of the empty catch processor is:
 
 ```java
@@ -89,4 +89,4 @@ $ java -classpath /path/to/binary/of/your/processor.jar:spoon-core-{{site.spoon_
 
 ## Bytecode analysis
 
-Note that spoon also supports the analysis of bytecode through decompilation. See [javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/JarLauncher.html).
+Note that spoon also supports the analysis of bytecode through decompilation. See [javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/JarLauncher.html).

--- a/doc/first_transformation.md
+++ b/doc/first_transformation.md
@@ -14,7 +14,7 @@ and initializes it in the constructor of the current class.
 
 ## Factories and setters
 
-With `Factory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/Factory.html)), 
+With `Factory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/factory/Factory.html)), 
 you can get and create all elements of the meta model. For example, if you want 
 to create a class with the name "Tacos", use the factory to create an empty class 
 and fill information on the created element to set its name.
@@ -33,7 +33,7 @@ final CtTypeReference<List<Date>> listRef = getFactory().Code().createCtTypeRefe
 listRef.addActualTypeArgument(dateRef);
 ```
 
-`dateRef`, a `CtTypeReference` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html)), 
+`dateRef`, a `CtTypeReference` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html)), 
 is created by our factory from `Date.class` given by Java. We also created `listRef` which 
 is created by our factory from `List.class` and we add our `dateRef` as actual type argument 
 which represents the generic type of the list.
@@ -50,7 +50,7 @@ listOfDates.addModifier(ModifierKind.PRIVATE);
 We have created a field named "dates", with a private visibility and typed by our previous type reference, 
 `listRef`, which is `java.util.List<java.util.Date>`. 
 
-Second, create the constructor. Before the creation of a `CtConstructor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtConstructor.html)), 
+Second, create the constructor. Before the creation of a `CtConstructor` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtConstructor.html)), 
 create all objects necessary for this constructor and set them in the target constructor. 
 The constructor has a parameter typed by the same type of the field previously created 
 and has a body to assign the parameter to the field.
@@ -72,10 +72,10 @@ constructor.addModifier(ModifierKind.PUBLIC);
 
 *Wow! Wait ... What is `CtCodeSnippetStatement`?*
 
-You can convert any string in a `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
-with `createCodeSnippetStatement(String statement)` or in `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
+You can convert any string in a `CtStatement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtStatement.html)) 
+with `createCodeSnippetStatement(String statement)` or in `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)) 
 with `createCodeSnippetExpression(String expression)`. In our case, we convert `this.dates = dates` 
-in a `CtAssignement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtAssignment.html)) 
+in a `CtAssignement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtAssignment.html)) 
 with an assignment and an assigned elements.
 
 With this last example, you have created a statement that you have put in a block. 

--- a/doc/launcher.md
+++ b/doc/launcher.md
@@ -6,7 +6,7 @@ keywords: usage, java
 
 ## The Launcher class
 
-The Spoon `Launcher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/Launcher.html)) is used to create the AST model of a project. It can be as short as:
+The Spoon `Launcher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/Launcher.html)) is used to create the AST model of a project. It can be as short as:
 
 ```java
 CtClass l = Launcher.parseClass("class A { void m() { System.out.println(\"yeah\");} }");
@@ -55,7 +55,7 @@ launcher.getEnvironment().setPrettyPrinterCreator(() -> {
 
 ## The MavenLauncher class
 
-The Spoon `MavenLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/MavenLauncher.html)) is used to create the AST model of a Maven project.
+The Spoon `MavenLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/MavenLauncher.html)) is used to create the AST model of a Maven project.
 It automatically infers the list of source folders and the dependencies from the `pom.xml` file.
 This Launcher handles multi-module Maven projects.
 
@@ -91,7 +91,7 @@ To avoid invoking maven over and over to build a classpath that has not changed,
 
 ## The JarLauncher class
 
-The Spoon `JarLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/JarLauncher.html)) is used to create the AST model from a jar.
+The Spoon `JarLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/JarLauncher.html)) is used to create the AST model from a jar.
 It automatically decompiles class files contained in the jar and analyzes them.
 If a pom file corresponding to the jar is provided, it will be used to build the classpath containing all dependencies.
 
@@ -156,7 +156,7 @@ compile 'fr.inria.gforge.spoon:spoon-core:{{site.spoon_release}}'
 
 ## Incremental Launcher
 
-`IncrementalLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/IncrementalLauncher.html)) allows cache AST and compiled classes. Any spoon analysis can then be restarted from where it stopped instead of restarting from scratch.
+`IncrementalLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/IncrementalLauncher.html)) allows cache AST and compiled classes. Any spoon analysis can then be restarted from where it stopped instead of restarting from scratch.
 
 ```java
 final File cache = new File("<path_to_cache>");

--- a/doc/path.md
+++ b/doc/path.md
@@ -4,8 +4,8 @@ tags: [quering]
 keywords: quering, query, path, ast, elements
 ---
 
-`CtPath` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPath.html))
-defines the path to a `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html))
+`CtPath` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPath.html))
+defines the path to a `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html))
 in a model, similarly to XPath for XML. For example, `.spoon.test.path.testclasses.Foo.foo#body#statement[index=0]` represents the first statement of the body of method foo.
 A `CtPath`is based on: names of elements (eg `foo`), and roles of elements with respect to their parent (eg `body`).
 A role is a relation between two AST nodes.
@@ -32,7 +32,7 @@ CtPath path = anElement.getPath();
 
 ### From a string
 
-`CtPathStringBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html)), creates a path object from a string according to the following syntax:
+`CtPathStringBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html)), creates a path object from a string according to the following syntax:
 
 - `.<name>` which denotes a child element with name `name`, eg `.fr.inria.Spoon` (the fully qualified name)
 - `#<role>` which denotes all children on `CtRole` `role` .statements, `#body#statement[index=2]#else` is the else branch of the second statement of a method body
@@ -44,17 +44,17 @@ CtPath path = anElement.getPath();
 
 ### From the API
 
-The low-level `CtPathBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html)) defines a fluent api to build your path:
+The low-level `CtPathBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html)) defines a fluent api to build your path:
 
-- `name(String, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#name-java.lang.String-java.lang.String:A...-))
+- `name(String, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#name-java.lang.String-java.lang.String:A...-))
 adds a name matcher to the current path.
-- `type(Class, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#type-java.lang.Class-java.lang.String:A...-))
+- `type(Class, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#type-java.lang.Class-java.lang.String:A...-))
 matches on element of a given type.
-- `role(CtPathRole, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#role-spoon.reflect.path.CtPathRole-java.lang.String:A...-))
+- `role(CtPathRole, String[])` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#role-spoon.reflect.path.CtPathRole-java.lang.String:A...-))
 matches on elements by their role (where `CtPathRole` gives all constants supported).
-- `wildcard()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#wildcard--))
+- `wildcard()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#wildcard--))
 matches only on elements child of current one.
-- `recursiveWildcard()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#recursiveWildcard--))
+- `recursiveWildcard()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html#recursiveWildcard--))
 matches on any child and sub-children.
 
 For instance, if we want all elements named by "toto" and with a default value in

--- a/doc/pattern.md
+++ b/doc/pattern.md
@@ -197,6 +197,7 @@ for (int i=0; i<n; i++) {
 ```
 
 One mark code to be matched inlined using method `configureInlineStatements`, which receives a  InlinedStatementConfigurator as follows:
+
 ```java
 Pattern t = PatternBuilder.create(...select pattern model...)
 	//...configure parameters...

--- a/doc/references.md
+++ b/doc/references.md
@@ -34,4 +34,4 @@ Since the references are weak, the targets of references do not have to exist be
 
 The price to pay for this low coupling is that to navigate from one code element to another, 
 one has to chain a navigation to the reference and then to the target. For instance, 
-to navigate from a field to the type of the field, one writes `field.getType().getDeclaration()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html#getDeclaration--)).
+to navigate from a field to the type of the field, one writes `field.getType().getDeclaration()` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/reference/CtTypeReference.html#getDeclaration--)).

--- a/doc/structural_elements.md
+++ b/doc/structural_elements.md
@@ -26,7 +26,7 @@ interface, class, variable, method, annotation, and enum declarations.
 - The code part contains the executable Java code, such as the one found in method bodies.
 - The reference part models the references to program elements (for instance a reference to a type).
 
-As shown in the figure, all elements inherit from `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) 
+As shown in the figure, all elements inherit from `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) 
 which declares a parent element denoting the containment relation in the source file. 
 For instance, the parent of a method node is a class node. All names are prefixed by 
 "CT" which means "compile-time".

--- a/doc/template_definition.md
+++ b/doc/template_definition.md
@@ -36,10 +36,10 @@ This template specifies a
 statement (in method `statement`) that is a precondition to check that a list 
 is smaller than a certain size. This piece of code will be injected at the 
 beginning of all methods dealing with size-bounded lists. This template has 
-one single template parameter called `_col_`, typed by `TemplateParameter` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/template/TemplateParameter.html)). 
+one single template parameter called `_col_`, typed by `TemplateParameter` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/template/TemplateParameter.html)). 
 In this case, the template parameter is meant to be an expression (`CtExpression`) 
 that returns a Collection (see constructor, line 3). All meta-model classes, 
-incl. `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)), 
+incl. `CtExpression` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/spoon-core/apidocs/spoon/reflect/code/CtExpression.html)), 
 implement interface `TemplateParameter`. A template parameter has a special method 
 (named `S`, for Substitution) that is used as a marker to indicate the places where 
 a template parameter substitution should occur. For a `CtExpression`, method `S()` 


### PR DESCRIPTION
Alternative to #2826 : Instead of redeploying javadoc to fit the old url, we adapt links.
Fix #2790 