### PR TITLE
feat: support for building Spoon models from modules declared in maven profiles

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -540,7 +540,7 @@ public class SpoonPom implements SpoonResource {
 
 	@Override
 	public String getName() {
-		return "pom";
+		return model.getName();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -39,8 +39,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -76,21 +78,53 @@ public class SpoonPom implements SpoonResource {
 	 * @throws XmlPullParserException when the file is corrupted
 	 */
 	public SpoonPom(String path, SpoonPom parent, MavenLauncher.SOURCE_TYPE sourceType, Environment environment) throws IOException, XmlPullParserException {
+		this(path, parent, sourceType, environment, Pattern.compile("^$"));
+	}
+
+	/**
+	 * Extract the information from the pom
+	 * @param path the path to the pom
+	 * @param parent the parent pom
+	 * @param profileFilter regex pattern to filter profiles when expanding defined modules. Only modules in matching profiles are expanded
+	 * @throws IOException when the file does not exist
+	 * @throws XmlPullParserException when the file is corrupted
+	 */
+	public SpoonPom(String path, SpoonPom parent, MavenLauncher.SOURCE_TYPE sourceType, Environment environment, Pattern profileFilter) throws IOException, XmlPullParserException {
 		this.parent = parent;
 		this.sourceType = sourceType;
 		this.environment = environment;
-		if (!path.endsWith(".xml") && !path.endsWith(".pom")) {
+
+		// directory may end in .xml|.pom so don't skip if thats the case
+		if ((!path.endsWith(".xml") && !path.endsWith(".pom")) || Paths.get(path).toFile().isDirectory()) {
 			path = Paths.get(path, "pom.xml").toString();
 		}
-		this.pomFile = new File(path);
+		this.pomFile = new File(path).getCanonicalFile();
 		if (!pomFile.exists()) {
 			throw new IOException("Pom does not exists.");
 		}
 		this.directory = pomFile.getParentFile();
+
 		MavenXpp3Reader pomReader = new MavenXpp3Reader();
 		try (FileReader reader = new FileReader(pomFile)) {
 			this.model = pomReader.read(reader);
+
+			Set<String> allModules = new HashSet<>();
+
+			for (Profile profile : model.getProfiles()) {
+				if (!profileFilter.matcher(profile.getId()).matches()) {
+					continue;
+				}
+				for (String module : profile.getModules()) {
+					allModules.add(module);
+					addModule(new SpoonPom(Paths.get(pomFile.getParent(), module).toString(), this, sourceType, environment));
+				}
+			}
+
+			// recursively build the POM hierarchy for modules not built from profiles
 			for (String module : model.getModules()) {
+				if (allModules.contains(module)) {
+					continue;
+				}
 				addModule(new SpoonPom(Paths.get(pomFile.getParent(), module).toString(), this, sourceType, environment));
 			}
 		} catch (FileNotFoundException e) {

--- a/src/test/java/spoon/support/compiler/SpoonPomTest.java
+++ b/src/test/java/spoon/support/compiler/SpoonPomTest.java
@@ -5,8 +5,9 @@ import org.junit.Test;
 import spoon.MavenLauncher;
 import spoon.support.StandardEnvironment;
 
-import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.junit.Assert.*;
 
@@ -29,5 +30,25 @@ public class SpoonPomTest {
 
 		//contract: Java version is read accurately from pom and does not trigger exceptions
 		assertEquals(expected, version);
+	}
+
+	@Test
+	public void getModuleNames() throws IOException, XmlPullParserException {
+		String[] expected = {"always"};
+		checkProfilesModules("src/test/resources/maven-launcher/profiles", expected, Pattern.compile("^$"));
+		String[] expected1 = {"profile-only", "always"};
+		checkProfilesModules("src/test/resources/maven-launcher/profiles", expected1, Pattern.compile(".+"));
+	}
+
+	public void checkProfilesModules(String path, String[] expected, Pattern profileFilter) throws IOException, XmlPullParserException {
+		SpoonPom pomModel = new SpoonPom(path, null, MavenLauncher.SOURCE_TYPE.APP_SOURCE, new StandardEnvironment(), profileFilter);
+		List<SpoonPom> modules = pomModel.getModules();
+
+		assertEquals(expected.length, modules.size());
+
+		// contract: modules declared in profiles that don't match the profileFilter are not included
+		for (int i = 0; i < modules.size(); i++) {
+			assertEquals(expected[i], modules.get(i).getName());
+		}
 	}
 }

--- a/src/test/resources/maven-launcher/profiles/always/pom.xml
+++ b/src/test/resources/maven-launcher/profiles/always/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>always</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>always</name>
+
+    <build>
+        <sourceDirectory>source/code</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
+    </build>
+</project>

--- a/src/test/resources/maven-launcher/profiles/pom.xml
+++ b/src/test/resources/maven-launcher/profiles/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>foobar</name>
+
+    <modules>
+        <module>always</module>
+    </modules>
+
+    <profiles>
+        <profile>
+            <id>test</id>
+            <modules>
+                <module>profile-only</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/src/test/resources/maven-launcher/profiles/profile-only/pom.xml
+++ b/src/test/resources/maven-launcher/profiles/profile-only/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>profile-only</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>profile-only</name>
+
+    <build>
+        <sourceDirectory>source/code</sourceDirectory>
+        <testSourceDirectory>test</testSourceDirectory>
+    </build>
+</project>


### PR DESCRIPTION
By default with the existing constructors, all profiles are ignored to retain previous behaviour.