### PR TITLE
fix(CodeFactory): createVariableAssignment now creates a CtVariableWrite

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -448,20 +448,6 @@ public class CodeFactory extends SubFactory {
 	}
 
 	/**
-	 * Creates a list of variable accesses for write.
-	 *
-	 * @param variables
-	 * 		the variables to be accessed
-	 */
-	public List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables) {
-		List<CtExpression<?>> result = new ArrayList<>(variables.size());
-		for (CtVariable<?> v : variables) {
-			result.add(createVariableWrite(v.getReference(), v.getModifiers().contains(ModifierKind.STATIC)));
-		}
-		return result;
-	}
-
-	/**
 	 * Creates a variable assignment (can be an expression or a statement).
 	 *
 	 * @param <T>

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -400,7 +400,7 @@ public class CodeFactory extends SubFactory {
 	}
 
 	/**
-	 * Creates a variable access.
+	 * Creates a variable access for read.
 	 */
 	public <T> CtVariableAccess<T> createVariableRead(CtVariableReference<T> variable, boolean isStatic) {
 		CtVariableAccess<T> va;
@@ -417,7 +417,7 @@ public class CodeFactory extends SubFactory {
 	}
 
 	/**
-	 * Creates a list of variable accesses.
+	 * Creates a list of variable accesses for read.
 	 *
 	 * @param variables
 	 * 		the variables to be accessed
@@ -426,6 +426,37 @@ public class CodeFactory extends SubFactory {
 		List<CtExpression<?>> result = new ArrayList<>(variables.size());
 		for (CtVariable<?> v : variables) {
 			result.add(createVariableRead(v.getReference(), v.getModifiers().contains(ModifierKind.STATIC)));
+		}
+		return result;
+	}
+
+	/**
+	 * Creates a variable access for write.
+	 */
+	public <T> CtVariableAccess<T> createVariableWrite(CtVariableReference<T> variable, boolean isStatic) {
+		CtVariableAccess<T> va;
+		if (variable instanceof CtFieldReference) {
+			va = factory.Core().createFieldWrite();
+			// creates a this target for non-static fields to avoid name conflicts...
+			if (!isStatic) {
+				((CtFieldAccess<T>) va).setTarget(createThisAccess(((CtFieldReference<T>) variable).getDeclaringType()));
+			}
+		} else {
+			va = factory.Core().createVariableWrite();
+		}
+		return va.setVariable(variable);
+	}
+
+	/**
+	 * Creates a list of variable accesses for write.
+	 *
+	 * @param variables
+	 * 		the variables to be accessed
+	 */
+	public List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables) {
+		List<CtExpression<?>> result = new ArrayList<>(variables.size());
+		for (CtVariable<?> v : variables) {
+			result.add(createVariableWrite(v.getReference(), v.getModifiers().contains(ModifierKind.STATIC)));
 		}
 		return result;
 	}
@@ -444,7 +475,7 @@ public class CodeFactory extends SubFactory {
 	 * @return a variable assignment
 	 */
 	public <A, T extends A> CtAssignment<A, T> createVariableAssignment(CtVariableReference<A> variable, boolean isStatic, CtExpression<T> expression) {
-		CtVariableAccess<A> vaccess = createVariableRead(variable, isStatic);
+		CtVariableAccess<A> vaccess = createVariableWrite(variable, isStatic);
 		return factory.Core().<A, T>createAssignment().<CtAssignment<A, T>>setAssignment(expression).setAssigned(vaccess);
 	}
 

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -292,6 +292,11 @@ public interface Factory {
 	<T> CtVariableAccess<T> createVariableRead(CtVariableReference<T> variable, boolean isStatic);
 
 	/**
+	 *  @see CodeFactory#createVariableWrite(CtVariableReference,boolean)
+	 */
+	<T> CtVariableAccess<T> createVariableWrite(CtVariableReference<T> variable, boolean isStatic);
+
+	/**
 	 *  @see CodeFactory#createCtField(String,CtTypeReference,String,ModifierKind[])
 	 */
 	<T> CtField<T> createCtField(String name, CtTypeReference<T> type, String exp, ModifierKind... visibilities);
@@ -320,6 +325,11 @@ public interface Factory {
 	 *  @see CodeFactory#createVariableReads(List)
 	 */
 	List<CtExpression<?>> createVariableReads(List<? extends CtVariable<?>> variables);
+
+	/**
+	 *  @see CodeFactory#createVariableWrites(List)
+	 */
+	List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables);
 
 	/**
 	 *  @see CodeFactory#createCtCatch(String,Class,CtBlock)

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -327,11 +327,6 @@ public interface Factory {
 	List<CtExpression<?>> createVariableReads(List<? extends CtVariable<?>> variables);
 
 	/**
-	 *  @see CodeFactory#createVariableWrites(List)
-	 */
-	List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables);
-
-	/**
 	 *  @see CodeFactory#createCtCatch(String,Class,CtBlock)
 	 */
 	CtCatch createCtCatch(String nameCatch, Class<? extends Throwable> exception, CtBlock<?> ctBlock);

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -557,6 +557,11 @@ public class FactoryImpl implements Factory, Serializable {
 	}
 
 	@Override
+	public <T> CtVariableAccess<T> createVariableWrite(CtVariableReference<T> variable, boolean isStatic) {
+		return Code().createVariableWrite(variable, isStatic);
+	}
+
+	@Override
 	public <T> CtField<T> createCtField(String name, CtTypeReference<T> type, String exp, ModifierKind... visibilities) {
 		return Code().createCtField(name, type, exp, visibilities);
 	}
@@ -584,6 +589,11 @@ public class FactoryImpl implements Factory, Serializable {
 	@Override
 	public List<CtExpression<?>> createVariableReads(List<? extends CtVariable<?>> variables) {
 		return Code().createVariableReads(variables);
+	}
+
+	@Override
+	public List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables) {
+		return Code().createVariableWrites(variables);
 	}
 
 	@Override

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -592,11 +592,6 @@ public class FactoryImpl implements Factory, Serializable {
 	}
 
 	@Override
-	public List<CtExpression<?>> createVariableWrites(List<? extends CtVariable<?>> variables) {
-		return Code().createVariableWrites(variables);
-	}
-
-	@Override
 	public CtCatch createCtCatch(String nameCatch, Class<? extends Throwable> exception, CtBlock<?> ctBlock) {
 		return Code().createCtCatch(nameCatch, exception, ctBlock);
 	}

--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -17,10 +17,18 @@
 package spoon.test.factory;
 
 import org.junit.Test;
+import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.code.CtVariableAccess;
+import spoon.reflect.code.CtVariableWrite;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtVariableReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -28,6 +36,8 @@ import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class CodeFactoryTest {
+	int i;
+
 	@Test
 	public void testThisAccess() {
 		final Factory factory = createFactory();
@@ -37,5 +47,18 @@ public class CodeFactoryTest {
 		assertNotNull(thisAccess.getTarget());
 		assertTrue(thisAccess.getTarget() instanceof CtTypeAccess);
 		assertEquals(type, ((CtTypeAccess) thisAccess.getTarget()).getAccessedType());
+	}
+
+	@Test
+	public void testCreateVariableAssignement() {
+		Factory factory = createFactory();
+		CtType t = factory.Class().create("my.MyClass");
+		CtField f = factory.createCtField("f", factory.Type().booleanPrimitiveType(), "false", ModifierKind.PRIVATE);
+		t.addField(f);
+		CtAssignment va = factory.Code().createVariableAssignment(f.getReference(),false,factory.createLiteral(true));
+
+		//Variable assignment's assignee is a CtVariableWrite that point toward the right variable.
+		assertTrue(va.getAssigned() instanceof CtVariableWrite);
+		assertEquals(f.getReference(), ((CtVariableWrite) va.getAssigned()).getVariable());
 	}
 }

--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -20,15 +20,12 @@ import org.junit.Test;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.reference.CtVariableReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;


### PR DESCRIPTION
Related to https://github.com/INRIA/spoon/issues/3155 .
createVariableWrite methods were creating CtVariableAccesses as CtVariableRead instead of CtVariableWrite. Replaced it usages with createVariableWrite and createFieldWrite. And added new methods which they are symmetrical implementations of write-access generator methods.