### PR TITLE
fix NPE with duplicate inner class

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1067,7 +1067,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		CtConstructor<Object> c = factory.Core().createConstructor();
 		// if the source start of the class is equals to the source start of the constructor
 		// it means that the constructor is implicit.
-		c.setImplicit(scope.referenceContext.sourceStart() == constructorDeclaration.sourceStart());
+		if (scope != null && scope.referenceContext != null) {
+			c.setImplicit(scope.referenceContext.sourceStart() == constructorDeclaration.sourceStart());
+		}
 		if (constructorDeclaration.binding != null) {
 			c.setExtendedModifiers(getModifiers(constructorDeclaration.binding.modifiers, true, true));
 		}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -620,7 +620,7 @@ public class JDTTreeBuilderHelper {
 			if (typeDeclaration.superclass != null) {
 				((CtClass) type).setSuperclass(jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope));
 			}
-			if (typeDeclaration.binding.isAnonymousType() || (typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null)) {
+			if (typeDeclaration.binding != null && (typeDeclaration.binding.isAnonymousType() || (typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null))) {
 				type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName()));
 			} else {
 				type.setSimpleName(new String(typeDeclaration.name));

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -42,12 +42,14 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.CodeFactory;
@@ -521,5 +523,21 @@ public class CompilationTest {
 		launcher.buildModel();
 		CtType t=launcher.getFactory().Type().get("ClassWithSyntheticEnumNotParsable");
 		assertEquals(2, t.getMethods().size());
+	}
+
+	@Test
+	public void buildAstWithDuplicateClass() {
+		File testFile = new File(
+				"src/test/resources/duplicateClass/DuplicateInnerClass.java");
+		String absoluteTestPath = testFile.getAbsolutePath();
+
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(absoluteTestPath);
+		final CtModel model = launcher.buildModel();
+		final List<String> pkgNames = model.getElements(new TypeFilter<>(CtPackage.class))
+				.stream()
+				.map(CtPackage::getQualifiedName)
+				.collect(Collectors.toList());
+		assertTrue(pkgNames.contains("P.F.G"));
 	}
 }

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -527,6 +527,7 @@ public class CompilationTest {
 
 	@Test
 	public void buildAstWithDuplicateClass() {
+		// contract: one can have inner classes with the same name
 		File testFile = new File(
 				"src/test/resources/duplicateClass/DuplicateInnerClass.java");
 		String absoluteTestPath = testFile.getAbsolutePath();
@@ -539,5 +540,12 @@ public class CompilationTest {
 				.map(CtPackage::getQualifiedName)
 				.collect(Collectors.toList());
 		assertTrue(pkgNames.contains("P.F.G"));
+		final List<String> classNames = model.getElements(new TypeFilter<>(CtType.class))
+				.stream()
+				.map(CtType::getQualifiedName)
+				.collect(Collectors.toList());
+		assertTrue(classNames.contains("P.F.G.DuplicateInnerClass"));
+		assertTrue(classNames.contains("P.F.G.DuplicateInnerClass$B"));
+		assertTrue(classNames.contains("P.F.G.DuplicateInnerClass$B$B"));
 	}
 }

--- a/src/test/resources/duplicateClass/DuplicateInnerClass.java
+++ b/src/test/resources/duplicateClass/DuplicateInnerClass.java
@@ -1,0 +1,15 @@
+package P.F.G;
+
+/**
+ * @author Charm
+ */
+
+public interface DuplicateInnerClass {
+
+    abstract class B {
+
+        private static class B implements DuplicateInnerClass {
+
+        }
+    }
+}


### PR DESCRIPTION
This code is decompilation of the bytecode file, but as I understand parser should never throw exception when it tries to build AST. I would prefer if it would just skip the second class, if it's possible. Or maybe you prefer another way for it? Thanks.

stacktrace:
java.lang.NullPointerException
	at spoon.support.compiler.jdt.JDTTreeBuilderHelper.createType(JDTTreeBuilderHelper.java:623)
	at spoon.support.compiler.jdt.JDTTreeBuilder.visit(JDTTreeBuilder.java:1663)
	at org.eclipse.jdt.internal.compiler.ast.TypeDeclaration.traverse(TypeDeclaration.java:1485)
