### PR TITLE
fix: Ensure unqualified member access remains unqualified

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -639,7 +639,12 @@ public class JDTTreeBuilderHelper {
 		} else {
 			typeReference.setSimpleName(CharOperation.charToString(singleNameReference.binding.readableName()));
 		}
-		jdtTreeBuilder.getReferencesBuilder().setPackageOrDeclaringType(typeReference, jdtTreeBuilder.getReferencesBuilder().getDeclaringReferenceFromImports(singleNameReference.token));
+		CtReference packageOrDeclaringType = jdtTreeBuilder.getReferencesBuilder().getDeclaringReferenceFromImports(singleNameReference.token);
+		if (packageOrDeclaringType != null) {
+		    // must be implicit as a SingleNameReference is not qualified, see #3363
+			packageOrDeclaringType.setImplicit(true);
+		}
+		jdtTreeBuilder.getReferencesBuilder().setPackageOrDeclaringType(typeReference, packageOrDeclaringType);
 		return jdtTreeBuilder.getFactory().Code().createTypeAccess(typeReference);
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -641,7 +641,7 @@ public class JDTTreeBuilderHelper {
 		}
 		CtReference packageOrDeclaringType = jdtTreeBuilder.getReferencesBuilder().getDeclaringReferenceFromImports(singleNameReference.token);
 		if (packageOrDeclaringType != null) {
-		    // must be implicit as a SingleNameReference is not qualified, see #3363
+			// must be implicit as a SingleNameReference is not qualified, see #3363
 			packageOrDeclaringType.setImplicit(true);
 		}
 		jdtTreeBuilder.getReferencesBuilder().setPackageOrDeclaringType(typeReference, packageOrDeclaringType);

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -731,4 +731,24 @@ public class TypeReferenceTest {
 		}
 		return (CtTypeReference<?>) ref;
 	}
+
+	@Test
+	public void testUnqualifiedExternalTypeMemberAccess() {
+		// contract: if a type member is accessed without qualification, but it is not part of the current
+		// compilation unit, any qualification attached to it through import resolution must remain implicit
+		// See #3363 for details
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/noclasspath/UnqualifiedExternalTypeMemberAccess.java");
+		launcher.getEnvironment().setNoClasspath(true);
+		CtModel model = launcher.buildModel();
+		List<CtTypeReference<?>> typeReferences = model.getElements(e -> e.getSimpleName().equals("SOMETHING"));
+
+		assertEquals("There should only be one reference to SOMETHING, check the resource!", 1, typeReferences.size());
+
+		CtTypeReference<?> typeRef = typeReferences.get(0);
+		CtTypeReference<?> declType = typeRef.getDeclaringType();
+
+		assertEquals("Constants", declType.getSimpleName());
+		assertTrue(declType.isImplicit());
+	}
 }

--- a/src/test/resources/noclasspath/UnqualifiedExternalTypeMemberAccess.java
+++ b/src/test/resources/noclasspath/UnqualifiedExternalTypeMemberAccess.java
@@ -1,0 +1,9 @@
+package pkg;
+
+import static pkg.constants.Constants.SOMETHING;
+
+public class UnqualifiedExternalTypeMemberAccess {
+    public static void main(String[] args) {
+        System.out.println(SOMETHING);
+    }
+}


### PR DESCRIPTION
Fix #3363 

This is a fix for the aforementioned issue. The approach I've taken here is outlined in #3363. If I'm not mistaken, this fix is simple and does not break anything.