### PR TITLE
fix: use input classloader for import resolution

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -11,6 +11,8 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+
+import spoon.compiler.Environment;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtMethod;
@@ -148,7 +150,7 @@ class JDTImportBuilder {
 
 			if (klass == null) {
 				try {
-					Class zeClass = this.getClass().getClassLoader().loadClass(className);
+					Class<?> zeClass = loadClass(className);
 					klass = this.factory.Type().get(zeClass);
 					return klass;
 				} catch (NoClassDefFoundError | ClassNotFoundException e) {
@@ -163,5 +165,15 @@ class JDTImportBuilder {
 			}
 		}
 		return klass;
+	}
+
+	private Class<?> loadClass(String className) throws ClassNotFoundException {
+		Class<?> zeClass;
+		if(this.factory.getEnvironment().getInputClassLoader() != null) {
+			zeClass = this.factory.getEnvironment().getInputClassLoader().loadClass(className);						
+		} else {
+			zeClass = this.getClass().getClassLoader().loadClass(className);						
+		}
+		return zeClass;
 	}
 }

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -12,7 +12,6 @@ import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 
-import spoon.compiler.Environment;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtMethod;
@@ -169,10 +168,10 @@ class JDTImportBuilder {
 
 	private Class<?> loadClass(String className) throws ClassNotFoundException {
 		Class<?> zeClass;
-		if(this.factory.getEnvironment().getInputClassLoader() != null) {
-			zeClass = this.factory.getEnvironment().getInputClassLoader().loadClass(className);						
+		if (this.factory.getEnvironment().getInputClassLoader() != null) {
+			zeClass = this.factory.getEnvironment().getInputClassLoader().loadClass(className);
 		} else {
-			zeClass = this.getClass().getClassLoader().loadClass(className);						
+			zeClass = this.getClass().getClassLoader().loadClass(className);	
 		}
 		return zeClass;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -171,7 +171,7 @@ class JDTImportBuilder {
 		if (this.factory.getEnvironment().getInputClassLoader() != null) {
 			zeClass = this.factory.getEnvironment().getInputClassLoader().loadClass(className);
 		} else {
-			zeClass = this.getClass().getClassLoader().loadClass(className);	
+			zeClass = this.getClass().getClassLoader().loadClass(className);
 		}
 		return zeClass;
 	}

--- a/src/test/java/spoon/support/compiler/jdt/JDTImportBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTImportBuilderTest.java
@@ -1,0 +1,164 @@
+package spoon.support.compiler.jdt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ImportReference;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import spoon.compiler.Environment;
+import spoon.experimental.CtUnresolvedImport;
+import spoon.reflect.cu.CompilationUnit;
+import spoon.reflect.declaration.CtImport;
+import spoon.reflect.factory.CompilationUnitFactory;
+import spoon.reflect.factory.CoreFactory;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.InterfaceFactory;
+import spoon.reflect.factory.TypeFactory;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtAbstractImportVisitor;
+import spoon.reflect.visitor.CtImportVisitor;
+import spoon.support.StandardEnvironment;
+import spoon.support.reflect.cu.CompilationUnitImpl;
+import spoon.support.util.ModelList;
+
+public class JDTImportBuilderTest {
+
+	@Mock
+	private Factory factory;
+
+	@Mock
+	private ICompilationUnit compilationUnit;
+
+	@Mock
+	private InterfaceFactory interfaceFactory;
+
+	private Environment environment = new StandardEnvironment();
+
+	private CompilationUnit spoonUnit = new CompilationUnitImpl();
+
+	private List<ImportReference> imports = new ArrayList<>();
+
+	@Before
+	public void setup() {
+		MockitoAnnotations.initMocks(this);
+
+		setupMockFactories();
+
+		when(compilationUnit.getContents()).thenReturn(new char[0]);
+	}
+
+	@Test
+	public void findunresolvedImport() {
+		// setup import
+		CompilationUnitDeclaration declarationUnit = setupImportStatement("some.unknown.package.RandomType");
+
+		// collect imports
+		new JDTImportBuilder(declarationUnit, factory).build();
+
+		// verify import not resolved
+		assertUnresolvedImport(spoonUnit.getImports().get(0), "some.unknown.package.RandomType");
+	}
+
+	@Test
+	public void classNotFoundIfNotInSameClassloader() throws Exception {
+		// setup JAR with imported types in separate classloader
+		setupEnvironmentWithCustomClassLoader("./src/test/resources/folderWithJar/jarFile.jar");
+		CompilationUnitDeclaration declarationUnit = setupImportStatement("spoon.test.reference.ReferencedClass");
+
+		// collect imports
+		new JDTImportBuilder(declarationUnit, factory).build();
+
+		// verify import resolved in classpath
+		assertResolvedImport(spoonUnit.getImports().get(0), "spoon.test.reference.ReferencedClass");
+	}
+
+	private CompilationUnitDeclaration setupImportStatement(String importName) {
+		imports.add(createImport(importName, false));
+		CompilationUnitDeclaration declarationUnit = setupImports(imports);
+		return declarationUnit;
+	}
+
+	private void setupEnvironmentWithCustomClassLoader(String jarFile) throws MalformedURLException {
+		File jarWithImportedType = new File(jarFile);
+		ClassLoader customLoader = new URLClassLoader(new URL[] { jarWithImportedType.toURI().toURL() },
+				JDTImportBuilder.class.getClassLoader());
+		environment.setInputClassLoader(customLoader);
+	}
+
+	private void assertResolvedImport(CtImport ctImport, String theImport) {
+		CtImportVisitor visitor = new CtAbstractImportVisitor() {
+			@Override
+			public <T> void visitTypeImport(CtTypeReference<T> typeReference) {
+				assertEquals(theImport, typeReference.getQualifiedName());
+			}
+
+			@Override
+			public <T> void visitUnresolvedImport(CtUnresolvedImport unresolvedImport) {
+				fail("expecting resolved import, found unresolved import instead "
+						+ unresolvedImport.getUnresolvedReference());
+			}
+		};
+		ctImport.accept(visitor);
+	}
+
+	private void assertUnresolvedImport(CtImport ctImport, String theImport) {
+		CtImportVisitor visitor = new CtAbstractImportVisitor() {
+			@Override
+			public <T> void visitTypeImport(CtTypeReference<T> typeReference) {
+				fail("expecting unresolved import, found resolved import instead " + typeReference.getQualifiedName());
+			}
+
+			@Override
+			public <T> void visitUnresolvedImport(CtUnresolvedImport unresolvedImport) {
+				assertEquals(theImport, unresolvedImport.getUnresolvedReference());
+			}
+		};
+		ctImport.accept(visitor);
+	}
+
+	private ImportReference createImport(String name, Boolean isStatic) {
+		ImportReference ref = mock(ImportReference.class);
+		when(ref.isStatic()).thenReturn(isStatic);
+		when(ref.toString()).thenReturn(name);
+		return ref;
+	}
+
+	private CompilationUnitDeclaration setupImports(List<ImportReference> imports) {
+
+		CompilationResult compilationResult = new CompilationResult("Foo.java".toCharArray(), 0, 10, 10);
+		compilationResult.compilationUnit = compilationUnit;
+		CompilationUnitDeclaration declarationUnit = new CompilationUnitDeclaration(mock(ProblemReporter.class),
+				compilationResult, 10);
+		declarationUnit.imports = imports.toArray(new ImportReference[0]);
+		return declarationUnit;
+	}
+
+	private void setupMockFactories() {
+		CompilationUnitFactory compilationUnitFactory = Mockito.mock(CompilationUnitFactory.class);
+		when(compilationUnitFactory.getOrCreate(Mockito.anyString())).thenReturn(spoonUnit);
+		when(factory.CompilationUnit()).thenReturn(compilationUnitFactory);
+		when(factory.Type()).thenReturn(new TypeFactory());
+		when(factory.Interface()).thenReturn(interfaceFactory);
+		when(factory.getEnvironment()).thenReturn(environment);
+		when(factory.Core()).thenReturn(mock(CoreFactory.class));
+	}
+
+}


### PR DESCRIPTION
This PR addresses the problem observed in https://github.com/INRIA/spoon/issues/3420
If an input classloader is specified in Environment it should be used to resolve imports. 
Otherwise only imported classes on the same class loader as JDTImportBuilder are found.

To reproduce the problem see tests in spoon.support.compiler.jdt.JDTImportBuilderTest