### PR TITLE
test: Failing test case when filtering with anonymous classes.

### DIFF
--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -1369,5 +1369,9 @@ public class FilterTest {
 		assertEquals(5, types2.size());
 	}
 
-
+	@Test
+	public void testStaticFalseForTargetedThisAccess() {
+		CtClass<?> c = Launcher.parseClass("class C { Object r = new Runnable() { public void run() {} }}");
+		assertEquals(1,c.getElements(new TypeFilter<>(CtMethod.class)).size());
+	}
 }


### PR DESCRIPTION
Filtering does not visit anonymous classes. This PR contains a failing test case that illustrates the issue with a method run() defined in an anonymous class that extends Runnable in a class C. AFAIK the filter should return one method (run) but currently returns 0.