### PR TITLE
chore: fix automatic deploy

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -1,15 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-        
-        <!-- must be empty otherwise reads ../pom.xml by default -->
-        <relativePath></relativePath>
-    </parent>
-
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
     <packaging>pom</packaging>


### PR DESCRIPTION
Sonatype has added a new validation rule. We need this otherwise deployment fails with `ReasonPhrase:Forbidden. and 'parent.relativePath' points at no local POM @ fr.inria.gforge.spoon:spoon-pom:1.0, /home/travis/build/SpoonLabs/spoon-deploy/spoon/spoon-pom/pom.xml, line 4, column 13`

See https://travis-ci.org/SpoonLabs/spoon-deploy/builds/549038609