### PR TITLE
fix: Fix dropping diamonds on constructor calls

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -93,6 +93,7 @@ public class TypeFactory extends SubFactory {
 	public final CtTypeReference<Set> SET = createReference(Set.class);
 	public final CtTypeReference<Map> MAP = createReference(Map.class);
 	public final CtTypeReference<Enum> ENUM = createReference(Enum.class);
+	public final CtTypeReference<?> OMITTED_TYPE_ARG_TYPE = createReference(CtTypeReference.OMITTED_TYPE_ARG_NAME);
 
 	private final Map<Class<?>, CtType<?>> shadowCache = new ConcurrentHashMap<>();
 

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -35,6 +35,11 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	String NULL_TYPE_NAME = "<nulltype>";
 
 	/**
+	 * Special type used as a type argument when actual type arguments can't be inferred.
+	 */
+	String OMITTED_TYPE_ARG_NAME = "<omitted>";
+
+	/**
 	 * Returns the simple (unqualified) name of this element.
 	 * Following the compilation convention, if the type is a local type,
 	 * the name starts with a numeric prefix (e.g. local class Foo has simple name 1Foo).

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -564,34 +564,51 @@ public class ReferenceBuilder {
 		if (original.resolvedType instanceof ProblemReferenceBinding && original.getTypeArguments() != null) {
 			for (TypeReference[] typeReferences : original.getTypeArguments()) {
 				if (typeReferences != null) {
-					if (typeReferences.length > 0) {
-						for (TypeReference typeReference : typeReferences) {
-							type.addActualTypeArgument(this.getTypeReference(typeReference.resolvedType));
-						}
-					} else {
-						// In noclasspath mode, type arguments to constructor calls on types not on the classpath
-						// cause the type arguments to not be resolved if they are implicit (i.e. just `<>`).
-						// See #3360 for details.
-						final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
-						assert stack.peek() != null;
-						assert stack.peek().node instanceof AllocationExpression;
-
-						AllocationExpression alloc = (AllocationExpression) stack.peek().node;
-						ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
-
-						if (expectedType != null) {
-							// type arguments can be recovered from the expected type
-							for (TypeBinding binding : expectedType.typeArguments()) {
-								CtTypeReference<?> typeArgRef = getTypeReference(binding);
-								typeArgRef.setImplicit(true);
-								type.addActualTypeArgument(typeArgRef);
-							}
-						} else {
-							// the expected type is not available if the constructor call occurs in e.g. a method call
-							type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE);
-						}
+					for (TypeReference typeReference : typeReferences) {
+						type.addActualTypeArgument(this.getTypeReference(typeReference.resolvedType));
 					}
 				}
+			}
+		}
+
+		if (original.isParameterizedTypeReference() && !type.isParameterized()) {
+			tryRecoverTypeArguments(type);
+		}
+	}
+
+	/**
+	 * In noclasspath mode, empty diamonds in constructor calls on generic types can be lost. This happens if any
+	 * of the following apply:
+	 *
+     * <ul>
+	 *     <li>The generic type is not on the classpath.</li>
+	 *     <li>The generic type is used in a context where the type arguments cannot be inferred, such as in an
+	 *     unresolved method
+	 *     </li>
+     * </ul>
+	 *
+	 * See #3360 for details.
+	 */
+	private void tryRecoverTypeArguments(CtTypeReference<?> type) {
+		final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
+		if (stack.peek() == null || !(stack.peek().node instanceof AllocationExpression)) {
+		    // have thus far only ended up here with a generic array type,
+			// don't know if we want or need to deal with those
+			return;
+		}
+
+		AllocationExpression alloc = (AllocationExpression) stack.peek().node;
+		if (alloc.expectedType() == null || !(alloc.expectedType() instanceof ParameterizedTypeBinding)) {
+			// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
+			// method, or in a method that did not expect a parameterized argument
+			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE);
+		} else {
+			ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
+			// type arguments can be recovered from the expected type
+			for (TypeBinding binding : expectedType.typeArguments()) {
+				CtTypeReference<?> typeArgRef = getTypeReference(binding);
+				typeArgRef.setImplicit(true);
+				type.addActualTypeArgument(typeArgRef);
 			}
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -580,19 +580,19 @@ public class ReferenceBuilder {
 	 * In noclasspath mode, empty diamonds in constructor calls on generic types can be lost. This happens if any
 	 * of the following apply:
 	 *
-     * <ul>
+	 * <ul>
 	 *     <li>The generic type is not on the classpath.</li>
 	 *     <li>The generic type is used in a context where the type arguments cannot be inferred, such as in an
 	 *     unresolved method
 	 *     </li>
-     * </ul>
+	 * </ul>
 	 *
 	 * See #3360 for details.
 	 */
 	private void tryRecoverTypeArguments(CtTypeReference<?> type) {
 		final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
 		if (stack.peek() == null || !(stack.peek().node instanceof AllocationExpression)) {
-		    // have thus far only ended up here with a generic array type,
+			// have thus far only ended up here with a generic array type,
 			// don't know if we want or need to deal with those
 			return;
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -601,7 +601,7 @@ public class ReferenceBuilder {
 		if (alloc.expectedType() == null || !(alloc.expectedType() instanceof ParameterizedTypeBinding)) {
 			// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
 			// method, or in a method that did not expect a parameterized argument
-			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE);
+			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.clone());
 		} else {
 			ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
 			// type arguments can be recovered from the expected type

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -571,7 +571,7 @@ public class ReferenceBuilder {
 					} else {
 						// In noclasspath mode, type arguments to constructor calls on types not on the classpath
 						// cause the type arguments to not be resolved if they are implicit (i.e. just `<>`).
-						// See #114 for details.
+						// See #3360 for details.
 						final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
 						assert stack.peek() != null;
 						assert stack.peek().node instanceof AllocationExpression;
@@ -587,7 +587,7 @@ public class ReferenceBuilder {
 								type.addActualTypeArgument(typeArgRef);
 							}
 						} else {
-							// the expected type is not available if the constructor call occurs in a method call
+							// the expected type is not available if the constructor call occurs in e.g. a method call
 							type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE);
 						}
 					}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -569,7 +569,7 @@ public class ReferenceBuilder {
 							type.addActualTypeArgument(this.getTypeReference(typeReference.resolvedType));
 						}
 					} else {
-					    // In noclasspath mode, type arguments to constructor calls on types not on the classpath
+						// In noclasspath mode, type arguments to constructor calls on types not on the classpath
 						// cause the type arguments to not be resolved if they are implicit (i.e. just `<>`).
 						// See #114 for details.
 						final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -580,7 +580,7 @@ public class ReferenceBuilder {
 						ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
 
 						if (expectedType != null) {
-						    // type arguments can be recovered from the expected type
+							// type arguments can be recovered from the expected type
 							for (TypeBinding binding : expectedType.typeArguments()) {
 								CtTypeReference<?> typeArgRef = getTypeReference(binding);
 								typeArgRef.setImplicit(true);

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -573,7 +573,6 @@ public class ReferenceBuilder {
 						// cause the type arguments to not be resolved if they are implicit (i.e. just `<>`).
 						// See #114 for details.
 						final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
-						assert jdtTreeBuilder.getFactory().getEnvironment().getNoClasspath();
 						assert stack.peek() != null;
 						assert stack.peek().node instanceof AllocationExpression;
 

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -170,6 +170,15 @@ public class ConstructorCallTest {
 		assertTrue(executableType.getActualTypeArguments().stream().allMatch(CtElement::isImplicit));
 	}
 
+	@Test
+	public void testParameterizedConstructorCallOmittedTypeArgsResolvedTypeNoClasspath() {
+		// contract: if a resolved type (here, java.util.ArrayList) is parameterized with empty diamonds in an
+		// unresolved method, the resolved type reference should still be parameterized.
+		String sourceFile = "./src/test/resources/noclasspath/GenericTypeEmptyDiamond.java";
+		CtTypeReference<?> executableType = getConstructorCallTypeFrom("ArrayList", sourceFile);
+		assertTrue(executableType.isParameterized());
+	}
+
 	private CtTypeReference<?> getConstructorCallTypeFrom(String simpleName, String sourceFile) {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);

--- a/src/test/resources/noclasspath/GenericTypeEmptyDiamond.java
+++ b/src/test/resources/noclasspath/GenericTypeEmptyDiamond.java
@@ -1,7 +1,13 @@
-// the purpose of this test class is to check that omitted type arguments are properly resolved
+// the purpose of this test class is to check that omitted type arguments are properly resolved in noclasspath mode
+import java.util.ArrayList;
+
 class GenericTypeEmptyDiamond {
     public static void main(String[] args) {
+        // the context should allow the type arguments for this constructor call to be recovered
         GenericKnownExpectedType<Integer, String> someGeneric = new GenericKnownExpectedType<>();
+        // meth is an unresolved method, so there is no context to allow for inference of type arguments
         meth(new GenericUnknownExpectedType<>());
+        // same as the above, but with a generic type that is available on the classpath
+        meth(new ArrayList<>());
     }
 }

--- a/src/test/resources/noclasspath/GenericTypeEmptyDiamond.java
+++ b/src/test/resources/noclasspath/GenericTypeEmptyDiamond.java
@@ -1,0 +1,7 @@
+// the purpose of this test class is to check that omitted type arguments are properly resolved
+class GenericTypeEmptyDiamond {
+    public static void main(String[] args) {
+        GenericKnownExpectedType<Integer, String> someGeneric = new GenericKnownExpectedType<>();
+        meth(new GenericUnknownExpectedType<>());
+    }
+}


### PR DESCRIPTION
Fix #3360 

This is an attempt to fix the problem discussed in #3360 

What I do here is essentially to try to recover the type arguments from the `AllocationExpression`'s expected type. To the best of my knowledge, empty diamonds are only allowed on constructor calls, so I only have an assert that the stack's top element is an `AllocationExpression`. It shouldn't be possible for it to be anything else.

If the constructor call occurs inside of an unresolved method, or another constructor call, then the `AllocationExpression` doesn't have an expected type (because it can't be resolved). In that case, I add the new `OMITTED_TYPE_ARG_TYPE` (name could use some work) to the type argument list so at least Spoon can detect that the constructor is in fact parameterized, and will then print `<>`.

This appears to work as intended, but I'll be running some more tests locally with my merge tool to see if other issues crop up.