### PR TITLE
chore: pin LSIF workflow to good commit

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Generate LSIF data
-        uses: sourcegraph/lsif-java-action@master
+        uses: sourcegraph/lsif-java-action@2de844423a3d94075b845b9d18b30b883b8b967c
         with:
           verbose: true
       - name: Upload LSIF data


### PR DESCRIPTION
`lsif-java@master` introduces some breaking commits for the action, so for using it with Spoon we can pin to a known good commit until we version stable releases of the tool/action.

Addresses https://github.com/INRIA/spoon/pull/3394#issuecomment-698150215.