### PR TITLE
fix: Fix issue #3052

### DIFF
--- a/src/main/java/spoon/reflect/factory/ClassFactory.java
+++ b/src/main/java/spoon/reflect/factory/ClassFactory.java
@@ -59,8 +59,7 @@ public class ClassFactory extends TypeFactory {
 	 * @param <T>
 	 *            type of created class
 	 * @param qualifiedName
-	 *            full name of class to create. Name can contain . or $ for
-	 *            inner types
+	 *            full name of class to create. Name can contain $ for inner types
 	 */
 	public <T> CtClass<T> create(String qualifiedName) {
 		if (hasInnerType(qualifiedName) > 0) {

--- a/src/main/java/spoon/reflect/factory/InterfaceFactory.java
+++ b/src/main/java/spoon/reflect/factory/InterfaceFactory.java
@@ -45,7 +45,13 @@ public class InterfaceFactory extends TypeFactory {
 	}
 
 	/**
-	 * Creates an interface.
+	 * Creates an interface from its qualified name.
+	 *
+	 * @param <T>
+	 * 		type of created interface
+	 *
+	 * @param qualifiedName
+	 * 		full name of interface to create. Name can contain $ for inner types
 	 */
 	@SuppressWarnings("unchecked")
 	public <T> CtInterface<T> create(String qualifiedName) {

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -204,6 +204,15 @@ public class ContextBuilder {
 		return variable;
 	}
 
+	/**
+	 * Returns qualified name with appropriate package separator and inner type separator
+	 */
+	private static String getNormalQualifiedName(ReferenceBinding referenceBinding) {
+		String pkg = new String(referenceBinding.getPackage().readableName()).replaceAll("\\.", "\\" + CtPackage.PACKAGE_SEPARATOR);
+		String name = new String(referenceBinding.qualifiedSourceName()).replaceAll("\\.", "\\" + CtType.INNERTTYPE_SEPARATOR);
+		return pkg.equals("") ? name : pkg + "." + name;
+	}
+
 	@SuppressWarnings("unchecked")
 	private <T, U extends CtVariable<T>> U getVariableDeclaration(
 			final String name, final Class<U> clazz) {
@@ -250,11 +259,12 @@ public class ContextBuilder {
 					final ReferenceBinding referenceBinding = referenceBindings.pop();
 					for (final FieldBinding fieldBinding : referenceBinding.fields()) {
 						if (name.equals(new String(fieldBinding.readableName()))) {
-							final String qualifiedNameOfParent =
-									new String(referenceBinding.readableName());
+							final String qualifiedNameOfParent = getNormalQualifiedName(referenceBinding);
+
 							final CtType parentOfField = referenceBinding.isClass()
 									? classFactory.create(qualifiedNameOfParent)
 									: interfaceFactory.create(qualifiedNameOfParent);
+
 							U field = (U) fieldFactory.create(parentOfField,
 									EnumSet.noneOf(ModifierKind.class),
 									referenceBuilder.getTypeReference(fieldBinding.type),

--- a/src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda1.java
+++ b/src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda1.java
@@ -1,0 +1,14 @@
+package com.pkg;
+
+public class InheritedClassesWithLambda1 {
+
+    private static class ExtendedFailClass extends Failing {
+        public void test(View itemView) {
+            itemView.setOnClickListener(v -> listener.foo());
+        }
+    }
+
+    public static class Failing {
+        ClickListener listener;
+    }
+}

--- a/src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda2.java
+++ b/src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda2.java
@@ -1,0 +1,15 @@
+public class InheritedClassesWithLambda2 {
+
+    private static class ExtendedFailClass extends OneMoreClass.Failing {
+        public void test(View itemView) {
+            itemView.setOnClickListener(v -> listener.foo());
+        }
+    }
+
+    public static class OneMoreClass
+    {
+        public static class Failing {
+            ClickListener listener;
+        }
+    }
+}

--- a/src/test/resources/noclasspath/lambdas/InheritedInterfacesWithLambda.java
+++ b/src/test/resources/noclasspath/lambdas/InheritedInterfacesWithLambda.java
@@ -1,0 +1,12 @@
+public class InheritedInterfacesWithLambda {
+
+    public interface Failing {
+        ClickListener listener;
+    }
+
+    private static class ExtendedFailClass implements Failing {
+        public void test(View itemView) {
+            itemView.setOnClickListener(v -> listener.foo());
+        }
+    }
+}


### PR DESCRIPTION
Fix #3052.
Here is why this bug is happening:
Eclipse jdt tells us that the binding of the `listener` variable inside the lambda is null in noclasspath mode, 
so we run `createVariableAccessNoClasspath()`, it calls `getVariableDeclaration()`, which uses `classFactory.create()` for inner classes improperly. This leads to the creation of a new top-level class `Failing` (with unknown position), so references get messed up and we get this new class with no position instead of the original `Failing`.

More specifically the problem was that the description of the `classFactory.create()` said that it can handle both `.` and `$`, but its implementation handles only `$`, so I added `getNormalQualifiedName()` and fixed context builder. By the way, it's not possible to handle them both in `classFactory.create()`, since `.` is used as a package separator and `$` as an inner type separator and we need to distinguish between the two of them.
