### PR TITLE
chore: add LSIF GitHub action for sourcegraph augmentation

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -1,0 +1,18 @@
+name: LSIF
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build and push LSIF data
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate LSIF data
+        uses: sourcegraph/lsif-java-action@master
+        with:
+          verbose: true
+      - name: Upload LSIF data
+        uses: sourcegraph/lsif-upload-action@master
+        with:
+          endpoint: https://sourcegraph.com
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dump.lsif

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -27,7 +27,7 @@ keywords: frequently asked questions, FAQ, question and answer, collapsible sect
 
 ### How to access Spoon's source code repository?
 
-See <https://github.com/INRIA/spoon/>.
+Spoon is developed on GitHub at <https://github.com/INRIA/spoon/>. You can browse the Spoon source using code intelligence (Go-to-definition, Find References, and Hover tooltips) at <https://sourcegraph.com/github.com/INRIA/spoon>.
 
 ### What is the meaning of each digit in the version X.Y.Z of spoon?
 


### PR DESCRIPTION
Hi Spoon folks! Let me know your thoughts on this PR for adding code intel with LSIF (@monperrus has some context, but this PR provides a complete picture for anyone interested). 

**Background**: [LSIF](https://code.visualstudio.com/blogs/2019/02/19/lsif#_language-server-index-format) is a file format for precomputed code intelligence data. An LSIF dump can be used to provide things like jump-to-definition, hover information, and find-references. 

I work at [Sourcegraph](https://github.com/sourcegraph) and we've added first class support for LSIF, and created [lsif-java](https://github.com/sourcegraph/lsif-java) to generate LSIF data for Java. The fun part is we use Spoon to generate this LSIF data! (thanks for this great project 😉). This makes it possible to use Spoon to generate code intel for many Java projects, including Spoon!

**What this PR does**: It adds a [GitHub action](https://github.com/features/actions) that:
1. generates an LSIF dump for the spoon project using Sourcegraph's [lsif-java](https://github.com/sourcegraph/lsif-java) via the [lsif-java-action](https://github.com/sourcegraph/lsif-java-action).
1. uploads this dump to Sourcegraph.com, which understands the LSIF format and can (a) surface the code intel info in your browser for this repository (either on GitHub directly using a Sourcegraph [plugin](https://docs.sourcegraph.com/integration/browser_extension), or at https://sourcegraph.com/github.com/INRIA/spoon) and (b) expose code intel info through a GraphQL API.

**Testing**: As a reference, the GH action in this PR was tested successfully in [my fork](https://github.com/rvantonder/spoon/runs/569303348?check_suite_focus=true), but since actions can only be added by repo collaborators with write access, this PR can't guarantee that the action works successfully on this repo. If you'd like to test and guarantee that it works without merging this PR into master, simply have a core member with write access push the workflow file to a separate branch,  which should trigger the GH action.

**Example**: Here's an example of the jump-to-definition functionality using the LSIF data:

![j2d](https://user-images.githubusercontent.com/888624/78866924-2270fd00-79f5-11ea-8891-bf9b3ace1b5d.gif)

You can try it out for yourself on the fork of this PR: https://sourcegraph.com/github.com/rvantonder/spoon@rvantonder/lsif-action/-/blob/src/main/java/spoon/refactoring/MethodInvocationSearch.java#L60:31

Cool things to note:

- After merging, every branch and pull request to Spoon will kick off LSIF generation and uploads, which will allow you to get code intel inside pull requests and branches
- This same GH action will potentially work for any Java project on GitHub that builds with Maven, meaning Spoon can power code intel for any (and perhaps eventually, every) build-compatible Java project. We'd like to expand to other Java projects using this action, and Spoon is a natural way to try LSIF integration and identify areas to improve!

There are still many areas of improvements (higher quality hover/definitions, and eventually, cross-repo jump-to-definitions). I'm happy to answer any questions or get feedback!

Additional resources:
- The process for adding LSIF is [documented](https://docs.sourcegraph.com/user/code_intelligence/adding_lsif_to_workflows#adding-lsif-to-your-workflows) (this PR already does these things) 
- How the [Sourcegraph service](https://docs.sourcegraph.com/user/code_intelligence/adding_lsif_to_workflows#uploading-lsif-data-to-sourcegraph-com) works.