### PR TITLE
fix(equality): Use .equals() when comparing Strings and Boxed types.

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -265,7 +265,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 			//push the context of this collection
 			sourceFragmentContextStack.push(listContext);
 			//and scan first element of that collection again in new context of that collection
-			if (isFragmentModified == Boolean.FALSE) {
+			if (isFragmentModified.equals(Boolean.FALSE)) {
 				mutableTokenWriter.getPrinterHelper().directPrint(fragment.getSourceCode());
 				//and mute the token writer and let DJPP scan it and ignore everything
 				mutableTokenWriter.setMuted(true);

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -265,7 +265,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 			//push the context of this collection
 			sourceFragmentContextStack.push(listContext);
 			//and scan first element of that collection again in new context of that collection
-			if (isFragmentModified.equals(Boolean.FALSE)) {
+			if (Boolean.FALSE.equals(isFragmentModified)) {
 				mutableTokenWriter.getPrinterHelper().directPrint(fragment.getSourceCode());
 				//and mute the token writer and let DJPP scan it and ignore everything
 				mutableTokenWriter.setMuted(true);

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
@@ -131,7 +131,7 @@ abstract class AbstractSourceFragmentContext implements SourceFragmentContext {
 			CollectionSourceFragment csf = (CollectionSourceFragment) fragment;
 			for (SourceFragment sourceFragment : csf.getItems()) {
 				Boolean modified = isFragmentModified(sourceFragment);
-				if (modified != Boolean.FALSE) {
+				if (!modified.equals(Boolean.FALSE)) {
 					return modified;
 				}
 			}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContext.java
@@ -131,7 +131,7 @@ abstract class AbstractSourceFragmentContext implements SourceFragmentContext {
 			CollectionSourceFragment csf = (CollectionSourceFragment) fragment;
 			for (SourceFragment sourceFragment : csf.getItems()) {
 				Boolean modified = isFragmentModified(sourceFragment);
-				if (!modified.equals(Boolean.FALSE)) {
+				if (!Boolean.FALSE.equals(modified)) {
 					return modified;
 				}
 			}

--- a/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
+++ b/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
@@ -51,7 +51,7 @@ public class ChangeResolver {
 			}
 		};
 		scanner.scan(this.element);
-		return scanner.getResult().equals(Boolean.TRUE);
+		return Boolean.TRUE.equals(scanner.getResult());
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
+++ b/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
@@ -51,7 +51,7 @@ public class ChangeResolver {
 			}
 		};
 		scanner.scan(this.element);
-		return scanner.getResult() == Boolean.TRUE;
+		return scanner.getResult().equals(Boolean.TRUE);
 	}
 
 	/**


### PR DESCRIPTION
This fixes 3 Sonarqube violations of rule S4973:
https://rules.sonarsource.com/java/RSPEC-4973