### PR TITLE
Added null check to handle anonymous classes to TypeFactory

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -565,6 +565,9 @@ public class TypeFactory extends SubFactory {
 				} catch (Throwable e) {
 					throw new SpoonClassNotFoundException("cannot create shadow class: " + cl.getName(), e);
 				}
+				if (newShadowClass == null) {
+					return null;
+				}
 				newShadowClass.setFactory(factory);
 				newShadowClass.accept(new CtScanner() {
 					@Override


### PR DESCRIPTION
When indexing https://github.com/google/gson with https://github.com/sourcegraph/lsif-java, anonymous class declarations (of the form `com.google.gson.<xyz>.SomeClass$1`), the following line would cause a NullPointerException https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/reflect/factory/TypeFactory.java#L568 

Was unsuccessful in reproducing at a smaller scale than google/gson. This PR may be just a symptom patch for a larger issue that Im not aware of where to find.

<details>
<summary>Debugger state view</summary>

![image](https://user-images.githubusercontent.com/18282288/91480387-ce2ec280-e89a-11ea-85f5-04bdf642d337.png)
</summary>

</details>

<details>
<summary>Stack trace</summary>

```
Exception in thread "main" java.lang.NullPointerException
        at spoon.reflect.factory.TypeFactory.get(TypeFactory.java:571)
        at spoon.support.reflect.reference.CtTypeReferenceImpl.getTypeDeclaration(CtTypeReferenceImpl.java:203)
        at spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction.sendResult(SuperInheritanceHierarchyFunction.java:353)
        at spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction.apply(SuperInheritanceHierarchyFunction.java:238)
        at spoon.reflect.visitor.filter.SuperInheritanceHierarchyFunction.apply(SuperInheritanceHierarchyFunction.java:38)
        at spoon.reflect.visitor.chain.CtQueryImpl$LazyFunctionWrapper._accept(CtQueryImpl.java:494)
        at spoon.reflect.visitor.chain.CtQueryImpl$AbstractStep.accept(CtQueryImpl.java:309)
        at spoon.reflect.visitor.chain.CtQueryImpl.forEach(CtQueryImpl.java:95)
        at spoon.reflect.visitor.filter.AllTypeMembersFunction.apply(AllTypeMembersFunction.java:81)
        at spoon.reflect.visitor.filter.AllTypeMembersFunction.apply(AllTypeMembersFunction.java:30)
        at spoon.reflect.visitor.chain.CtQueryImpl$LazyFunctionWrapper._accept(CtQueryImpl.java:494)
        at spoon.reflect.visitor.chain.CtQueryImpl$AbstractStep.accept(CtQueryImpl.java:309)
        at spoon.reflect.visitor.chain.CtQueryImpl.forEach(CtQueryImpl.java:95)
        at spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction.apply(PotentialVariableDeclarationFunction.java:100)
        at spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction.apply(PotentialVariableDeclarationFunction.java:59)
        at spoon.reflect.visitor.chain.CtQueryImpl$LazyFunctionWrapper._accept(CtQueryImpl.java:494)
        at spoon.reflect.visitor.chain.CtQueryImpl$AbstractStep.accept(CtQueryImpl.java:309)
        at spoon.reflect.visitor.chain.CtQueryImpl.first(CtQueryImpl.java:138)
        at spoon.reflect.visitor.chain.CtQueryImpl.first(CtQueryImpl.java:121)
        at spoon.support.reflect.reference.CtLocalVariableReferenceImpl.getDeclaration(CtLocalVariableReferenceImpl.java:62)
        at spoon.support.reflect.reference.CtLocalVariableReferenceImpl.getDeclaration(CtLocalVariableReferenceImpl.java:21)
        at DocumentIndexer$ReferencesVisitor.visitCtVariableRead(DocumentIndexer.java:184)
        at spoon.support.reflect.code.CtVariableReadImpl.accept(CtVariableReadImpl.java:18)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtInvocation(CtScanner.java:502)
        at DocumentIndexer$ReferencesVisitor.visitCtInvocation(DocumentIndexer.java:199)
        at spoon.support.reflect.code.CtInvocationImpl.accept(CtInvocationImpl.java:46)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtReturn(CtScanner.java:675)
        at spoon.support.reflect.code.CtReturnImpl.accept(CtReturnImpl.java:27)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
        at spoon.reflect.visitor.CtScanner.visitCtBlock(CtScanner.java:299)
        at spoon.support.reflect.code.CtBlockImpl.accept(CtBlockImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtMethod(CtScanner.java:556)
        at spoon.support.reflect.declaration.CtMethodImpl.accept(CtMethodImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
        at spoon.reflect.visitor.CtScanner.visitCtClass(CtScanner.java:335)
        at spoon.support.reflect.declaration.CtClassImpl.accept(CtClassImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtNewClass(CtScanner.java:601)
        at spoon.support.reflect.code.CtNewClassImpl.accept(CtNewClassImpl.java:25)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtReturn(CtScanner.java:675)
        at spoon.support.reflect.code.CtReturnImpl.accept(CtReturnImpl.java:27)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
        at spoon.reflect.visitor.CtScanner.visitCtBlock(CtScanner.java:299)
        at spoon.support.reflect.code.CtBlockImpl.accept(CtBlockImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtTry(CtScanner.java:728)
        at spoon.support.reflect.code.CtTryImpl.accept(CtTryImpl.java:43)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
        at spoon.reflect.visitor.CtScanner.visitCtBlock(CtScanner.java:299)
        at spoon.support.reflect.code.CtBlockImpl.accept(CtBlockImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.visitCtMethod(CtScanner.java:556)
        at spoon.support.reflect.declaration.CtMethodImpl.accept(CtMethodImpl.java:58)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:177)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:169)
        at spoon.reflect.visitor.CtScanner.scan(CtScanner.java:142)
        at spoon.reflect.visitor.CtScanner.visitCtClass(CtScanner.java:335)
        at spoon.support.reflect.declaration.CtClassImpl.accept(CtClassImpl.java:58)
        at DocumentIndexer.visitReferences(DocumentIndexer.java:56)
        at ProjectIndexer.index(ProjectIndexer.java:73)
        at Main.main(Main.java:16)
```
</details>