### PR TITLE
chore: next release will be 8.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <artifactId>spoon-core</artifactId>
   <packaging>jar</packaging>
-  <version>7.6.0-SNAPSHOT</version>
+  <version>8.0.0-SNAPSHOT</version>
   <name>Spoon Core</name>
   <description>Spoon is a tool for meta-programming, analysis and transformation of Java programs.</description>
   <url>http://spoon.gforge.inria.fr/</url>


### PR DESCRIPTION
With the recent major overhaul of imports, there are many cases of changed behavior, so we'll release 8.0.0.