### PR TITLE
fix: fix Maven source and test source directory resolving

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -133,7 +133,7 @@ public class SpoonPom implements SpoonResource {
 		}
 	}
 
-	public void addModule(SpoonPom module) {
+	private void addModule(SpoonPom module) {
 		modules.add(module);
 	}
 

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -133,7 +133,7 @@ public class SpoonPom implements SpoonResource {
 		}
 	}
 
-	private void addModule(SpoonPom module) {
+	public void addModule(SpoonPom module) {
 		modules.add(module);
 	}
 

--- a/src/test/java/spoon/support/compiler/SpoonPomTest.java
+++ b/src/test/java/spoon/support/compiler/SpoonPomTest.java
@@ -6,12 +6,9 @@ import spoon.MavenLauncher;
 import spoon.support.StandardEnvironment;
 
 import java.io.IOException;
-<<<<<<< HEAD
 import java.util.List;
 import java.util.regex.Pattern;
-=======
 import java.nio.file.Paths;
->>>>>>> 7c8b18599... Added test for getting maven source directory from ancestors
 
 import static org.junit.Assert.*;
 
@@ -69,6 +66,6 @@ public class SpoonPomTest {
 		SpoonPom childModel = pomModel.getModules().get(0);
 		//contract: source directory is derived from parent pom.xml if not declared in the current
 		// (childModel) SpoonPom
-		assertEquals(expected, childModel.getSourceDirectories().get(0).getAbsolutePath(), expected);
+		assertEquals(expected, childModel.getSourceDirectories().get(0).getAbsolutePath());
 	}
 }

--- a/src/test/java/spoon/support/compiler/SpoonPomTest.java
+++ b/src/test/java/spoon/support/compiler/SpoonPomTest.java
@@ -6,8 +6,12 @@ import spoon.MavenLauncher;
 import spoon.support.StandardEnvironment;
 
 import java.io.IOException;
+<<<<<<< HEAD
 import java.util.List;
 import java.util.regex.Pattern;
+=======
+import java.nio.file.Paths;
+>>>>>>> 7c8b18599... Added test for getting maven source directory from ancestors
 
 import static org.junit.Assert.*;
 
@@ -50,5 +54,21 @@ public class SpoonPomTest {
 		for (int i = 0; i < modules.size(); i++) {
 			assertEquals(expected[i], modules.get(i).getName());
 		}
+	}
+	
+	public void getSourceDirectory() throws IOException, XmlPullParserException {
+		checkSourceDirectory(
+			"src/test/resources/maven-launcher/hierarchy",
+			Paths.get("src/test/resources/maven-launcher/hierarchy/child/src").toAbsolutePath().toString()
+		);
+	}
+
+	public void checkSourceDirectory(String path, String expected) throws IOException, XmlPullParserException {
+		SpoonPom pomModel = new SpoonPom(path, null, MavenLauncher.SOURCE_TYPE.APP_SOURCE, new StandardEnvironment());
+
+		SpoonPom childModel = pomModel.getModules().get(0);
+		//contract: source directory is derived from parent pom.xml if not declared in the current
+		// (childModel) SpoonPom
+		assertEquals(expected, childModel.getSourceDirectories().get(0).getAbsolutePath(), expected);
 	}
 }

--- a/src/test/resources/maven-launcher/hierarchy/child/pom.xml
+++ b/src/test/resources/maven-launcher/hierarchy/child/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>sample.text</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <groupId>sample.text</groupId>
+    <artifactId>child</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <packaging>jar</packaging>
+</project>

--- a/src/test/resources/maven-launcher/hierarchy/child/src/Test.java
+++ b/src/test/resources/maven-launcher/hierarchy/child/src/Test.java
@@ -1,0 +1,5 @@
+package maven-launcher.hierarchy.child.src;
+
+public class Test {
+	
+}

--- a/src/test/resources/maven-launcher/hierarchy/pom.xml
+++ b/src/test/resources/maven-launcher/hierarchy/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>sample.text</groupId>
+        <artifactId>project</artifactId>
+        <version>2.2.2.RELEASE</version>
+        <relativePath/>
+    </parent>
+    <groupId>sample.text</groupId>
+    <artifactId>parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>child</module>
+    </modules>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src</sourceDirectory>
+    </build>
+</project>


### PR DESCRIPTION
By climbing the pom.xml hierarchy to find the nearest ancestor that declares the source directory rather than immediately falling back to src/(main|test)/java if not declared in this immediate pom.

Also added interpolating (project|pom|'').basedir which is not uncommonly found in projects. 