### PR TITLE
review2 fix: order of processing LexicalScope elements of Type

### DIFF
--- a/src/main/java/spoon/experimental/CtUnresolvedImport.java
+++ b/src/main/java/spoon/experimental/CtUnresolvedImport.java
@@ -56,7 +56,7 @@ public class CtUnresolvedImport extends CtElementImpl implements CtImport {
 
 	@Override
 	public void accept(CtImportVisitor visitor) {
-
+		visitor.visitUnresolvedImport(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/visitor/CtAbstractImportVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractImportVisitor.java
@@ -5,6 +5,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
@@ -34,5 +35,8 @@ public class CtAbstractImportVisitor implements CtImportVisitor {
 
 	@Override
 	public <T> void visitAllStaticMembersImport(CtTypeMemberWildcardImportReference typeReference) {
+	}
+	@Override
+	public <T> void visitUnresolvedImport(CtUnresolvedImport unresolvedImport) {
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/CtImportVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtImportVisitor.java
@@ -5,6 +5,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
@@ -40,4 +41,9 @@ public interface CtImportVisitor {
 	 * <code>import apackage.Type.*;</code>
 	 */
 	<T> void visitAllStaticMembersImport(CtTypeMemberWildcardImportReference typeReference);
+
+	/**
+	 * Called for unresolved import
+	 */
+	<T> void visitUnresolvedImport(CtUnresolvedImport ctUnresolvedImport);
 }

--- a/src/main/java/spoon/reflect/visitor/NameScopeImpl.java
+++ b/src/main/java/spoon/reflect/visitor/NameScopeImpl.java
@@ -68,6 +68,9 @@ class NameScopeImpl implements LexicalScope {
 	@Override
 	public <T> T forEachElementByName(String name, Function<? super CtNamedElement, T> consumer) {
 		T r = forEachByName(elementsByName, name, consumer);
+		if (r != null) {
+			return r;
+		}
 		if (scopeElement instanceof CtNamedElement) {
 			CtNamedElement named = (CtNamedElement) scopeElement;
 			if (name.equals(named.getSimpleName())) {

--- a/src/main/java/spoon/reflect/visitor/TypeNameScope.java
+++ b/src/main/java/spoon/reflect/visitor/TypeNameScope.java
@@ -41,9 +41,11 @@ class TypeNameScope extends NameScopeImpl {
 
 	@Override
 	public <T> T forEachElementByName(String name, Function<? super CtNamedElement, T> consumer) {
-		super.forEachElementByName(name, consumer);
+		//1st check scope of type members
+		//2nd check scope of type name itself
+		T r;
 		assureCacheInitialized();
-		T r = forEachByName(fieldsByName, name, consumer);
+		r = forEachByName(fieldsByName, name, consumer);
 		if (r != null) {
 			return r;
 		}
@@ -52,6 +54,10 @@ class TypeNameScope extends NameScopeImpl {
 			return r;
 		}
 		r = forEachByName(methodsByName, name, consumer);
+		if (r != null) {
+			return r;
+		}
+		r = super.forEachElementByName(name, consumer);
 		if (r != null) {
 			return r;
 		}

--- a/src/main/java/spoon/reflect/visitor/TypeNameScope.java
+++ b/src/main/java/spoon/reflect/visitor/TypeNameScope.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtImport;
@@ -150,6 +151,10 @@ class TypeNameScope extends NameScopeImpl {
 							}
 						}
 					});
+				}
+				@Override
+				public <T> void visitUnresolvedImport(CtUnresolvedImport ctUnresolvedImport) {
+					//there is no usable type member under unresolved import
 				}
 			});
 		});

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -23,6 +23,7 @@ import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
+import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtInvocation;
@@ -1479,6 +1480,12 @@ public class ImportTest {
 			public <T> void visitAllStaticMembersImport(CtTypeMemberWildcardImportReference typeReference) {
 				info.setKind(CtImportKind.ALL_STATIC_MEMBERS);
 				assertSame(imprt.getReference(), typeReference);
+			}
+			
+			@Override
+			public <T> void visitUnresolvedImport(CtUnresolvedImport ctUnresolvedImport) {
+				info.setKind(CtImportKind.UNRESOLVED);
+				assertSame(imprt.getReference(), ctUnresolvedImport);
 			}
 		});
 		assertSame(imprt.getImportKind(), info.kind);


### PR DESCRIPTION
The type members names must be visited before Type name itself.

Will be tested by GenericsWithAmbiguousStaticField after #2683 is merged.