### PR TITLE
WIP: feature: add method to CtType getAllAnnotationsFromSuperTypes

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -353,4 +353,13 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * A new unique method name is given for each copy, and this method can be called several times.
 	 */
 	CtType<?> copyType();
+
+	/**
+	 * Generates a list of annotations for this type and all supertypes. Setting includeClasses/includeInterfaces to false excludes all superclasses/superInterfaces from the search.
+	 * The list may contains duplicates, if two types have the same annotation. Ignoring classes still includes interfaces implemented by the classes.
+	 * @param includeClasses if classes should be considered
+	 * @param includeInterfaces if interfaces should be considered
+	 * @return a list of all annotations from supertypes including this type.
+	 */
+	List<CtAnnotation<?>> getAnnotationsFromSuperTypes(boolean includeClasses, boolean includeInterfaces);
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -1001,24 +1001,22 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@Override
 	public List<CtAnnotation<?>> getAnnotationsFromSuperTypes(boolean includeClasses, boolean includeInterfaces) {
 		List<CtAnnotation<?>> annotations = new ArrayList<>();
-		Set<CtType<?>> classes = getSuperClasses(this, new HashSet<CtType<?>>());
+		Set<CtType<?>> superClasses = getSuperClasses(this, new HashSet<CtType<?>>());
 		Set<CtType<?>> visited = new HashSet<>();
 		annotations.addAll(this.getAnnotations());
 		visited.add(this);
-			for (CtType<?> type : classes) {
+			for (CtType<?> type : superClasses) {
 				if (includeInterfaces) {
-				for (CtType<?> ctType : getSuperInterfaces(type)) {
-					if (!visited.contains(ctType)) {
-						annotations.addAll(ctType.getAnnotations());
-						visited.add(ctType);
+					for (CtType<?> superInterface : getSuperInterfaces(type)) {
+						if (!visited.contains(superInterface)) {
+							annotations.addAll(superInterface.getAnnotations());
+							visited.add(superInterface);
+							}
 						}
 					}
-				}
-				if (includeClasses) {
-					if (!visited.contains(type)) {
+				if (includeClasses && !visited.contains(type)) {
 					annotations.addAll(type.getAnnotations());
 					visited.add(type);
-					}
 				}
 			}
 	return annotations;


### PR DESCRIPTION
as discussed in #3294 this method would simplify usage for some users. 
Open question is still if we should add a method like `public boolean hasAnnotation(boolean includeSuperClasses, boolean includeSuperInterfaces, Class<? extends Annotation> annotation)`
this? Only real problem could be namespace pollution.