### PR TITLE
Next() first checks hasNext() and throws the correct error

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CtBFSIterator.java
+++ b/src/main/java/spoon/reflect/visitor/CtBFSIterator.java
@@ -55,6 +55,9 @@ public class CtBFSIterator extends CtScanner implements Iterator<CtElement> {
 	 */
 	@Override
 	public CtElement next() {
+		if (!hasNext()) {
+			throw new java.util.NoSuchElementException();
+		}
 		CtElement next = deque.poll(); // get the element to expand from the deque
 		next.accept(this); // call @scan for each direct child of the node
 		return next;

--- a/src/main/java/spoon/reflect/visitor/CtIterator.java
+++ b/src/main/java/spoon/reflect/visitor/CtIterator.java
@@ -73,6 +73,9 @@ public class CtIterator extends CtScanner implements Iterator<CtElement> {
 	 */
 	@Override
 	public CtElement next() {
+		if (!hasNext()) {
+			throw new java.util.NoSuchElementException();
+		}
 		CtElement next = deque.pollFirst(); // get the element to expand from the deque
 		current_children.clear(); // clear for this scan
 		next.accept(this); // call @scan for each direct child of the node


### PR DESCRIPTION
This fixes 2 Sonarqube violations of rule S2272:
https://rules.sonarsource.com/java/type/Bug/RSPEC-2272