### PR TITLE
fix: NPE in isInSamePackage() and canAccess()

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -574,6 +574,10 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	@Override
 	public boolean canAccess(CtTypeReference<?> type) {
 		try {
+			if (type == null) {
+				//noclasspath mode
+				return true;
+			}
 			if (type.getTypeDeclaration() == null) {
 				return true;
 			}
@@ -664,7 +668,12 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	}
 
 	private boolean isInSamePackage(CtTypeReference<?> type) {
-		return type.getTopLevelType().getPackage().getSimpleName().equals(this.getTopLevelType().getPackage().getSimpleName());
+		CtPackageReference thisPackage = this.getTopLevelType().getPackage();
+		CtPackageReference otherPackage = type.getTopLevelType().getPackage();
+		if (thisPackage == null || otherPackage == null) {
+			return true;
+		}
+		return thisPackage.getQualifiedName().equals(otherPackage.getQualifiedName());
 	}
 
 	@Override

--- a/src/test/resources/noclasspath/A5.java
+++ b/src/test/resources/noclasspath/A5.java
@@ -1,0 +1,9 @@
+public class A5<T> extends UnknownKlass {
+
+    T a;
+
+    void m1() {
+        X x;
+        someMethod();
+    }
+}


### PR DESCRIPTION
fix #2845
I managed to reproduce NPE inside `canAccess()` and `isInSamePackage()` in noclasspath mode.
It turned out that NPE occurs if the `type` is null or if `type.getPackage()` returns null (it's a generic type for example).
So this PR is to fix that.