### PR TITLE
fix: fix non terminating PositionBuilder

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -587,7 +587,7 @@ public class PositionBuilder {
 
 			// this is the index into the modifier char array snippet, so must be +o1 if >-1
 			int chevronIndex = ArrayUtils.indexOf(Arrays.copyOfRange(contents, o1, o2), '<');
-			if (chevronIndex != -1) {
+			if (chevronIndex > 0) {
 				o2 = o1 + chevronIndex;
 			}
 

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -90,6 +90,7 @@ import spoon.test.position.testclasses.FooLabel;
 import spoon.test.position.testclasses.FooLambda;
 import spoon.test.position.testclasses.FooMethod;
 import spoon.test.position.testclasses.FooStatement;
+import spoon.test.position.testclasses.AnnotationWithAngleBracket;
 import spoon.test.position.testclasses.FooSwitch;
 import spoon.test.position.testclasses.Kokos;
 import spoon.test.position.testclasses.NoMethodModifiers;
@@ -107,6 +108,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 
@@ -422,6 +424,13 @@ public class PositionTest {
 		assertEquals("n", contentAtPosition(classContent, position3.getNameStart(), position3.getNameEnd()));
 
 		assertEquals("protected static", contentAtPosition(classContent, position3.getModifierSourceStart(), position3.getModifierSourceEnd()));
+	}
+
+	@Test(timeout=10000)
+	public void testPositionTerminates() {
+		assertDoesNotThrow(() -> {
+			final Factory build = build(AnnotationWithAngleBracket.class);
+		});
 	}
 
 	@Test

--- a/src/test/java/spoon/test/position/testclasses/AnnotationWithAngleBracket.java
+++ b/src/test/java/spoon/test/position/testclasses/AnnotationWithAngleBracket.java
@@ -1,0 +1,8 @@
+package spoon.test.position.testclasses;
+
+import spoon.processing.Property;
+
+public class AnnotationWithAngleBracket {
+	@Property(value = "min <= desired")
+	private static int test;
+}


### PR DESCRIPTION
PositionBuilder would get caught in the `<` in the annotation string, resulting in `o2` == `o1` and no advancement being made.
This fix ignores the opening angle bracket if it comes at the start of the search space