### PR TITLE
fix: not finding sources in non-standard directories

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -121,9 +121,10 @@ public class SpoonPom implements SpoonResource {
 			sourcePath = build.getSourceDirectory();
 		}
 		if (sourcePath == null) {
-			sourcePath = Paths.get(directory.getAbsolutePath(), "src", "main", "java").toString();
+			sourcePath = "src\\main\\java";
 		}
-		File source = new File(sourcePath);
+		String absoluteSourcePath = Paths.get(directory.getAbsolutePath(), sourcePath).toString();
+		File source = new File(absoluteSourcePath);
 		if (source.exists()) {
 			output.add(source);
 		}
@@ -150,9 +151,10 @@ public class SpoonPom implements SpoonResource {
 			sourcePath = build.getTestSourceDirectory();
 		}
 		if (sourcePath == null) {
-			sourcePath = Paths.get(directory.getAbsolutePath(), "src", "test", "java").toString();
+			sourcePath = "src\\test\\java";
 		}
-		File source = new File(sourcePath);
+		String absoluteSourcePath = Paths.get(directory.getAbsolutePath(), sourcePath).toString();
+		File source = new File(absoluteSourcePath);
 		if (source.exists()) {
 			output.add(source);
 		}

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -121,7 +121,7 @@ public class SpoonPom implements SpoonResource {
 			sourcePath = build.getSourceDirectory();
 		}
 		if (sourcePath == null) {
-			sourcePath = "src\\main\\java";
+			sourcePath = Paths.get("src/main/java").toString();
 		}
 		String absoluteSourcePath = Paths.get(directory.getAbsolutePath(), sourcePath).toString();
 		File source = new File(absoluteSourcePath);
@@ -151,7 +151,7 @@ public class SpoonPom implements SpoonResource {
 			sourcePath = build.getTestSourceDirectory();
 		}
 		if (sourcePath == null) {
-			sourcePath = "src\\test\\java";
+			sourcePath = Paths.get("src/test/java").toString();
 		}
 		String absoluteSourcePath = Paths.get(directory.getAbsolutePath(), sourcePath).toString();
 		File source = new File(absoluteSourcePath);

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -149,6 +149,12 @@ public class MavenLauncherTest {
 	}
 
 	@Test
+	public void testPomSourceDirectory() {
+		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/source-directory", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		assertEquals(2, launcher.getModelBuilder().getInputSources().size());
+	}
+
+	@Test
 	public void mavenLauncherTestMultiModulesAndVariables() {
 		// contract: variables coming from parent should be resolved
 		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/pac4j/pac4j-config", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);

--- a/src/test/resources/maven-launcher/source-directory/pom.xml
+++ b/src/test/resources/maven-launcher/source-directory/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <build>
+        <sourceDirectory>source/code</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
+    </build>
+</project>

--- a/src/test/resources/maven-launcher/source-directory/source/code/Test.java
+++ b/src/test/resources/maven-launcher/source-directory/source/code/Test.java
@@ -1,0 +1,3 @@
+public class Test {
+    int field = 42;
+}

--- a/src/test/resources/maven-launcher/source-directory/test/Test.java
+++ b/src/test/resources/maven-launcher/source-directory/test/Test.java
@@ -1,0 +1,3 @@
+public class Test {
+    int field = 42;
+}


### PR DESCRIPTION
In Maven POM, the standard directory layout for sources and test sources can be overridden from the standard `src/main/java` and `src/test/java` as follows:

```xml
<build>
    <sourceDirectory>source/code</sourceDirectory>
    <testSourceDirectory>test</testSourceDirectory>
</build>
```

The description for the field `sourceDirectory` states:
>This element specifies a directory containing the source of the project. The generated build system will compile the source in this directory when the project is built. **The path given is relative to the project descriptor.**

Previously, when using MavenLauncher, if this value is defined it will be used instead of the standard directory structure when searching for sources. The issue is that this relative path is not prefixed with the absolute path to the project directory. This means that it assumes the current working directory, which is not necessarily the path to the Maven project being analysed.

PR contains previously failing test case with suggested fix.