### PR TITLE
doc: unify headers

### DIFF
--- a/doc/_data/sidebar_doc.yml
+++ b/doc/_data/sidebar_doc.yml
@@ -18,13 +18,6 @@ entries:
           product: all
           version: all
 
-        - title: Code Transformation
-          url: /first_transformation.html
-          audience: writers, designers
-          platform: all
-          product: all
-          version: all
-
         - title: Architecture Checking
           url: /architecture_test.html
           audience: writers, designers
@@ -39,8 +32,8 @@ entries:
           product: all
           version: all
 
-        - title: Examples
-          url: /examples.html
+        - title: Processor for elements
+          url: /processor.html
           audience: writers, designers
           platform: all
           product: all
@@ -60,6 +53,89 @@ entries:
           product: all
           version: all
 
+    - title: Querying source code elements
+      audience: writers, designers
+      platform: all
+      product: all
+      version: all
+
+      items:
+        - title: AST Traversing
+          url: /filter.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: AST Paths and Roles
+          url: /path.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Matcher
+          url: /matcher.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Pattern
+          url: /pattern.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+    - title: Code Transformation
+      audience: writers, designers
+      platform: all
+      product: all
+      version: all
+
+      items:
+        - title: Code Transformation
+          url: /first_transformation.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Transformation Examples
+          url: /examples.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Transformation with annotations
+          url: /processor_annotations.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+          
+        - title: Transformation with Templates
+          url: /template_definition.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Code Generation
+          url: '/pattern.html#generator'
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
+        - title: Testing transformations
+          url: /testing_quickstart.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
 
     - title: Usage
       audience: writers, designers
@@ -138,79 +214,3 @@ entries:
           product: all
           version: all
 
-    - title: Querying source code elements
-      audience: writers, designers
-      platform: all
-      product: all
-      version: all
-
-      items:
-        - title: AST Traversing
-          url: /filter.html
-          audience: writers, designers
-          platform: all
-          product: all
-          version: all
-
-        - title: AST Paths and Roles
-          url: /path.html
-          audience: writers, designers
-          platform: all
-          product: all
-          version: all
-
-        - title: Matcher
-          url: /matcher.html
-          audience: writers, designers
-          platform: all
-          product: all
-          version: all
-
-        - title: Pattern
-          url: /pattern.html
-          audience: writers, designers
-          platform: all
-          product: all
-          version: all
-
-    - title: Transforming source code
-      audience: writers, designers
-      platform: all
-      product: all
-      version: all
-
-      items:
-          - title: Processor for elements
-            url: /processor.html
-            audience: writers, designers
-            platform: all
-            product: all
-            version: all
-
-          - title: Processor for annotations
-            url: /processor_annotations.html
-            audience: writers, designers
-            platform: all
-            product: all
-            version: all
-            
-          - title: Transformation with Templates
-            url: /template_definition.html
-            audience: writers, designers
-            platform: all
-            product: all
-            version: all
-
-          - title: Code Generation
-            url: '/pattern.html#generator'
-            audience: writers, designers
-            platform: all
-            product: all
-            version: all
-
-          - title: Testing transformations
-            url: /testing_quickstart.html
-            audience: writers, designers
-            platform: all
-            product: all
-            version: all

--- a/doc/architecture_test.md
+++ b/doc/architecture_test.md
@@ -9,8 +9,7 @@ Since architectural rules must be automatically checked as often as possible, it
 
 To write an architectural rule in Spoon that is checked in CI, the idea is to write a standard Junit test case that loads the application code, express the rule and check it. Doing this only requires to depend on Spoon at testing time, ie `<scope>test</scope>` in Maven.
 
-Example rule: never use the TreeSet constructor
-----------------------------------
+### Example rule: never use the TreeSet constructor
 
 For instance, let's imagine that you want to forbid the usage of `TreeSet`'s constructor, in your code base, you would simply write a test case as follows:
 
@@ -35,8 +34,7 @@ That's it! Every time you run the tests, incl. on your continuous integration se
 For instance, you can check that you never return null, or always use an appropriate factory, or that all classes implementing an interface are in the same package.
 
 
-Example rule: all test classes must start or end with "Test"
-----------------------------
+### Example rule: all test classes must start or end with "Test"
 
 A common mistake is to forget to follow a naming convention. For instance, if you use Maven, all test classes must be named `Test*` or `*Test` in order to be run by Maven's standard test plugin `surefire` ([see doc](http://maven.apache.org/surefire/maven-surefire-plugin/examples/inclusion-exclusion.html)). This rule simply reads:
 
@@ -58,8 +56,7 @@ public void testGoodTestClassNames() throws Exception {
 }
 ```
 
-Example rule: all public methods must be documented
-----------------------------
+### Example rule: all public methods must be documented
 
 How to check that all public methods of the API contain proper Javadoc? One can also use Spoon to check documentation rules like this one.
 
@@ -87,8 +84,7 @@ public void testDocumentation() throws Exception {
 }
 ```
 
-Related work in architecture enforcement
-----------------------------------------
+### Related work in architecture enforcement
 
 * [Architecture enforcement with Checkstyle](https://saturnnetwork.wordpress.com/2012/11/26/ultimate-architecture-enforcement-prevent-code-violations-at-code-commit-time/)
 * [Sonar architecture rule engine](https://docs.sonarqube.org/display/SONARQUBE44/Architecture+Rule+Engine)

--- a/doc/command_line.md
+++ b/doc/command_line.md
@@ -1,5 +1,5 @@
 ---
-title: Command Line
+title: Using Spoon from the Command Line
 tags: [usage]
 keywords: command, line, usage, java, jar
 ---
@@ -52,7 +52,7 @@ Options :
         List of path to sources files.
 
   [(-p|--processors) <processors>]
-        List of processor's qualified name to be used.
+        List of processor qualified name to be used.
 
   [(-t|--template) <template>]
         List of path to templates java files.
@@ -106,6 +106,6 @@ Options :
         if multiple are given).
 
   [-a|--disable-model-self-checks]
-        Disables checks made on the AST (hashcode violation, method's signature
+        Disables checks made on the AST (hashcode violation, method signature
         violation and parent violation). Default: false.
 ```

--- a/doc/comments.md
+++ b/doc/comments.md
@@ -3,8 +3,6 @@ title: Comments and position
 keywords: comments position
 ---
 
-# Comment
-
 In Spoon there are four different kinds of comments:
 
 * File comments (comment at the begin of the file, generally licence) `CtComment.CommentType.FILE`
@@ -21,11 +19,11 @@ You can retrieve the comments of each `CtElement` via the API `CtElement.getComm
 
 The parsing of the comments can be enabled in the Environment via the option `Environment.setCommentEnabled(boolean)` or the command line argument `--enable-comments` (or `-c`).  
 
-## Javadoc Comments
+### Javadoc Comments
 
 The Javadoc comments are also available via the API `CtElement.getDocComment()` but this API returns directly the content of the Javadoc as `String`.
 
-## Comment Attribution
+### Comment Attribution
 
 * Each element can have multiple comments
 * Comments in the same line of a statement are attached to the statement
@@ -33,8 +31,6 @@ The Javadoc comments are also available via the API `CtElement.getDocComment()` 
 * Comments cannot be associated to other comments
 * Comments at the end of a block are considered as orphan comments
 * Comments before a class definition are attached to the class
-
-### Comment Examples
 
 Class comment
 
@@ -71,7 +67,7 @@ Multiple line comment
 int a;
 ```
 
-## Process Comments
+### Processing Comments
 
 You can process comments like every `CtElement`.
 
@@ -94,7 +90,7 @@ public class CtCommentProcessor extends AbstractProcessor<CtComment> {
 }
 ```
 
-# Source Position
+### Source Positions
 
 `SourcePosition` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/cu/SourcePosition.html)) defines the position of the `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html)) in the original source file. 
 SourcePosition is extended by three specialized positions:

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -1,21 +1,9 @@
 ---
-title: Examples of Spoon Usages
+title: Examples of Spoon Transformation Usages
 keywords: examples
 ---
 
 We provide examples for learning and teaching Spoon in <https://github.com/SpoonLabs/spoon-examples/>. Don't hesitate to propose new examples as pull-request!
-
-The [HelloWorldProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/HelloWorldProcessor.java) prints hello world with compile-time reflection.
-
-## Program Analysis
-
-The [CatchProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java) detects empty catch blocks.
-
-The [ReferenceProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java) detects circular references between packages.
-
-This [Factory example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java) example detects wrong uses of the factory pattern.
-
-## Program Transformation
 
 ### Transformation with API
 
@@ -44,7 +32,5 @@ The [RetryTemplate example](https://github.com/SpoonLabs/spoon-examples/tree/mas
 ### Transformation with Patterns
 
 TBD, see <https://github.com/INRIA/spoon/issues/3140>
-
-## Miscelanous
 
 The [Distributed Calculus example](https://gforge.inria.fr/scm/viewvc.php/trunk/spoon-examples/src/main/java/spoon/examples/distcalc/?root=spoon) creates a fun new language for distributed computing using Java and Spoon.

--- a/doc/factories.md
+++ b/doc/factories.md
@@ -1,9 +1,10 @@
 ---
-title: Create elements with factories
+title: Creating AST elements
 tags: [meta-model]
 keywords: factories, elements, ast, meta, model
 ---
 
+### Create elements with factories
 When you design and implement transformations, with processors 
 or templates, you need to create new elements, fill their data and add 
 them in the AST built by Spoon.
@@ -45,9 +46,9 @@ All these factories contribute to facilitate the creation of elements.
 When you have created an element from a factory, set it in an existing element 
 to build a new AST.
 
-## SpoonifierVisitor
+### Generating Spoon code for an element
 
-It is possible to visit an existing Spoon AST to generate calls to the factory that recreates the same AST.
+With `SpoonifierVisitor`, it is possible to visit an existing Spoon AST to generate calls to the factory that recreates the same AST.
 
 Example:
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -3,9 +3,11 @@ title: FAQ
 keywords: frequently asked questions, FAQ, question and answer, collapsible sections, expand, collapse
 ---
 
-## Practical Information
+#### Where is the Javadoc?
 
-### Are there snapshots versions deployed somewhere?
+The javadoc is at <http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs>
+
+#### Are there snapshots versions deployed somewhere?
 
 ```xml
 <dependencies>
@@ -25,26 +27,22 @@ keywords: frequently asked questions, FAQ, question and answer, collapsible sect
 ```
 
 
-### How to access Spoon's source code repository?
+#### How to access Spoon's source code repository?
 
 Spoon is developed on GitHub at <https://github.com/INRIA/spoon/>. You can browse the Spoon source using code intelligence (Go-to-definition, Find References, and Hover tooltips) at <https://sourcegraph.com/github.com/INRIA/spoon>.
 
-### What is the meaning of each digit in the version X.Y.Z of spoon?
+#### What is the meaning of each digit in the version X.Y.Z of spoon?
 
 - X is the digit for the major version (major new features or major incompatible API changes).
 - Y is the digit for the minor version (bug fixes or minor API changes).
 - Z is the digit for the critical bug fixes of the current major or minor version.
 
-## Basics
 
-### Where is the Spoon metamodel?
+#### Where is the Spoon metamodel?
 
 The Spoon metamodel consists of all interfaces that are in packages `spoon.reflect.declaration` (structural part: classes, methods, etc.) and `spoon.reflect.code` (behavioral part: if, loops, etc.).
 
-
-## Advanced
-
-### How to prevent Annotation processors from consuming the annotations that they process?
+#### How to prevent Annotation processors from consuming the annotations that they process?
 
 By default, whenever an Annotation Processor processes a CtElement it will consume (delete) the processed annotation from it. If you want the annotation to be kept, override the init() method from the `AbstractAnnotationProcessor` class, and call the protected method `clearConsumedAnnotationTypes` like so:
 
@@ -56,7 +54,7 @@ public void init() {
 }
 ```
 
-### How to compare and create type references in a type-safe way?
+#### How to compare and create type references in a type-safe way?
 
 Use actual classes instead of strings.
 
@@ -67,7 +65,7 @@ Factory f=...
 t=f.Type().createReference(int.class);
 ```
 
-## How to parametrized the JDT compiler arguments?
+#### How to set the JDT compiler arguments?
 
 `SpoonModelBuilder` exposes a method named `build(JDTBuilder)`. This method compiles the target source code with data specified in the JDTBuilder parameter.
 

--- a/doc/filter.md
+++ b/doc/filter.md
@@ -5,8 +5,8 @@ keywords: quering, query, filter, ast, elements
 ---
 
 
-Getters
--------
+### Getters
+
 
 All elements provide a set of appropriate getters to get the children of an element.
 
@@ -28,8 +28,7 @@ allDescendants = ctElement.getDirectChildren();
 ```
 
 
-Filters
--------
+### Filters
 
 A Filter defines a predicate of the form of a `matches` method that
 returns `true` if an element has to be selected in the filtering operation.
@@ -63,8 +62,8 @@ list3 = rootPackage.filterChildren(
 ).list();
 ```
 
-Scanners
---------
+### Scanners
+
 
 `CtScanner` provides a simple way to visit a node and its children.
 
@@ -91,8 +90,7 @@ assertEquals(1, scanner.visited);
 
 See also `CtVisitor`.
 
-Iterator
---------
+### Iterator
 
 `CtIterator` provides an iterator on all transitive children of a node in depth first order.
 
@@ -106,8 +104,7 @@ while (iterator.hasNext()) {
 
 `CtBFSIterator` is similar to CtIterator but in Breadth first order.
 
-Queries
--------
+### Queries
 
 The Query, introduced in Spoon 5.5 by Pavel Vojtechovsky, is an improved filter mechanism:
 

--- a/doc/first_analysis_processor.md
+++ b/doc/first_analysis_processor.md
@@ -1,15 +1,18 @@
 ---
-title: First steps with Spoon
+title: Core concepts
 tags: [getting-started]
 keywords: start, begin, hello world, processor, spoon
 ---
 
-## Visualizing the Spoon AST of a Java file
+### Abstract Syntax Tree
 
-To get started with the metamodel, you can browse the model (ie the Spoon AST) of a java file (say `MyClass.java`) as follows:
+An [Abstract Syntax Tree](https://en.wikipedia.org/wiki/Abstract_syntax_tree), also known as ASTs, is a a tree-based representation of source code. Spoon is a library to build and manipulates ASTs of Java source code.
+
+With Spoon, you can visualize the AST of a Java file, as follows:
 
 ```
-$ java -cp spoon-core-{{site.spoon_release}}-jar-with-dependencies.jar spoon.Launcher -i MyClass.java --gui
+$ java -cp spoon-core-{{site.spoon_release}}-jar-with-dependencies.jar spoon.Launcher \
+   -i MyClass.java --gui
 ```
 
 <img src="images/gui.png"/>
@@ -19,11 +22,11 @@ If you have Java 11 with Java FX, there is a new GUI, see <https://github.com/IN
 <img src="https://raw.githubusercontent.com/INRIA/spoon/master/spoon-visualisation/doc/appFeat.png"/>
 
 
-## Your first processor
+### Code Analysis
 
-In Spoon, a processor is a combination of query and analysis code.
-With this concept, developer can analyse all elements of a type given 
-and inspect each element of this type one per one.
+Spoon is a tool for doing [static code analysis](https://en.wikipedia.org/wiki/Static_program_analysis) at the source code level.
+
+In Spoon, the core concept for code analysis is a processor. A processor analyses all AST elements of a  given type, one per one.
 
 For a first processor, we'll analyze all catch blocks of a `try {...} catch {...}` 
 element to know how many empty catch blocks we have in a project. This kind of empty 
@@ -60,12 +63,11 @@ When the class `AbstractProcessor` ([javadoc](http://spoon.gforge.inria.fr/mvnsi
 is extended, we implement the method `void process(E element)`where `E` is a generic type for 
 any elements of the AST (all classes in the Spoon meta model which extends `CtElement` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/declaration/CtElement.html))). It is in this method that you can access all information you want of the the current `CtCatch` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/code/CtCatch.html)). 
 
-## Apply the processor
-
-First, compile your processor. You can use javac in command line to generate the `CatchProcessor.class` file. Then we execute Spoon as follows to analyze all catch blocks in Java files that are in `/path/to/src/of/your/project`:
+Next, you can compile your processor. You can use javac in command line to generate the `CatchProcessor.class` file. Then we execute Spoon as follows to analyze all catch blocks in Java files that are in `/path/to/src/of/your/project`:
 
 ```bash
-$ java -classpath /path/to/binary/of/your/processor.jar:spoon-core-{{site.spoon_release}}-jar-with-dependencies.jar spoon.Launcher -i /path/to/src/of/your/project -p processors.CatchProcessor
+$ java -classpath /path/to/processor.jar:spoon-core-{{site.spoon_release}}-jar-with-dependencies.jar \
+    spoon.Launcher -i /path/to/src/of/your/project -p processors.CatchProcessor
 ```
 
 {{site.data.alerts.important}} 
@@ -75,6 +77,6 @@ $ java -classpath /path/to/binary/of/your/processor.jar:spoon-core-{{site.spoon_
 
 There are many more examples of source code analysis in <https://github.com/SpoonLabs/spoon-examples>.
 
-## Bytecode analysis
+### Code Transformation
 
-Note that spoon also supports the analysis of bytecode through decompilation. See [javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/JarLauncher.html).
+An unique feature of Spoon is its ability to automatically transform source code, for instance for [instrumentation](https://en.wikipedia.org/wiki/Instrumentation_(computer_programming)) or refactoring, see section "Transformation" below.

--- a/doc/first_transformation.md
+++ b/doc/first_transformation.md
@@ -1,18 +1,15 @@
 ---
-title: First transformation processor
+title: Transformation processors
 tags: [getting-started]
 keywords: start, begin, hello world, processor, spoon, factory, setter
 ---
-
-
-## Goal
 
 
 We'll make a first transformation that adds a field to a class
 and initializes it in the constructor of the current class.
 
 
-## Factories and setters
+### Factories and setters to create AST elements
 
 With `Factory` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/factory/Factory.html)), 
 you can get and create all elements of the meta model. For example, if you want 
@@ -115,7 +112,7 @@ public class ClassProcessor extends AbstractProcessor<CtClass<?>> {
 }
 ```
 
-## Refactoring transformations
+### Refactoring transformations
 
 Spoon provides some methods for automated refactoring:.
 

--- a/doc/gradle.md
+++ b/doc/gradle.md
@@ -1,5 +1,5 @@
 ---
-title: Gradle
+title: Using Spoon from Gradle
 tags: [usage]
 keywords: gradle, usage, java, plugin
 ---

--- a/doc/launcher.md
+++ b/doc/launcher.md
@@ -1,10 +1,10 @@
 ---
-title: How to use Spoon in Java?
+title: Using Spoon as a Java library
 tags: [usage]
 keywords: usage, java
 ---
 
-## The Launcher class
+### The Launcher class
 
 The Spoon `Launcher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/Launcher.html)) is used to create the AST model of a project. It can be as short as:
 
@@ -53,7 +53,7 @@ launcher.getEnvironment().setPrettyPrinterCreator(() -> {
 ```
 **Comments** In addition, depending on the value of `Environment#getCommentEnabled`, the comments are removed or kept from the Java files saved to disk (call `Environment#setCommentEnabled(true)` to keep comments).
 
-## The MavenLauncher class
+### The MavenLauncher class
 
 The Spoon `MavenLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/MavenLauncher.html)) is used to create the AST model of a Maven project.
 It automatically infers the list of source folders and the dependencies from the `pom.xml` file.
@@ -89,14 +89,12 @@ CtModel model = launcher.getModel();
 ```
 To avoid invoking maven over and over to build a classpath that has not changed, it is stored in a file `spoon.classpath.tmp` (or depending on the scope `spoon.classpath-app.tmp` or `spoon.classpath-test.tmp`) in the same folder as the `pom.xml`. This classpath will be refreshed is the file is deleted or if it has not been modified since 1h.
 
-## Analyzing bytecode
+### Analyzing bytecode with JarLauncher
 
 There are two ways to analyze bytecode with spoon:
 
  * Bytecode resources can be added in the classpath, (some information will be extracted through reflection)
  * A decompiler may be used, and then, the analyzes will be performed on the decompiled sources.
-
-### The JarLauncher class
 
 The Spoon `JarLauncher` ([JavaDoc](https://github.com/INRIA/spoon/blob/master/spoon-decompiler/src/main/java/spoon/JarLauncher.java)) is used to create the AST model from a jar.
 It automatically decompiles class files contained in the jar and analyzes them.
@@ -144,7 +142,7 @@ launcher.addInputResource(
 
 **Warning** The `JarLauncher` feature (and all features relying on decompilation) are not included in `spoon-core` but in `spoon-decompiler`. If you want to use them you should declare a dependency to `spoon-decompiler`.
 
-## About the classpath
+### Resolution of elements and classpath
 
 Spoon analyzes source code. However, this source code may refer to libraries (as a field, parameter, or method return type). There are two cases:
 
@@ -178,7 +176,9 @@ compile 'fr.inria.gforge.spoon:spoon-core:{{site.spoon_release}}'
 ```
 
 
-## Incremental Launcher
+## Advanced launchers
+
+### Incremental Launcher
 
 `IncrementalLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/IncrementalLauncher.html)) allows cache AST and compiled classes. Any spoon analysis can then be restarted from where it stopped instead of restarting from scratch.
 
@@ -200,7 +200,7 @@ CtModel newModel = launcher.buildModel();
 launcher.saveCache();
 //Cache is now up to date
 ```
-## Fluent LauncherAPI
+### Fluent LauncherAPI
 
 `FluentLauncher` ([JavaDoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/FluentLauncher.html)) allows simple, fluent launcher usage with setting most options directly.
 

--- a/doc/maven.md
+++ b/doc/maven.md
@@ -1,5 +1,5 @@
 ---
-title: Maven
+title: Using Spoon from Maven
 tags: [usage]
 keywords: maven, central, usage, java, plugin
 ---

--- a/doc/path.md
+++ b/doc/path.md
@@ -11,7 +11,7 @@ A `CtPath`is based on: names of elements (eg `foo`), and roles of elements with 
 A role is a relation between two AST nodes.
 For instance, a "then" branch in a if/then/else is a role (and not an node). All roles can be found in `CtRole`. In addition, each getter or setter in the metamodel is annotated with its role.
 
-## Evaluating paths
+### Evaluating AST paths
 
 Paths are used to find code elements, from a given root elements.
 
@@ -20,9 +20,9 @@ path = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.fo
 List<CtElement> l = path.evaluateOn(root)
 ```
 
-## Creating paths
+### Creating AST paths
 
-### From an existing element
+#### From an existing element
 
 Method `getPath` in `CtElement` returns a path
 
@@ -30,7 +30,7 @@ Method `getPath` in `CtElement` returns a path
 CtPath path = anElement.getPath();
 ```
 
-### From a string
+#### From a string
 
 `CtPathStringBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathStringBuilder.html)), creates a path object from a string according to the following syntax:
 
@@ -42,7 +42,7 @@ CtPath path = anElement.getPath();
   - Example of constructor signature: `#constructor[signature=(int)]`
 - `index=<idx>` - fitler which accepts only idx-th element of the List. The first element has index 0. the fifth type memeber in a class `#typeMember[index=4]`
 
-### From the API
+#### From the API
 
 The low-level `CtPathBuilder` ([javadoc](http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/spoon/reflect/path/CtPathBuilder.html)) defines a fluent api to build your path:
 

--- a/doc/pattern.md
+++ b/doc/pattern.md
@@ -11,7 +11,7 @@ The main classes of Spoon patterns are those in package `spoon.pattern`:
 
 See also [examples in project `spoon-examples`](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/PatternTest.java)
 
-## Example usage
+### Example usage
 
 ```java
 Factory spoonFactory = ...
@@ -26,7 +26,7 @@ pattern.forEachMatch(spoonFactory.getRootPackage(), (Match match) -> {
 });
 ```
 
-## PatternBuilder
+### PatternBuilder
 
 To create a Spoon pattern, one must use `PatternBuilder`, which takes AST nodes as input, and _pattern parameters_ can be defined.
 
@@ -47,7 +47,7 @@ Pattern t = PatternBuilder.create(elem)
 
 One can also create specific parameters with `.configureParameters(pb -> pb.parameter("name").byXXXX` (see below)
 
-## Pattern 
+### Pattern 
 
 Once a `PatternBuilder` returns a `Pattern`, the main methods of `Pattern` are `getMatches` and `forEachMatch`.
 
@@ -55,15 +55,15 @@ Once a `PatternBuilder` returns a `Pattern`, the main methods of `Pattern` are `
 List<Match> matches = pattern.getMatches(ctClass);
 ```
 
-## Match
+### Match
 
 A `Match` represent a match of a pattern on a code elements. The main methods are `getMatchingElement` and `getMatchingElements`.
 
-## PatternBuilderHelper
+### PatternBuilderHelper
 
 `PatternBuilderHelper` is useful to select AST nodes that would act as pattern. See method to get the body (method `setBodyOfMethod`) or the return expression of a method (method `setReturnExpressionOfMethod`).
 
-## PatternParameterConfigurator
+### PatternParameterConfigurator
 
 To create pattern paramters, one uses a `PatternParameterConfigurator` as a lambda:
 
@@ -144,7 +144,7 @@ The `setValueType(type)` is called internally too, so match condition assures bo
   * `ContainerKind#MAP` - The values are always stored as `Map`.
 
 
-## InlinedStatementConfigurator
+### InlinedStatementConfigurator
 
 It is possible to match inlined code, eg:
 
@@ -182,11 +182,11 @@ inline statements
 * `markAsInlined(CtForEach|CtIf)` - provided CtForEach or CtIf statement
 is understood as inline statement
 
-## Generator
+### Generator
 
 All patterns can be used for code generation. The idea is that one calls `#generator()` on a pattern object to get a `Generator`. This class contains methods that takes as input a map of string,objects where each string key points to a pattern parameter name and each map value contains the element to be put in place of the pattern parameter.
 
-## Notes
+### Notes on patterns
 
 The unique feature of Spoon pattern matching is that we are matching on AST trees and not source code text. It means that:
 

--- a/doc/processor.md
+++ b/doc/processor.md
@@ -1,5 +1,5 @@
 ---
-title: Processor for elements
+title: More about Spoon Processors
 tags: [processor]
 keywords: processor, processing, elements
 ---
@@ -53,7 +53,19 @@ public class CatchProcessor extends AbstractProcessor<CtCatch> {
 	}
 }
 ```
-## Parallel Processor
+### Examples of Analysis Processors
+
+The [HelloWorldProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/HelloWorldProcessor.java) prints hello world with compile-time reflection.
+
+The [CatchProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/CatchProcessor.java) detects empty catch blocks.
+
+The [ReferenceProcessor example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/ReferenceProcessor.java) detects circular references between packages.
+
+This [Factory example](https://github.com/SpoonLabs/spoon-examples/blob/master/src/main/java/fr/inria/gforge/spoon/analysis/FactoryProcessor.java) example detects wrong uses of the factory pattern.
+
+
+
+### Parallel Processor
 
 Lets assume you want to use multiple cores for your processor. Spoon provides a simple high-level API for this task.
 Using the CatchProcessor from before create a `AbstractParallelProcessor`. 

--- a/doc/processor_annotations.md
+++ b/doc/processor_annotations.md
@@ -29,7 +29,7 @@ annotations on any arbitrary code elements (including within method bodies), and
 supports the modification of the existing code.
 
 
-## Annotation Processing with Spoon
+### Annotation Processing Example
 
 Spoon provides developers with a way to specify the analyses and transformations 
 associated with annotations. Annotations are metadata on code that start with `@` in Java.
@@ -62,7 +62,7 @@ The implementation of such an annotation would not be straightforward using Java
 since it would not allow us to just insert the NULL check in the body of the annotated method. 
 
 
-## The Annotation Processor Interface
+### The Annotation Processor Interface
 
 In Spoon, the full code model can be used  for compile-time annotation processing. To this end, 
 Spoon provides a special kind of processor called `AnnotationProcessor` whose interface is:

--- a/doc/references.md
+++ b/doc/references.md
@@ -21,16 +21,16 @@ From Spoon 5.0.0, CtReference is a subclass of CtElement.
 
 ![References of the Spoon Java 8 metamodel]({{ "/images/references-elements.png" | prepend: site.baseurl }})
 
-##  How are references resolved? 
+###  How are references resolved? 
 
 References are resolved when the model is built, the resolved references are those 
 that point to classes for which the source code is available in the Spoon input path.
 
-## Do targets of references have to exist before you can reference them?
+### Do targets of references have to exist before you can reference them?
 
 Since the references are weak, the targets of references do not have to exist before one references them. 
 
-## How does this limit transforming code? 
+### How does this limit transforming code? 
 
 The price to pay for this low coupling is that to navigate from one code element to another, 
 one has to chain a navigation to the reference and then to the target. For instance, 

--- a/doc/template_definition.md
+++ b/doc/template_definition.md
@@ -16,8 +16,8 @@ contexts and give different results, depending on its parameters.
 
 ![Overview of Spoon's Templating System]({{ "/images/template-overview.svg" | prepend: site.baseurl }})
 
-Definition of templates
------------------------
+### Definition of templates
+
 
 Class `CheckBoundTemplate` below defines a Spoon template. 
 
@@ -50,8 +50,7 @@ checked. Instead of being executed, the template source code is taken as input b
 templating engine which is described above. Consequently, the template source is 
 well-typed, compiles, but the binary code of the template is thrown away.
 
-Template Instantiation
--------------
+### Template Instantiation
 
 In order to be correctly substituted, the template parameters need 
 to be bound to actual values. This is done during template instantiation.
@@ -81,8 +80,8 @@ method.getBody().insertBegin(injectedCode);
 
 ```
 
-Kinds of templating
--------------------
+### Kinds of templating
+
 
 There are different kinds of templating.
 
@@ -145,8 +144,7 @@ Substitution.insertAll(aCtClass, t);
 
 ```
 
-Template parameters
-------------------
+### Template parameters
 
 #### AST elements
 All meta-model elements can be used as template parameter. 

--- a/doc/testing_quickstart.md
+++ b/doc/testing_quickstart.md
@@ -1,10 +1,9 @@
 ---
-title: Quickstart
+title: Testing code transformations
 tags: [quickstart]
 keywords: testing, quickstart
 ---
 
-## Overview
 
 Spoon module testing is a Java library that provides a fluent api for writing assertions. 
 Its main goal is to propose an easy way to test Java source code transformation.
@@ -12,7 +11,7 @@ Its main goal is to propose an easy way to test Java source code transformation.
 This module is directly integrated in the spoon project and can be used as soon as the
 dependency is specified in your project.
 
-## Getting started
+### The Assert class
 
 The Assert class is the entry point for assertion methods for different data types.
 Each method in this class is a static factory for the type-specific assertion objects. 
@@ -34,7 +33,7 @@ import static spoon.testing.Assert.assertThat;
 assertThat('Foo.java').withProcessor(new AProcessor()).isEqualTo('FooTransformed.java');
 ```
 
-## Assertion Types
+### Assertion Types
 
 There are three types of assertions:
 
@@ -44,7 +43,7 @@ FileAssert | Assertions available on a file.
 CtElementAssert | Assertions available on a `CtElement`.
 CtPackageAssert | Assertions available between two `CtPackage`.
 
-## CtElement assertion example
+### Assertion example
 
 Let's say that you have a processor which change the name of all fields by the name "j".
 


### PR DESCRIPTION
Unify documentation headers to achieve a beautiful table of contents

 * Introduction
  * Getting started
    * Core concepts
      * Abstract Syntax Tree
      * Code Analysis
      * Code Transformation
    * Using Spoon for Architecture Enforcement
      * Example rule: never use the TreeSet constructor
      * Example rule: all test classes must start or end with "Test"
      * Example rule: all public methods must be documented
      * Related work in architecture enforcement
    * Using Spoon as a Better Runtime Reflection API
    * More about Spoon Processors
      * Examples of Analysis Processors
      * Parallel Processor
    * FAQ
        * Where is the Javadoc?
        * Are there snapshots versions deployed somewhere?
        * How to access Spoon's source code repository?
        * What is the meaning of each digit in the version X.Y.Z of spoon?
        * Where is the Spoon metamodel?
        * How to prevent Annotation processors from consuming the annotations that they process?
        * How to compare and create type references in a type-safe way?
        * How to set the JDT compiler arguments?
  * Querying source code elements
    * Navigation and Query
      * Getters
      * Filters
      * Scanners
      * Iterator
      * Queries
    * Path
      * Evaluating AST paths
      * Creating AST paths
        * From an existing element
        * From a string
        * From the API
    * Matching elements
    * Spoon Patterns
      * Example usage
      * PatternBuilder
      * Pattern
      * Match
      * PatternBuilderHelper
      * PatternParameterConfigurator
      * InlinedStatementConfigurator
      * Generator
      * Notes on patterns
  * Code Transformation
    * Transformation processors
      * Factories and setters to create AST elements
      * Refactoring transformations
    * Examples of Spoon Transformation Usages
      * Transformation with API
      * Transformation with Annotations
      * Transformation with Templates
      * Transformation with Patterns
    * Processor for annotations
      * Annotation Processing Example
      * The Annotation Processor Interface
    * Transformation with Templates
      * Definition of templates
      * Template Instantiation
      * Kinds of templating
        * Subclassing 
        * StatementTemplate
        * Subclassing 
        * BlockTemplate
        * Subclassing 
        * ExpressionTemplate
        * Subclassing 
        * ExtensionTemplate
      * Template parameters
        * AST elements
        * Literal template Parameters
        * Inlining foreach expressions
    * Testing code transformations
      * The Assert class
      * Assertion Types
      * Assertion example
  * Usage
    * Using Spoon as a Java library
      * The Launcher class
      * Pretty-printing modes
      * The MavenLauncher class
      * Analyzing bytecode with JarLauncher
      * Resolution of elements and classpath
    * Declaring the dependency to Spoon
      * Maven
      * Gradle
    * Advanced launchers
      * Incremental Launcher
      * Fluent LauncherAPI
    * Using Spoon from the Command Line
    * Using Spoon from Maven
    * Using Spoon from Gradle
  * Spoon Meta model
    * Structural elements
    * Code elements
      * CtArrayRead
      * CtArrayWrite
      * CtAssert
      * CtAssignment
      * CtBinaryOperator
      * CtBlock
      * CtBreak
      * CtCase
      * CtConditional
      * CtConstructorCall
      * CtContinue
      * CtDo
      * CtExecutableReferenceExpression
      * CtFieldRead
      * CtFieldWrite
      * CtFor
      * CtForEach
      * CtIf
      * CtInvocation
      * CtJavaDoc
      * CtLambda
      * CtLiteral
      * CtLocalVariable
      * CtNewArray
      * CtNewClass
      * CtOperatorAssignment
      * CtReturn
      * CtSuperAccess
      * CtSwitch
      * CtSwitchExpression
      * CtSynchronized
      * CtThisAccess
      * CtThrow
      * CtTry
      * CtTryWithResource
      * CtTypeAccess
      * CtUnaryOperator
      * CtVariableRead
      * CtVariableWrite
      * CtWhile
      * CtYieldStatement
      * CtAnnotation
      * CtClass
    * References
      * How are references resolved?
      * Do targets of references have to exist before you can reference them?
      * How does this limit transforming code?
    * Creating AST elements
      * Create elements with factories
      * Generating Spoon code for an element
    * Comments and position
      * Javadoc Comments
      * Comment Attribution
      * Processing Comments
      * Source Positions
