### PR TITLE
fix(CtElementImpl#toString): fix toString for SniperPrinter

### DIFF
--- a/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
@@ -43,6 +43,14 @@ public interface PrettyPrinter {
 	String printTypes(CtType<?>... type);
 
 	/**
+	 * Prints an element. This method shall be called by the toString() method of an element.
+	 * It is responsible for any initialization required to print an arbitrary element.
+	 * @param element
+	 * @return A string containing the pretty printed element (and descendants).
+	 */
+	String printElement(CtElement element);
+
+	/**
 	 * Gets the contents of the compilation unit.
 	 */
 	String getResult();

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -12,7 +12,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 import spoon.compiler.Environment;
 import spoon.reflect.CtModel;
@@ -60,28 +59,6 @@ public class ChangeCollector {
 				env.setModelChangeListener(mcl);
 			}
 		}
-	}
-
-	/**
-	 * Allows to run code using change collector switched off.
-	 * It means that any change of spoon model done by the `runnable` is ignored by the change collector.
-	 * Note: it is actually needed to wrap CtElement#toString() calls which sometime modifies spoon model.
-	 * See TestSniperPrinter#testPrintChangedReferenceBuilder()
-	 * @param env Spoon environment
-	 * @param callable the code to be called
-	 */
-	public static Object callWithoutChangeListener(Environment env, Callable callable) throws Exception {
-		Object result = null;
-		FineModelChangeListener mcl = env.getModelChangeListener();
-		if (mcl instanceof ChangeListener) {
-			env.setModelChangeListener(new EmptyModelChangeListener());
-			try {
-				result = callable.call();
-			} finally {
-				env.setModelChangeListener(mcl);
-			}
-		}
-		return result;
 	}
 
 	/**

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -12,6 +12,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 import spoon.compiler.Environment;
 import spoon.reflect.CtModel;
@@ -59,6 +60,28 @@ public class ChangeCollector {
 				env.setModelChangeListener(mcl);
 			}
 		}
+	}
+
+	/**
+	 * Allows to run code using change collector switched off.
+	 * It means that any change of spoon model done by the `runnable` is ignored by the change collector.
+	 * Note: it is actually needed to wrap CtElement#toString() calls which sometime modifies spoon model.
+	 * See TestSniperPrinter#testPrintChangedReferenceBuilder()
+	 * @param env Spoon environment
+	 * @param callable the code to be called
+	 */
+	public static Object callWithoutChangeListener(Environment env, Callable callable) throws Exception {
+		Object result = null;
+		FineModelChangeListener mcl = env.getModelChangeListener();
+		if (mcl instanceof ChangeListener) {
+			env.setModelChangeListener(new EmptyModelChangeListener());
+			try {
+				result = callable.call();
+			} finally {
+				env.setModelChangeListener(mcl);
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -42,6 +42,7 @@ import spoon.reflect.visitor.filter.AnnotationFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.DerivedProperty;
 import spoon.support.StandardEnvironment;
+import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.util.EmptyClearableList;
 import spoon.support.util.EmptyClearableSet;
@@ -304,7 +305,11 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 			printer.applyPreProcessors(clone);
 
-			printer.scan(clone);
+			if (printer instanceof SniperJavaPrettyPrinter) {
+				((SniperJavaPrettyPrinter) printer).scanClone(clone, this);
+			} else {
+				printer.scan(clone);
+			}
 		} catch (ParentNotInitializedException ignore) {
 			LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);
 			errorMessage = ERROR_MESSAGE_TO_STRING;

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -7,7 +7,6 @@ package spoon.support.reflect.declaration;
 
 import org.apache.log4j.Logger;
 import spoon.Launcher;
-import spoon.compiler.Environment;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
@@ -43,10 +42,6 @@ import spoon.reflect.visitor.filter.AnnotationFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.DerivedProperty;
 import spoon.support.StandardEnvironment;
-import spoon.support.modelobs.ChangeCollector;
-import spoon.support.modelobs.EmptyModelChangeListener;
-import spoon.support.modelobs.FineModelChangeListener;
-import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.util.EmptyClearableList;
 import spoon.support.util.EmptyClearableSet;
@@ -297,52 +292,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	public String toString() {
 		DefaultJavaPrettyPrinter printer = (DefaultJavaPrettyPrinter) getFactory().getEnvironment().createPrettyPrinter();
 
-		String errorMessage = "";
-		if (printer instanceof SniperJavaPrettyPrinter) {
-			try {
-				CtElement clone = (CtElement) ChangeCollector.callWithoutChangeListener(getFactory().getEnvironment(), () -> {
-
-					// now that pretty-printing can change the model, we only do it on a clone
-					CtElement tmpClone = this.clone();
-
-					// required: in DJPP some decisions are taken based on the content of the parent
-					if (this.isParentInitialized()) {
-						tmpClone.setParent(this.getParent());
-					}
-					//this.replace(tmpClone);
-					return tmpClone;
-				});
-
-				//printer.applyPreProcessors(clone);
-				((SniperJavaPrettyPrinter) printer).scanClone(clone, this);
-			} catch (Exception ignore) {
-				LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);
-				errorMessage = ERROR_MESSAGE_TO_STRING;
-			}
-		} else {
-			try {
-				// now that pretty-printing can change the model, we only do it on a clone
-				CtElement clone = this.clone();
-
-				// required: in DJPP some decisions are taken based on the content of the parent
-				if (this.isParentInitialized()) {
-					clone.setParent(this.getParent());
-				}
-				printer.applyPreProcessors(clone);
-
-				/*if (printer instanceof SniperJavaPrettyPrinter) {
-					((SniperJavaPrettyPrinter) printer).scanClone(clone, this);
-				} else {*/
-					printer.scan(clone);
-				//}
-			} catch (ParentNotInitializedException ignore) {
-				LOGGER.error(ERROR_MESSAGE_TO_STRING, ignore);
-				errorMessage = ERROR_MESSAGE_TO_STRING;
-			}
-		}
-		// in line-preservation mode, newlines are added at the beginning to matches the lines
-		// removing them from the toString() representation
-		return printer.toString().replaceFirst("^\\s+", "") + errorMessage;
+		return printer.printElement(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -14,6 +14,7 @@ import spoon.SpoonException;
 import spoon.compiler.Environment;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.CompilationUnit;
+import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
@@ -199,8 +200,9 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 	@Override
 	public String printElement(CtElement element) {
 		if (element != null && !hasImplicitAncestor(element)) {
-			if (element.getPosition().getCompilationUnit() != null) {
-				CompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
+			CompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
+			if (compilationUnit != null
+					&& !(compilationUnit instanceof NoSourcePosition.NullCompilationUnit)) {
 
 				//use line separator of origin source file
 				setLineSeparator(detectLineSeparator(compilationUnit.getOriginalSourceCode()));

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -177,14 +177,22 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 	}
 
 
+
+	private static boolean hasImplicitAncestor(CtElement el) {
+		if(el == null) return false;
+		if(el == el.getFactory().getModel().getRootPackage()) return false;
+		else if (el.isImplicit()) return true;
+		else return hasImplicitAncestor(el.getParent());
+	}
+
 	/**
-	 * Ugly hack to start printing an arbitrary element of the ast, that is a clone.
+	 * Start printing an arbitrary element of the ast, that is a clone.
 	 * @param element clone to print
 	 * @param original its original
 	 * @return this
 	 */
 	public SniperJavaPrettyPrinter scanClone(CtElement element, CtElement original) {
-		if (element != null) {
+		if (element != null && !hasImplicitAncestor(element)) {
 			if (element.getPosition().getCompilationUnit() != null) {
 				CompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
 
@@ -192,25 +200,25 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 				setLineSeparator(detectLineSeparator(compilationUnit.getOriginalSourceCode()));
 
 				CtRole role = getRoleInCompilationUnit(original);
+				ElementSourceFragment esf = original.getOriginalSourceFragment();
 
-				runInContext(new SourceFragmentContextList(mutableTokenWriter,
+				runInContext(
+						new SourceFragmentContextList(mutableTokenWriter,
 								element,
-								Collections.singletonList(original.getOriginalSourceFragment()),
+								Collections.singletonList(esf),
 								new ChangeResolver(getChangeCollector(), element)),
-						() -> {
-							onPrintEvent(new ElementPrinterEvent(role, element) {
-								@Override
-								public void print(Boolean muted) {
-									superScanInContext(element, SourceFragmentContextPrettyPrint.INSTANCE, muted);
-								}
-								@Override
-								public void printSourceFragment(SourceFragment fragment, Boolean isModified) {
-									scanInternal(role, element, fragment, isModified);
-								}
-							});
-						});
-			} else {
-				super.scan(element);
+						() -> onPrintEvent(new ElementPrinterEvent(role, element) {
+							@Override
+							public void print(Boolean muted) {
+								superScanInContext(element, SourceFragmentContextPrettyPrint.INSTANCE, muted);
+							}
+
+							@Override
+							public void printSourceFragment(SourceFragment fragment, Boolean isModified) {
+								scanInternal(role, element, fragment, isModified);
+							}
+						})
+				);
 			}
 		}
 		return this;
@@ -219,6 +227,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 
 	/**
 	 * Called whenever {@link DefaultJavaPrettyPrinter} scans/prints an element
+	 * Warning: DO not call on a cloned element. Use scanClone instead.
 	 */
 	@Override
 	public SniperJavaPrettyPrinter scan(CtElement element) {

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -90,7 +90,7 @@ public class CloneHelper {
 	}
 
 	/**
-	 * clones a element and adds it's clone as value into targetCollection
+	 * clones an element and adds it's clone as value into targetCollection
 	 * @param targetCollection - the collection which will receive a clone of element
 	 * @param element to be cloned element
 	 */

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -19,6 +19,8 @@ package spoon.test.prettyprinter;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.processing.Processor;
+import spoon.reflect.CtModel;
+import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtCompilationUnit;
@@ -31,6 +33,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.ImportCleaner;
 import spoon.reflect.visitor.ImportConflictDetector;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.modelobs.ChangeCollector;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.test.prettyprinter.testclasses.ToBeChanged;
@@ -42,6 +45,7 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
@@ -262,5 +266,20 @@ public class TestSniperPrinter {
 			lastImportEnd = m.end();
 		}
 		return source.substring(lastImportEnd).trim();
+	}
+
+	@Test
+	public void testBinaryOperatorElement() throws Exception {
+
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/java/spoon/test/prettyprinter/testclasses/ElementScan.java");
+		launcher.getEnvironment().setPrettyPrinterCreator(
+				() -> new SniperJavaPrettyPrinter(launcher.getEnvironment())
+		);
+
+		CtModel model = launcher.buildModel();
+		List<CtBinaryOperator> ops = model.getElements(new TypeFilter<>(CtBinaryOperator.class));
+
+		ops.stream().forEach(op -> System.out.println("el: " + op));
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -314,10 +314,10 @@ public class TestSniperPrinter {
 				.filter(el -> !(el instanceof spoon.reflect.CtModelImpl.CtRootPackage) &&
 						!(el instanceof spoon.reflect.factory.ModuleFactory.CtUnnamedModule)
 				).forEach(el -> {
-			assertTrue("ToString() on element (" + el.getClass().getName() + ") =  \"" + el + "\" lead is not in original content", originalContent.contains(el.toString().replace("\t","")));
-			System.out.print("el (" + el.getClass().getName() + "): ");
 			try {
-				System.out.println(el);
+				//Contract, calling toString on unmodified AST elements should draw only from original.
+				assertTrue("ToString() on element (" + el.getClass().getName() + ") =  \"" + el + "\" is not in original content",
+						originalContent.contains(el.toString().replace("\t","")));
 			} catch (UnsupportedOperationException | SpoonException e) {
 				//Printer should not throw exception on printable element. (Unless there is a bug in the printer...)
 				fail("ToString() on Element (" + el.getClass().getName() + "): at " + el.getPath() + " lead to an exception: " + e);

--- a/src/test/java/spoon/test/prettyprinter/testclasses/ElementScan.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/ElementScan.java
@@ -1,0 +1,23 @@
+package spoon.test.prettyprinter.testclasses;
+
+/**
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+import spoon.reflect.cu.SourcePositionHolder;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.visitor.EarlyTerminatingScanner;
+
+public class ElementScan {
+
+	public void isElementExists(SourcePositionHolder element) {
+		EarlyTerminatingScanner<Boolean> scanner = new EarlyTerminatingScanner<Boolean>() {
+			@Override
+			protected void enter(CtElement e) {
+				if (element == e) {
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
Since recent changes, `CtElement#toString()` calls the default prettyprinter which can be a `SniperPrinter`. 
AFAIU, this fails for two reasons:
 * `toString()` clone the element before printing it, and `SniperPrinter` use `getRoleInCompilationUnit()`. But `getRoleInCompilationUnit()` implement a Scanner that look for the exact element in its parent children. Of course the clone has a parent but is not among the children of its parent.
 * `SniperPrinter` require some `SourceFragmentContext` to be pushed on a stack to print an arbitrary element that is not a `CompilationUnit`. This must be initialized before.

This PR implement a POC that solves these two problems. But I am not sure if that's the direction we want to take. (Currently it makes an ugly check in `toString()`'s body to check what sort of printer we have, but it could be rewritten to be hidden inside `SniperPrinter`.)
WDYT? 
@monperrus 
@pvojtechovsky (if you have time) am I mistaken on the behavior of `SniperPrinter`? 