### PR TITLE
fix(MavenLauncher): allowing rebuilding of classpath

### DIFF
--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -125,7 +125,7 @@ public class MavenLauncher extends Launcher {
 		}
 
 		if (classpath == null) {
-			classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, false);
+			classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, forceRefresh);
 		}
 
 		// dependencies
@@ -133,5 +133,13 @@ public class MavenLauncher extends Launcher {
 
 		// compliance level
 		this.getEnvironment().setComplianceLevel(model.getSourceVersion());
+	}
+
+	/**
+	 * Triggers regeneration of the classpath
+	 */
+	public void rebuildClasspath() {
+		String[] classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, true);
+		this.getModelBuilder().setSourceClasspath(classpath);
 	}
 }

--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -136,7 +136,7 @@ public class MavenLauncher extends Launcher {
 	}
 
 	/**
-	 * Triggers regeneration of the classpath
+	 * Triggers regeneration of the classpath that is used for building the model, based on pom.xml
 	 */
 	public void rebuildClasspath() {
 		String[] classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, true);

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -27,6 +27,8 @@ import spoon.support.compiler.FileSystemFolder;
 import spoon.support.compiler.SpoonPom;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Paths;
@@ -140,6 +142,36 @@ public class MavenLauncherTest {
 		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
 		assertEquals(1, launcher.getEnvironment().getSourceClasspath().length);
 		assertTrue(launcher.getEnvironment().getSourceClasspath()[0].endsWith("lib/bridge-method-annotation-1.13.jar"));
+	}
+
+	@Test
+	public void testForceRefresh() throws FileNotFoundException {
+		// ensure classpath file exists so first constructor invocation won't build classpath
+		File file = new File("./src/test/resources/maven-launcher/system-dependency/spoon.classpath.tmp");
+		new PrintWriter(file).close();
+
+		// contract: classpath is not built
+		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);
+
+		// contract: calling constructor with forceRefresh=true should result in classpath being rebuilt
+		MavenLauncher newLauncher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE, true);
+		assertEquals(1, newLauncher.getEnvironment().getSourceClasspath().length);
+	}
+
+	@Test
+	public void testRebuildClasspath() throws FileNotFoundException {
+		// ensure classpath file exists so first constructor invocation won't build classpath
+		File file = new File("./src/test/resources/maven-launcher/system-dependency/spoon.classpath.tmp");
+		new PrintWriter(file).close();
+
+		// contract: classpath is not built
+		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);
+
+		// contract: classpath should be rebuilt
+		launcher.rebuildClasspath();
+		assertEquals(1, launcher.getEnvironment().getSourceClasspath().length);
 	}
 
 	@Test


### PR DESCRIPTION
The class `MavenLauncher` has constructors with parameter `forceRefresh`, with the JavaDoc comment:

> @param forceRefresh force the regeneration of classpath

However the value was actually never passed through to the `SpoonPom` method responsible for generating the classpath, as it was hardcoded to false. This is fixed and a method `rebuildClasspath` is added to `MavenLauncher` to enable rebuilding of the classpath without instantiating a new launcher (or directly calling the `SpoonPom` method). Tests for both use cases also added.