### PR TITLE
fix: sort type references by position and qualified name (may be BREAKING)

### DIFF
--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -16,6 +16,15 @@ import spoon.reflect.declaration.CtElement;
 import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.comparator.QualifiedNameComparator;
 
+/**
+ * The set properties of this set are based on the qualified name of the element inserted. Using this set for elements
+ * without a qualified name does not work well. See the {@link QualifiedNameComparator} for details.
+ *
+ * The order of the iterator and stream of this set is based on two properties: qualified name and position. See
+ * {@link #stream()} for details.
+ *
+ * @param <E>
+ */
 public class QualifiedNameBasedSortedSet<E extends CtElement> extends
 		TreeSet<E> {
 
@@ -30,13 +39,34 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> extends
 		super(new QualifiedNameComparator());
 	}
 
+	/**
+	 * The order of elements in this iterator is described in {@link #stream()}.
+	 *
+	 * @return A sorted iterator with all elements in this set.
+	 */
 	@Override
 	public Iterator<E> iterator() {
 		return stream().iterator();
 	}
 
+	/**
+	 * The elements of this stream is ordered into two partitions: elements without source position and elements with
+	 * source position.
+	 *
+	 * Elements without source position appear first, and are between themselves ordered by their qualified names.
+	 * Elements with source position appear last, and are between themselves ordered by their source position.
+	 *
+	 * The rationale for this ordering is that elements such as types listed in implements clauses, or types
+	 * listed in thrown clauses, should not be reordered by qualified name as a result of parsing and printing with
+	 * Spoon.
+	 *
+	 * @return A sorted stream of all elements in this set.
+	 */
 	@Override
 	public Stream<E> stream() {
+		// implementation detail: the elements are all ready sorted by the QualifiedNameComparator. Stable sort with
+		// the CtLineElementComparator ensures that elements with no source position appear before elements with source
+		// position, but the noposition elements' order relative to each other is not changed.
 		return super.stream().sorted(new CtLineElementComparator());
 	}
 }

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -7,14 +7,24 @@
  */
 package spoon.support.util;
 
+import java.io.Serializable;
 import java.util.Collection;
-import java.util.TreeSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import spoon.Launcher;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.reference.CtReference;
 import spoon.support.comparator.QualifiedNameComparator;
 
-public class QualifiedNameBasedSortedSet<E extends CtElement> extends
-		TreeSet<E> {
+public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>, Serializable {
+    private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
 
 	private static final long serialVersionUID = 1L;
 
@@ -24,7 +34,116 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> extends
 	}
 
 	public QualifiedNameBasedSortedSet() {
-		super(new QualifiedNameComparator());
+	    set = new LinkedHashSet<>();
+	}
+
+	@Override
+	public int size() {
+		return set.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return set.isEmpty();
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		return o instanceof CtElement && set.contains(new QualifiedNameHashEqualsWrapper((CtElement) o));
+	}
+
+	@Override
+    @SuppressWarnings("unchecked")
+	public Iterator<E> iterator() {
+		return set.stream().map(e -> (E) e.element).iterator();
+	}
+
+	@Override
+	public Object[] toArray() {
+		return set.stream().map(e -> e.element).toArray();
+	}
+
+	@Override
+	public <T> T[] toArray(T[] ts) {
+		return set.stream().map(e -> e.element).collect(Collectors.toList()).toArray(ts);
+	}
+
+	@Override
+	public boolean add(E e) {
+		return set.add(new QualifiedNameHashEqualsWrapper(e));
+	}
+
+	@Override
+	public boolean remove(Object o) {
+		return o instanceof CtElement &&
+				set.removeIf(e -> getQualifiedName(e.element).equals(getQualifiedName((CtElement) o)));
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> collection) {
+	    return collection.stream().allMatch(this::contains);
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends E> collection) {
+		return collection.stream().anyMatch(this::add);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> collection) {
+	    throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> collection) {
+	    throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void clear() {
+		set.clear();
+	}
+
+	/**
+	 * A small wrapper around a CtElement that provides hashCode and equals methods based on the element's qualified
+	 * name.
+	 */
+	private static final class QualifiedNameHashEqualsWrapper implements Serializable {
+		final CtElement element;
+
+		private static final long serialVersionUID = 1L;
+
+		QualifiedNameHashEqualsWrapper(CtElement element) {
+			this.element = element;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			QualifiedNameHashEqualsWrapper that = (QualifiedNameHashEqualsWrapper) o;
+			return QualifiedNameComparator.INSTANCE.compare(element, that.element) == 0;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(getQualifiedName(element));
+		}
+	}
+
+	private static String getQualifiedName(CtElement element) {
+		if (element instanceof CtTypeInformation) {
+			return ((CtTypeInformation) element).getQualifiedName();
+		} else if (element instanceof CtPackage) {
+			return ((CtPackage) element).getQualifiedName();
+		} else if (element instanceof CtReference) {
+			return ((CtReference) element).getSimpleName();
+		} else if (element instanceof CtNamedElement) {
+			return ((CtNamedElement) element).getSimpleName();
+		}
+
+		Launcher.LOGGER.warn( QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
+		return "";
 	}
 
 }

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -24,9 +24,9 @@ import spoon.reflect.reference.CtReference;
 import spoon.support.comparator.QualifiedNameComparator;
 
 public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>, Serializable {
-    private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
-
 	private static final long serialVersionUID = 1L;
+
+	private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
 
 	public QualifiedNameBasedSortedSet(Collection<E> elements) {
 		this();
@@ -34,7 +34,22 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	}
 
 	public QualifiedNameBasedSortedSet() {
-	    set = new LinkedHashSet<>();
+		set = new LinkedHashSet<>();
+	}
+
+	private static String getQualifiedName(CtElement element) {
+		if (element instanceof CtTypeInformation) {
+			return ((CtTypeInformation) element).getQualifiedName();
+		} else if (element instanceof CtPackage) {
+			return ((CtPackage) element).getQualifiedName();
+		} else if (element instanceof CtReference) {
+			return ((CtReference) element).getSimpleName();
+		} else if (element instanceof CtNamedElement) {
+			return ((CtNamedElement) element).getSimpleName();
+		}
+
+		Launcher.LOGGER.warn(QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
+		return "";
 	}
 
 	@Override
@@ -53,7 +68,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	}
 
 	@Override
-    @SuppressWarnings("unchecked")
+	@SuppressWarnings("unchecked")
 	public Iterator<E> iterator() {
 		return set.stream().map(e -> (E) e.element).iterator();
 	}
@@ -81,7 +96,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 
 	@Override
 	public boolean containsAll(Collection<?> collection) {
-	    return collection.stream().allMatch(this::contains);
+		return collection.stream().allMatch(this::contains);
 	}
 
 	@Override
@@ -91,12 +106,12 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 
 	@Override
 	public boolean retainAll(Collection<?> collection) {
-	    throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean removeAll(Collection<?> collection) {
-	    throw new UnsupportedOperationException();
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -109,9 +124,8 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	 * name.
 	 */
 	private static final class QualifiedNameHashEqualsWrapper implements Serializable {
-		final CtElement element;
-
 		private static final long serialVersionUID = 1L;
+		final CtElement element;
 
 		QualifiedNameHashEqualsWrapper(CtElement element) {
 			this.element = element;
@@ -129,21 +143,6 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 		public int hashCode() {
 			return Objects.hash(getQualifiedName(element));
 		}
-	}
-
-	private static String getQualifiedName(CtElement element) {
-		if (element instanceof CtTypeInformation) {
-			return ((CtTypeInformation) element).getQualifiedName();
-		} else if (element instanceof CtPackage) {
-			return ((CtPackage) element).getQualifiedName();
-		} else if (element instanceof CtReference) {
-			return ((CtReference) element).getSimpleName();
-		} else if (element instanceof CtNamedElement) {
-			return ((CtNamedElement) element).getSimpleName();
-		}
-
-		Launcher.LOGGER.warn( QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
-		return "";
 	}
 
 }

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -24,9 +24,9 @@ import spoon.reflect.reference.CtReference;
 import spoon.support.comparator.QualifiedNameComparator;
 
 public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>, Serializable {
-	private static final long serialVersionUID = 1L;
+    private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
 
-	private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
+	private static final long serialVersionUID = 1L;
 
 	public QualifiedNameBasedSortedSet(Collection<E> elements) {
 		this();
@@ -34,22 +34,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	}
 
 	public QualifiedNameBasedSortedSet() {
-		set = new LinkedHashSet<>();
-	}
-
-	private static String getQualifiedName(CtElement element) {
-		if (element instanceof CtTypeInformation) {
-			return ((CtTypeInformation) element).getQualifiedName();
-		} else if (element instanceof CtPackage) {
-			return ((CtPackage) element).getQualifiedName();
-		} else if (element instanceof CtReference) {
-			return ((CtReference) element).getSimpleName();
-		} else if (element instanceof CtNamedElement) {
-			return ((CtNamedElement) element).getSimpleName();
-		}
-
-		Launcher.LOGGER.warn(QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
-		return "";
+	    set = new LinkedHashSet<>();
 	}
 
 	@Override
@@ -68,7 +53,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
 	public Iterator<E> iterator() {
 		return set.stream().map(e -> (E) e.element).iterator();
 	}
@@ -96,7 +81,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 
 	@Override
 	public boolean containsAll(Collection<?> collection) {
-		return collection.stream().allMatch(this::contains);
+	    return collection.stream().allMatch(this::contains);
 	}
 
 	@Override
@@ -106,12 +91,12 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 
 	@Override
 	public boolean retainAll(Collection<?> collection) {
-		throw new UnsupportedOperationException();
+	    throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public boolean removeAll(Collection<?> collection) {
-		throw new UnsupportedOperationException();
+	    throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -124,8 +109,9 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	 * name.
 	 */
 	private static final class QualifiedNameHashEqualsWrapper implements Serializable {
-		private static final long serialVersionUID = 1L;
 		final CtElement element;
+
+		private static final long serialVersionUID = 1L;
 
 		QualifiedNameHashEqualsWrapper(CtElement element) {
 			this.element = element;
@@ -143,6 +129,21 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 		public int hashCode() {
 			return Objects.hash(getQualifiedName(element));
 		}
+	}
+
+	private static String getQualifiedName(CtElement element) {
+		if (element instanceof CtTypeInformation) {
+			return ((CtTypeInformation) element).getQualifiedName();
+		} else if (element instanceof CtPackage) {
+			return ((CtPackage) element).getQualifiedName();
+		} else if (element instanceof CtReference) {
+			return ((CtReference) element).getSimpleName();
+		} else if (element instanceof CtNamedElement) {
+			return ((CtNamedElement) element).getSimpleName();
+		}
+
+		Launcher.LOGGER.warn( QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
+		return "";
 	}
 
 }

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -7,24 +7,14 @@
  */
 package spoon.support.util;
 
-import java.io.Serializable;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeSet;
 
-import spoon.Launcher;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtTypeInformation;
-import spoon.reflect.reference.CtReference;
 import spoon.support.comparator.QualifiedNameComparator;
 
-public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>, Serializable {
-    private final LinkedHashSet<QualifiedNameHashEqualsWrapper> set;
+public class QualifiedNameBasedSortedSet<E extends CtElement> extends
+		TreeSet<E> {
 
 	private static final long serialVersionUID = 1L;
 
@@ -34,116 +24,7 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> implements Set<E>,
 	}
 
 	public QualifiedNameBasedSortedSet() {
-	    set = new LinkedHashSet<>();
-	}
-
-	@Override
-	public int size() {
-		return set.size();
-	}
-
-	@Override
-	public boolean isEmpty() {
-		return set.isEmpty();
-	}
-
-	@Override
-	public boolean contains(Object o) {
-		return o instanceof CtElement && set.contains(new QualifiedNameHashEqualsWrapper((CtElement) o));
-	}
-
-	@Override
-    @SuppressWarnings("unchecked")
-	public Iterator<E> iterator() {
-		return set.stream().map(e -> (E) e.element).iterator();
-	}
-
-	@Override
-	public Object[] toArray() {
-		return set.stream().map(e -> e.element).toArray();
-	}
-
-	@Override
-	public <T> T[] toArray(T[] ts) {
-		return set.stream().map(e -> e.element).collect(Collectors.toList()).toArray(ts);
-	}
-
-	@Override
-	public boolean add(E e) {
-		return set.add(new QualifiedNameHashEqualsWrapper(e));
-	}
-
-	@Override
-	public boolean remove(Object o) {
-		return o instanceof CtElement &&
-				set.removeIf(e -> getQualifiedName(e.element).equals(getQualifiedName((CtElement) o)));
-	}
-
-	@Override
-	public boolean containsAll(Collection<?> collection) {
-	    return collection.stream().allMatch(this::contains);
-	}
-
-	@Override
-	public boolean addAll(Collection<? extends E> collection) {
-		return collection.stream().anyMatch(this::add);
-	}
-
-	@Override
-	public boolean retainAll(Collection<?> collection) {
-	    throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public boolean removeAll(Collection<?> collection) {
-	    throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public void clear() {
-		set.clear();
-	}
-
-	/**
-	 * A small wrapper around a CtElement that provides hashCode and equals methods based on the element's qualified
-	 * name.
-	 */
-	private static final class QualifiedNameHashEqualsWrapper implements Serializable {
-		final CtElement element;
-
-		private static final long serialVersionUID = 1L;
-
-		QualifiedNameHashEqualsWrapper(CtElement element) {
-			this.element = element;
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
-			QualifiedNameHashEqualsWrapper that = (QualifiedNameHashEqualsWrapper) o;
-			return QualifiedNameComparator.INSTANCE.compare(element, that.element) == 0;
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(getQualifiedName(element));
-		}
-	}
-
-	private static String getQualifiedName(CtElement element) {
-		if (element instanceof CtTypeInformation) {
-			return ((CtTypeInformation) element).getQualifiedName();
-		} else if (element instanceof CtPackage) {
-			return ((CtPackage) element).getQualifiedName();
-		} else if (element instanceof CtReference) {
-			return ((CtReference) element).getSimpleName();
-		} else if (element instanceof CtNamedElement) {
-			return ((CtNamedElement) element).getSimpleName();
-		}
-
-		Launcher.LOGGER.warn( QualifiedNameBasedSortedSet.class.getName() + " used for element without name: " + element.getClass().getName());
-		return "";
+		super(new QualifiedNameComparator());
 	}
 
 }

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -8,9 +8,12 @@
 package spoon.support.util;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.TreeSet;
+import java.util.stream.Stream;
 
 import spoon.reflect.declaration.CtElement;
+import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.comparator.QualifiedNameComparator;
 
 public class QualifiedNameBasedSortedSet<E extends CtElement> extends
@@ -27,4 +30,13 @@ public class QualifiedNameBasedSortedSet<E extends CtElement> extends
 		super(new QualifiedNameComparator());
 	}
 
+	@Override
+	public Iterator<E> iterator() {
+		return stream().iterator();
+	}
+
+	@Override
+	public Stream<E> stream() {
+		return super.stream().sorted(new CtLineElementComparator());
+	}
 }

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -17,7 +17,7 @@ import spoon.support.visitor.clone.CloneVisitor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +78,7 @@ public class CloneHelper {
 		if (elements == null || elements.isEmpty()) {
 			return EmptyClearableSet.instance();
 		}
-		Set<T> others = new HashSet<>(elements.size());
+		Set<T> others = new LinkedHashSet<>(elements.size());
 		for (T element : elements) {
 			addClone(others, element);
 		}

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -17,7 +17,7 @@ import spoon.support.visitor.clone.CloneVisitor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +78,7 @@ public class CloneHelper {
 		if (elements == null || elements.isEmpty()) {
 			return EmptyClearableSet.instance();
 		}
-		Set<T> others = new LinkedHashSet<>(elements.size());
+		Set<T> others = new HashSet<>(elements.size());
 		for (T element : elements) {
 			addClone(others, element);
 		}

--- a/src/test/java/spoon/support/util/QualifiedNameBasedSortedSetTest.java
+++ b/src/test/java/spoon/support/util/QualifiedNameBasedSortedSetTest.java
@@ -1,0 +1,115 @@
+package spoon.support.util;
+
+import org.junit.Test;
+import spoon.reflect.cu.CompilationUnit;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.support.visitor.java.JavaReflectionTreeBuilder;
+import spoon.testing.utils.ModelUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class QualifiedNameBasedSortedSetTest {
+    @Test
+    public void testIteratorOrdering() {
+        // contract: elements without source position should appear before any element with source position,
+        // and be ordered between themselves by qualified name. Elements with source position should be ordered
+        // between themselves by source position.
+        final CtType<?> linkedListType = new JavaReflectionTreeBuilder(ModelUtils.createFactory())
+                .scan(LinkedList.class);
+
+        final MockSourcePosition smallerSourcePos = new MockSourcePosition(10, 12);
+        final MockSourcePosition largerSourcePos = new MockSourcePosition(14, 15);
+
+        QualifiedNameBasedSortedSet<CtTypeReference<?>> superInterfaces = new QualifiedNameBasedSortedSet<>(
+                linkedListType.getSuperInterfaces());
+        List<CtTypeReference<?>> expectedInterfaceOrder = new ArrayList<>(superInterfaces);
+
+        CtTypeReference<?> largerSourcePosElem = expectedInterfaceOrder.remove(0);
+        CtTypeReference<?> smallerSourcePosElem = expectedInterfaceOrder.remove(0);
+        // setting the source positions will reorder the elements when fetched from the original set
+        largerSourcePosElem.setPosition(largerSourcePos);
+        smallerSourcePosElem.setPosition(smallerSourcePos);
+        expectedInterfaceOrder.add(smallerSourcePosElem);
+        expectedInterfaceOrder.add(largerSourcePosElem);
+
+        Iterator<CtTypeReference<?>> expected = expectedInterfaceOrder.iterator();
+        Iterator<CtTypeReference<?>> actual = superInterfaces.iterator();
+
+        assertTrue(expected.hasNext());
+        while (expected.hasNext()) {
+            assertEquals(expected.next(), actual.next());
+        }
+        assertFalse(actual.hasNext());
+    }
+
+
+    private static class MockSourcePosition implements SourcePosition {
+        final int sourceStart;
+        final int sourceEnd;
+
+        public MockSourcePosition(int sourceStart, int sourceEnd) {
+            this.sourceStart = sourceStart;
+            this.sourceEnd = sourceEnd;
+        }
+
+        @Override
+        public boolean isValidPosition() {
+            return true;
+        }
+
+        @Override
+        public int getSourceEnd() {
+            return sourceEnd;
+        }
+
+        @Override
+        public int getSourceStart() {
+            return sourceStart;
+        }
+
+        /*
+         * Methods below here don't matter
+         */
+
+        @Override
+        public File getFile() {
+            return null;
+        }
+
+        @Override
+        public CompilationUnit getCompilationUnit() {
+            return null;
+        }
+
+        @Override
+        public int getLine() {
+            return 0;
+        }
+
+        @Override
+        public int getEndLine() {
+            return 0;
+        }
+
+        @Override
+        public int getColumn() {
+            return 0;
+        }
+
+        @Override
+        public int getEndColumn() {
+            return 0;
+        }
+
+    }
+}

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -26,6 +26,7 @@ import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnnotationMethod;
 import spoon.reflect.declaration.CtAnnotationType;
@@ -219,6 +220,11 @@ public class JavaReflectionTreeBuilderTest {
 
 		assertFalse(type.isShadow());
 		assertTrue(shadowType.isShadow());
+
+		// Some elements, such as superinterfaces and thrown types, are ordered by their source position if they have
+		// one. As a shadow model has no source positions, but a model built from source does, we must unset the source
+		// positions of the normal model's elements to ensure that there are no ordering discrepancies.
+		type.descendantIterator().forEachRemaining(e -> e.setPosition(SourcePosition.NOPOSITION));
 
 		ShadowEqualsVisitor sev = new ShadowEqualsVisitor(new HashSet<>(Arrays.asList(
 				//shadow classes has no body

--- a/src/test/java/spoon/test/api/MetamodelTest.java
+++ b/src/test/java/spoon/test/api/MetamodelTest.java
@@ -63,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -284,10 +285,19 @@ public class MetamodelTest {
 		}
 		assertSame(expectedConcept.getMetamodelInterface().getActualClass(), runtimeConcept.getMetamodelInterface().getActualClass());
 		assertEquals(expectedConcept.getKind(), runtimeConcept.getKind());
-		assertEquals(expectedConcept.getSuperConcepts().size(), runtimeConcept.getSuperConcepts().size());
-		for (int i = 0; i < expectedConcept.getSuperConcepts().size(); i++) {
-			assertConceptsEqual(expectedConcept.getSuperConcepts().get(i), runtimeConcept.getSuperConcepts().get(i));
+
+		// must be sorted as the order of super concepts from source is affected by the order of elements in the
+		// implements clause
+		List<MetamodelConcept> expectedSuperConcepts = expectedConcept.getSuperConcepts();
+		List<MetamodelConcept> runtimeSuperConcepts = runtimeConcept.getSuperConcepts();
+		expectedSuperConcepts.sort(Comparator.comparing(MetamodelConcept::getName));
+		runtimeSuperConcepts.sort(Comparator.comparing(MetamodelConcept::getName));
+
+		assertEquals(expectedSuperConcepts.size(), runtimeSuperConcepts.size());
+		for (int i = 0; i < expectedSuperConcepts.size(); i++) {
+			assertConceptsEqual(expectedSuperConcepts.get(i), runtimeSuperConcepts.get(i));
 		}
+
 		Map<CtRole, MetamodelProperty> expectedRoleToProperty = new HashMap(expectedConcept.getRoleToProperty());
 		for (Map.Entry<CtRole, MetamodelProperty> e : runtimeConcept.getRoleToProperty().entrySet()) {
 			MetamodelProperty runtimeProperty = e.getValue();

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -476,7 +476,7 @@ public class CommentTest {
 				+ "// comment before parameters" + newLine
 				+ "// comment before type parameter" + newLine
 				+ "// comment before name parameter" + newLine
-				+ "int i) throws java.lang.Error, java.lang.Exception {" + newLine
+				+ "int i) throws java.lang.Exception, java.lang.Error {" + newLine
 				+ "}", m2.toString());
 	}
 
@@ -638,7 +638,7 @@ public class CommentTest {
 				+ "/* comment before parameters */" + newLine
 				+ "/* comment before type parameter */" + newLine
 				+ "/* comment before name parameter */" + newLine
-				+ "int i) throws java.lang.Error, java.lang.Exception {" + newLine
+				+ "int i) throws java.lang.Exception, java.lang.Error {" + newLine
 				+ "}", m2.toString());
 
 		// contract: one does not crash when setting a comment starting with '//' in a block comment

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -18,11 +18,13 @@ package spoon.test.ctType;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtNamedElement;
@@ -35,12 +37,16 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.ctType.testclasses.X;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -212,5 +218,23 @@ public class CtTypeTest {
 			name = ref.getParent(CtNamedElement.class).getSimpleName();
 		}
 		return ref.toString() + " " + name;
+	}
+
+	@Test
+	public void testRetainsInterfaceOrder() {
+		final Launcher launcher = new Launcher();
+		List<String> expectedInterfaceOrder = Arrays.asList(
+				"java.util.function.Supplier<java.lang.Integer>",
+				"java.util.function.Consumer<java.lang.Integer>",
+				"java.lang.Comparable<java.lang.Integer>"
+		);
+		launcher.addInputResource("./src/test/java/spoon/test/ctType/testclasses/MultiInterfaceImplementation.java");
+
+		CtModel model = launcher.buildModel();
+		CtType<?> type = model.getAllTypes().iterator().next();
+		List<String> interfaces = type.getSuperInterfaces()
+				.stream().map(CtElement::toString).collect(Collectors.toList());
+
+		assertEquals(expectedInterfaceOrder, interfaces);
 	}
 }

--- a/src/test/java/spoon/test/ctType/testclasses/MultiInterfaceImplementation.java
+++ b/src/test/java/spoon/test/ctType/testclasses/MultiInterfaceImplementation.java
@@ -1,0 +1,20 @@
+package spoon.test.ctType.testclasses;
+
+public class MultiInterfaceImplementation implements
+        java.util.function.Supplier<Integer>,
+        java.util.function.Consumer<Integer>,
+        java.lang.Comparable<java.lang.Integer> {
+    public int compareTo(Integer i) {
+        return 0;
+    }
+
+    public Integer get() {
+        return 1;
+    }
+
+    public void accept(Integer i) {
+        // thanks!
+    }
+}
+
+


### PR DESCRIPTION
Fix #3354 

This is a rough draft to fix #3554. Currently, this fails the `testGenerateRoleHandler` test as a new role handler `CtType_MODIFIER_RoleHandler` is generated. I'm not quite sure why that is, but it has something to do with elements being ordered by insertion order instead of by name order.

I'm not quite sure how to proceed with this, or even if we want to proceed with this. Perhaps it is more trouble than its worth.