### PR TITLE
test: fix assertions for newer jdks and refactor old test code.

### DIFF
--- a/src/test/java/spoon/test/factory/TypeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/TypeFactoryTest.java
@@ -1,18 +1,16 @@
 /**
- * Copyright (C) 2006-2018 INRIA and contributors
- * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006-2018 INRIA and contributors Spoon - http://spoon.gforge.inria.fr/
  *
- * This software is governed by the CeCILL-C License under French law and
- * abiding by the rules of distribution of free software. You can use, modify
- * and/or redistribute the software under the terms of the CeCILL-C license as
- * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ * This software is governed by the CeCILL-C License under French law and abiding by the rules of
+ * distribution of free software. You can use, modify and/or redistribute the software under the
+ * terms of the CeCILL-C license as circulated by CEA, CNRS and INRIA at http://www.cecill.info.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * CeCILL-C License for more details.
  *
- * The fact that you are presently reading this means that you have had
- * knowledge of the CeCILL-C license and that you accept its terms.
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL-C
+ * license and that you accept its terms.
  */
 package spoon.test.factory;
 
@@ -34,6 +32,8 @@ import java.io.File;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypeFactoryTest {
 
@@ -59,11 +59,17 @@ public class TypeFactoryTest {
 	@Test
 	public void reflectionAPI() {
 		// Spoon can be used as reflection API
-		CtType s = new TypeFactory().get(String.class);
-		assertEquals("String", s.getSimpleName());
-		assertEquals("java.lang.String", s.getQualifiedName());
-		assertEquals(3, s.getSuperInterfaces().size());
-		assertEquals(2, s.getMethodsByName("toLowerCase").size());
+		CtType<?> s = new TypeFactory().get(String.class);
+		assertAll(
+			() -> assertEquals("String", s.getSimpleName()),
+			() -> assertEquals("java.lang.String", s.getQualifiedName()),
+			/*
+			In java 12 string got 2 new interfaces (see https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/String.html)
+			Constable, ConstantDesc. To support the CI with jdk8 and newer CIs for local testing this assertion is needed.
+			*/
+			() -> assertTrue(3 == s.getSuperInterfaces().size() || 5 == s.getSuperInterfaces().size()),
+			() -> assertEquals(3, s.getSuperInterfaces().size()),
+			() -> assertEquals(2, s.getMethodsByName("toLowerCase").size()));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -1,18 +1,9 @@
 /**
- * Copyright (C) 2006-2018 INRIA and contributors
- * Spoon - http://spoon.gforge.inria.fr/
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
- * This software is governed by the CeCILL-C License under French law and
- * abiding by the rules of distribution of free software. You can use, modify
- * and/or redistribute the software under the terms of the CeCILL-C license as
- * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ * Copyright (C) 2006-2019 INRIA and contributors
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
- *
- * The fact that you are presently reading this means that you have had
- * knowledge of the CeCILL-C license and that you accept its terms.
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
  */
 package spoon.test.model;
 
@@ -25,11 +16,9 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.TypeFactory;
-import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.AllTypeMembersFunction;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -37,25 +26,33 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class TypeTest {
 
 	@Test
-	public void testGetAllExecutables() throws Exception {
+	public void testGetDifferentElements() throws Exception {
+		// contract: All elements of a model must be found.
 		CtClass<?> type = build("spoon.test.model", "Foo");
-		assertEquals(1, type.getDeclaredFields().size());
-		assertEquals(3, type.getMethods().size());
-		assertEquals(4, type.getDeclaredExecutables().size());
-		assertEquals(2, type.getAllFields().size());
-		assertEquals(1, type.getConstructors().size());
-		assertEquals(16, type.getAllMethods().size());
-		assertEquals(12, type.getFactory().Type().get(Object.class).getAllMethods().size());
+		assertAll(
+				() -> assertEquals(1, type.getDeclaredFields().size()),
+				() -> assertEquals(3, type.getMethods().size()),
+				() -> assertEquals(4, type.getDeclaredExecutables().size()),
+				() -> assertEquals(2, type.getAllFields().size()),
+				() -> assertEquals(1, type.getConstructors().size()),
+				() -> assertEquals(16, type.getAllMethods().size()),
+				() -> assertEquals(12, type.getFactory().Type().get(Object.class).getAllMethods().size()));
 
 		// we have 3  methods in Foo + 2 in Baz - 1 common in Foo.bar (m) + 12 in Object + 1 explicit constructor in Foo
-		Collection<CtExecutableReference<?>> allExecutables = type.getAllExecutables();
-		assertEquals(17, allExecutables.size());
+		/*
+		This assertion is needed because in java.lang.object the method registerNative was removed.
+		See https://bugs.openjdk.java.net/browse/JDK-8232801 for details.
+		To fit this change and support new jdks and the CI both values are correct.
+		In jdk8 object has 12 methods and in newer jdk object has 11
+		 */
+		assertTrue(17 == type.getAllExecutables().size() || 16 == type.getAllExecutables().size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -59,13 +59,21 @@ public class TypeTest {
 	public void testAllTypeMembersFunctionMode() throws Exception {
 		// contract: AllTypeMembersFunction can be configured to return all members or only internally visible members
 		CtClass<?> type = build("spoon.test.model", "Foo");
-		List<CtMethod> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.SKIP_PRIVATE)).list();
-		List<CtMethod> allMethods = type.map(new AllTypeMembersFunction(CtMethod.class)).list();
-		assertEquals(16, internallyAccessibleMethods.size());
-		assertEquals(17, allMethods.size());
+		List<CtMethod<?>> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.SKIP_PRIVATE)).list();
+		List<CtMethod<?>> allMethods = type.map(new AllTypeMembersFunction(CtMethod.class)).list();
+		assertAll(
+			() -> assertEquals(16, internallyAccessibleMethods.size()),
+			() -> assertTrue(17 == allMethods.size() || 16 == allMethods.size()));
+
+		/*
+		This if-clause is needed because in java.lang.object the method registerNative was removed.
+		See https://bugs.openjdk.java.net/browse/JDK-8232801 for details.
+		*/
 		allMethods.removeAll(internallyAccessibleMethods);
-		assertEquals(1, allMethods.size());
-		assertEquals("registerNatives()", allMethods.get(0).getSignature());
+		if (allMethods.size() == 1) {
+			assertEquals(1, allMethods.size());
+			assertEquals("registerNatives()", allMethods.get(0).getSignature());
+		}
 	}
 
 	@Test

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -127,19 +127,27 @@ public class ExecutableReferenceTest {
 	}
 
 	@Test
-	public void testSpecifyGetAllExecutablesMethod() {
+	public void testGetAllExecutablesMethodForInterface() {
+		// contract: As interfaces doesn't extend object, the Foo interface must have 1 method and no method from object.
 		Launcher launcher = new Launcher();
 		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses");
 		launcher.run();
-
 		CtInterface<Foo> foo = launcher.getFactory().Interface().get(spoon.test.reference.testclasses.Foo.class);
 		Collection<CtExecutableReference<?>> fooExecutables = foo.getAllExecutables();
 		assertAll(
 				() ->assertEquals(1, fooExecutables.size()),
 				() ->assertEquals(foo.getSuperInterfaces().iterator().next().getTypeDeclaration().getMethod("m").getReference(),
-									launcher.getFactory().Interface().get(SuperFoo.class).getMethod("m").getReference()));
+						launcher.getFactory().Interface().get(SuperFoo.class).getMethod("m").getReference()));
+	}
 
+	@Test
+	public void testGetAllExecutablesMethodForClasses() {
+		// contract: As classes extend object and the Bar class has 1 method, getAllExecutables for Bar must return 12/13.
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
+		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses");
+		launcher.run();
 		CtClass<Bar> bar = launcher.getFactory().Class().get(Bar.class);
 		Collection<CtExecutableReference<?>> barExecutables = bar.getAllExecutables();
 		/*

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -1,18 +1,9 @@
 /**
- * Copyright (C) 2006-2018 INRIA and contributors
- * Spoon - http://spoon.gforge.inria.fr/
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
- * This software is governed by the CeCILL-C License under French law and
- * abiding by the rules of distribution of free software. You can use, modify
- * and/or redistribute the software under the terms of the CeCILL-C license as
- * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ * Copyright (C) 2006-2019 INRIA and contributors
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
- *
- * The fact that you are presently reading this means that you have had
- * knowledge of the CeCILL-C license and that you accept its terms.
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
  */
 package spoon.test.reference;
 


### PR DESCRIPTION
As i wrote in issue #3547 we have some testcase, which are jdk dependent. Goal of this patch is to fix them all and as always refactor the testcase to reach a higher quality standard. Looking into the older testcases, there is still alot of refactoring work needed unrelated to bugs. I try to create as minimal diffs as possible while still refactoring the code to a newer style.

- [x] spoon.test.model.TypeTest > testGetAllExecutables 
- [x] spoon.test.reference.ExecutableReferenceTest > testSpecifyGetAllExecutablesMethod 
- [x] spoon.test.model.TypeTest > testAllTypeMembersFunctionMode 
- [x] spoon.test.factory.TypeFactoryTest > reflectionAPI 