### PR TITLE
WIP feat(printer): add diff printer that print the diff 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.8.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.cloudbees</groupId>
+      <artifactId>diff4j</artifactId>
+      <version>1.2</version>
+    </dependency>
   <!-- https://mvnrepository.com/artifact/org.tukaani/xz -->
 	<dependency>
     	<groupId>org.tukaani</groupId>

--- a/src/main/java/spoon/support/sniper/DiffGenerator.java
+++ b/src/main/java/spoon/support/sniper/DiffGenerator.java
@@ -54,7 +54,9 @@ public class DiffGenerator {
 	public void setNumContextLines(int numContextLines) {
 		this.numContextLines = numContextLines;
 	}
-
+	/**
+	 * Generates the diff between the original source code and the modified model.
+	 */
 	public String diff(CtModel model) {
 		StringBuilder sb = new StringBuilder();
 		Set<CompilationUnit> compilationUnits = new HashSet<>();

--- a/src/main/java/spoon/support/sniper/DiffGenerator.java
+++ b/src/main/java/spoon/support/sniper/DiffGenerator.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.support.sniper;
+
+import com.cloudbees.diff.Diff;
+import spoon.SpoonException;
+import spoon.compiler.Environment;
+import spoon.reflect.CtModel;
+import spoon.reflect.cu.CompilationUnit;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.visitor.PrettyPrinter;
+import spoon.support.Experimental;
+import spoon.support.modelobs.SourceFragmentCreator;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+@Experimental
+public class DiffGenerator {
+
+	private final SourceFragmentCreator fragmentCreator;
+	private SniperJavaPrettyPrinter sniper;
+	private String diffRoot;
+	private boolean ignoreWhiteSpace = false;
+	private int numContextLines = 1;
+
+	/**
+	 * Creates a new {@link PrettyPrinter} which copies origin sources and prints only diff.
+	 */
+	public DiffGenerator(Environment env, String diffRoot) {
+		this.sniper = new SniperJavaPrettyPrinter(env);
+		this.diffRoot = diffRoot;
+		if (!diffRoot.isEmpty() && diffRoot.charAt(diffRoot.length() - 1) != '/') {
+			this.diffRoot += "/";
+		}
+		this.fragmentCreator = new SourceFragmentCreator();
+		this.fragmentCreator.attachTo(env);
+	}
+
+	public void setIgnoreWhiteSpace(boolean ignoreWhiteSpace) {
+		this.ignoreWhiteSpace = ignoreWhiteSpace;
+	}
+
+	public void setNumContextLines(int numContextLines) {
+		this.numContextLines = numContextLines;
+	}
+
+	public String diff(CtModel model) {
+		StringBuilder sb = new StringBuilder();
+		Set<CompilationUnit> compilationUnits = new HashSet<>();
+		List<CtType> newTypes = new ArrayList<>();
+		for (CtType<?> type : model.getAllTypes()) {
+			if (type.getPosition().getCompilationUnit() != null) {
+				compilationUnits.add(type.getPosition().getCompilationUnit());
+			} else {
+				newTypes.add(type);
+			}
+		}
+
+		// print changes
+		for (CompilationUnit ctCompilationUnit : compilationUnits) {
+			String newContent = "";
+			if (!ctCompilationUnit.getDeclaredTypes().isEmpty()) {
+				newContent = this.sniper.printCompilationUnit(ctCompilationUnit);
+			}
+			sb.append(generateDiff(ctCompilationUnit, newContent));
+		}
+		// print removed type diff
+		Collection<CompilationUnit> originalCompilationUnits = model.getRootPackage().getFactory().CompilationUnit().getMap().values();
+		originalCompilationUnits.removeAll(compilationUnits);
+		for (CompilationUnit ctCompilationUnit : originalCompilationUnits) {
+			sb.append(generateDiff(ctCompilationUnit, ""));
+		}
+
+		// print new type diff
+		for (CtType type : newTypes) {
+			CompilationUnit compilationUnit = type.getFactory().CompilationUnit().getOrCreate(type);
+			String newContent = type.getFactory().getEnvironment().createPrettyPrinter().printCompilationUnit(compilationUnit);
+			sb.append(generateDiff(compilationUnit, newContent));
+		}
+		return sb.toString();
+	}
+
+	private String generateDiff(CtCompilationUnit compilationUnit, String generateContent) {
+		String originalSourceCode = "";
+		if (compilationUnit.getFile().exists()) {
+			originalSourceCode = compilationUnit.getOriginalSourceCode();
+		}
+		String path = compilationUnit.getFile().getPath();
+		path = path.replace(diffRoot, "");
+
+		return generateDiff(path, originalSourceCode, generateContent);
+	}
+
+	private String generateDiff(String path, String originalSourceCode, String generateContent) {
+		String diff;
+		try {
+			Diff diffResult = Diff.diff(
+					new StringReader(originalSourceCode),
+					new StringReader(generateContent),
+					this.ignoreWhiteSpace);
+			if (diffResult.isEmpty()) {
+				return "";
+			}
+			diff =	diffResult.toUnifiedDiff(path,
+					path,
+					new StringReader(originalSourceCode),
+					new StringReader(generateContent),
+					this.numContextLines);
+		} catch (IOException e) {
+			throw new SpoonException("Unable to generate the diff.", e);
+		}
+
+		return diff.replaceAll("\n\\\\ No newline at end of file", "");
+	}
+}

--- a/src/test/java/spoon/test/prettyprinter/TestDiffPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestDiffPrinter.java
@@ -1,0 +1,93 @@
+package spoon.test.prettyprinter;
+
+import org.junit.Assert;
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtIf;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.sniper.DiffGenerator;
+
+import java.io.File;
+
+public class TestDiffPrinter {
+
+    @Test
+    public void diffPrinterWithoutChangesTest() {
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/Validation.java");
+        launcher.buildModel();
+        DiffGenerator printer = new DiffGenerator(launcher.getEnvironment(), new File("").getAbsolutePath());
+        Factory f = launcher.getFactory();
+
+        String output = printer.diff(f.getModel());
+
+        Assert.assertEquals("", output);
+    }
+
+    @Test
+    public void diffPrinterChangeConditionTest() {
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/Validation.java");
+        launcher.buildModel();
+
+        DiffGenerator printer = new DiffGenerator(launcher.getEnvironment(), new File("").getAbsolutePath());
+
+        Factory f = launcher.getFactory();
+
+        final CtClass<?> ctClass = f.Class().get("spoon.test.prettyprinter.testclasses.Validation");
+        CtIf ctIf = ctClass.getElements(new TypeFilter<>(CtIf.class)).get(0);
+        ctIf.setCondition(f.createLiteral(true));
+
+        String output = printer.diff(f.getModel());
+
+        Assert.assertEquals("--- src/test/java/spoon/test/prettyprinter/testclasses/Validation.java\n" +
+                "+++ src/test/java/spoon/test/prettyprinter/testclasses/Validation.java\n" +
+                "@@ -41,3 +41,3 @@\n" +
+                " \tstatic {\n" +
+                "-\t\tif (IS_SECURITY_ENABLED) {\n" +
+                "+\t\tif (true) {\n" +
+                " \t\t\tSKIP_IDENTIFIER_CHECK = AccessController.doPrivileged(\n", output);
+    }
+
+    @Test
+    public void diffPrinterAddAndRemoveClassTest() {
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/AClass.java");
+        launcher.buildModel();
+
+        DiffGenerator printer = new DiffGenerator(launcher.getEnvironment(), new File("").getAbsolutePath());
+        Factory f = launcher.getFactory();
+
+        f.Class().create("test.Test");
+
+        final CtClass<?> ctClass = f.Class().get("spoon.test.prettyprinter.testclasses.AClass");
+        ctClass.getPackage().removeType(ctClass);
+
+        String output = printer.diff(f.getModel());
+
+        Assert.assertEquals("--- src/test/java/spoon/test/prettyprinter/testclasses/AClass.java\n" +
+                "+++ src/test/java/spoon/test/prettyprinter/testclasses/AClass.java\n" +
+                "@@ -1,14 +0,0 @@\n" +
+                "-package spoon.test.prettyprinter.testclasses;\n" +
+                "-\n" +
+                "-import java.util.ArrayList;\n" +
+                "-import java.util.List;\n" +
+                "-\n" +
+                "-public class AClass {\n" +
+                "-\tpublic List<?> aMethod() {\n" +
+                "-\t\treturn new ArrayList<>();\n" +
+                "-\t}\n" +
+                "-\n" +
+                "-\tpublic List<? extends ArrayList> aMethodWithGeneric() {\n" +
+                "-\t\treturn new ArrayList<>();\n" +
+                "-\t}\n" +
+                "-}\n" +
+                "--- spooned/test/Test.java\n" +
+                "+++ spooned/test/Test.java\n" +
+                "@@ -0,0 +1,2 @@\n" +
+                "+package test;\n" +
+                "+class Test {}\n", output);
+    }
+}


### PR DESCRIPTION
A small experiment that aims to see if it is possible to print the diff of transformation instead of a complete file.

The current POC has some limitation since it uses the current JavaOutputProcessor and consequently, it will print the diff output inside a java file. The "correct" behavior would be to generate only one diff file for all the changes and not a diff file for each file.

I don't really know how to integrate this nicely in Spoon, I think it can be really useful to debug transformation or to generate PR automatically.

How would you integrate it?

# Usage 
```java
launcher.getEnvironment().setPrettyPrinterCreator(() ->
      // root of the diff is used to not have the absolute path in the diff
      new DiffJavaPrettyPrinter(launcher.getEnvironment(), <root of the diff>))
 );
```
# Output of the printer:
`<spoon_ouput>/src/test/java/spoon/test/prettyprinter/testclasses/Validation.java`
```diff
--- src/test/java/spoon/test/prettyprinter/testclasses/Validation.java
+++ src/test/java/spoon/test/prettyprinter/testclasses/Validation.java
@@ -1,2 +1,2 @@
-/*
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
@@ -16,8 +16,7 @@
  */
-
 package spoon.test.prettyprinter.testclasses;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
+
+
 public class Validation {

```

# TODO

- [x] Use it own output processor instead of the javaoutputprocessor
- [x] Support deleted file
- [x] Support new file (e.g. new class)
- [ ] rename class
- [ ] rename package