### PR TITLE
refactor: rename internal method with particularly confusing name

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -209,16 +209,16 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	CtTypeParameter getTypeParameterDeclaration();
 
 	/**
-	 * @param parentIsImplicit false then fully qualified name is printed.
-	 * 		true then type simple name is printed.
+	 * @param isSimplyQualified false then the reference is printed fully qualified name.
+	 * 		true then only the type name is printed.
 	 */
 	@DerivedProperty
-	CtTypeReference<T> setImplicitParent(boolean parentIsImplicit);
+	CtTypeReference<T> setSimplyQualified(boolean isSimplyQualified);
 
 	/**
 	 * @return false then fully qualified name is printed.
 	 * 		true then type simple name is printed.
 	 */
 	@DerivedProperty
-	boolean isImplicitParent();
+	boolean isSimplyQualified();
 }

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1733,7 +1733,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	private boolean printQualified(CtTypeReference<?> ref) {
-		return ignoreImplicit || !ref.isImplicitParent();
+		return ignoreImplicit || !ref.isSimplyQualified();
 		}
 
 

--- a/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
@@ -36,7 +36,7 @@ public class ForceFullyQualifiedProcessor extends ImportAnalyzer<LexicalScopeSca
 
 	@Override
 	protected void handleTypeReference(CtTypeReference<?> reference, LexicalScope nameScope, CtRole role) {
-		if (reference.isImplicitParent() || reference.isImplicit()) {
+		if (reference.isSimplyQualified() || reference.isImplicit()) {
 			if (isThisAccess(reference)) {
 				//do not force FQ names in this access
 				return;
@@ -53,7 +53,7 @@ public class ForceFullyQualifiedProcessor extends ImportAnalyzer<LexicalScopeSca
 			}
 			//force fully qualified name
 			reference.setImplicit(false);
-			reference.setImplicitParent(false);
+			reference.setSimplyQualified(false);
 		}
 	}
 

--- a/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
@@ -35,7 +35,7 @@ public class ForceImportProcessor extends ImportAnalyzer<LexicalScopeScanner, Le
 	protected void handleTypeReference(CtTypeReference<?> reference, LexicalScope nameScope, CtRole role) {
 		if (reference.getPackage() != null) {
 			//force import of package of top level types only
-			reference.setImplicitParent(true);
+			reference.setSimplyQualified(true);
 		} else {
 			//it is a reference to an child type
 			//if it is a reference in scope of parent type declaration then make it implicit, else keep it as it is
@@ -45,7 +45,7 @@ public class ForceImportProcessor extends ImportAnalyzer<LexicalScopeScanner, Le
 				CtTypeReference<?> referenceDeclaringType = reference.getDeclaringType();
 				if (referenceDeclaringType != null && referenceDeclaringType.getQualifiedName().equals(topLevelType.getQualifiedName())) {
 					//the reference to direct child type has to be made implicit
-					reference.setImplicitParent(true);
+					reference.setSimplyQualified(true);
 					return;
 				} else {
 					//reference to deeper nested child type or to child type from different type has to be kept as it is
@@ -59,7 +59,7 @@ public class ForceImportProcessor extends ImportAnalyzer<LexicalScopeScanner, Le
 				topLevelTypeRef = topLevelTypeRef.getDeclaringType();
 			}
 			if (topLevelTypeRef != null) {
-				topLevelTypeRef.setImplicitParent(true);
+				topLevelTypeRef.setSimplyQualified(true);
 			}
 		}
 	}

--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -109,7 +109,7 @@ public class ImportCleaner extends ImportAnalyzer<ImportCleaner.ImportCleanerSca
 			}
 			//else do nothing. E.g. in case of implicit type of lambda parameter
 			//`(e) -> {...}`
-		} else if (reference.isImplicitParent()) {
+		} else if (reference.isSimplyQualified()) {
 			/*
 			 * the package is implicit. E.g. `Assert.assertTrue`
 			 * where package `org.junit` is implicit

--- a/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
+++ b/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
@@ -47,7 +47,7 @@ import spoon.support.Experimental;
  *  }
  * }
  *</pre></code>
- * and fixes them by call of {@link CtElement#setImplicit(boolean)} and {@link CtTypeReference#setImplicitParent(boolean)}
+ * and fixes them by call of {@link CtElement#setImplicit(boolean)} and {@link CtTypeReference#setSimplyQualified(boolean)}
  */
 @Experimental
 public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, LexicalScope> {
@@ -131,7 +131,7 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, 
 								return true;
 							}
 							ref.setImplicit(false);
-							ref.setImplicitParent(true);
+							ref.setSimplyQualified(true);
 							return false;
 						}
 						//no conflict with type or field name
@@ -160,14 +160,14 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, 
 					}
 					//else there is a conflict. Make type explicit and package implicit
 					ref.setImplicit(false);
-					ref.setImplicitParent(true);
+					ref.setSimplyQualified(true);
 					return false;
 				});
 			}
 			//else do nothing like in case of implicit type of lambda parameter
 			//`(e) -> {...}`
 		}
-		if (!ref.isImplicit() && ref.isImplicitParent()) {
+		if (!ref.isImplicit() && ref.isSimplyQualified()) {
 			/*
 			 * the package is implicit. E.g. `Assert.assertTrue`
 			 * where package `org.junit` is implicit
@@ -188,7 +188,7 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, 
 				}
 				//we have found a variable, field or type of different name
 				ref.setImplicit(false);
-				ref.setImplicitParent(false);
+				ref.setSimplyQualified(false);
 				return false;
 			});
 		} //else it is already fully qualified
@@ -203,12 +203,12 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, 
 		if (typeRef == null) {
 			return;
 		}
-		if (!typeRef.isImplicitParent()) {
+		if (!typeRef.isSimplyQualified()) {
 			//we have to print fully qualified type name
 			//is the first part of package name in conflict with something else?
 			if (isPackageNameConflict(nameScope, typeRef)) {
 				//the package must be imported, then simple name might be used in this scope
-				typeRef.setImplicitParent(true);
+				typeRef.setSimplyQualified(true);
 				if (isSimpleNameConflict(nameScope, typeRef)) {
 					//there is conflict with simple name too
 					typeRef.setImplicit(true);
@@ -219,7 +219,7 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScopeScanner, 
 				if (isSimpleNameConflict(nameScope, typeRef)) {
 					//there is conflict with simple name
 					//use qualified name
-					typeRef.setImplicitParent(false);
+					typeRef.setSimplyQualified(false);
 				}
 			}
 		}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -958,7 +958,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		if (typeAccess.getAccessedType() instanceof CtArrayTypeReference) {
 			CtTypeReference<?> arrayType = ((CtArrayTypeReference) typeAccess.getAccessedType()).getArrayType();
 			arrayType.setAnnotations(this.references.buildTypeReference(arrayTypeReference, scope).getAnnotations());
-			arrayType.setImplicitParent(true);
+			arrayType.setSimplyQualified(true);
 		}
 		context.enter(typeAccess, arrayTypeReference);
 		return true;
@@ -1530,7 +1530,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		} else if (singleNameReference.binding instanceof VariableBinding) {
 			context.enter(helper.createVariableAccess(singleNameReference), singleNameReference);
 		} else if (singleNameReference.binding instanceof TypeBinding) {
-			context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.getTypeReference((TypeBinding) singleNameReference.binding).setImplicitParent(true)), singleNameReference);
+			context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.getTypeReference((TypeBinding) singleNameReference.binding).setSimplyQualified(true)), singleNameReference);
 		} else if (singleNameReference.binding instanceof ProblemBinding) {
 			if (context.stack.peek().element instanceof CtInvocation && Character.isUpperCase(CharOperation.charToString(singleNameReference.token).charAt(0))) {
 				context.enter(helper.createTypeAccessNoClasspath(singleNameReference), singleNameReference);
@@ -1620,7 +1620,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		CtTypeReference<?> typeRef = references.buildTypeReference(singleTypeReference, scope);
 		if (typeRef != null) {
-			typeRef.setImplicitParent(true);
+			typeRef.setSimplyQualified(true);
 		}
 		context.enter(factory.Code().createTypeAccessWithoutCloningReference(typeRef), singleTypeReference);
 		return true;

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -221,7 +221,7 @@ public class ReferenceBuilder {
 		}
 		//detect whether something is implicit
 		if (type instanceof SingleTypeReference) {
-			typeReference.setImplicitParent(true);
+			typeReference.setSimplyQualified(true);
 		} else if (type instanceof QualifiedTypeReference) {
 			jdtTreeBuilder.getHelper().handleImplicit((QualifiedTypeReference) type, typeReference);
 		}
@@ -503,7 +503,7 @@ public class ReferenceBuilder {
 			ctRef = getTypeReference(ref);
 		}
 		if (ref instanceof SingleTypeReference) {
-			ctRef.setImplicitParent(true);
+			ctRef.setSimplyQualified(true);
 		} else if (ref instanceof QualifiedTypeReference) {
 			jdtTreeBuilder.getHelper().handleImplicit((QualifiedTypeReference) ref, ctRef);
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -110,17 +110,17 @@ public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implemen
 	}
 
 	@Override
-	public boolean isImplicitParent() {
+	public boolean isSimplyQualified() {
 		if (componentType != null) {
-			return componentType.isImplicitParent();
+			return componentType.isSimplyQualified();
 		}
 		return false;
 	}
 
 	@Override
-	public CtArrayTypeReferenceImpl<T> setImplicitParent(boolean packageIsImplicit) {
+	public CtArrayTypeReferenceImpl<T> setSimplyQualified(boolean isSimplyQualified) {
 		if (componentType != null) {
-			componentType.setImplicitParent(packageIsImplicit);
+			componentType.setSimplyQualified(isSimplyQualified);
 		}
 		return this;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -88,17 +88,17 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	}
 
 	@Override
-	public boolean isImplicitParent() {
+	public boolean isSimplyQualified() {
 		if (bounds != null && bounds.size() > 0) {
-			return bounds.get(0).isImplicitParent();
+			return bounds.get(0).isSimplyQualified();
 		}
 		return false;
 	}
 
 	@Override
-	public CtIntersectionTypeReferenceImpl<T> setImplicitParent(boolean packageIsImplicit) {
+	public CtIntersectionTypeReferenceImpl<T> setSimplyQualified(boolean isSimplyQualified) {
 		if (bounds != null && bounds.size() > 0) {
-			bounds.get(0).setImplicitParent(packageIsImplicit);
+			bounds.get(0).setSimplyQualified(isSimplyQualified);
 		}
 		return this;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -203,13 +203,13 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	}
 
 	@Override
-	public boolean isImplicitParent() {
+	public boolean isSimplyQualified() {
 		return false;
 	}
 
 	@Override
 	@UnsettableProperty
-	public CtTypeParameterReferenceImpl setImplicitParent(boolean packageIsImplicit) {
+	public CtTypeParameterReferenceImpl setSimplyQualified(boolean isSimplyQualified) {
 		return this;
 	}
 }

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -870,7 +870,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	@Override
 	@DerivedProperty
-	public boolean isImplicitParent() {
+	public boolean isSimplyQualified() {
 		if (pack != null) {
 			return pack.isImplicit();
 		} else if (declaringType != null) {
@@ -881,11 +881,11 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	@Override
 	@DerivedProperty
-	public CtTypeReferenceImpl<T> setImplicitParent(boolean parentIsImplicit) {
+	public CtTypeReferenceImpl<T> setSimplyQualified(boolean isSimplyQualified) {
 		if (pack != null) {
-			pack.setImplicit(parentIsImplicit);
+			pack.setImplicit(isSimplyQualified);
 		} else if (declaringType != null) {
-			declaringType.setImplicit(parentIsImplicit);
+			declaringType.setImplicit(isSimplyQualified);
 		}
 		return this;
 	}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1590,7 +1590,7 @@ launcher.addInputResource("./src/test/java/spoon/test/imports/testclasses/JavaLo
 		typeRef.addActualTypeArgument(f.Type().createTypeParameterReference("T"));
 		assertEquals("some.package.SomeType<T>", typeRef.toString());
 		typeRef.setImplicit(true);
-		typeRef.setImplicitParent(true);
+		typeRef.setSimplyQualified(true);
 		assertTrue(typeRef.isImplicit());
 		assertTrue(typeRef.getPackage().isImplicit());
 		CtImport imprt = f.Type().createImport(typeRef);

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -22,7 +22,6 @@ import spoon.SpoonModelBuilder;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.CtModel;
-import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
@@ -663,21 +662,23 @@ public class TypeReferenceTest {
 	
 	@Test
 	public void testTypeReferenceImplicitParent() throws Exception {
-		// contract: CtTypeReference#isImplicitParent can be used read / write implicit value of the parent
+		// contract: CtTypeReference#isSimplyQualified can be used read / write implicit value of the parent
 		CtType<?> type = ModelUtils.buildClass(SuperAccess.class);
 		CtTypeReference<?> typeRef = type.getSuperclass();
-		assertTrue(typeRef.isImplicitParent());
+		assertTrue(typeRef.isSimplyQualified());
 		assertTrue(typeRef.getPackage().isImplicit());
 		
-		//calling of setImplicitParent influences implicitnes of parent
-		typeRef.setImplicitParent(false);
-		assertFalse(typeRef.isImplicitParent());
+		// a type reference can be printed fully qualified
+		typeRef.setSimplyQualified(false);
+		assertFalse(typeRef.isSimplyQualified());
 		assertFalse(typeRef.getPackage().isImplicit());
+		assertEquals("spoon.test.reference.testclasses.Parent", typeRef.toStringDebug());
 
-		//calling of setImplicit on parent influences return value of isImplicitParent
+		// a type reference can be printed simply qualified
 		typeRef.getPackage().setImplicit(true);
-		assertTrue(typeRef.isImplicitParent());
+		assertTrue(typeRef.isSimplyQualified());
 		assertTrue(typeRef.getPackage().isImplicit());
+		assertEquals("Parent", typeRef.toStringDebug());
 	}
 
 	@Test


### PR DESCRIPTION
in most cases, `setImplicitParent` meant NOT changing the implicitness of the parent.