### PR TITLE
fix: adds support to the VisitorPartialEvaluator for the NEG UnaryOperator

### DIFF
--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -524,6 +524,10 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 			case NOT:
 				res.setValue(!(Boolean) object);
 				break;
+			case NEG:
+				res.setValue(convert(operator.getType(),
+					-1 * ((Number) object).longValue()));
+				break;
 			default:
 				throw new RuntimeException("unsupported operator " + operator.getKind());
 			}

--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -188,6 +188,19 @@ public class EvalTest {
 	}
 
 	@Test
+	public void testVisitorPartialEvaluator_unary() {
+
+    	{ // NEG urnary operator
+      		Launcher launcher = new Launcher();
+      		CtCodeElement el =
+          		launcher.getFactory().Code().createCodeSnippetExpression("-(100+1)").compile();
+      		VisitorPartialEvaluator eval = new VisitorPartialEvaluator();
+      		CtElement element = eval.evaluate(el);
+      		assertEquals("-101", element.toString());
+    	}
+	}
+
+	@Test
 	public void testVisitorPartialEvaluator_if() {
 		Launcher launcher = new Launcher();
 		{ // the untaken branch is removed


### PR DESCRIPTION
Adds support to the VisitorPartialEvaluator for the NEG UnaryOperator. Adds test for the operator.

Before this when a NEG UnaryOperator was encountered by the VisitorPartialEvaluator it would throw the unsupported operator Runtime Exception.