### PR TITLE
chore: allow LSIF upload action to pass even if upload fails

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -19,3 +19,4 @@ jobs:
           endpoint: https://sourcegraph.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file: dump.lsif
+          ignore_upload_failure: true


### PR DESCRIPTION
Hi @monperrus I noticed that GH was showing a red ❌  for the build due to a setting for that uploading LSIF data in the GH action (sorry about that!). 

It's unfortunate that we can't tell GH to ignore the status of failed actions (and so give a nice ✅  instead of X even if this action fails). There is already an upstream fix for the action, but this PR will also stop any other spurious causes that may show a red ❌  for the build if it is LSIF upload related.