### PR TITLE
refactor: call setBoundingType after we have a factory

### DIFF
--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -645,6 +645,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory {
 	public CtWildcardReference createWildcardReference() {
 		CtWildcardReference e = new CtWildcardReferenceImpl();
 		e.setFactory(getMainFactory());
+		e.setBoundingType(null);
 		return e;
 	}
 

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
@@ -33,7 +33,6 @@ public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implem
 
 	public CtWildcardReferenceImpl() {
 		simplename = "?";
-		setBoundingType(null);
 	}
 
 	@Override


### PR DESCRIPTION
to avoid creating a factory that we throw away just after