### PR TITLE
fix: Remove incorrect implicitness for package reference

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -775,7 +775,6 @@ public class ReferenceBuilder {
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 			} else {
 				CtPackageReference packageReference = getPackageReference(binding.getPackage());
-				packageReference.setImplicit(true);
 				ref.setPackage(packageReference);
 			}
 			ref.setSimpleName(new String(binding.sourceName()));

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -39,9 +39,11 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtParameterReference;
+import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtWildcardReference;
@@ -701,5 +703,32 @@ public class TypeReferenceTest {
 		// test type with null package
 		CtTypeReference tr2 = fields.get(0).getType();
 		assertTrue(vars.get(0).getReference().getType().canAccess(tr2));
+	}
+
+	@Test
+	public void testQualifiedArrayTypeReferenceNoClasspath() {
+		// contract: component type of explicitly qualified array type reference should have explicit package reference
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/noclasspath/QualifiedArrayType.java");
+		launcher.getEnvironment().setNoClasspath(true);
+		CtModel model = launcher.buildModel();
+		List<CtArrayTypeReference<?>> refs = model.getElements(e -> true);
+
+		int loopIterations = 0; // for meta assert
+		for (CtArrayTypeReference<?> arrayTypeRef : refs) {
+		    CtTypeReference<?> compType = getDeepestComponentType(arrayTypeRef);
+		    assertFalse(compType.getPackage().isImplicit());
+			loopIterations++;
+		}
+
+		assertTrue("Test loop did not execute", loopIterations > 0);
+	}
+
+	private static CtTypeReference<?> getDeepestComponentType(CtArrayTypeReference<?> arrayTypeRef) {
+		CtReference ref = arrayTypeRef;
+		while (ref instanceof CtArrayTypeReference) {
+			ref = ((CtArrayTypeReference<?>) ref).getComponentType();
+		}
+		return (CtTypeReference<?>) ref;
 	}
 }

--- a/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
+++ b/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
@@ -230,8 +230,8 @@ public class SpoonifierTest {
 				"\t\t\t\t\tCtExecutableReference ctExecutableReference0 = factory.createExecutableReference();\n" +
 				"\t\t\t\t\tctExecutableReference0.setSimpleName(\"<init>\");\n" +
 				"\t\t\t\t\tctInvocation0.setValueByRole(CtRole.EXECUTABLE_REF, ctExecutableReference0);\n" +
-				"\t\t\t\t\t\tctExecutableReference0.setValueByRole(CtRole.DECLARING_TYPE, factory.Type().createSimplyQualifiedReference(\"java.lang.Object\"));\n" +
-				"\t\t\t\t\t\tctExecutableReference0.setValueByRole(CtRole.TYPE, factory.Type().createSimplyQualifiedReference(\"java.lang.Object\"));\n" +
+				"\t\t\t\t\t\tctExecutableReference0.setValueByRole(CtRole.DECLARING_TYPE, factory.Type().createReference(\"java.lang.Object\"));\n" +
+				"\t\t\t\t\t\tctExecutableReference0.setValueByRole(CtRole.TYPE, factory.Type().createReference(\"java.lang.Object\"));\n" +
 				"\t\t\tctBlock0.setValueByRole(CtRole.STATEMENT, ctBlock0Statements);\n" +
 				"\t\tCtField ctField0 = factory.createField();\n" +
 				"\t\tctField0.setSimpleName(\"i\");\n" +
@@ -273,7 +273,7 @@ public class SpoonifierTest {
 				"\t\t\t\t\t\tCtParameterReference ctParameterReference0 = factory.createParameterReference();\n" +
 				"\t\t\t\t\t\tctParameterReference0.setSimpleName(\"toto\");\n" +
 				"\t\t\t\t\t\tctVariableRead0.setValueByRole(CtRole.VARIABLE, ctParameterReference0);\n" +
-				"\t\t\t\t\t\t\tctParameterReference0.setValueByRole(CtRole.TYPE, factory.Type().createSimplyQualifiedReference(\"java.lang.String\"));\n" +
+				"\t\t\t\t\t\t\tctParameterReference0.setValueByRole(CtRole.TYPE, factory.Type().createReference(\"java.lang.String\"));\n" +
 				"\t\t\tctBlock1.setValueByRole(CtRole.STATEMENT, ctBlock1Statements);\n" +
 				"\t\tctMethod0.setValueByRole(CtRole.PARAMETER, ctMethod0Parameters);\n" +
 				"\tctClass0.setValueByRole(CtRole.TYPE_MEMBER, ctClass0TypeMembers);\n";

--- a/src/test/resources/noclasspath/QualifiedArrayType.java
+++ b/src/test/resources/noclasspath/QualifiedArrayType.java
@@ -1,0 +1,6 @@
+import java.util.*;
+
+public class QualifiedArrayType {
+    java.lang.Object[] builtinTypeArray;
+    java.util.Collection[] importedTypeArray;
+}


### PR DESCRIPTION
Fix #3336 

This is an attempt to fix the problem discussed in the aforementioned issue. I don't know why the package reference is to implicit where it is, but removing it with edf9700 fixed my problems. This also causes some changes in generated code, so I had to update `testGeneratedSpoonifyCode` with 8acb899.

I really don't know if this PR is reasonable. It works for me and does not appear to cause any breakage other than `testGeneratedSpoonifyCode`. Accidentally setting an explicit reference to implicit is in my opinion much worse than the other way around, as the former can cause compile errors, and has done so for me multiple times.