### PR TITLE
fix:Removing the use of 3rd party internal constants

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.core.util.CommentRecorderParser;
@@ -75,7 +74,7 @@ public class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Ma
 		for (int round = 0; round < 2; round++) {
 			for (CompilationUnit compilationUnit : this.compilationUnits) {
 				char[] charName = compilationUnit.getFileName();
-				boolean isModuleInfo = CharOperation.endsWith(charName, TypeConstants.MODULE_INFO_FILE_NAME);
+				boolean isModuleInfo = CharOperation.endsWith(charName, JDTConstants.MODULE_INFO_FILE_NAME);
 				if (isModuleInfo == (round == 0)) { // 1st round: modules, 2nd round others (to ensure populating pathToModCU well in time)
 
 					String fileName = new String(charName);

--- a/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.support.compiler.jdt;
+
+/**
+ * Extracts a subset of constants as defined in {@link org.eclipse.jdt.internal.compiler.lookup.TypeConstants}, since
+ * this class is only meant for internal use.
+ */
+public class JDTConstants {
+
+    public static final char[] MODULE_INFO_FILE_NAME = "module-info.java".toCharArray();
+    public static final char[] MODULE_INFO_CLASS_NAME = "module-info.class".toCharArray();
+
+}

--- a/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
@@ -11,7 +11,9 @@ package spoon.support.compiler.jdt;
  */
 public class JDTConstants {
 
-    public static final char[] MODULE_INFO_FILE_NAME = "module-info.java".toCharArray();
-    public static final char[] MODULE_INFO_CLASS_NAME = "module-info.class".toCharArray();
+	private JDTConstants() {}
+
+	public static final char[] MODULE_INFO_FILE_NAME = "module-info.java".toCharArray();
+	public static final char[] MODULE_INFO_CLASS_NAME = "module-info.class".toCharArray();
 
 }

--- a/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
@@ -11,7 +11,9 @@ package spoon.support.compiler.jdt;
  */
 public class JDTConstants {
 
-	private JDTConstants() {}
+	private JDTConstants() {
+
+	}
 
 	public static final char[] MODULE_INFO_FILE_NAME = "module-info.java".toCharArray();
 	public static final char[] MODULE_INFO_CLASS_NAME = "module-info.class".toCharArray();

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.Messages;
 
 
@@ -36,8 +35,8 @@ class TreeBuilderCompiler extends org.eclipse.jdt.internal.compiler.Compiler {
 		Arrays.sort(sourceUnits, (u1, u2) -> {
 			char[] fn1 = u1.getFileName();
 			char[] fn2 = u2.getFileName();
-			boolean isMod1 = CharOperation.endsWith(fn1, TypeConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn1, TypeConstants.MODULE_INFO_CLASS_NAME);
-			boolean isMod2 = CharOperation.endsWith(fn2, TypeConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn2, TypeConstants.MODULE_INFO_CLASS_NAME);
+			boolean isMod1 = CharOperation.endsWith(fn1, JDTConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn1, JDTConstants.MODULE_INFO_CLASS_NAME);
+			boolean isMod2 = CharOperation.endsWith(fn2, JDTConstants.MODULE_INFO_FILE_NAME) || CharOperation.endsWith(fn2, JDTConstants.MODULE_INFO_CLASS_NAME);
 			if (isMod1 == isMod2) {
 				return 0;
 			}


### PR DESCRIPTION
All uses of constants defined in `org.eclipse.jdt.internal.compiler.lookup.TypeConstants`, which is an internal class, are replaced by custom defined constants. Closes #3185.