### PR TITLE
Feat: add notNullable property for processor properties

### DIFF
--- a/src/main/java/spoon/processing/Property.java
+++ b/src/main/java/spoon/processing/Property.java
@@ -24,7 +24,7 @@ public @interface Property {
 	 */
 	String value() default "";
 	/**
-	 * If a value is nullable, spoon will expect that the user handles null values and will not print errors.
+	 * If a value is notNullable, spoon will throw a {@link spoon.SpoonException} for null values.
 	 */
-	boolean nullable() default false;
+	boolean notNullable() default false;
 }

--- a/src/main/java/spoon/processing/Property.java
+++ b/src/main/java/spoon/processing/Property.java
@@ -23,4 +23,8 @@ public @interface Property {
 	 * An optional text that describes the property.
 	 */
 	String value() default "";
+	/**
+	 * If a value is nullable, spoon will expect that the user handles null values and will not print errors.
+	 */
+	boolean nullable() default false;
 }

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -57,9 +57,11 @@ public final class ProcessorUtils {
 								throw new SpoonException("Error while assigning the value to " + f.getName(), e);
 							}
 						} else {
-								if (!f.getAnnotation(Property.class).nullable()) {
+								if (f.getAnnotation(Property.class).notNullable()) {
 									p.getFactory().getEnvironment().report(p, Level.WARN,
 											"No value found for property '" + f.getName() + "' in processor " + p.getClass().getName());
+											throw new SpoonException("No value found for property '" + f.getName()
+																								+ "' in processor " + p.getClass().getName());
 							}
 						}
 					}

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -57,8 +57,10 @@ public final class ProcessorUtils {
 								throw new SpoonException("Error while assigning the value to " + f.getName(), e);
 							}
 						} else {
-							p.getFactory().getEnvironment().report(p, Level.WARN,
-									"No value found for property '" + f.getName() + "' in processor " + p.getClass().getName());
+								if (!f.getAnnotation(Property.class).nullable()) {
+									p.getFactory().getEnvironment().report(p, Level.WARN,
+											"No value found for property '" + f.getName() + "' in processor " + p.getClass().getName());
+							}
 						}
 					}
 				}

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -8,7 +8,6 @@
 package spoon.testing.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.logging.log4j.Level;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.processing.Processor;
@@ -58,10 +57,8 @@ public final class ProcessorUtils {
 							}
 						} else {
 								if (f.getAnnotation(Property.class).notNullable()) {
-									p.getFactory().getEnvironment().report(p, Level.WARN,
-											"No value found for property '" + f.getName() + "' in processor " + p.getClass().getName());
-											throw new SpoonException("No value found for property '" + f.getName()
-																								+ "' in processor " + p.getClass().getName());
+										throw new SpoonException("No value found for property '" + f.getName()
+																							+ "' in processor " + p.getClass().getName());
 							}
 						}
 					}

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -436,53 +437,16 @@ public class ProcessingTest {
 	@Test
 	public void testNullableSettingForProcessor() throws IOException {
 		class AProcessor extends AbstractProcessor<CtElement> {
-			@Property(nullable = false)
+			@Property(notNullable = false)
 			String aString = null;
 
-			@Property(nullable = true)
+			@Property
 			int anInt;
 
 			@Property
 			Object anObject;
 
-			@Property(nullable = true)
-			int[] arrayInt;
-
-			@Override
-			public void process(CtElement element) {
-			}
-		}
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
-		Processor<CtElement> processor = new AProcessor();
-		processor.setFactory(launcher.getFactory());
-		ProcessorProperties props = new ProcessorPropertiesImpl();
-
-		props.set("aString", null);
-		props.set("anInt", "42");
-		props.set("anObject", null);
-		props.set("arrayInt", "[42,43]");
-
-		ProcessorUtils.initProperties(processor, props);
-		launcher.addProcessor(processor);
-		launcher.run();
-		int warnings = launcher.getEnvironment().getWarningCount();
-		assertTrue(warnings == 2);
-	}
-
-	@Test
-	public void testNullableSettingForProcessor2() throws IOException {
-		class AProcessor extends AbstractProcessor<CtElement> {
-			@Property(nullable = true)
-			String aString = null;
-
-			@Property(nullable = true)
-			int anInt;
-
-			@Property(nullable = true)
-			Object anObject;
-
-			@Property(nullable = true)
+			@Property
 			int[] arrayInt;
 
 			@Override
@@ -505,5 +469,38 @@ public class ProcessingTest {
 		launcher.run();
 		int warnings = launcher.getEnvironment().getWarningCount();
 		assertTrue(warnings == 0);
+	}
+
+	@Test
+	public void testNullableSettingForProcessor2() throws IOException {
+		class AProcessor extends AbstractProcessor<CtElement> {
+			@Property(notNullable = true)
+			String aString = null;
+
+			@Property(notNullable = true)
+			int anInt;
+
+			@Property(notNullable = true)
+			Object anObject;
+
+			@Property(notNullable = true)
+			int[] arrayInt;
+
+			@Override
+			public void process(CtElement element) {
+			}
+		}
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
+		Processor<CtElement> processor = new AProcessor();
+		processor.setFactory(launcher.getFactory());
+		ProcessorProperties props = new ProcessorPropertiesImpl();
+
+		props.set("aString", null);
+		props.set("anInt", "42");
+		props.set("anObject", null);
+		props.set("arrayInt", "[42,43]");
+
+		assertThrows(SpoonException.class, () -> ProcessorUtils.initProperties(processor, props));
 	}
 }

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -436,6 +436,7 @@ public class ProcessingTest {
 
 	@Test
 	public void testNullableSettingForProcessor() throws IOException {
+		//contract: nullable( = notNullable == false) properties with a null value must not throw a exception.
 		class AProcessor extends AbstractProcessor<CtElement> {
 			@Property(notNullable = false)
 			String aString = null;
@@ -473,6 +474,8 @@ public class ProcessingTest {
 
 	@Test
 	public void testNullableSettingForProcessor2() throws IOException {
+		//contract: notNullable( = notNullable == true) properties with a null value must throw a spoonexception.
+
 		class AProcessor extends AbstractProcessor<CtElement> {
 			@Property(notNullable = true)
 			String aString = null;

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -24,6 +24,7 @@ import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.processing.AbstractManualProcessor;
 import spoon.processing.AbstractProcessor;
+import spoon.processing.Processor;
 import spoon.processing.ProcessorProperties;
 import spoon.processing.ProcessorPropertiesImpl;
 import spoon.processing.Property;
@@ -430,5 +431,79 @@ public class ProcessingTest {
 		assertFalse(fileContent.contains("import spoon.test.processing.testclasses.test.sub.A;"));
 		assertTrue(fileContent.contains("import spoon.test.processing.testclasses.test.sub.D;"));
 		assertTrue(fileContent.contains("private D a = new D();"));
+	}
+
+	@Test
+	public void testNullableSettingForProcessor() throws IOException {
+		class AProcessor extends AbstractProcessor<CtElement> {
+			@Property(nullable = false)
+			String aString = null;
+
+			@Property(nullable = true)
+			int anInt;
+
+			@Property
+			Object anObject;
+
+			@Property(nullable = true)
+			int[] arrayInt;
+
+			@Override
+			public void process(CtElement element) {
+			}
+		}
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
+		Processor<CtElement> processor = new AProcessor();
+		processor.setFactory(launcher.getFactory());
+		ProcessorProperties props = new ProcessorPropertiesImpl();
+
+		props.set("aString", null);
+		props.set("anInt", "42");
+		props.set("anObject", null);
+		props.set("arrayInt", "[42,43]");
+
+		ProcessorUtils.initProperties(processor, props);
+		launcher.addProcessor(processor);
+		launcher.run();
+		int warnings = launcher.getEnvironment().getWarningCount();
+		assertTrue(warnings == 2);
+	}
+
+	@Test
+	public void testNullableSettingForProcessor2() throws IOException {
+		class AProcessor extends AbstractProcessor<CtElement> {
+			@Property(nullable = true)
+			String aString = null;
+
+			@Property(nullable = true)
+			int anInt;
+
+			@Property(nullable = true)
+			Object anObject;
+
+			@Property(nullable = true)
+			int[] arrayInt;
+
+			@Override
+			public void process(CtElement element) {
+			}
+		}
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
+		Processor<CtElement> processor = new AProcessor();
+		processor.setFactory(launcher.getFactory());
+		ProcessorProperties props = new ProcessorPropertiesImpl();
+
+		props.set("aString", null);
+		props.set("anInt", "42");
+		props.set("anObject", null);
+		props.set("arrayInt", "[42,43]");
+
+		ProcessorUtils.initProperties(processor, props);
+		launcher.addProcessor(processor);
+		launcher.run();
+		int warnings = launcher.getEnvironment().getWarningCount();
+		assertTrue(warnings == 0);
 	}
 }

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -463,7 +463,7 @@ public class ProcessingTest {
 		props.set("aString", null);
 		props.set("anInt", "42");
 		props.set("anObject", null);
-		props.set("arrayInt", "[42,43]");
+		props.set("arrayInt", "[42,44]");
 
 		ProcessorUtils.initProperties(processor, props);
 		launcher.addProcessor(processor);


### PR DESCRIPTION
See #3339 for discussion why. I would add a simple boolean field to the property annotation because:
- Change the null to a nullObject like in SourcePosition would be backwards breaking
- Doesn't pollute the namespace with a new method.

Maybe a open issue issue is where to document it? 

Edit: need to fix git sry
Edit2: git fixed