### PR TITLE
ref: toString() in sniper return toStringDebug()

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -182,7 +182,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	}
 
 	/** Warning, not in the API, public for testing purposes */
-	private static boolean hasImplicitAncestor(CtElement el) {
+	public static boolean hasImplicitAncestor(CtElement el) {
 		if (el == null || !el.isParentInitialized()) {
 			return false;
 		}

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -182,7 +182,8 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	}
 
 
-	private static boolean hasImplicitAncestor(CtElement el) {
+	/** Warning, not in the API, public for testing purposes */
+	public static boolean hasImplicitAncestor(CtElement el) {
 		if (el == null) {
 			return false;
 		}
@@ -203,10 +204,10 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 		return element.toStringDebug();
 	}
 
-	/** Warning: debug method only, not part of the public API */
+	/** Warning: debug and test method only, not part of the public API */
 	public String printElementSniper(CtElement element) {
-		applyPreProcessors(element);
-		if (element != null && !hasImplicitAncestor(element)) {
+		reset();
+		if (!hasImplicitAncestor(element)) {
 			CompilationUnit compilationUnit = element.getPosition().getCompilationUnit();
 			if (compilationUnit != null
 					&& !(compilationUnit instanceof NoSourcePosition.NullCompilationUnit)) {

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -196,10 +196,15 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	}
 
 	/**
-	 * Prints an element in sniper mode
+	 * The sniper mode only works from JavaOutputProcessor
 	 */
 	@Override
 	public String printElement(CtElement element) {
+		return element.toStringDebug();
+	}
+
+	/** Warning: debug method only, not part of the public API */
+	public String printElementSniper(CtElement element) {
 		applyPreProcessors(element);
 		if (element != null && !hasImplicitAncestor(element)) {
 			CompilationUnit compilationUnit = element.getPosition().getCompilationUnit();

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -311,10 +311,10 @@ public class TestSniperPrinter {
 
 		new SourceFragmentCreator().attachTo(launcher.getFactory().getEnvironment());
 
+		final SniperJavaPrettyPrinter sp = new SniperJavaPrettyPrinter(launcher.getEnvironment());
+
 		launcher.getEnvironment().setPrettyPrinterCreator(
 				() -> {
-					SniperJavaPrettyPrinter sp = new SniperJavaPrettyPrinter(launcher.getEnvironment());
-					sp.setIgnoreImplicit(true);
 					return sp;
 				}
 		);
@@ -326,9 +326,11 @@ public class TestSniperPrinter {
 						!(el instanceof spoon.reflect.factory.ModuleFactory.CtUnnamedModule)
 				).forEach(el -> {
 			try {
+				sp.reset();
+				sp.printElementSniper(el);
 				//Contract, calling toString on unmodified AST elements should draw only from original.
 				assertTrue("ToString() on element (" + el.getClass().getName() + ") =  \"" + el + "\" is not in original content",
-						originalContent.contains(el.toString().replace("\t","")));
+						originalContent.contains(sp.getResult().replace("\t","")));
 			} catch (UnsupportedOperationException | SpoonException e) {
 				//Printer should not throw exception on printable element. (Unless there is a bug in the printer...)
 				fail("ToString() on Element (" + el.getClass().getName() + "): at " + el.getPath() + " lead to an exception: " + e);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -36,6 +36,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtPackageReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.ImportCleaner;
@@ -329,8 +330,14 @@ public class TestSniperPrinter {
 				sp.reset();
 				sp.printElementSniper(el);
 				//Contract, calling toString on unmodified AST elements should draw only from original.
+				String result = sp.getResult();
+
+				if (!sp.hasImplicitAncestor(el) && !(el instanceof CtPackage) && !(el instanceof CtReference)) {
+					assertTrue(result.length()>0);
+				}
+
 				assertTrue("ToString() on element (" + el.getClass().getName() + ") =  \"" + el + "\" is not in original content",
-						originalContent.contains(sp.getResult().replace("\t","")));
+						originalContent.contains(result.replace("\t","")));
 			} catch (UnsupportedOperationException | SpoonException e) {
 				//Printer should not throw exception on printable element. (Unless there is a bug in the printer...)
 				fail("ToString() on Element (" + el.getClass().getName() + "): at " + el.getPath() + " lead to an exception: " + e);


### PR DESCRIPTION
otherwise a debugger session is a nightmare (the debugger always calls toString :-)