### PR TITLE
fix: Calling toString() on an array

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -199,7 +199,7 @@ public class CodeFactory extends SubFactory {
 		CtNewClass<T> ctNewClass = factory.Core().createNewClass();
 		CtConstructor<T> constructor = ((CtClass) superClass).getConstructor(Arrays.stream(parameters).map(x -> x.getType()).toArray(CtTypeReference[]::new));
 		if (constructor == null) {
-			throw new SpoonException("no appropriate constructor for these parameters " + parameters.toString());
+			throw new SpoonException("no appropriate constructor for these parameters " + Arrays.toString(parameters));
 		}
 		CtExecutableReference<T> executableReference = constructor.getReference();
 		ctNewClass.setArguments(Arrays.asList(parameters));


### PR DESCRIPTION
Hi,

This resolves a bug reported by Sonarqube regarding calling toString() on arrays.
The bug in question: https://rules.sonarsource.com/java/RSPEC-2116