### PR TITLE
fix: intersection types with wildcard "?" are allowed as simplename

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -116,6 +116,10 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 		for (String simpleName:simplenameParts) {
 			//because arrays use e.g. int[] and @Number is used for instances of an object e.g. foo@1
 			simpleName = simpleName.replaceAll("\\[\\]|@", "");
+			if (isWildCard(simpleName)) {
+				// because in intersection types a typeReference sometimes has '?' as simplename
+				return false;
+			}
 			if (isKeyword(simpleName) || checkIdentifierChars(simpleName)) {
 				return true;
 		}
@@ -132,5 +136,13 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 	"transient", "catch", "extends", "try", "final", "interface", "static", "finally",  "strictfp", "volatile",
 	"const",  "native", "super", "while", "_")
 	.collect(Collectors.toCollection(HashSet::new));
+	}
+
+	/**
+	 * checks if the input is a wildcard '?'. The method is not null safe.
+	 * @return boolean true is input wildcard, false otherwise
+	 */
+	private boolean isWildCard(String name) {
+		return name.equals("?");
 	}
 }

--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -7,9 +7,7 @@ import org.junit.Test;
 import spoon.FluentLauncher;
 import spoon.Launcher;
 import spoon.SpoonException;
-import spoon.reflect.CtModel;
 import spoon.reflect.reference.CtLocalVariableReference;
-import spoon.test.GitHubIssue;
 /**
  * for correct identifier see JLS chapter 3.8 and for keywords 3.9.
  * Ignored tests because we have to cut some corners between spec and jdt.
@@ -73,11 +71,9 @@ public class CorrectIdentifierTest {
 		assertDoesNotThrow(() -> localVariableRef.setSimpleName("処理"));
 	}
 
-	@Ignore
-	@GitHubIssue(issueNumber = 3564)
 	@Test
-	public void fooTest() {
-		CtModel model = new FluentLauncher().inputResource("./src/test/resources/identifier/InliningImplementationMatcher.java").buildModel();
-		// after fix byte-buddy/byte-buddy-dep must run
+	public void intersectionTypeIdentifierTest() {
+		//contract: intersectionTypes can have simpleNames with '?' for wildcards.
+		assertDoesNotThrow(() -> new FluentLauncher().inputResource("./src/test/resources/identifier/InliningImplementationMatcher.java").buildModel());
 	}
 }

--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -73,6 +73,7 @@ public class CorrectIdentifierTest {
 		assertDoesNotThrow(() -> localVariableRef.setSimpleName("処理"));
 	}
 
+	@Ignore
 	@GitHubIssue(issueNumber = 3564)
 	@Test
 	public void fooTest() {

--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.Ignore;
 import org.junit.Test;
+import spoon.FluentLauncher;
 import spoon.Launcher;
 import spoon.SpoonException;
+import spoon.reflect.CtModel;
 import spoon.reflect.reference.CtLocalVariableReference;
+import spoon.test.GitHubIssue;
 /**
  * for correct identifier see JLS chapter 3.8 and for keywords 3.9.
  * Ignored tests because we have to cut some corners between spec and jdt.
@@ -68,5 +71,12 @@ public class CorrectIdentifierTest {
 	public void correctIdentiferUtfChinese() {
 		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
 		assertDoesNotThrow(() -> localVariableRef.setSimpleName("処理"));
+	}
+
+	@GitHubIssue(issueNumber = 3564)
+	@Test
+	public void fooTest() {
+		CtModel model = new FluentLauncher().inputResource("./src/test/resources/identifier/InliningImplementationMatcher.java").buildModel();
+		// after fix byte-buddy/byte-buddy-dep must run
 	}
 }

--- a/src/test/resources/identifier/InliningImplementationMatcher.java
+++ b/src/test/resources/identifier/InliningImplementationMatcher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2014 - 2020 Rafael Winterhalter
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.bytebuddy.dynamic.scaffold.inline;
+
+import net.bytebuddy.build.HashCodeAndEqualsPlugin;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import net.bytebuddy.matcher.LatentMatcher;
+
+import static net.bytebuddy.matcher.ElementMatchers.*;
+
+/**
+ * A latent method matcher that identifies methods to instrument when redefining or rebasing a type.
+ */
+@HashCodeAndEqualsPlugin.Enhance
+public class InliningImplementationMatcher implements LatentMatcher<MethodDescription> {
+
+    /**
+     * A method matcher that matches any ignored method.
+     */
+    private final LatentMatcher<? super MethodDescription> ignoredMethods;
+
+    /**
+     * A method matcher that matches any predefined method.
+     */
+    private final ElementMatcher<? super MethodDescription> predefinedMethodSignatures;
+
+    /**
+     * Creates a new inline implementation matcher.
+     *
+     * @param ignoredMethods             A method matcher that matches any ignored method.
+     * @param predefinedMethodSignatures A method matcher that matches any predefined method.
+     */
+    protected InliningImplementationMatcher(LatentMatcher<? super MethodDescription> ignoredMethods,
+                                            ElementMatcher<? super MethodDescription> predefinedMethodSignatures) {
+        this.ignoredMethods = ignoredMethods;
+        this.predefinedMethodSignatures = predefinedMethodSignatures;
+    }
+
+    /**
+     * Creates a matcher where only overridable or declared methods are matched unless those are ignored. Methods that
+     * are declared by the target type are only matched if they are not ignored. Declared methods that are not found on the
+     * target type are always matched.
+     *
+     * @param ignoredMethods A method matcher that matches any ignored method.
+     * @param originalType   The original type of the instrumentation before adding any user methods.
+     * @return A latent method matcher that identifies any method to instrument for a rebasement or redefinition.
+     */
+    protected static LatentMatcher<MethodDescription> of(LatentMatcher<? super MethodDescription> ignoredMethods, TypeDescription originalType) {
+        ElementMatcher.Junction<MethodDescription> predefinedMethodSignatures = none();
+        for (MethodDescription methodDescription : originalType.getDeclaredMethods()) {
+            ElementMatcher.Junction<MethodDescription> signature = methodDescription.isConstructor()
+                    ? isConstructor()
+                    : ElementMatchers.<MethodDescription>named(methodDescription.getName());
+            signature = signature.and(returns(methodDescription.getReturnType().asErasure()));
+            signature = signature.and(takesArguments(methodDescription.getParameters().asTypeList().asErasures()));
+            predefinedMethodSignatures = predefinedMethodSignatures.or(signature);
+        }
+        return new InliningImplementationMatcher(ignoredMethods, predefinedMethodSignatures);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ElementMatcher<? super MethodDescription> resolve(TypeDescription typeDescription) {
+        return (ElementMatcher<? super MethodDescription>) not(ignoredMethods.resolve(typeDescription))
+                .and(isVirtual().and(not(isFinal())).or(isDeclaredBy(typeDescription)))
+                .or(isDeclaredBy(typeDescription).and(not(predefinedMethodSignatures)));
+    }
+}


### PR DESCRIPTION
Sometimes intersectiontypes set simplename for a typereference to "?". We should allow this. Sadly we are cutting more and more corners in this check, because we have 1 check for all `setSimplename `methods. Now spoon would accept `int a? =3;`, which isn't problematic for analyzing code, but for transformations. More problematic is that we have at least 2 implementations for the identifier check, see [here](https://github.com/INRIA/spoon/blob/1de9318fcb97fa99ba18c3fd40025163a55df89b/src/main/java/spoon/reflect/visitor/JavaIdentifiers.java). But maybe we should continue step by step fixing the issue and after that find a solution for the problem described above.