### PR TITLE
Exclude unused transitive dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,24 @@
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
       <version>3.16.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.core.resources</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.core.runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.core.filesystem</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.eclipse.platform</groupId>
+          <artifactId>org.eclipse.text</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.stefanbirkner</groupId>
@@ -117,6 +135,10 @@
         <exclusion>
           <groupId>com.mysema.commons</groupId>
           <artifactId>mysema-commons-lang</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.infradna.tool</groupId>
+          <artifactId>bridge-method-annotation</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Spoon depends direclty on `org.eclipse.jdt.core`. However, the dependencies `org.eclipse.core.resources`, `org.eclipse.core.runtime`, `org.eclipse.core.filesystem`, and  `org.eclipse.text` are not used by Spoon and can be excluded safely. 

These transitive dependencies with compile scope introduce bloat in the Spoon library as we can see in the current dependency tree:
```
+- org.eclipse.jdt:org.eclipse.jdt.core:jar:3.16.0:compile
|  +- org.eclipse.platform:org.eclipse.core.resources:jar:3.13.500:compile
|  |  +- org.eclipse.platform:org.eclipse.core.expressions:jar:3.6.500:compile
|  |  |  \- (org.eclipse.platform:org.eclipse.core.runtime:jar:3.16.0:compile - omitted for duplicate)
|  |  +- (org.eclipse.platform:org.eclipse.core.filesystem:jar:1.7.500:compile - omitted for duplicate)
|  |  \- (org.eclipse.platform:org.eclipse.core.runtime:jar:3.16.0:compile - omitted for duplicate)
|  +- org.eclipse.platform:org.eclipse.core.runtime:jar:3.16.0:compile
|  |  +- org.eclipse.platform:org.eclipse.osgi:jar:3.15.0:compile
|  |  +- org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile
|  |  +- org.eclipse.platform:org.eclipse.core.jobs:jar:3.10.500:compile
|  |  |  \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  |  +- org.eclipse.platform:org.eclipse.equinox.registry:jar:3.8.500:compile
|  |  |  \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  |  +- org.eclipse.platform:org.eclipse.equinox.preferences:jar:3.7.500:compile
|  |  |  \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  |  +- org.eclipse.platform:org.eclipse.core.contenttype:jar:3.7.400:compile
|  |  |  +- (org.eclipse.platform:org.eclipse.equinox.preferences:jar:3.7.500:compile - omitted for duplicate)
|  |  |  +- (org.eclipse.platform:org.eclipse.equinox.registry:jar:3.8.500:compile - omitted for duplicate)
|  |  |  \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  |  \- org.eclipse.platform:org.eclipse.equinox.app:jar:1.4.300:compile
|  |     +- (org.eclipse.platform:org.eclipse.equinox.registry:jar:3.8.500:compile - omitted for duplicate)
|  |     \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  +- org.eclipse.platform:org.eclipse.core.filesystem:jar:1.7.500:compile**
|  |  +- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|  |  +- (org.eclipse.platform:org.eclipse.equinox.registry:jar:3.8.500:compile - omitted for duplicate)
|  |  \- (org.eclipse.platform:org.eclipse.osgi:jar:3.15.0:compile - omitted for duplicate)
|  \- org.eclipse.platform:org.eclipse.text:jar:3.9.0:compile
|     +- org.eclipse.platform:org.eclipse.core.commands:jar:3.9.500:compile
|     |  \- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|     +- (org.eclipse.platform:org.eclipse.equinox.common:jar:3.10.500:compile - omitted for duplicate)
|     +- (org.eclipse.platform:org.eclipse.equinox.preferences:jar:3.7.500:compile - omitted for duplicate)
|     \- (org.eclipse.platform:org.eclipse.core.runtime:jar:3.16.0:compile - omitted for duplicate)
```

The transitive dependency `com.infradna.tool:bridge-method-annotation` of `com.mysema.querydsl:querydsl-core` can also be excluded  because it is not used.
