### PR TITLE
fix: fetchin module from the JDT compiler

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -91,8 +91,7 @@ public class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Ma
 							} else {
 								lastSlash += 1;
 							}
-							//TODO the module name parsed by JDK compiler is in `this.modNames`
-							compilationUnit.module = CharOperation.subarray(modulePath, lastSlash, modulePath.length);
+							compilationUnit.module = this.module.name();
 							pathToModName.put(String.valueOf(modulePath), compilationUnit.module);
 						}
 					} else {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -91,7 +91,14 @@ public class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Ma
 							} else {
 								lastSlash += 1;
 							}
-							compilationUnit.module = this.module.name();
+
+							if (this.module == null) {
+								compilationUnit.module = CharOperation.subarray(modulePath, lastSlash, modulePath.length);
+							} else {
+								//TODO the module name parsed by JDK compiler is in `this.modNames`, consider using that instead?
+								compilationUnit.module = this.module.name();
+							}
+
 							pathToModName.put(String.valueOf(modulePath), compilationUnit.module);
 						}
 					} else {

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -262,10 +262,13 @@ public class CompilationTest {
 
 	@Test
 	public void testModuleResolution() throws InterruptedException {
+		// contract: module name is set from the info extract from the module-info.java file
+		// when such file exists
 		Launcher launcher = new Launcher();
 
+		// contract: ComplianceLevel must be >=9 to build a model from an input resource
+		// that contains module-info.java file(s)
 		launcher.getEnvironment().setComplianceLevel(9);
-		launcher.getEnvironment().setSpoonProgress(new ProgressLogger(launcher.getEnvironment()));
 		launcher.addInputResource("./src/test/resources/simple-module");
 		launcher.buildModel();
 		

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -261,6 +261,18 @@ public class CompilationTest {
 	}
 
 	@Test
+	public void testModuleResolution() throws InterruptedException {
+		Launcher launcher = new Launcher();
+
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.getEnvironment().setSpoonProgress(new ProgressLogger(launcher.getEnvironment()));
+		launcher.addInputResource("./src/test/resources/simple-module");
+		launcher.buildModel();
+		
+		assertTrue(launcher.getModel().getAllModules().iterator().next().getSimpleName().equals("spoonmod"));
+	}
+
+	@Test
 	public void testFilterResourcesDir() {
 		// shows how to filter input java dir
 		// only in package called "reference"

--- a/src/test/resources/simple-module/module-info.java
+++ b/src/test/resources/simple-module/module-info.java
@@ -1,0 +1,3 @@
+module spoonmod {
+	
+}

--- a/src/test/resources/simple-module/spoonmod/TestClass.java
+++ b/src/test/resources/simple-module/spoonmod/TestClass.java
@@ -1,0 +1,5 @@
+package spoonmod;
+
+public class TestClass {
+	public TestClass() {}
+}


### PR DESCRIPTION
Hi, I'm a new code intel SWE at Sourcegraph, and I'll be owning the https://github.com/sourcegraph/lsif-java project for the foreseeable time :) 

We came across an issue with Java 9 modules (tracking [here](https://github.com/sourcegraph/lsif-java/issues/8#issuecomment-666879764)), and I discovered a relevant `TODO` https://github.com/INRIA/spoon/blob/d7da4c6684/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java#L94

The following screenshot gives some insight into the state leading up to the exception, where it seems to extract the wrong module name from the file folder

<details>
<summary>VSCode Java Debugger state</summary>

![image](https://user-images.githubusercontent.com/18282288/91213820-123e8d80-e70a-11ea-9448-9a23e174adf9.png)
</details>

I havent tested this PR in multi-module scenarios, this was the simpler path instead of sorting `this.filenames` and `this.modNames` and determining the most recent module name (from the sorted list), given non module-info.java and package-info.java entries in this.filenames have `null` set for their index in `this.modNames`.
If this doesn't work as expected in multi-module scenarios (which I will follow up on after this PR is made), this PR can be amended or a new one made for it.

Thanks :)

Note: I'm relying on CI tests to run as [I'm unable to run them locally](https://github.com/INRIA/spoon/issues/3547) as of yet

