### PR TITLE
fix: Incorrect model for empty for loop

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -541,7 +541,7 @@ public class ParentExiter extends CtInheritanceScanner {
 		} else if (isContainedInForUpdate() && child instanceof CtStatement) {
 			forLoop.addForUpdate((CtStatement) child);
 			return;
-		} else if (forLoop.getExpression() == null && child instanceof CtExpression) {
+		} else if (isContainedInForCondition() && child instanceof CtExpression) {
 			forLoop.setExpression((CtExpression<Boolean>) child);
 			return;
 		}
@@ -578,6 +578,14 @@ public class ParentExiter extends CtInheritanceScanner {
 			}
 		}
 		return false;
+	}
+
+	private boolean isContainedInForCondition() {
+		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ForStatement)) {
+			return false;
+		}
+		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		return parent.condition != null && parent.condition.equals(childJDT);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -17,6 +17,8 @@
 package spoon.test.loop;
 
 import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtForEach;
@@ -32,6 +34,7 @@ import spoon.test.loop.testclasses.Join;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
@@ -60,5 +63,17 @@ public class LoopTest {
 				"for (spoon.test.loop.testclasses.Condition<? super T> condition : conditions)" + nl //
 						+ "    this.conditions.add(spoon.test.loop.testclasses.Join.notNull(condition));" + nl;
 		assertEquals(expected, ctLoop.toString());
+	}
+
+	@Test
+	public void testEmptyForLoopExpression() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/java/spoon/test/loop/testclasses/EmptyLoops.java");
+		CtModel model = launcher.buildModel();
+		CtFor ctFor = model.getElements(new TypeFilter<>(CtFor.class)).get(0);
+		assertTrue(ctFor.getForInit().isEmpty());
+		assertNull(ctFor.getExpression());
+		assertTrue(ctFor.getForUpdate().isEmpty());
+		assertEquals("x = 5;", ctFor.getBody().toString().trim());
 	}
 }

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -34,7 +34,6 @@ import spoon.test.loop.testclasses.Join;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
@@ -75,6 +74,6 @@ public class LoopTest {
 		assertTrue(ctFor.getForInit().isEmpty());
 		assertNull(ctFor.getExpression());
 		assertTrue(ctFor.getForUpdate().isEmpty());
-		assertNotNull(ctFor.getBody());
+		assertEquals("x = 5", ((CtBlock)ctFor.getBody()).getStatement(0).toString().trim());
 	}
 }

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -34,6 +34,7 @@ import spoon.test.loop.testclasses.Join;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
@@ -74,6 +75,6 @@ public class LoopTest {
 		assertTrue(ctFor.getForInit().isEmpty());
 		assertNull(ctFor.getExpression());
 		assertTrue(ctFor.getForUpdate().isEmpty());
-		assertEquals("x = 5;", ctFor.getBody().toString().trim());
+		assertNotNull(ctFor.getBody());
 	}
 }

--- a/src/test/java/spoon/test/loop/testclasses/EmptyLoops.java
+++ b/src/test/java/spoon/test/loop/testclasses/EmptyLoops.java
@@ -1,0 +1,8 @@
+package spoon.test.loop.testclasses;
+
+public class EmptyLoops {
+    void m1() {
+        int x = 0;
+        for (;;) x = 5;
+    }
+}


### PR DESCRIPTION
Hi! I found out that Spoon generates incorrect model for the following code:
```
for (;;)
    x = 5;
```

But the model is:
`for (; x = 5; );`

This PR provides corresponding test and possible fix.