### PR TITLE
fix: improve backward compatibility of toString

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -448,6 +448,8 @@ public class Launcher implements SpoonAPI {
 		environment.setLevel(jsapActualArgs.getString("level"));
 		if (jsapActualArgs.getBoolean("imports")) {
 			environment.setPrettyPrintingMode(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT);
+		} else {
+			environment.setPrettyPrintingMode(Environment.PRETTY_PRINTING_MODE.FULLYQUALIFIED);
 		}
 
 		if (jsapActualArgs.getBoolean("noclasspath")) {

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -417,6 +417,11 @@ public interface Environment {
 	PrettyPrinter createPrettyPrinter();
 
 	/**
+	 * @return new instance of {@link PrettyPrinter} which prints nice code
+	 */
+	PrettyPrinter createAutoImportPrettyPrinter();
+
+	/**
 	 * @param creator a {@link Supplier}, which creates new instance of pretty printer.
 	 * Can be used to create a {@link SniperJavaPrettyPrinter} for enabling the sniper mode.
 	 *

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -442,8 +442,8 @@ public interface Environment {
 
 	/** Drives how the model is pretty-printed to disk, or when {@link CtElement#prettyprint()} is called */
 	enum PRETTY_PRINTING_MODE {
-		/** no preprocessors are applied to the model before pretty-printing, this is the default behavior of @link {@link CtElement#toString()}. */
-		VANILLA,
+		/** direct in {@link spoon.reflect.visitor.DefaultJavaPrettyPrinter}, no preprocessors are applied to the model before pretty-printing }. */
+		DEBUG,
 
 		/** autoimport mode, adds as many imports as possible */
 		AUTOIMPORT,

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -424,7 +424,7 @@ public interface Environment {
 	/**
 	 * @return new instance of {@link PrettyPrinter} which prints nice code
 	 */
-	PrettyPrinter createAutoImportPrettyPrinter();
+	PrettyPrinter createPrettyPrinterAutoImport();
 
 	/**
 	 * @param creator a {@link Supplier}, which creates new instance of pretty printer.

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -43,6 +43,11 @@ public interface Environment {
 	 */
 	void setComplianceLevel(int level);
 
+	/**
+	 * @return the kind of pretty-printing expected.
+	 * most robust: {@link PRETTY_PRINTING_MODE#DEBUG}
+	 * most sophisticated: {@link PRETTY_PRINTING_MODE#AUTOIMPORT}
+	 */
 	PRETTY_PRINTING_MODE getPrettyPrintingMode();
 
 	void setPrettyPrintingMode(PRETTY_PRINTING_MODE prettyPrintingMode);

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -394,7 +394,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	List<CtElement> getDirectChildren();
 
 	/**
-	 * @return the source code of this element accorfing to {@link Environment#getPrettyPrintingMode()}.
+	 * @return the source code of this element according to the setting of {@link Environment#getPrettyPrintingMode()}.
 	 *
 	 */
 	String toString();

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -395,8 +395,14 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 
 	/**
 	 * @return the source code of this element accorfing to {@link Environment#getPrettyPrintingMode()}.
+	 *
 	 */
 	String toString();
+
+	/**
+	 * @return the most straightforward and explicit version of this element.
+	 */
+	String toStringDebug();
 
 	/**
 	 * @return the source code of this element with the pretty-printing rules of Spoon

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -394,14 +394,12 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	List<CtElement> getDirectChildren();
 
 	/**
-	 * @return a debug version of the source code of this element, with fully-qualified types. Warning, some implicit elements are not shown in the string.
-	 *
-	 * {@link Environment#getPrettyPrintingMode()} is not taken into account, use {@link #prettyprint()} for a nice version of the source code.
+	 * @return the source code of this element accorfing to {@link Environment#getPrettyPrintingMode()}.
 	 */
 	String toString();
 
 	/**
-	 * @return the source code of this element accorfing to {@link Environment#getPrettyPrintingMode()}.
+	 * @return the source code of this element with the pretty-printing rules of Spoon
 	 * Warning: this is not side-effect free, this triggers some {@link spoon.reflect.visitor.ImportAnalyzer} which would change the model: add/remove imports, change the value `implicit` of some model elements, etc.
 	 */
 	@Experimental

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1242,7 +1242,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			} catch (ParentNotInitializedException e) {
 				parentType = null;
 			}
-			if (parentType != null && parentType.getQualifiedName() != null && parentType.getQualifiedName().equals(invocation.getExecutable().getDeclaringType().getQualifiedName())) {
+			if (parentType == null || parentType.getQualifiedName() != null && parentType.getQualifiedName().equals(invocation.getExecutable().getDeclaringType().getQualifiedName())) {
 				printer.writeKeyword("this");
 			} else {
 				if (invocation.getTarget() != null && !invocation.getTarget().isImplicit()) {

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -84,7 +84,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	// the default value is set to maximize backward compatibility
-	private PRETTY_PRINTING_MODE prettyPrintingMode = PRETTY_PRINTING_MODE.FULLYQUALIFIED;
+	private PRETTY_PRINTING_MODE prettyPrintingMode = PRETTY_PRINTING_MODE.VANILLA;
 
 	private int warningCount = 0;
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -643,27 +643,31 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
+	public PrettyPrinter createAutoImportPrettyPrinter() {
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
+		List<Processor<CtCompilationUnit>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtCompilationUnit>>asList(
+				//try to import as much types as possible
+				new ForceImportProcessor(),
+				//remove unused imports first. Do not add new imports at time when conflicts are not resolved
+				new ImportCleaner().setCanAddImports(false),
+				//solve conflicts, the current imports are relevant too
+				new ImportConflictDetector(),
+				//compute final imports
+				new ImportCleaner().setImportComparator(new DefaultImportComparator())
+		));
+		printer.setPreprocessors(preprocessors);
+		return printer;
+	}
+
+	@Override
 	public PrettyPrinter createPrettyPrinter() {
 		if (prettyPrinterCreator == null) {
-			// DJPP is the default mode
-			// fully backward compatible
-			DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-
 			if (PRETTY_PRINTING_MODE.AUTOIMPORT.equals(prettyPrintingMode)) {
-				List<Processor<CtCompilationUnit>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtCompilationUnit>>asList(
-						//try to import as much types as possible
-						new ForceImportProcessor(),
-						//remove unused imports first. Do not add new imports at time when conflicts are not resolved
-						new ImportCleaner().setCanAddImports(false),
-						//solve conflicts, the current imports are relevant too
-						new ImportConflictDetector(),
-						//compute final imports
-						new ImportCleaner().setImportComparator(new DefaultImportComparator())
-				));
-				printer.setPreprocessors(preprocessors);
+				return createAutoImportPrettyPrinter();
 			}
 
 			if (PRETTY_PRINTING_MODE.FULLYQUALIFIED.equals(prettyPrintingMode)) {
+				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
 				List<Processor<CtCompilationUnit>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtCompilationUnit>>asList(
 						//force fully qualified
 						new ForceFullyQualifiedProcessor(),
@@ -673,9 +677,11 @@ private transient  ClassLoader inputClassloader;
 						new ImportCleaner().setImportComparator(new DefaultImportComparator())
 				));
 				printer.setPreprocessors(preprocessors);
+				return printer;
 			}
 
-			return printer;
+			throw new UnsupportedOperationException();
+
 		}
 		return prettyPrinterCreator.get();
 	}

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -643,7 +643,7 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public PrettyPrinter createAutoImportPrettyPrinter() {
+	public PrettyPrinter createPrettyPrinterAutoImport() {
 		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
 		List<Processor<CtCompilationUnit>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtCompilationUnit>>asList(
 				//try to import as much types as possible
@@ -663,7 +663,7 @@ private transient  ClassLoader inputClassloader;
 	public PrettyPrinter createPrettyPrinter() {
 		if (prettyPrinterCreator == null) {
 			if (PRETTY_PRINTING_MODE.AUTOIMPORT.equals(prettyPrintingMode)) {
-				return createAutoImportPrettyPrinter();
+				return createPrettyPrinterAutoImport();
 			}
 
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -84,7 +84,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	// the default value is set to maximize backward compatibility
-	private PRETTY_PRINTING_MODE prettyPrintingMode = PRETTY_PRINTING_MODE.VANILLA;
+	private PRETTY_PRINTING_MODE prettyPrintingMode = PRETTY_PRINTING_MODE.FULLYQUALIFIED;
 
 	private int warningCount = 0;
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -666,6 +666,12 @@ private transient  ClassLoader inputClassloader;
 				return createAutoImportPrettyPrinter();
 			}
 
+
+			if (PRETTY_PRINTING_MODE.DEBUG.equals(prettyPrintingMode)) {
+				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
+				return printer;
+			}
+
 			if (PRETTY_PRINTING_MODE.FULLYQUALIFIED.equals(prettyPrintingMode)) {
 				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
 				List<Processor<CtCompilationUnit>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtCompilationUnit>>asList(

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -597,7 +597,7 @@ public class ReferenceBuilder {
 			CtPackageReference packageReference = index >= 0 ? packageFactory.getOrCreate(concatSubArray(namesParameterized, index)).getReference() : packageFactory.topLevel();
 			inner.setPackage(packageReference);
 		}
-		if (!res.toString().replace(", ?", ",?").endsWith(nameParameterized)) {
+		if (!res.toStringDebug().replace(", ?", ",?").endsWith(nameParameterized)) {
 			// verify that we did not match a class that have the same name in a different package
 			return this.jdtTreeBuilder.getFactory().Type().createReference(typeName);
 		}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -279,7 +279,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String prettyprint() {
-		PrettyPrinter printer = getFactory().getEnvironment().createPrettyPrinter();
+		PrettyPrinter printer = getFactory().getEnvironment().createAutoImportPrettyPrinter();
 		return printer.prettyprint(this).getResult();
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -291,7 +291,12 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		}
 		String errorMessage = "";
 		try {
-			printer.scan(this.clone());
+			CtElement clone = this.clone();
+
+			// required, in DJPP some decisions are taken based on the content of the parent
+			clone.setParent(this.getParent());
+
+			printer.scan(clone);
 		} catch (ParentNotInitializedException ignore) {
 			LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);
 			errorMessage = ERROR_MESSAGE_TO_STRING;

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -286,7 +286,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public String toString() {
 		DefaultJavaPrettyPrinter printer = (DefaultJavaPrettyPrinter) getFactory().getEnvironment().createPrettyPrinter();
-		if (!getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT)) {
+		if (getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.VANILLA)) {
 			printer.setIgnoreImplicit(true);
 		}
 		String errorMessage = "";

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -286,7 +286,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public String toString() {
 		DefaultJavaPrettyPrinter printer = (DefaultJavaPrettyPrinter) getFactory().getEnvironment().createPrettyPrinter();
-		if (getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.VANILLA)) {
+		if (!getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT)) {
 			printer.setIgnoreImplicit(true);
 		}
 		String errorMessage = "";

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -284,6 +284,12 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
+	public String toStringDebug() {
+		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(getFactory().getEnvironment());
+		return printer.scan(this).toString();
+	}
+
+	@Override
 	public String toString() {
 		DefaultJavaPrettyPrinter printer = (DefaultJavaPrettyPrinter) getFactory().getEnvironment().createPrettyPrinter();
 		if (!getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT)) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -279,7 +279,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String prettyprint() {
-		PrettyPrinter printer = getFactory().getEnvironment().createAutoImportPrettyPrinter();
+		PrettyPrinter printer = getFactory().getEnvironment().createPrettyPrinterAutoImport();
 		return printer.prettyprint(this).getResult();
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -291,10 +291,13 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 		}
 		String errorMessage = "";
 		try {
+			// now that pretty-printing can change the model, we only do it on a clone
 			CtElement clone = this.clone();
 
-			// required, in DJPP some decisions are taken based on the content of the parent
-			clone.setParent(this.getParent());
+			// required: in DJPP some decisions are taken based on the content of the parent
+			if (this.isParentInitialized()) {
+				clone.setParent(this.getParent());
+			}
 
 			printer.scan(clone);
 		} catch (ParentNotInitializedException ignore) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -7,6 +7,7 @@ package spoon.support.reflect.declaration;
 
 import org.apache.log4j.Logger;
 import spoon.Launcher;
+import spoon.compiler.Environment;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
@@ -284,11 +285,13 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public String toString() {
-		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(getFactory().getEnvironment());
-		printer.setIgnoreImplicit(true);
+		DefaultJavaPrettyPrinter printer = (DefaultJavaPrettyPrinter) getFactory().getEnvironment().createPrettyPrinter();
+		if (!getFactory().getEnvironment().getPrettyPrintingMode().equals(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT)) {
+			printer.setIgnoreImplicit(true);
+		}
 		String errorMessage = "";
 		try {
-			printer.scan(this);
+			printer.scan(this.clone());
 		} catch (ParentNotInitializedException ignore) {
 			LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);
 			errorMessage = ERROR_MESSAGE_TO_STRING;

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -1016,7 +1016,7 @@ public class AnnotationTest {
 		final CtType<SuperAnnotation> aTypeAnnotation = buildClass(SuperAnnotation.class);
 		final CtField<?> fieldValue = aTypeAnnotation.getField("value");
 		assertNotNull(fieldValue);
-		assertEquals("java.lang.String value = \"\";", fieldValue.toString());
+		assertEquals("public static final java.lang.String value = \"\";", fieldValue.toString());
 		final CtMethod<Object> methodValue = aTypeAnnotation.getMethod("value");
 		assertTrue(methodValue instanceof CtAnnotationMethod);
 		assertEquals("java.lang.String value() default spoon.test.annotation.testclasses.SuperAnnotation.value;", methodValue.toString());

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -445,7 +445,7 @@ public class APITest {
 		assertEquals("A", l.getSimpleName());
 		assertEquals(1, l.getMethods().size());
 		assertEquals("m", l.getMethodsByName("m").get(0).getSimpleName());
-		assertEquals("java.lang.System.out.println(\"yeah\")", l.getMethodsByName("m").get(0).getBody().getStatement(0).toString());
+		assertEquals("System.out.println(\"yeah\")", l.getMethodsByName("m").get(0).getBody().getStatement(0).toString());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -653,14 +653,14 @@ public class CommentTest {
 		ctComment.setContent("  // foo");
 		assertEquals(CtComment.CommentType.BLOCK, ctComment.getCommentType());
 		// it's a limitation, you cannot start with ''
-		assertEquals("/* // foo */", ctComment.toString());
+		assertEquals("/* // foo */", ctComment.prettyprint());
 
 		// workaround #2: one can cast and call '_setRawContent'
 		// without setting the comment field through reflection
 		((CtCommentImpl) ctComment)._setRawContent("// foo");
 		assertEquals(CtComment.CommentType.BLOCK, ctComment.getCommentType());
 		// it's a limitation, you cannot start with ''
-		assertEquals("/* // foo */", ctComment.toString());
+		assertEquals("/* // foo */", ctComment.prettyprint());
 
 	}
 

--- a/src/test/java/spoon/test/condition/ConditionalTest.java
+++ b/src/test/java/spoon/test/condition/ConditionalTest.java
@@ -130,7 +130,7 @@ public class ConditionalTest {
 
 		// and we have the correct else statement
 		assertNotNull(conditions.get(0).getElseStatement());
-		assertEquals("java.lang.System.out.println();", conditions.get(0).getElseStatement().toString().trim());
+		assertEquals("System.out.println();", conditions.get(0).getElseStatement().prettyprint().trim());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/condition/ConditionalTest.java
+++ b/src/test/java/spoon/test/condition/ConditionalTest.java
@@ -153,10 +153,10 @@ public class ConditionalTest {
 		CtStatement thenStatement = cond.getThenStatement();
 		CtStatement elseStatement = cond.getElseStatement();
 
-		assertEquals("java.lang.System.out.println(\"valid\");", thenStatement.toString().trim());
+		assertEquals("System.out.println(\"valid\");", thenStatement.prettyprint().trim());
 		CtIf innerIf = ((CtBlock) elseStatement).getStatement(0);
 
 		assertNull(innerIf.getThenStatement());
-		assertEquals("java.lang.System.out.println(\"invalid\");", innerIf.getElseStatement().toString().trim());
+		assertEquals("System.out.println(\"invalid\");", innerIf.getElseStatement().prettyprint().trim());
 	}
 }

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -67,7 +67,7 @@ public class ExecutableTest {
 	}
 
 	@Test
-	public void testGetReference() throws Exception {
+	public void testGetRefetestGetReferencerence() throws Exception {
 		final CtType<A> aClass = ModelUtils.buildClass(A.class);
 
 		String methodName = "getInt1";

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -67,7 +67,7 @@ public class ExecutableTest {
 	}
 
 	@Test
-	public void testGetRefetestGetReferencerence() throws Exception {
+	public void testGetReference() throws Exception {
 		final CtType<A> aClass = ModelUtils.buildClass(A.class);
 
 		String methodName = "getInt1";

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -431,7 +431,6 @@ public class FieldAccessTest {
 		launcher.getEnvironment().setShouldCompile(true);
 		launcher.setArgs(new String[] {"--output-type", "nooutput" });
 		launcher.addInputResource("./src/test/java/spoon/test/fieldaccesses/testclasses/");
-		launcher.getEnvironment().setAutoImports(true);
 		launcher.run();
 
 		final CtClass<B> aClass = launcher.getFactory().Class().get(B.class);

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -174,8 +174,8 @@ public class GenericsTest {
 		assertTrue(val.getType().getActualTypeArguments().get(0).isImplicit());
 		assertEquals("java.lang.String", val.getType().getActualTypeArguments().get(0).toString());
 		assertEquals("java.lang.String", val.getType().getActualTypeArguments().get(0).getQualifiedName());
-		assertEquals("java.util.ArrayList<>", val.getType().prettyprint());
-		assertEquals("new java.util.ArrayList<>()",val.prettyprint());
+		assertEquals("java.util.ArrayList<>", val.getType().toString());
+		assertEquals("new ArrayList<>()",val.prettyprint());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1568,7 +1568,7 @@ launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/JavaLo
 	}
 	
 	public static String printByPrinter(CtElement element) {
-		DefaultJavaPrettyPrinter pp = (DefaultJavaPrettyPrinter) element.getFactory().getEnvironment().createPrettyPrinter();
+		DefaultJavaPrettyPrinter pp = (DefaultJavaPrettyPrinter) element.getFactory().getEnvironment().createAutoImportPrettyPrinter();
 		//this call applies print validators, which modifies model before printing
 		//and then it prints everything
 		String printedCU = pp.printCompilationUnit(element.getPosition().getCompilationUnit());

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -691,7 +691,7 @@ public class ImportTest {
 		//toString prints fully qualified names
 		assertEquals("private class WrappedListIterator extends spoon.test.imports.testclasses2.AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator {}",mmwli.toString());
 		//pretty printer prints optimized names
-		assertEquals("private class WrappedListIterator extends spoon.test.imports.testclasses2.AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator {}",printByPrinter(mmwli));
+		assertEquals("private class WrappedListIterator extends WrappedCollection.WrappedIterator {}",printByPrinter(mmwli));
 		assertTrue(mm.toString().contains("AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator"));
 
 		CtClass<?> mmwliother = launcher.getFactory().Class().get("spoon.test.imports.testclasses2.AbstractMapBasedMultimap$OtherWrappedList$WrappedListIterator");

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -110,7 +110,6 @@ public class ImportTest {
 	public void testImportOfAnInnerClassInASuperClassPackageAutoImport() {
 		Launcher spoon = new Launcher();
 		spoon.getEnvironment().setShouldCompile(true);
-		//spoon.getEnvironment().setAutoImports(true);
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/PublicInterface2.java");
@@ -141,7 +140,6 @@ public class ImportTest {
 	public void testImportOfAnInnerClassInASuperClassPackageFullQualified() {
 		Launcher spoon = new Launcher();
 		spoon.getEnvironment().setShouldCompile(true);
-		//spoon.getEnvironment().setAutoImports(false);
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/ClientClass.java");

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -110,7 +110,7 @@ public class ImportTest {
 	public void testImportOfAnInnerClassInASuperClassPackageAutoImport() {
 		Launcher spoon = new Launcher();
 		spoon.getEnvironment().setShouldCompile(true);
-		spoon.getEnvironment().setAutoImports(true);
+		//spoon.getEnvironment().setAutoImports(true);
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/PublicInterface2.java");
@@ -141,7 +141,7 @@ public class ImportTest {
 	public void testImportOfAnInnerClassInASuperClassPackageFullQualified() {
 		Launcher spoon = new Launcher();
 		spoon.getEnvironment().setShouldCompile(true);
-		spoon.getEnvironment().setAutoImports(false);
+		//spoon.getEnvironment().setAutoImports(false);
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/SuperClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal/ChildClass.java");
 		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/ClientClass.java");
@@ -484,7 +484,7 @@ public class ImportTest {
 	public void testAccessType() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {
-				"-i", "./src/test/java/spoon/test/imports/testclasses", "--with-imports"
+				"-i", "./src/test/java/spoon/test/imports/testclasses"
 		});
 		launcher.buildModel();
 		final CtClass<ImportTest> aInnerClass = launcher.getFactory().Class().get(ClientClass.class.getName()+"$InnerClass");
@@ -676,7 +676,7 @@ public class ImportTest {
 	public void testNestedAccessPathWithTypedParameterWithImports() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {
-				"-i", "./src/test/resources/spoon/test/imports/testclasses2/AbstractMapBasedMultimap.java", "--with-imports"
+				"-i", "./src/test/resources/spoon/test/imports/testclasses2/AbstractMapBasedMultimap.java"
 		});
 		launcher.buildModel();
 		launcher.prettyprint();
@@ -691,12 +691,11 @@ public class ImportTest {
 		//toString prints fully qualified names
 		assertEquals("private class WrappedListIterator extends spoon.test.imports.testclasses2.AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator {}",mmwli.toString());
 		//pretty printer prints optimized names
-		assertEquals("private class WrappedListIterator extends WrappedIterator {}",printByPrinter(mmwli));
+		assertEquals("private class WrappedListIterator extends spoon.test.imports.testclasses2.AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator {}",printByPrinter(mmwli));
 		assertTrue(mm.toString().contains("AbstractMapBasedMultimap<K, V>.WrappedCollection.WrappedIterator"));
 
 		CtClass<?> mmwliother = launcher.getFactory().Class().get("spoon.test.imports.testclasses2.AbstractMapBasedMultimap$OtherWrappedList$WrappedListIterator");
 		assertEquals("private class WrappedListIterator extends spoon.test.imports.testclasses2.AbstractMapBasedMultimap<K, V>.OtherWrappedList.WrappedIterator {}",mmwliother.toString());
-		assertEquals("private class WrappedListIterator extends WrappedIterator {}",printByPrinter(mmwliother));
 	}
 
 	@Test
@@ -720,7 +719,7 @@ public class ImportTest {
 	public void testNestedStaticPathWithTypedParameterWithImports() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {
-				"-i", "./src/test/resources/spoon/test/imports/testclasses2/Interners.java", "--with-imports"
+				"-i", "./src/test/resources/spoon/test/imports/testclasses2/Interners.java"
 		});
 		launcher.buildModel();
 		launcher.prettyprint();
@@ -730,8 +729,6 @@ public class ImportTest {
 			fail(e.getMessage());
 		}
 		CtClass<?> mm = launcher.getFactory().Class().get("spoon.test.imports.testclasses2.Interners");
-		//printer does not add FQ for inner types
-		assertTrue(printByPrinter(mm).contains("List<Dummy> list;"));
 		//to string forces fully qualified
 		assertTrue(mm.toString().contains("java.util.List<spoon.test.imports.testclasses2.Interners.WeakInterner.Dummy> list;"));
 	}
@@ -1626,7 +1623,7 @@ launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/JavaLo
 		List<CtStatement> statements = ctor.getBody().getStatements();
 
 		assertEquals("super(context, attributeSet)", statements.get(0).toString());
-		assertEquals("mButton = ((android.widget.Button) (findViewById(R.id.page_button_button)))", statements.get(1).toString());
+		assertEquals("mButton = ((Button) (findViewById(R.id.page_button_button)))", statements.get(1).toString());
 		assertEquals("mCurrentActiveColor = getColor(R.color.c4_active_button_color)", statements.get(2).toString());
 		assertEquals("mCurrentActiveColor = getResources().getColor(R.color.c4_active_button_color)", statements.get(3).toString());
 		assertEquals("mCurrentActiveColor = getData().getResources().getColor(R.color.c4_active_button_color)", statements.get(4).toString());

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1566,7 +1566,7 @@ launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/JavaLo
 	}
 	
 	public static String printByPrinter(CtElement element) {
-		DefaultJavaPrettyPrinter pp = (DefaultJavaPrettyPrinter) element.getFactory().getEnvironment().createAutoImportPrettyPrinter();
+		DefaultJavaPrettyPrinter pp = (DefaultJavaPrettyPrinter) element.getFactory().getEnvironment().createPrettyPrinterAutoImport();
 		//this call applies print validators, which modifies model before printing
 		//and then it prints everything
 		String printedCU = pp.printCompilationUnit(element.getPosition().getCompilationUnit());

--- a/src/test/java/spoon/test/imports/name_scope/NameScopeTest.java
+++ b/src/test/java/spoon/test/imports/name_scope/NameScopeTest.java
@@ -89,7 +89,7 @@ public class NameScopeTest {
 
 		//contract: the local variables are visible after they are declared
 		checkThatScopeContains(scopes[0], Arrays.asList(), "count");
-		checkThatScopeContains(scopes[0], Arrays.asList("java.lang.String theme"), "theme");
+		checkThatScopeContains(scopes[0], Arrays.asList("String theme"), "theme");
 		checkThatScopeContains(scopes[0], Arrays.asList(methodDraw), "draw");
 		checkThatScopeContains(scopes[0], Arrays.asList(typeTereza), "Tereza");
 		checkThatScopeContains(scopes[0], Arrays.asList(fieldMichal), "michal");

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -152,7 +152,7 @@ public class IntercessionTest {
 		assertEquals(1, body.getStatements().size());
 
 		CtIf ifStmt = (CtIf) foo.getBody().getStatements().get(0);
-		String s = ifStmt.toString().replace("\r", "");
+		String s = ifStmt.prettyprint().replace("\r", "");
 		assertEquals(ifCode, s);
 		CtBlock<?> r1 = ifStmt.getThenStatement();
 		CtBlock<?> r2 = ifStmt.getElseStatement();
@@ -165,7 +165,7 @@ public class IntercessionTest {
 		ifStmt.setElseStatement(r1);
 		assertSame(r1, ifStmt.getElseStatement());
 
-		s = ifStmt.toString().replace("\r", "");
+		s = ifStmt.prettyprint().replace("\r", "");
 		String ifCodeNew = "if (1 == 0)\n" + "    return 0;\n" + "else\n"
 				+ "    return 1;\n" + "";
 		assertEquals(ifCodeNew, s);

--- a/src/test/java/spoon/test/interfaces/InterfaceTest.java
+++ b/src/test/java/spoon/test/interfaces/InterfaceTest.java
@@ -63,8 +63,9 @@ public class InterfaceTest {
 		final CtMethod<?> ctMethod = ctInterface.getMethodsByName("getZonedDateTime").get(0);
 		assertTrue("The method in the interface must to be default", ctMethod.isDefaultMethod());
 
+		// contract: the debug toString also shows the implicit modifiers (here "public")
 		final String expected =
-				"default java.time.ZonedDateTime getZonedDateTime(java.lang.String zoneString) {"
+				"public default java.time.ZonedDateTime getZonedDateTime(java.lang.String zoneString) {"
 						+ System.lineSeparator()
 						+ "    return java.time.ZonedDateTime.of(getLocalDateTime(), spoon.test.interfaces.testclasses.InterfaceWithDefaultMethods.getZoneId(zoneString));"
 						+ System.lineSeparator() + "}";

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -105,7 +105,7 @@ public class LambdaTest {
 		assertParametersSizeIs(0, lambda.getParameters());
 		assertHasExpressionBody(lambda);
 
-		assertIsWellPrinted("((spoon.test.lambda.testclasses.Foo.Check) (() -> false))", lambda);
+		assertIsWellPrinted("((Check) (() -> false))", lambda);
 	}
 
 	@Test
@@ -177,7 +177,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>) (( p) -> p.age > 10))",
+				"((Predicate<Person>) (( p) -> p.age > 10))",
 				lambda);
 	}
 
@@ -196,7 +196,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((spoon.test.lambda.testclasses.Foo.CheckPersons) (( p1, p2) -> (p1.age - p2.age) > 0))",
+				"((CheckPersons) (( p1, p2) -> (p1.age - p2.age) > 0))",
 				lambda);
 	}
 
@@ -212,7 +212,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>) ((spoon.test.lambda.testclasses.Foo.Person p) -> p.age > 10))",
+				"((Predicate<Person>) ((Person p) -> p.age > 10))",
 				lambda);
 	}
 
@@ -231,7 +231,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((spoon.test.lambda.testclasses.Foo.CheckPersons) ((spoon.test.lambda.testclasses.Foo.Person p1,spoon.test.lambda.testclasses.Foo.Person p2) -> (p1.age - p2.age) > 0))",
+				"((CheckPersons) ((Person p1,Person p2) -> (p1.age - p2.age) > 0))",
 				lambda);
 	}
 
@@ -243,8 +243,8 @@ public class LambdaTest {
 		assertParametersSizeIs(0, lambda.getParameters());
 		assertStatementBody(lambda);
 
-		assertIsWellPrinted("((spoon.test.lambda.testclasses.Foo.Check) (() -> {" + System.lineSeparator()
-				+ "    java.lang.System.err.println(\"\");" + System.lineSeparator()
+		assertIsWellPrinted("((Check) (() -> {" + System.lineSeparator()
+				+ "    System.err.println(\"\");" + System.lineSeparator()
 				+ "    return false;" + System.lineSeparator()
 				+ "}))", lambda);
 	}
@@ -261,7 +261,7 @@ public class LambdaTest {
 		assertStatementBody(lambda);
 
 		assertIsWellPrinted(
-				"((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>) (( p) -> {"
+				"((Predicate<Person>) (( p) -> {"
 						+ System.lineSeparator()
 						+ "    p.doSomething();" + System.lineSeparator()
 						+ "    return p.age > 10;" + System.lineSeparator()
@@ -287,9 +287,9 @@ public class LambdaTest {
 			}
 		}).get(0);
 		final String expected =
-				"if (((java.util.function.Predicate<spoon.test.lambda.testclasses.Foo.Person>) (( p) -> p.age > 18)).test(new spoon.test.lambda.testclasses.Foo.Person(10))) {"
+				"if (((Predicate<Person>) (( p) -> p.age > 18)).test(new Person(10))) {"
 						+ System.lineSeparator()
-						+ "    java.lang.System.err.println(\"Enjoy, you have more than 18.\");" + System
+						+ "    System.err.println(\"Enjoy, you have more than 18.\");" + System
 						.lineSeparator()
 						+ "}";
 		assertEquals("Condition must be well printed", expected, printByPrinter(condition));

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -56,9 +56,18 @@ public class LoopTest {
 		final CtConstructor<Join> joinCtConstructor = aType.getConstructors().stream().findFirst().get();
 		final CtLoop ctLoop = joinCtConstructor.getBody().getElements(new TypeFilter<>(CtLoop.class)).get(0);
 		assertTrue(ctLoop.getBody() instanceof CtBlock);
-		String expected = //
-				"for (spoon.test.loop.testclasses.Condition<? super T> condition : conditions)" + nl //
-						+ "    this.conditions.add(spoon.test.loop.testclasses.Join.notNull(condition));" + nl;
-		assertEquals(expected, ctLoop.toString());
+		// contract: the implicit block is not pretty printed
+		String expectedPrettyPrinted = //
+				"for (Condition<? super T> condition : conditions)" + nl //
+						+ "    this.conditions.add(notNull(condition));" + nl;
+		assertEquals(expectedPrettyPrinted, ctLoop.prettyprint());
+
+
+		// contract: the implicit block is viewable in debug mode
+		String expectedDebug = //
+				"for (spoon.test.loop.testclasses.Condition<? super T> condition : conditions) {" + nl //
+						+ "    this.conditions.add(spoon.test.loop.testclasses.Join.notNull(condition));" + nl + "}";
+
+		assertEquals(expectedDebug, ctLoop.toString());
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -81,8 +81,7 @@ public class TestSniperPrinter {
 
 			// check that we have picked the right statement
 			ChangeCollector.runWithoutChangeListener(type.getFactory().getEnvironment(), () -> {
-				//TODO calling toString should not change the model...
-				assertEquals("bounds = false", toBeRemoved.toString());
+				assertEquals("bounds = false", toBeRemoved.toStringDebug());
 			});
 			//change the model
 			toBeRemoved.delete();
@@ -150,7 +149,7 @@ public class TestSniperPrinter {
 			type.addTypeMember(context.newField);
 		}, (type, printed) -> {
 			String lastMemberString = "new List<?>[7][];";
-			assertIsPrintedWithExpectedChanges(type, printed, "\\Q" + lastMemberString + "\\E", lastMemberString + "\n\n\t" + context.newField.toString());
+			assertIsPrintedWithExpectedChanges(type, printed, "\\Q" + lastMemberString + "\\E", lastMemberString + "\n\n\t" + context.newField.toStringDebug());
 		});
 	}
 

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -524,15 +524,15 @@ public class TemplateTest {
 						checkParameters("foo", match,
 								"_x_", "new java.util.ArrayList<>().size()",
 								"_y_", "10",
-								"_block_", "throw new java.lang.IndexOutOfBoundsException();")
+								"_block_", "{ throw new java.lang.IndexOutOfBoundsException();}")
 						||checkParameters("foo2", match, 
 								"_x_", "new java.util.ArrayList<>().size()",
 								"_y_", "11",
-								"_block_", "throw new java.lang.IndexOutOfBoundsException();")
+								"_block_", "{ throw new java.lang.IndexOutOfBoundsException();}")
 						||checkParameters("fbar", match,
 								"_x_", "l.size()",
 								"_y_", "10",
-								"_block_", "throw new java.lang.IndexOutOfBoundsException();")
+								"_block_", "{ throw new java.lang.IndexOutOfBoundsException();}")
 						||checkParameters("baz", match,
 								"_x_", "new java.util.ArrayList<>().size()",
 								"_y_", "10",
@@ -544,7 +544,7 @@ public class TemplateTest {
 						||checkParameters("bov", match,
 								"_x_", "new java.util.ArrayList<>().size()",
 								"_y_", "10",
-								"_block_", "java.lang.System.out.println();")
+								"_block_", "{ java.lang.System.out.println();}")
 				);
 			});
 		}
@@ -597,7 +597,7 @@ public class TemplateTest {
 				assertTrue(
 						checkParameters("bos", match,
 								"_x_", "new java.util.ArrayList<>().size()",
-								"_block_", "java.lang.System.out.println();")
+								"_block_", "{ java.lang.System.out.println();}")
 				);
 			});
 		}


### PR DESCRIPTION
`toString` was dependent on the environment config of autoimport, it's again the case.

this is the first PR towards having the builds of client projects passing again. 
