### PR TITLE
WIP: fix: improve the creation of qualified type references 

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.internal.compiler.ast.ModuleReference;
 import org.eclipse.jdt.internal.compiler.ast.OpensStatement;
 import org.eclipse.jdt.internal.compiler.ast.ProvidesStatement;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedNameReference;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ReferenceExpression;
 import org.eclipse.jdt.internal.compiler.ast.RequiresStatement;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
@@ -611,14 +612,25 @@ public class JDTTreeBuilderHelper {
 
 		if (typeDeclaration.superInterfaces != null) {
 			for (TypeReference ref : typeDeclaration.superInterfaces) {
-				final CtTypeReference superInterface = jdtTreeBuilder.references.buildTypeReference(ref, null);
+				CtTypeReference superInterface;
+				if (ref instanceof QualifiedTypeReference) {
+					superInterface = jdtTreeBuilder.references.buildTypeReference((QualifiedTypeReference) ref, typeDeclaration.scope);
+				} else {
+					superInterface = jdtTreeBuilder.references.buildTypeReference(ref, null);
+				}
 				type.addSuperInterface(superInterface);
 			}
 		}
 
 		if (type instanceof CtClass) {
 			if (typeDeclaration.superclass != null) {
-				((CtClass) type).setSuperclass(jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope));
+				CtTypeReference superClass;
+				if (typeDeclaration.superclass instanceof QualifiedTypeReference) {
+					superClass = jdtTreeBuilder.references.buildTypeReference((QualifiedTypeReference) typeDeclaration.superclass, typeDeclaration.scope);
+				} else {
+					superClass = jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope);
+				}
+				((CtClass) type).setSuperclass(superClass);
 			}
 			if (typeDeclaration.binding != null && (typeDeclaration.binding.isAnonymousType() || (typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null))) {
 				type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName()));


### PR DESCRIPTION
I did those changes but I am not sure if it makes real sense. 

It should compute correctly the access path to inner public classes in a protected class.
The previous implementation only supported one level. This implementation should support more than one.