### PR TITLE
chore(checkstyle): add check for internal imports

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -28,6 +28,10 @@
     <module name="AvoidStarImport"/>
     <module name="IllegalImport"/> <!-- defaults to sun.* packages -->
     <module name="RedundantImport"/>
+    <module name="IllegalImport">
+      <property name="regexp" value="true" />
+      <property name="illegalClasses" value="^(?!.*(spoon|jdt)).*internal.*$" />
+    </module>
     <module name="UnusedImports">
       <property name="processJavadoc" value="true"/>
     </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -31,6 +31,10 @@
     <module name="IllegalImport">
       <property name="regexp" value="true" />
       <property name="illegalClasses" value="^(?!.*(spoon|jdt)).*internal.*$" />
+      <!--The regex looks for imports containing internal and not containing spoon or jdt. Some examples are:
+      import spoon.pattern.internal.node.ForEachNode; // allowed because internal package but from spoon.
+      import org.eclipse.jdt.internal.compiler.batch.CompilationUnit; //allowed because internal package but from jdt.
+      import org.apache.commons.jexl2.internal.introspection; //rejected because import of internal package -->
     </module>
     <module name="UnusedImports">
       <property name="processJavadoc" value="true"/>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <configLocation>checkstyle.xml</configLocation>

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -37,7 +37,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-decompiler/pom.xml
+++ b/spoon-decompiler/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-		        <version>3.0.0</version>
+		        <version>3.1.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>


### PR DESCRIPTION
Fix for #3186. Spoon has a lot of jdt.internal imports so we cant reject them in checkstyle.
But the regex `^(?!.*(spoon|jdt)).*internal.*$` should catch all other unwanted internal imports.
The update of the checkstyle version from 3.0.0 to 3.1.0 is necessary, because 3.0.0 does not contain regex property.