### PR TITLE
fix(pom.xml): upgrade jackson-databind version to 2.9.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.9</version>
+      <version>2.9.9.3</version>
     </dependency>
     <dependency>
       <!-- support for compressed serialized ASTs -->


### PR DESCRIPTION
It seems that the security notification from github has been dismissed, but as upgrading cost nothing...