### PR TITLE
fix: Unqualified static method calls should be implicit

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -640,11 +640,8 @@ public class JDTTreeBuilderHelper {
 			typeReference.setSimpleName(CharOperation.charToString(singleNameReference.binding.readableName()));
 		}
 		CtReference packageOrDeclaringType = jdtTreeBuilder.getReferencesBuilder().getDeclaringReferenceFromImports(singleNameReference.token);
-		if (packageOrDeclaringType != null) {
-			// must be implicit as a SingleNameReference is not qualified, see #3363
-			packageOrDeclaringType.setImplicit(true);
-		}
-		jdtTreeBuilder.getReferencesBuilder().setPackageOrDeclaringType(typeReference, packageOrDeclaringType);
+		// package/declaring type must be added as implicit as a SingleNameReference is not qualified, see #3363 and #3370
+		jdtTreeBuilder.getReferencesBuilder().setImplicitPackageOrDeclaringType(typeReference, packageOrDeclaringType);
 		return jdtTreeBuilder.getFactory().Code().createTypeAccess(typeReference);
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1127,8 +1127,8 @@ public class ReferenceBuilder {
 	 * not modified (but they may be replaced).
 	 */
 	void setImplicitPackageOrDeclaringType(CtTypeReference<?> ref, CtReference declaring) {
-	    CtTypeReference<?> oldDeclaring = ref.getDeclaringType();
-	    CtPackageReference oldPackage = ref.getPackage();
+		CtTypeReference<?> oldDeclaring = ref.getDeclaringType();
+		CtPackageReference oldPackage = ref.getPackage();
 
 		setPackageOrDeclaringType(ref, declaring);
 		CtTypeReference<?> currentDeclaring = ref.getDeclaringType();

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1119,6 +1119,29 @@ public class ReferenceBuilder {
 		}
 	}
 
+	/**
+	 * Same as {@link #setPackageOrDeclaringType(CtTypeReference, CtReference)}, but ensures that the set declaring
+	 * type or package reference is made implicit.
+	 *
+	 * NOTE: Only a package/declaring type that's set by this method is made implicit, pre-existing references are
+	 * not modified (but they may be replaced).
+	 */
+	void setImplicitPackageOrDeclaringType(CtTypeReference<?> ref, CtReference declaring) {
+	    CtTypeReference<?> oldDeclaring = ref.getDeclaringType();
+	    CtPackageReference oldPackage = ref.getPackage();
+
+		setPackageOrDeclaringType(ref, declaring);
+		CtTypeReference<?> currentDeclaring = ref.getDeclaringType();
+		CtPackageReference currentPackage = ref.getPackage();
+
+		if (currentDeclaring != oldDeclaring) {
+			currentDeclaring.setImplicit(true);
+		}
+		if (currentPackage != oldPackage) {
+			currentPackage.setImplicit(true);
+		}
+	}
+
 	private static boolean containsStarImport(ImportReference[] imports) {
 		return imports != null && Arrays.stream(imports).anyMatch(imp -> imp.toString().endsWith("*"));
 	}

--- a/src/test/resources/noclasspath/UnqualifiedStaticMethodCall.java
+++ b/src/test/resources/noclasspath/UnqualifiedStaticMethodCall.java
@@ -1,0 +1,7 @@
+package pkg;
+
+class UnqualifiedStaticMethodCall {
+    public static void main(String[] args) {
+        SomeClass.someMethod(args);
+    }
+}


### PR DESCRIPTION
Fix #3370 

This is a suggestion for solving #3370. It is a unified solution for both this and #3363 , as the fix I implement for the latter in #3364 was apparently only a partial solution to the problem.

I decided to add the `setImplicitPackageOrDeclaringType` to complement `setPackageOrDeclaringType` as the latter seems to be used in places where it's not obvious that the package/declaring type should be implicit. But in this particular case, we know we want it to be implicit as the `createTypeAccessNoClasspath(SingleNameReference)` is called with a `SingleNameReference` (i.e. not qualified).