### PR TITLE
bug: SniperPrettyPrinter fails when calling toString on CtElement

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -168,6 +168,24 @@ public class TestSniperPrinter {
 		});
 	}
 
+	@Test
+	public void testBinaryOperatorElement() throws Exception {
+		final String[] args = {
+				"-i", "/Users/haris/Documents/Skola/Exjobb/programming/spoon_fork/src/test/java/spoon/test/processing/testclasses/ElementScan.java",
+				"-o", "target/spooned/",
+				"-p", "spoon.test.processing.processors.ElementScanProcessor",
+				"--compile"
+		};
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setPrettyPrinterCreator(() -> {
+					return new SniperJavaPrettyPrinter(launcher.getEnvironment());
+				}
+		);
+		launcher.setArgs(args);
+		launcher.run();
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -171,7 +171,7 @@ public class TestSniperPrinter {
 	@Test
 	public void testBinaryOperatorElement() throws Exception {
 		final String[] args = {
-				"-i", "/Users/haris/Documents/Skola/Exjobb/programming/spoon_fork/src/test/java/spoon/test/processing/testclasses/ElementScan.java",
+				"-i", "./src/test/java/spoon/test/processing/testclasses/ElementScan.java",
 				"-o", "target/spooned/",
 				"-p", "spoon.test.processing.processors.ElementScanProcessor",
 				"--compile"

--- a/src/test/java/spoon/test/processing/processors/ElementScanProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/ElementScanProcessor.java
@@ -1,0 +1,24 @@
+package spoon.test.processing.processors;
+
+import spoon.processing.AbstractProcessor;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.declaration.CtElement;
+
+public class ElementScanProcessor extends AbstractProcessor<CtElement> {
+
+    public ElementScanProcessor(){}
+
+    @Override
+    public boolean isToBeProcessed(CtElement candidate)
+    {
+        if (candidate instanceof CtBinaryOperator){
+            return true;
+        }
+        return false;
+    }
+    @Override
+    public void process(CtElement element) {
+        CtBinaryOperator bo = (CtBinaryOperator)element;
+        System.out.println(bo);
+    }
+}

--- a/src/test/java/spoon/test/processing/testclasses/ElementScan.java
+++ b/src/test/java/spoon/test/processing/testclasses/ElementScan.java
@@ -1,0 +1,23 @@
+package spoon.test.processing.testclasses;
+
+/**
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+import spoon.reflect.cu.SourcePositionHolder;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.EarlyTerminatingScanner;
+
+public class ElementScan {
+
+    public void isElementExists(SourcePositionHolder element) {
+        EarlyTerminatingScanner<Boolean> scanner = new EarlyTerminatingScanner<Boolean>() {
+            @Override
+            protected void enter(CtElement e) {
+                if (element == e) {
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Failing test case which showcases how SniperPrettyPrinter crashes with SpoonException: Missing SourceFragmentContext when calling toString on a CtElement.

To see that it is the SniperPrettyPrinter which fails, lines 181-184 in TestSniperPrinter.java
can be commented to deactivate SniperPretty. The test then passes.

This is **not** reproducible in version 7.5 so it's a pretty recent bug.