### PR TITLE
feature(SpoonPom): expose result of maven classpath build

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -15,6 +15,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -55,6 +56,7 @@ public class SpoonPom implements SpoonResource {
 	File directory;
 	MavenLauncher.SOURCE_TYPE sourceType;
 	Environment environment;
+	boolean classpathBuiltSuccessfully = false;
 
 	/**
 	 * Extract the information from the pom
@@ -361,7 +363,8 @@ public class SpoonPom implements SpoonResource {
 			invoker.setErrorHandler(s -> LOGGER.debug(s));
 			invoker.setOutputHandler(s -> LOGGER.debug(s));
 			try {
-				invoker.execute(request);
+				InvocationResult result = invoker.execute(request);
+				this.classpathBuiltSuccessfully = (result.getExitCode() == 0);
 			} catch (MavenInvocationException e) {
 				throw new SpoonException("Maven invocation failed to build a classpath.");
 			}
@@ -471,6 +474,14 @@ public class SpoonPom implements SpoonResource {
 		} else {
 			return spoonClasspathTmpFileName;
 		}
+	}
+
+	/**
+	 * Whether the classpath was built successfully
+	 * @return true if the most recent maven invocation was successful, false otherwise
+	 */
+	public boolean classpathBuiltSuccessfully() {
+		return classpathBuiltSuccessfully;
 	}
 
 	/**

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class MavenLauncherTest {
 
@@ -134,6 +135,16 @@ public class MavenLauncherTest {
 	@Test(expected = SpoonException.class)
 	public void mavenLauncherOnDirectoryWithoutPomTest() {
 		new MavenLauncher("./src", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
+	}
+
+	@Test
+	public void classpathBuildResultTest() {
+		//contract: Maven invocation fails
+		MavenLauncher failLauncher = new MavenLauncher("./src/test/resources/maven-launcher/non-existent-dependency", MavenLauncher.SOURCE_TYPE.APP_SOURCE, true);
+		assertFalse(failLauncher.getPomFile().classpathBuiltSuccessfully());
+		//contract: Maven invocation succeeds
+		MavenLauncher successLauncher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.APP_SOURCE, true);
+		assertTrue(successLauncher.getPomFile().classpathBuiltSuccessfully());
 	}
 
 	@Test

--- a/src/test/resources/maven-launcher/non-existent-dependency/pom.xml
+++ b/src/test/resources/maven-launcher/non-existent-dependency/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>some.fake.group</groupId>
+            <artifactId>fake-artifact</artifactId>
+            <version>0.0.0.0.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/maven-launcher/non-existent-dependency/src/main/java/Test.java
+++ b/src/test/resources/maven-launcher/non-existent-dependency/src/main/java/Test.java
@@ -1,0 +1,3 @@
+public class Test {
+    int field = 42;
+}


### PR DESCRIPTION
When the classpath is built in `SpoonPom` it would be useful to know if the Maven invocation was successful. Invocation was successful if exit code was 0, or failed otherwise. Unfortunately I can't find a way to relay information about the reason for failure, so for now a simple boolean flag would allow action to be taken if the classpath was not built successfully.