### PR TITLE
fix: fix PositionBuilder if modifier is followed by generic with out whitespace e.g public static<T>

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.compiler.jdt;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.AbstractVariableDeclaration;
@@ -46,6 +47,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.compiler.jdt.ContextBuilder.CastInfo;
 import spoon.support.reflect.CtExtendedModifier;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -577,6 +579,13 @@ public class PositionBuilder {
 			if (o2 == -1) {
 				o2 = end;
 			}
+
+			// this is the index into the modifier char array snippet, so must be +o1 if >-1
+			int chevronIndex = ArrayUtils.indexOf(Arrays.copyOfRange(contents, o1, o2), '<');
+			if (chevronIndex != -1) {
+				o2 = o1 + chevronIndex;
+			}
+
 			String modifierName = String.valueOf(contents, o1, o2 - o1);
 			CtExtendedModifier modifier = explicitModifiersByName.remove(modifierName);
 			if (modifier != null) {

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -368,7 +368,12 @@ public class PositionBuilder {
 
 			TypeParameter[] typeParameters = methodDeclaration.typeParameters();
 			if (typeParameters != null && typeParameters.length > 0) {
-				modifiersSourceEnd = typeParameters[0].declarationSourceStart - 3;
+				// if there is no space between the modifier and the type parameter vs if there is a space
+				if (contents[typeParameters[0].declarationSourceStart - 2] != ' ') {
+					modifiersSourceEnd = typeParameters[0].declarationSourceStart - 2;
+				} else {
+					modifiersSourceEnd = typeParameters[0].declarationSourceStart - 3;
+				}
 			}
 
 			if (getModifiers(methodDeclaration.modifiers, false, true).isEmpty()) {

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -379,10 +379,10 @@ public class PositionTest {
 		BodyHolderSourcePosition position = (BodyHolderSourcePosition) foo.getPosition();
 
 		assertEquals(3, position.getLine());
-		assertEquals(31, position.getEndLine());
+		assertEquals(35, position.getEndLine());
 
 		assertEquals(42, position.getSourceStart());
-		assertEquals(411, position.getSourceEnd());
+		assertEquals(468, position.getSourceEnd());
 
 		assertEquals("FooGeneric", contentAtPosition(classContent, position.getNameStart(), position.getNameEnd()));
 		assertEquals("public", contentAtPosition(classContent, position.getModifierSourceStart(), position.getModifierSourceEnd()));
@@ -411,6 +411,17 @@ public class PositionTest {
 
 		// /!\ the annotations can be between two modifiers
 		assertEquals("public @Deprecated static", contentAtPosition(classContent, position2.getModifierSourceStart(), position2.getModifierSourceEnd()));
+
+		CtMethod<?> method2 = foo.getMethodsByName("n").get(0);
+		BodyHolderSourcePosition position3 = (BodyHolderSourcePosition) method2
+				.getPosition();
+
+		assertEquals("protected static<S> S n(int parm2) {\n"
+				+ "\t\treturn null;\n"
+				+ "\t}", contentAtPosition(classContent, position3));
+		assertEquals("n", contentAtPosition(classContent, position3.getNameStart(), position3.getNameEnd()));
+
+		assertEquals("protected static", contentAtPosition(classContent, position3.getModifierSourceStart(), position3.getModifierSourceEnd()));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/position/testclasses/FooGeneric.java
+++ b/src/test/java/spoon/test/position/testclasses/FooGeneric.java
@@ -8,6 +8,10 @@ public class FooGeneric<T extends Object> {
 		return null;
 	}
 
+	protected static<S> S n(int parm2) {
+		return null;
+	}
+
 	/**
 	 * Method with javadoc
 	 * @param parm1 the parameter


### PR DESCRIPTION
The following line would result in `o2` being of a value that would cause `modifierName` to include the generic type param, causing the looking into `explicitModifiersByName` to return null. https://github.com/google/gson/blob/master/gson/src/test/java/com/google/gson/ParameterizedTypeFixtures.java#L129

If a space would be between `static` and `<T>`, the modifier position is extracted properly.