### PR TITLE
fix: OOB in JDTCommentBuilder

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1237,7 +1237,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			List<CtComment> comments = elementPrinterHelper.getComments(ifElement, CommentOffset.INSIDE);
 			if (thenStmt != null) {
 				SourcePosition thenPosition = thenStmt.getPosition();
-				if (!thenPosition.isValidPosition()) {
+				if (!thenPosition.isValidPosition() && thenStmt instanceof CtBlock) {
 					CtStatement thenExpression = ((CtBlock) thenStmt).getStatement(0);
 					thenPosition = thenExpression.getPosition();
 				}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -375,10 +375,18 @@ public class JDTCommentBuilder {
 				}
 				CtStatement elseStatement = e.getElseStatement();
 				if (elseStatement != null && thenStatement != null) {
-					CtStatement thenExpression = ((CtBlock) thenStatement).getStatement(0);
-					CtStatement elseExpression = ((CtBlock) thenStatement).getStatement(0);
-					SourcePosition thenPosition = thenStatement.getPosition().isValidPosition() ? thenStatement.getPosition() : thenExpression.getPosition();
-					SourcePosition elsePosition = elseStatement.getPosition().isValidPosition() ? elseStatement.getPosition() : elseExpression.getPosition();
+					SourcePosition thenPosition = thenStatement.getPosition();
+					if (!thenPosition.isValidPosition())
+					{
+						CtStatement thenExpression = ((CtBlock) thenStatement).getStatement(0);
+						thenPosition = thenExpression.getPosition();
+					}
+					SourcePosition elsePosition = elseStatement.getPosition();
+					if (!elsePosition.isValidPosition())
+					{
+						CtStatement elseExpression = ((CtBlock) elseStatement).getStatement(0);
+						elsePosition = elseExpression.getPosition();
+					}
 					if (comment.getPosition().getSourceStart() > thenPosition.getSourceEnd() && comment.getPosition().getSourceEnd() < elsePosition.getSourceStart()) {
 						elseStatement.addComment(comment);
 					}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -376,14 +376,12 @@ public class JDTCommentBuilder {
 				CtStatement elseStatement = e.getElseStatement();
 				if (elseStatement != null && thenStatement != null) {
 					SourcePosition thenPosition = thenStatement.getPosition();
-					if (!thenPosition.isValidPosition())
-					{
+					if (!thenPosition.isValidPosition()) {
 						CtStatement thenExpression = ((CtBlock) thenStatement).getStatement(0);
 						thenPosition = thenExpression.getPosition();
 					}
 					SourcePosition elsePosition = elseStatement.getPosition();
-					if (!elsePosition.isValidPosition())
-					{
+					if (!elsePosition.isValidPosition()) {
 						CtStatement elseExpression = ((CtBlock) elseStatement).getStatement(0);
 						elsePosition = elseExpression.getPosition();
 					}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -376,12 +376,12 @@ public class JDTCommentBuilder {
 				CtStatement elseStatement = e.getElseStatement();
 				if (elseStatement != null && thenStatement != null) {
 					SourcePosition thenPosition = thenStatement.getPosition();
-					if (!thenPosition.isValidPosition()) {
+					if (!thenPosition.isValidPosition() && thenStatement instanceof CtBlock) {
 						CtStatement thenExpression = ((CtBlock) thenStatement).getStatement(0);
 						thenPosition = thenExpression.getPosition();
 					}
 					SourcePosition elsePosition = elseStatement.getPosition();
-					if (!elsePosition.isValidPosition()) {
+					if (!elsePosition.isValidPosition() && elseStatement instanceof CtBlock) {
 						CtStatement elseExpression = ((CtBlock) elseStatement).getStatement(0);
 						elsePosition = elseExpression.getPosition();
 					}

--- a/src/test/java/spoon/test/condition/testclasses/Foo2.java
+++ b/src/test/java/spoon/test/condition/testclasses/Foo2.java
@@ -16,4 +16,9 @@ public class Foo2 {
 		else
 			System.out.println("invalid");
 	}
+
+	void bug3() {
+		if (false) {} // some comment
+		else if (false) {}
+	}
 }


### PR DESCRIPTION
I think that refactoring of JDTCommentBuilder in #2822 did not go so well :|
This PR is to fix IndexOutOfBoundsException during model build for the following code:
```
void bug3() {
    if (false) {} // some comment
    else if (false) {}
}
```
```
java.lang.IndexOutOfBoundsException: Index: 0

	at spoon.support.util.EmptyClearableList.get(EmptyClearableList.java:90)
	at spoon.support.util.ModelList.get(ModelList.java:55)
	at spoon.support.reflect.code.CtBlockImpl.getStatement(CtBlockImpl.java:78)
	at spoon.support.compiler.jdt.JDTCommentBuilder$1.visitCtIf(JDTCommentBuilder.java:378)
	at spoon.support.reflect.code.CtIfImpl.accept(CtIfImpl.java:45)
	at spoon.reflect.visitor.CtInheritanceScanner.scan(CtInheritanceScanner.java:184)
	at spoon.support.compiler.jdt.JDTCommentBuilder$1.scan(JDTCommentBuilder.java:233)
	at spoon.support.compiler.jdt.JDTCommentBuilder.insertCommentInAST(JDTCommentBuilder.java:437)
	at spoon.support.compiler.jdt.JDTCommentBuilder.buildComment(JDTCommentBuilder.java:147)
```
