### PR TITLE
fix: Use shell command to detect Maven home version on Mac systems without failure

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -408,6 +408,8 @@ public class SpoonPom implements SpoonResource {
 			String[] cmd;
 			if (System.getProperty("os.name").contains("Windows")) {
 				cmd = new String[]{"mvn.cmd", "-version"};
+			} else if (System.getProperty("os.name").contains("Mac")) {
+				cmd = new String[]{"sh", "-c", "mvn -version"};
 			} else {
 				cmd = new String[]{"mvn", "-version"};
 			}


### PR DESCRIPTION
This is a fix for bug #3530.
The fallback command that retrieves Maven home using a `mvn -version` command only works on Unix-based systems.
For it to work on MacOS systems it requires a shell execution that will search for Maven executable in the PATH environment variable: `sh -c "mvn -version"`.