### PR TITLE
bug: Type of string concatenation is null

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -423,7 +423,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				op.setKind(BinaryOperatorKind.PLUS);
 				op.setLeftHandOperand(operator.getRightHandOperand());
 				op.setRightHandOperand((CtExpression<?>) child);
-				//op.setType((CtTypeReference) operator.getFactory().Type().STRING);
+				op.setType((CtTypeReference) operator.getFactory().Type().STRING.clone());
 				operator.setRightHandOperand(op);
 				int[] lineSeparatorPositions = jdtTreeBuilder.getContextBuilder().getCompilationUnitLineSeparatorPositions();
 				SourcePosition leftPosition = op.getLeftHandOperand().getPosition();

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -423,6 +423,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				op.setKind(BinaryOperatorKind.PLUS);
 				op.setLeftHandOperand(operator.getRightHandOperand());
 				op.setRightHandOperand((CtExpression<?>) child);
+				//op.setType((CtTypeReference) operator.getFactory().Type().STRING);
 				operator.setRightHandOperand(op);
 				int[] lineSeparatorPositions = jdtTreeBuilder.getContextBuilder().getCompilationUnitLineSeparatorPositions();
 				SourcePosition leftPosition = op.getLeftHandOperand().getPosition();

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -18,6 +18,7 @@ package spoon.test.type;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
@@ -428,5 +429,15 @@ public class TypeTest {
 			}
 			assertEquals(Arrays.asList("<init>", "method1", "field2", "TypeMembersOrder", "method4", "field5", "", "nestedType6", "field7", "method8", "method9"), typeMemberNames);
 		}
+	}
+
+	@Test
+	public void testBinaryOpStringsType() {
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("./src/test/java/spoon/test/type/testclasses/Foo.java");
+		CtModel model = launcher.buildModel();
+		List<CtBinaryOperator> concats = model.getElements(new TypeFilter<>(CtBinaryOperator.class));
+		concats.forEach(c -> assertEquals("java.lang.String", c.getType().toString()));
 	}
 }

--- a/src/test/java/spoon/test/type/testclasses/Foo.java
+++ b/src/test/java/spoon/test/type/testclasses/Foo.java
@@ -1,0 +1,10 @@
+package spoon.test.type.testclasses;
+
+public class Foo {
+	public void m1() {
+		String s1 = "one" + "two";
+		String s2 = "one" + "two" + "three";
+		String s3 = "one" + "two" + "three" + "four";
+		String s4 = "one" + "two" + "three" + "four" + "five" + "six" + "seven" + "eight";
+	}
+}


### PR DESCRIPTION
Hi!
I found out that Spoon returns null type for 2 or more concatenations of string literals.
For example:
`String s = "one" + "two" + "three";`
Spoon says that the type of "two" + "three" is null, but it's actually String.
I provided the test that demonstrates that.

Moreover, I'm sure that the problem is here:
https://github.com/INRIA/spoon/blob/f2ecd5def520d0e8fb5f7c43a8889affd1347aa2/src/main/java/spoon/support/compiler/jdt/ParentExiter.java#L421-L432
We create a new `CtBinaryOperator` but do not set its type.

So I tried to fix that by adding setType call:
`op.setType((CtTypeReference) operator.getFactory().Type().STRING);`

This fix works and type appears, but `AstParentConsistencyChecker` does not like it, because `setType` sets parent of the reference to `op`, so I'm getting:
```
java.lang.IllegalStateException: Element: java.lang.String
Signature: spoon.support.reflect.reference.CtTypeReferenceImpl@943a4c32
Class: class spoon.support.reflect.reference.CtTypeReferenceImpl
position: (unknown file)
 is set as child of
Element: (("two" + "three") + "four")
Signature: spoon.support.reflect.code.CtBinaryOperatorImpl@1
Class: class spoon.support.reflect.code.CtBinaryOperatorImpl
position: (/home/egor/spoon/src/test/java/spoon/test/type/testclasses/Foo.java:7)
however it is visited as a child of
Element: ("two" + "three")
Signature: spoon.support.reflect.code.CtBinaryOperatorImpl@1
Class: class spoon.support.reflect.code.CtBinaryOperatorImpl
position: (/home/egor/spoon/src/test/java/spoon/test/type/testclasses/Foo.java:7)
```

Do you have any ideas how to set the parent properly here?
Thanks.