### PR TITLE
fix: fixed identifier correctness check when simplenamePart == ""

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -93,22 +93,22 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 		return false;
 	}
 	private void checkIdentiferForJLSCorrectness(String simplename) {
-	/*
-  * At the level of the Java Virtual Machine, every constructor written in the Java programming language (JLS §8.8)
-  * appears as an instance initialization method that has the special name <init>.
-  * This name is supplied by a compiler. Because the name is not a valid identifier,
-  * it cannot be used directly in a program written in the Java programming language.
-  */
-	//JDTTreeBuilderHelper.computeAnonymousName returns "$numbers$Name" so we have to skip them if they start with numbers
-	//allow empty identifier because they are sometimes used.
+		/*
+		 * At the level of the Java Virtual Machine, every constructor written in the Java programming language (JLS §8.8)
+		 * appears as an instance initialization method that has the special name <init>.
+		 * This name is supplied by a compiler. Because the name is not a valid identifier,
+		 * it cannot be used directly in a program written in the Java programming language.
+		 */
+		//JDTTreeBuilderHelper.computeAnonymousName returns "$numbers$Name" so we have to skip them if they start with numbers
+		//allow empty identifier because they are sometimes used.
 		if (!simplename.matches("<.*>|\\d.*|^.{0}$")) {
 			//split at "<" and ">" because "Iterator<Cache.Entry<K,Store.ValueHolder<V>>>" submits setSimplename ("Cache.Entry<K")
 			String[] splittedSimplename = simplename.split("\\.|<|>");
 			if (checkAllParts(splittedSimplename)) {
 				throw new SpoonException("Not allowed javaletter or keyword in identifier found. See JLS for correct identifier. Identifier: " + simplename);
 			}
+		}
 	}
-}
 	private boolean isKeyword(String simplename) {
 		return keywords.contains(simplename);
 	}
@@ -118,19 +118,25 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 			simpleName = simpleName.replaceAll("\\[\\]|@", "");
 			if (isKeyword(simpleName) || checkIdentifierChars(simpleName)) {
 				return true;
+			}
 		}
-	}
-	return false;
+		return false;
 	}
 	private boolean checkIdentifierChars(String simplename) {
-		return (!Character.isJavaIdentifierStart(simplename.charAt(0))) || simplename.chars().anyMatch(letter -> !Character.isJavaIdentifierPart(letter));
+		if (simplename.length() == 0) {
+			return false;
+		}
+		return (!Character.isJavaIdentifierStart(simplename.charAt(0)))
+			|| simplename.chars().anyMatch(letter -> !Character.isJavaIdentifierPart(letter)
+		);
 	}
+
 	private static Collection<String> fillWithKeywords() {
-	//removed types because needed as ref: "int","short", "char", "void", "byte","float", "true","false","boolean","double","long","class", "null"
-	return Stream.of("abstract", "continue", "for", "new", "switch", "assert", "default", "if", "package", "synchronized",  "do", "goto", "private",
-	"this", "break",  "implements", "protected", "throw", "else", "import", "public", "throws", "case", "enum", "instanceof", "return",
-	"transient", "catch", "extends", "try", "final", "interface", "static", "finally",  "strictfp", "volatile",
-	"const",  "native", "super", "while", "_")
-	.collect(Collectors.toCollection(HashSet::new));
+		//removed types because needed as ref: "int","short", "char", "void", "byte","float", "true","false","boolean","double","long","class", "null"
+		return Stream.of("abstract", "continue", "for", "new", "switch", "assert", "default", "if", "package", "synchronized",  "do", "goto", "private",
+			"this", "break",  "implements", "protected", "throw", "else", "import", "public", "throws", "case", "enum", "instanceof", "return",
+			"transient", "catch", "extends", "try", "final", "interface", "static", "finally",  "strictfp", "volatile",
+			"const",  "native", "super", "while", "_")
+			.collect(Collectors.toCollection(HashSet::new));
 	}
 }

--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -1,13 +1,16 @@
 package spoon.generating;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.Ignore;
 import org.junit.Test;
 import spoon.FluentLauncher;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.reference.CtLocalVariableReference;
+import spoon.reflect.reference.CtTypeReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * for correct identifier see JLS chapter 3.8 and for keywords 3.9.
  * Ignored tests because we have to cut some corners between spec and jdt.
@@ -79,7 +82,7 @@ public class CorrectIdentifierTest {
 
 	@Test
 	public void correctSquareBrackets() {
-		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
+		CtTypeReference localVariableRef = new Launcher().getFactory().createTypeReference();
 		assertDoesNotThrow(() -> localVariableRef.setSimpleName("List<String>[]"));
 	}
 }

--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -69,4 +69,10 @@ public class CorrectIdentifierTest {
 		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
 		assertDoesNotThrow(() -> localVariableRef.setSimpleName("処理"));
 	}
+
+	@Test
+	public void correctSquareBrackets() {
+		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
+		assertDoesNotThrow(() -> localVariableRef.setSimpleName("List<String>[]"));
+	}
 }


### PR DESCRIPTION
Exception when indexing https://github.com/google/gson library in module mode (with `module-info.java` and `package-info.java`s) with https://github.com/sourcegraph/lsif-java with #3549 applied.

Exception does not occur when the library is not a module (with `module-info.java` and `package-info.java`s removed) (Note, need to double check the behaviour in each scenario: gson-module+3549, gson-not-module+3549, gson-module, gson-not-module)

Occurs with `TypeToken<List<String>[]>` @ https://github.com/google/gson/blob/master/gson/src/test/java/com/google/gson/GenericArrayTypeTest.java#L45

Debug state screenshots for context:

<details>
<summary>Stacktrace</summary>

```
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: 0
        at java.base/java.lang.StringLatin1.charAt(StringLatin1.java:48)
        at java.base/java.lang.String.charAt(String.java:711)
        at spoon.support.reflect.reference.CtReferenceImpl.checkIdentifierChars(CtReferenceImpl.java:129)
        at spoon.support.reflect.reference.CtReferenceImpl.checkAllParts(CtReferenceImpl.java:119)
        at spoon.support.reflect.reference.CtReferenceImpl.checkIdentiferForJLSCorrectness(CtReferenceImpl.java:107)
        at spoon.support.reflect.reference.CtReferenceImpl.setSimpleName(CtReferenceImpl.java:52)
        at spoon.support.compiler.jdt.ReferenceBuilder.getTypeParameterReference(ReferenceBuilder.java:738)
        at spoon.support.compiler.jdt.ReferenceBuilder.getTypeReference(ReferenceBuilder.java:691)
        at spoon.support.compiler.jdt.ReferenceBuilder.getTypeReference(ReferenceBuilder.java:637)
        at spoon.support.compiler.jdt.ReferenceBuilder.getTypeReference(ReferenceBuilder.java:519)
        at spoon.support.compiler.jdt.ReferenceBuilder.getExecutableReference(ReferenceBuilder.java:457)
        at spoon.support.compiler.jdt.JDTTreeBuilder.visit(JDTTreeBuilder.java:907)
        at org.eclipse.jdt.internal.compiler.ast.QualifiedAllocationExpression.traverse(QualifiedAllocationExpression.java:673)
        at org.eclipse.jdt.internal.compiler.ast.MessageSend.traverse(MessageSend.java:1110)
        at org.eclipse.jdt.internal.compiler.ast.LocalDeclaration.traverse(LocalDeclaration.java:480)
        at org.eclipse.jdt.internal.compiler.ast.MethodDeclaration.traverse(MethodDeclaration.java:365)
        at org.eclipse.jdt.internal.compiler.ast.TypeDeclaration.traverse(TypeDeclaration.java:1479)
        at org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration.traverse(CompilationUnitDeclaration.java:826)
        at org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration.traverse(CompilationUnitDeclaration.java:787)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.lambda$buildModel$0(JDTBasedSpoonCompiler.java:437)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.forEachCompilationUnit(JDTBasedSpoonCompiler.java:466)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildModel(JDTBasedSpoonCompiler.java:435)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildUnitsAndModel(JDTBasedSpoonCompiler.java:372)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.buildSources(JDTBasedSpoonCompiler.java:337)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.build(JDTBasedSpoonCompiler.java:114)
        at spoon.support.compiler.jdt.JDTBasedSpoonCompiler.build(JDTBasedSpoonCompiler.java:97)
        at spoon.Launcher.buildModel(Launcher.java:755)
        at ProjectIndexer.index(ProjectIndexer.java:44)
        at Main.main(Main.java:16)
```
</details>

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/18282288/91224063-70bf3800-e719-11ea-9df4-a6e5ec1587bb.png)

![image](https://user-images.githubusercontent.com/18282288/91224099-816fae00-e719-11ea-953a-d05153815cd5.png)
</details>