### PR TITLE
refactor: migrate to org.apache.logging.log4j:log4j-core:2.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>2.9.10.1</version>
     </dependency>
     <dependency>
       <!-- support for compressed serialized ASTs -->

--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,9 @@
       <version>2.1</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.13.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.1</version>
+      <version>2.9.10</version>
     </dependency>
     <dependency>
       <!-- support for compressed serialized ASTs -->

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -15,8 +15,9 @@ import com.martiansoftware.jsap.stringparsers.FileStringParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import spoon.SpoonModelBuilder.InputType;
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonResource;
@@ -601,7 +602,7 @@ public class Launcher implements SpoonAPI {
 	/**
 	 * A default logger to be used by Spoon.
 	 */
-	public static final Logger LOGGER = Logger.getLogger(Launcher.class);
+	public static final Logger LOGGER = LogManager.getLogger();
 
 	/**
 	 * Creates a new Spoon Java compiler in order to process and compile Java

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -5,7 +5,7 @@
  */
 package spoon.compiler;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.OutputType;
 import spoon.compiler.builder.EncodingProvider;
 import spoon.processing.FileGenerator;

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -5,7 +5,7 @@
  */
 package spoon.processing;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -5,7 +5,8 @@
  */
 package spoon.reflect.visitor;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import spoon.SpoonException;
 import spoon.compiler.Environment;
 import spoon.experimental.CtUnresolvedImport;
@@ -235,7 +236,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 
-	protected static final Logger LOGGER = Logger.getLogger(DefaultJavaPrettyPrinter.class);
+	protected static final Logger LOGGER = LogManager.getLogger();
 	public static final String ERROR_MESSAGE_TO_STRING = "Error in printing the node. One parent isn't initialized!";
 	/**
 	 * Prints an element. This method shall be called by the toString() method of an element.

--- a/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
@@ -5,7 +5,7 @@
  */
 package spoon.reflect.visitor;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;

--- a/src/main/java/spoon/support/RuntimeProcessingManager.java
+++ b/src/main/java/spoon/support/RuntimeProcessingManager.java
@@ -5,7 +5,7 @@
  */
 package spoon.support;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.processing.ProcessInterruption;
 import spoon.processing.ProcessingManager;
 import spoon.processing.Processor;

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -6,8 +6,9 @@
 package spoon.support;
 
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonException;
@@ -166,7 +167,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	@Override
 	public void setLevel(String level) {
 		this.level = toLevel(level);
-		logger.setLevel(this.level);
+		Configurator.setRootLevel(this.level);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -5,7 +5,7 @@
  */
 package spoon.support.compiler;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Model;

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -6,7 +6,7 @@
 package spoon.support.compiler.jdt;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -5,7 +5,8 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
@@ -67,7 +68,7 @@ import java.util.regex.Pattern;
  */
 public class JDTCommentBuilder {
 
-	private static final Logger LOGGER = Logger.getLogger(JDTCommentBuilder.class);
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	private final CompilationUnitDeclaration declarationUnit;
 	private String filePath;

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -5,7 +5,8 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ast.AND_AND_Expression;
@@ -182,7 +183,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		return LOGGER;
 	}
 
-	private static final Logger LOGGER = Logger.getLogger(JDTTreeBuilder.class);
+	private static final Logger LOGGER = LogManager.getLogger();
 
 	public PositionBuilder getPositionBuilder() {
 		return position;
@@ -215,7 +216,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		this.exiter = new ParentExiter(this);
 		this.references = new ReferenceBuilder(this);
 		this.helper = new JDTTreeBuilderHelper(this);
-		LOGGER.setLevel(factory.getEnvironment().getLevel());
+		//LOGGER.setLevel(factory.getEnvironment().getLevel());
 	}
 
 	// an abstract class here is better because the method is actually package-protected, as the type, (and not public as in the case of interface methods in Java)

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -7,7 +7,6 @@ package spoon.support.reflect.declaration;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.config.Configurator;
 import spoon.Launcher;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -5,7 +5,9 @@
  */
 package spoon.support.reflect.declaration;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
 import spoon.Launcher;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
@@ -70,7 +72,7 @@ import static spoon.reflect.visitor.CommentHelper.printComment;
  */
 public abstract class CtElementImpl implements CtElement, Serializable {
 	private static final long serialVersionUID = 1L;
-	protected static final Logger LOGGER = Logger.getLogger(CtElementImpl.class);
+	protected static final Logger LOGGER = LogManager.getLogger();
 	public static final String ERROR_MESSAGE_TO_STRING = "Error in printing the node. One parent isn't initialized!";
 	private static final Factory DEFAULT_FACTORY = new FactoryImpl(new DefaultCoreFactory(), new StandardEnvironment());
 
@@ -453,7 +455,8 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public void setFactory(Factory factory) {
 		this.factory = factory;
-		LOGGER.setLevel(factory.getEnvironment().getLevel());
+		//Configurator.setLevel(CtElementImpl.class.getName(),factory.getEnvironment().getLevel());
+		//LOGGER.setLevel(factory.getEnvironment().getLevel());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -455,8 +455,6 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public void setFactory(Factory factory) {
 		this.factory = factory;
-		//Configurator.setLevel(CtElementImpl.class.getName(),factory.getEnvironment().getLevel());
-		//LOGGER.setLevel(factory.getEnvironment().getLevel());
 	}
 
 	@Override

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -6,7 +6,7 @@
 package spoon.testing.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.processing.Processor;

--- a/src/test/java/spoon/test/logging/LogTest.java
+++ b/src/test/java/spoon/test/logging/LogTest.java
@@ -16,8 +16,7 @@
  */
 package spoon.test.logging;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.Priority;
+import org.apache.logging.log4j.Level;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,9 +70,9 @@ public class LogTest {
 		Launcher.LOGGER.error("Log error");
 		Launcher.LOGGER.debug("Log debug");
 
-		assertEquals(isInfo, Launcher.LOGGER.isEnabledFor(Priority.INFO));
-		assertEquals(isWarn, Launcher.LOGGER.isEnabledFor(Priority.WARN));
-		assertEquals(isError, Launcher.LOGGER.isEnabledFor(Priority.ERROR));
-		assertEquals(isDebug, Launcher.LOGGER.isEnabledFor(Priority.DEBUG));
+		assertEquals(isInfo, Launcher.LOGGER.getLevel().isLessSpecificThan(Level.INFO));
+		assertEquals(isWarn, Launcher.LOGGER.getLevel().isLessSpecificThan(Level.WARN));
+		assertEquals(isError, Launcher.LOGGER.getLevel().isLessSpecificThan(Level.ERROR));
+		assertEquals(isDebug, Launcher.LOGGER.getLevel().isLessSpecificThan(Level.DEBUG));
 	}
 }

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -18,7 +18,7 @@ package spoon.test.processing;
 
 import com.google.common.io.Files;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonException;

--- a/src/test/java/spoon/test/processing/processors/TestProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/TestProcessor.java
@@ -18,7 +18,7 @@ package spoon.test.processing.processors;
 
 import java.util.Date;
 
-import org.apache.log4j.Level;
+import org.apache.logging.log4j.Level;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtClass;


### PR DESCRIPTION
`log4j:log4j` is stuck to `1.2.7`, which contains a security vulnerability. 
The new artifact for log4j is now `org.apache.logging.log4j:log4j-core`.
The api has slightly changed for version `2.x`, see [this page](https://logging.apache.org/log4j/2.x/manual/migration.html) for migration information.