### PR TITLE
test(SniperPrettyPrinter): test line break after the insertion of a throw in the beginning of a statement (#3401)

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -26,7 +26,9 @@ import spoon.processing.Processor;
 import spoon.processing.ProcessorProperties;
 import spoon.processing.TraversalStrategy;
 import spoon.reflect.CtModel;
+import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtThrow;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -48,6 +50,7 @@ import spoon.support.modelobs.SourceFragmentCreator;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.test.GitHubIssue;
 import spoon.test.prettyprinter.testclasses.OneLineMultipleVariableDeclaration;
+import spoon.test.prettyprinter.testclasses.Throw;
 import spoon.test.prettyprinter.testclasses.ToBeChanged;
 
 import java.io.File;
@@ -74,6 +77,23 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TestSniperPrinter {
+
+	@Test
+	public void testPrintInsertedThrow() {
+		testSniper(Throw.class.getName(), type -> {
+			CtConstructorCall ctConstructorCall = (CtConstructorCall) type.getMethodsByName("foo").get(0).getBody().getStatements().get(0);
+			CtThrow ctThrow = type.getFactory().createCtThrow(ctConstructorCall.toString());
+			ctConstructorCall.replace(ctThrow);
+		}, (type, printed) -> {
+			assertIsPrintedWithExpectedChanges(type, printed,
+					"\\Qvoid foo(int x) {\n" +
+					"\t\tnew IllegalArgumentException(\"x must be nonnegative\");\n" +
+					"\t}",
+					"void foo(int x) {\n" +
+					"\t\tthrow new java.lang.IllegalArgumentException(\"x must be nonnegative\");\n" +
+					"\t}");
+		});
+	}
 
 	@Test
 	public void testPrintOneLineMultipleVariableDeclaration() {

--- a/src/test/java/spoon/test/prettyprinter/testclasses/Throw.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/Throw.java
@@ -1,0 +1,7 @@
+package spoon.test.prettyprinter.testclasses;
+
+public class Throw {
+	void foo(int x) {
+		new IllegalArgumentException("x must be nonnegative");
+	}
+}


### PR DESCRIPTION
Reproduces #3401