### PR TITLE
Possible fix for auto imports (issue #2996)

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -454,6 +454,7 @@ public class ReferenceBuilder {
 		ref.setType(this.<T>getTypeReference(messageSend.expectedType(), true));
 		if (messageSend.receiver.resolvedType == null) {
 			// It is crisis dude! static context, we don't have much more information.
+			ref.setStatic(true);
 			if (messageSend.receiver instanceof SingleNameReference) {
 				ref.setDeclaringType(jdtTreeBuilder.getHelper().createTypeAccessNoClasspath((SingleNameReference) messageSend.receiver).getAccessedType());
 			} else if (messageSend.receiver instanceof QualifiedNameReference) {

--- a/src/test/resources/import-resources/fr/inria/PageButtonNoClassPath.java
+++ b/src/test/resources/import-resources/fr/inria/PageButtonNoClassPath.java
@@ -1,0 +1,25 @@
+package fr.inria;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.Button;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+
+import com.carconnectivity.mlmediaplayer.R;
+
+public class PageButtonNoClassPath extends FrameLayout {
+    private final Button mButton;
+    private int mCurrentActiveColor;
+
+    public PageButtonNoClassPath(Context context, AttributeSet attributeSet) {
+        super(context, attributeSet);
+        mButton = (Button) findViewById(R.id.page_button_button);
+        mCurrentActiveColor = getColor(R.color.c4_active_button_color);
+        mCurrentActiveColor = getResources().getColor(R.color.c4_active_button_color);
+        mCurrentActiveColor = getData().getResources().getColor(R.color.c4_active_button_color);
+    }
+}


### PR DESCRIPTION
fix #2996
As far as I understand from debugging, the problem is that when the binding of some unknown method in chain is null, it is not set to static by default (like for `ProblemMethodBinding`), which affects how `ImportsScanner` processes it. 
So my workaround is to set static = true here as well.