### PR TITLE
fix(spoon-control-flow): add switchExpression to visitor

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>7.3.0-SNAPSHOT</version>
+            <version>8.1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
@@ -60,6 +60,7 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.code.CtSuperAccess;
 import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtSwitchExpression;
 import spoon.reflect.code.CtSynchronized;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.code.CtThrow;
@@ -738,6 +739,11 @@ public class ControlFlowBuilder implements CtVisitor {
 		//Return as last node the convergence node
 		lastNode = convergenceNode;
 		breakingBad.pop();
+	}
+
+	@Override
+	public <T, S> void visitCtSwitchExpression(CtSwitchExpression<T, S> switchExpression) {
+		//TODO: missing, implementation needed
 	}
 
 	@Override


### PR DESCRIPTION
currently the ControlFlowBuilder doesn't override the method `	public <T, S> void visitCtSwitchExpression(CtSwitchExpression<T, S> switchExpression)`. With this fix the CI should work again, as soon as the latest snapshot with the merged switchexpressions #3259 is published on mavencentral. As soon as the new version is published this patch should compile. Updated version of spoon dependency, because CI is using the newest anyway.
Edit: Seems like the CI already has the newest version.