### PR TITLE
ref(sniper): only isFragmentModified is responsible for computing fragment modification

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -586,6 +586,15 @@ public class PositionBuilder {
 					//TODO handle comments correctly here. E.g. List<T /*ccc*/ >
 					sourceEnd = findNextNonWhitespace(contents, contents.length - 1, getSourceEndOfTypeReference(contents, tr, tr.sourceEnd) + 1);
 				}
+				// hack to get sniper of varargs right
+				// we remove the "..." from the source position
+				// hence from the fragment
+				if (contents[sourceEnd] == '.'
+						&& contents[sourceEnd-1] == '.'
+						&& contents[sourceEnd-2] == '.'
+				) {
+					sourceEnd = sourceEnd -3;
+				}
 			} else {
 				//SomeType<>
 				int startIdx = findNextNonWhitespace(contents, contents.length - 1, sourceEnd + 1);

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -590,10 +590,10 @@ public class PositionBuilder {
 				// we remove the "..." from the source position
 				// hence from the fragment
 				if (contents[sourceEnd] == '.'
-						&& contents[sourceEnd-1] == '.'
-						&& contents[sourceEnd-2] == '.'
+						&& contents[sourceEnd - 1] == '.'
+						&& contents[sourceEnd - 2] == '.'
 				) {
-					sourceEnd = sourceEnd -3;
+					sourceEnd = sourceEnd - 3;
 				}
 			} else {
 				//SomeType<>

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -277,7 +277,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 						return;
 					}
 
-					//something is changed in this element
+					//something is changed in this element, so we pretty-print it normally
 					superScanInContext(this.element, new SourceFragmentContextNormal(mutableTokenWriter, sourceFragment, new ChangeResolver(getChangeCollector(), this.element)));
 				} else {
 					throw new SpoonException("Unsupported fragment type: " + fragment.getClass());

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -249,10 +249,6 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 
 			@Override
 			public void printSourceFragment(SourceFragment fragment, ModificationStatus isModified) {
-				if (mutableTokenWriter.isMuted()) {
-					throw new SpoonException("Unexpected state of sniper pretty printer. TokenWriter is muted.");
-				}
-
 
 				// we don't have any source fragment for this element, so we simply pretty-print it normally
 				if (fragment == null) {
@@ -275,24 +271,14 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 					}
 				} else if (fragment instanceof ElementSourceFragment) {
 					ElementSourceFragment sourceFragment = (ElementSourceFragment) fragment;
-					//it is fragment with single value
-					ChangeResolver changeResolver1 = null;
-					if (isModified == ModificationStatus.UNKNOWN) {
-						changeResolver1 = new ChangeResolver(getChangeCollector(), this.element);
-						isModified = ModificationStatus.fromBoolean(changeResolver1.hasChangedRole());
-					}
 					if (isModified == ModificationStatus.NOT_MODIFIED) {
 						//nothing is changed, we can print origin sources of this element
 						mutableTokenWriter.getPrinterHelper().directPrint(fragment.getSourceCode());
 						return;
 					}
-					//check what roles of this element are changed
-					if (changeResolver1 == null) {
-						changeResolver1 = new ChangeResolver(getChangeCollector(), this.element);
-					}
-					//changeResolver.hasChangedRole() is false when element is added
+
 					//something is changed in this element
-					superScanInContext(this.element, new SourceFragmentContextNormal(mutableTokenWriter, sourceFragment, changeResolver1));
+					superScanInContext(this.element, new SourceFragmentContextNormal(mutableTokenWriter, sourceFragment, new ChangeResolver(getChangeCollector(), this.element)));
 				} else {
 					throw new SpoonException("Unsupported fragment type: " + fragment.getClass());
 				}


### PR DESCRIPTION
We have duplication of code, which hinders understandability and maintainability, this PR fixes that: only isFragmentModified (not shown in the diff) is responsible for computing fragment modification status