### PR TITLE
doc: fix doc JavadocDescription.java

### DIFF
--- a/src/main/java/spoon/javadoc/internal/JavadocDescription.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocDescription.java
@@ -13,8 +13,6 @@ package spoon.javadoc.internal;
 
 	/**
 	* A javadoc text, potentially containing inline tags.
-	*
-	* <p>For example <code>This class is totally unrelated to {@link com.github.javaparser.Range}
 	* </code>
 	*/
 	public class JavadocDescription implements Serializable {


### PR DESCRIPTION
Fix link to missing class which breaks the Javadoc linter

```
[ERROR] /home/travis/build/SpoonLabs/spoon-deploy/spoon/src/main/java/spoon/javadoc/internal/JavadocDescription.java:17: error: reference not found
[ERROR] 	* <p>For example <code>This class is totally unrelated to {@link com.github.javaparser.Range}
```