### PR TITLE
refactor: adding getter for modules to SpoonPom

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -101,6 +101,14 @@ public class SpoonPom implements SpoonResource {
 	}
 
 	/**
+	 * Get the list of modules defined in this POM
+	 * @return the list of modules
+	 */
+	public List<SpoonPom> getModules() {
+		return Collections.unmodifiableList(modules);
+	}
+
+	/**
 	 * Get the Project Object Model
 	 * @return the Project Object Model
 	 */


### PR DESCRIPTION
As per #3262 I'd like to propose adding a getter to `SpoonPom` so that information about the (maven) modules declared in that POM can be retrieved. Currently only the top level `SpoonPom` is accessible from `MavenLauncher`.