### PR TITLE
fix(ContextBuilder): catch PositionBuilder exception and log them instead of crashing

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -24,12 +24,14 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 
+import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.cu.CompilationUnit;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
@@ -97,7 +99,12 @@ public class ContextBuilder {
 		stack.push(new ASTPair(e, node));
 		if (!(e instanceof CtPackage) || (compilationUnitSpoon.getFile() != null && compilationUnitSpoon.getFile().getName().equals(DefaultJavaPrettyPrinter.JAVA_PACKAGE_DECLARATION))) {
 			if (compilationunitdeclaration != null && !e.isImplicit()) {
-				e.setPosition(this.jdtTreeBuilder.getPositionBuilder().buildPositionCtElement(e, node));
+				try {
+					e.setPosition(this.jdtTreeBuilder.getPositionBuilder().buildPositionCtElement(e, node));
+				} catch (Exception ex) {
+					e.setPosition(SourcePosition.NOPOSITION);
+					Launcher.LOGGER.warn("PositionBuilder failed for element " + e.toString(), ex);
+				}
 			}
 		}
 

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1311,7 +1311,7 @@ public class PositionTest {
 			assertTrue(cl.getSimpleName().equals("A"));
 			assertTrue(cl.getMethods().size() == 1);
 		} catch(Exception e) {
-			fail("");
+			fail("Error while parsing incomplete class declaration");
 		}
 	}
 }

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1301,4 +1301,17 @@ public class PositionTest {
 		CtFieldReference<?> fieldRef2 = fieldRead.getVariable();
 		assertEquals("f", contentAtPosition(classContent, fieldRef2.getPosition()));
 	}
+
+	@Test
+	public void testPositionBuilderFailureIsCaugth() {
+		//contract: parsing incorrect java code should not lead to a crash because of the position builder,
+		//      but rather, incomplete position information.
+		try {
+			CtClass cl = Launcher.parseClass("class A { void foo() {");
+			assertTrue(cl.getSimpleName().equals("A"));
+			assertTrue(cl.getMethods().size() == 1);
+		} catch(Exception e) {
+			fail("");
+		}
+	}
 }


### PR DESCRIPTION
fix#2888