### PR TITLE
fix(JDTTreeBuilderHelper): executable reference return type

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -581,8 +581,8 @@ public class JDTTreeBuilderHelper {
 			executableReference.setSimpleName(CharOperation.charToString(referenceExpression.selector));
 			executableReference.setDeclaringType(jdtTreeBuilder.getReferencesBuilder().getTypeReference(referenceExpression.lhs.resolvedType));
 		}
-		final CtTypeReference<T> declaringType = (CtTypeReference<T>) executableReference.getDeclaringType();
-		executableReference.setType(declaringType == null ? null : declaringType.clone());
+		final CtTypeReference<T> returnType = executableReference.getType();
+		executableReference.setType(returnType == null ? null : returnType.clone());
 		executableRef.setExecutable(executableReference);
 		return executableRef;
 	}

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -18,6 +18,8 @@ package spoon.reflect.ast;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.support.modelobs.FineModelChangeListener;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtFieldRead;
@@ -46,7 +48,28 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
+
 public class AstCheckerTest {
+
+	@Test
+	public void testExecutableReference() {
+
+		Launcher l = new Launcher();
+		l.getEnvironment().setNoClasspath(true);
+		l.addInputResource("./src/test/resources/noclasspath/A4.java");
+		l.buildModel();
+
+		CtClass<Object> klass = l.getFactory().Class().get("A4");
+		CtMethod<?> bMethod = klass.getMethodsByName("b").get(0);
+		CtMethod<?> cMethod = klass.getMethodsByName("c").get(0);
+		List<CtExecutableReference> elements = cMethod.getElements(new TypeFilter<>(CtExecutableReference.class));
+		CtExecutableReference methodRef = elements.stream().filter(e -> e.getSimpleName().equals("b")).findFirst().get();
+
+		//contract: Executable reference declaring type and return type match those of the actual executable
+		assertEquals(bMethod.getType().getTypeDeclaration(),methodRef.getType().getTypeDeclaration());
+		assertEquals(bMethod.getDeclaringType(),methodRef.getDeclaringType().getTypeDeclaration());
+	}
 
 	@Test
 	public void testAvoidSetCollectionSavedOnAST() {

--- a/src/test/resources/noclasspath/A4.java
+++ b/src/test/resources/noclasspath/A4.java
@@ -1,0 +1,16 @@
+import java.util.List;
+import java.util.ArrayList;
+
+public class A4 {
+
+	int field;
+
+	public static boolean b(Integer param) {
+		return param > 1;
+	}
+
+	public void c(int param) {
+		List<Integer> list = new ArrayList();
+		long l = list.stream().filter(A4::b).count();
+	}
+}


### PR DESCRIPTION
Executable reference return type should match actual executable.
Reproduce, test and fix #2966 