### PR TITLE
fix: NullPointerException in the 'insertCommentInAST' method for an empty switch statement.

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -351,6 +351,12 @@ public class JDTCommentBuilder {
 			public <E> void visitCtSwitch(CtSwitch<E> e) {
 				List<CtCase<? super E>> cases = e.getCases();
 				CtCase previous = null;
+
+				if (cases.isEmpty()) {
+					e.addComment(comment);
+					return;
+				}
+
 				for (CtCase<? super E> ctCase : cases) {
 					if (previous == null) {
 						if (comment.getPosition().getSourceStart() < ctCase.getPosition().getSourceStart()

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -351,12 +351,6 @@ public class JDTCommentBuilder {
 			public <E> void visitCtSwitch(CtSwitch<E> e) {
 				List<CtCase<? super E>> cases = e.getCases();
 				CtCase previous = null;
-
-				if (cases.isEmpty()) {
-					e.addComment(comment);
-					return;
-				}
-
 				for (CtCase<? super E> ctCase : cases) {
 					if (previous == null) {
 						if (comment.getPosition().getSourceStart() < ctCase.getPosition().getSourceStart()
@@ -378,7 +372,7 @@ public class JDTCommentBuilder {
 					}
 					previous = ctCase;
 				}
-				if (previous.getPosition().getSourceEnd() < comment.getPosition().getSourceStart()) {
+				if (previous != null && previous.getPosition().getSourceEnd() < comment.getPosition().getSourceStart()) {
 					addCommentToNear(comment, new ArrayList<>(previous.getStatements()));
 					try {
 						comment.getParent();

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -1120,6 +1120,7 @@ public class CommentTest {
 				" * @version 1.0\r" + 
 				" */", type.getComments().get(0).getRawContent());
 	}
+
 	@Test
 	public void testEmptyStatementComments() {
 		//contract: model building should not produce NPE, comments should exist
@@ -1127,10 +1128,15 @@ public class CommentTest {
 		launcher.addInputResource("./src/test/java/spoon/test/comment/testclasses/EmptyStatementComments.java");
 		launcher.getEnvironment().setCommentEnabled(true);
 
-		CtModel model = launcher.buildModel();
-		List<CtIf> conditions = model.getElements(new TypeFilter<>(CtIf.class));
+		List<CtMethod<?>> methods = launcher.buildModel().getElements(new TypeFilter<>(CtMethod.class));
+
+		List<CtIf> conditions = methods.get(0).getElements(new TypeFilter<>(CtIf.class));
 		assertEquals("comment", conditions.get(0).getComments().get(0).getContent());
 		assertEquals("comment", conditions.get(1).getComments().get(0).getContent());
+
+		List<CtSwitch<?>> switches = methods.get(1).getElements(new TypeFilter<>(CtSwitch.class));
+		assertEquals("commentInline", switches.get(0).getComments().get(0).getContent());
+		assertEquals("commentBlock", switches.get(1).getComments().get(0).getContent());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/testclasses/EmptyStatementComments.java
+++ b/src/test/java/spoon/test/comment/testclasses/EmptyStatementComments.java
@@ -8,4 +8,14 @@ public class EmptyStatementComments {
         if (true) /* comment */
             ;
     }
+
+    void m2(int value) {
+        switch (value) {
+            // commentInline
+        }
+
+        switch (value) {
+            /* commentBlock */
+        }
+    }
 }


### PR DESCRIPTION
Hi )

I offer the pull request, which fixes NullPointerException in JDTCommentBuilder.java.
It occurred in the case, when spoon gathered comments in an empty switch statement.