### PR TITLE
fix: be more protective to avoid wrong usages of sniper mode

### DIFF
--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -18,7 +18,6 @@ import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
-import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
 import spoon.reflect.visitor.chain.CtScannerListener;
 import spoon.reflect.visitor.chain.ScanningMode;
@@ -103,7 +102,7 @@ public class ChangeCollector {
 			@Override
 			public ScanningMode enter(CtElement element) {
 				if (depth == 0) {
-		 			// we want the top-level role directly under currentElement
+					// we want the top-level role directly under currentElement
 					checkedRole = scanner.getScannedRole();
 				}
 

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -18,6 +18,7 @@ import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
 import spoon.reflect.visitor.chain.CtScannerListener;
 import spoon.reflect.visitor.chain.ScanningMode;
@@ -74,7 +75,7 @@ public class ChangeCollector {
 
 	/**
 	 * @param currentElement the {@link CtElement} whose changes has to be checked
-	 * @return set of {@link CtRole}s whose attribute was directly changed on `currentElement` since this {@link ChangeCollector} was attached
+	 * @return set of {@link CtRole}s in direct children on of `currentElement` where something has changed since this {@link ChangeCollector} was attached
 	 * The 'directly' means that value of attribute of `currentElement` was changed.
 	 * Use {@link #getChanges(CtElement)} to detect changes in child elements too
 	 */
@@ -87,32 +88,37 @@ public class ChangeCollector {
 	}
 
 	/**
-	 * @param currentElement the {@link CtElement} whose changes has to be checked
-	 * @return set of {@link CtRole}s whose attribute was changed on `currentElement`
-	 * or any child of this attribute was changed
+	 * Return the set of {@link CtRole}s for which children have changed from `currentElement`
 	 * since this {@link ChangeCollector} was attached
+	 * Warning: change in IMPLICIT are ignored
+	 * @param currentElement the {@link CtElement} whose changes has to be checked
 	 */
 	public Set<CtRole> getChanges(CtElement currentElement) {
 		final Set<CtRole> changes = new HashSet<>(getDirectChanges(currentElement));
 		final Scanner scanner = new Scanner();
+		// collecting the changes deeped in currentElement
 		scanner.setListener(new CtScannerListener() {
 			int depth = 0;
 			CtRole checkedRole;
 			@Override
 			public ScanningMode enter(CtElement element) {
 				if (depth == 0) {
-					//we are checking children of role checkedRole
+		 			// we want the top-level role directly under currentElement
 					checkedRole = scanner.getScannedRole();
 				}
+
+				// Optimization, in theory could be removed
 				if (changes.contains(checkedRole)) {
-					//we already know that some child of `checkedRole` attribute is modified. Skip others
+					//we already know that some child with `checkedRole` is modified. Skip others
 					return ScanningMode.SKIP_ALL;
 				}
-				if (elementToChangeRole.containsKey(element)) {
-					//we have found a modified element in children of `checkedRole`
+
+				if (elementToChangeRole.containsKey(element) && !elementToChangeRole.get(element).contains(CtRole.IS_IMPLICIT)) {
+					//we have found a modified element in some sub children of `checkedRole`
 					changes.add(checkedRole);
 					return ScanningMode.SKIP_ALL;
 				}
+
 				depth++;
 				//continue searching for an modification
 				return ScanningMode.NORMAL;
@@ -164,6 +170,7 @@ public class ChangeCollector {
 
 		@Override
 		public void onObjectUpdate(CtElement currentElement, CtRole role, Object newValue, Object oldValue) {
+
 			onChange(currentElement, role);
 		}
 

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -417,14 +417,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 			mutableTokenWriter.setMuted(muted);
 			code.run();
 		} finally {
-			//assure that muted status did not changed in between
-			if (mutableTokenWriter.isMuted() != muted) {
-				if (mutableTokenWriter.isMuted()) {
-					throw new SpoonException("Unexpected state: Token writer is muted after scanning"); //NOSONAR
-				} else {
-					throw new SpoonException("Unexpected state: Token writer is not muted after scanning"); //NOSONAR
-				}
-			}
+			// restore origin state
 			mutableTokenWriter.setMuted(originMuted);
 		}
 	}

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -417,7 +417,14 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter {
 			mutableTokenWriter.setMuted(muted);
 			code.run();
 		} finally {
-			// restore origin state
+			//assure that muted status did not changed in between
+			if (mutableTokenWriter.isMuted() != muted) {
+				if (mutableTokenWriter.isMuted()) {
+					throw new SpoonException("Unexpected state: Token writer is muted after scanning"); //NOSONAR
+				} else {
+					throw new SpoonException("Unexpected state: Token writer is not muted after scanning"); //NOSONAR
+				}
+			}
 			mutableTokenWriter.setMuted(originMuted);
 		}
 	}


### PR DESCRIPTION
This extracts the interesting changes of #3194, which was hard to debug.

Changes in IMPLICIT are ignored in `#getChanges()`, it's less dangerous because well, less ... implicit :-)

Fix #3176