### PR TITLE
Remove deprecated `mvn eclipse:eclipse` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,6 @@ mvn test
 
 The download information is at <http://spoon.gforge.inria.fr/>.
 
-### Eclipse IDE Setup
-
-In order to generate the Eclipse project files required for importing run the following commands from the root spoon directory (requires Maven):
-```
-mvn eclipse:clean
-mvn eclipse:eclipse
-```
-
 ### Ecosystem
 
 See <http://spoon.gforge.inria.fr/ecosystem.html>


### PR DESCRIPTION
`mvn eclipse:eclipse` has been deprecated for many years now. Importing a Maven project in Eclipse IDE is usually better done by the File > Import > Maven > Existing Maven project... wizard.