### PR TITLE
fix: Qualified name in catch clause resolved incorrectly (noclasspath)

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -127,7 +127,12 @@ public class JDTTreeBuilderHelper {
 			//do not set type of variable yet. It will be initialized later by visit of multiple types. Each call then ADDs one type
 			return result;
 		} else {
-			CtTypeReference ctTypeReference = jdtTreeBuilder.getReferencesBuilder().<Throwable>getTypeReference(typeReference.resolvedType);
+			CtTypeReference ctTypeReference;
+			if (typeReference.resolvedType instanceof ProblemReferenceBinding) {
+				ctTypeReference = jdtTreeBuilder.getReferencesBuilder().buildTypeReference(typeReference, null);
+			} else {
+				ctTypeReference = jdtTreeBuilder.getReferencesBuilder().<Throwable>getTypeReference(typeReference.resolvedType);
+			}
 			return result.<CtCatchVariable>setType(ctTypeReference);
 		}
 	}

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -320,4 +320,19 @@ public class TryCatchTest {
 		assertNull(catches.get(1).getParameter().getType()); // multicatch with UnknownException
 		assertNull(catches.get(2).getParameter().getType()); // multicatch with UnknownException
 	}
+
+	@Test
+	public void testCatchQualifiedReferenceNoClasspath() {
+	    Launcher launcher = new Launcher();
+	    launcher.getEnvironment().setNoClasspath(true);
+	    launcher.addInputResource("./src/test/resources/noclasspath/CatchQualifiedReference.java");
+	    CtModel model = launcher.buildModel();
+
+	    List<CtCatch> catchers = model.getElements(e -> true);
+
+	    assertEquals("There should only be one catch statement, check the resource", 1, catchers.size());
+	    CtTypeReference<?> caughtType = catchers.get(0).getParameter().getType();
+
+	    assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
+	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -333,6 +333,7 @@ public class TryCatchTest {
 	    assertEquals("There should only be one catch statement, check the resource", 1, catchers.size());
 	    CtTypeReference<?> caughtType = catchers.get(0).getParameter().getType();
 
-	    assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
+           assertEquals("CustomException", caughtType.getSimpleName());
+           assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -323,17 +323,17 @@ public class TryCatchTest {
 
 	@Test
 	public void testCatchQualifiedReferenceNoClasspath() {
-	    Launcher launcher = new Launcher();
-	    launcher.getEnvironment().setNoClasspath(true);
-	    launcher.addInputResource("./src/test/resources/noclasspath/CatchQualifiedReference.java");
-	    CtModel model = launcher.buildModel();
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("./src/test/resources/noclasspath/CatchQualifiedReference.java");
+		CtModel model = launcher.buildModel();
 
-	    List<CtCatch> catchers = model.getElements(e -> true);
+		List<CtCatch> catchers = model.getElements(e -> true);
 
-	    assertEquals("There should only be one catch statement, check the resource", 1, catchers.size());
-	    CtTypeReference<?> caughtType = catchers.get(0).getParameter().getType();
+		assertEquals("There should only be one catch statement, check the resource", 1, catchers.size());
+		CtTypeReference<?> caughtType = catchers.get(0).getParameter().getType();
 
-           assertEquals("CustomException", caughtType.getSimpleName());
-           assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
+		assertEquals("CustomException", caughtType.getSimpleName());
+		assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
 	}
 }

--- a/src/test/resources/noclasspath/CatchQualifiedReference.java
+++ b/src/test/resources/noclasspath/CatchQualifiedReference.java
@@ -1,0 +1,7 @@
+public class CatchQualifiedReference {
+    public static void main(String[] args) {
+        try {
+        } catch (some.neat.pkg.CustomException e) {
+        }
+    }
+}


### PR DESCRIPTION
This is a test case to reproduce #3372 

I haven't yet had the time to look into solutions.

update fixes #3372 