### PR TITLE
refactor: SourcePositionHolder depends on SourceFragment

### DIFF
--- a/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
+++ b/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
@@ -7,8 +7,8 @@
  */
 package spoon.reflect.cu;
 
-import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.Experimental;
+import spoon.support.sniper.internal.SourceFragment;
 
 /**
  * This interface represents an element which knows its position in a source file.
@@ -18,14 +18,11 @@ public interface SourcePositionHolder {
 	SourcePosition getPosition();
 
 	/**
-	 * Returns the original source code (maybe different from toString() if a transformation has been applied.
-	 * Or {@link ElementSourceFragment#NO_SOURCE_FRAGMENT} if this element has no original source fragment.
+	 * Returns the original source code (maybe different from toString() if a transformation has been applied).
 	 *
 	 * Warning: this is a advanced method which cannot be considered as part of the stable API
 	 *
 	 */
 	@Experimental
-	default ElementSourceFragment getOriginalSourceFragment() {
-		return ElementSourceFragment.NO_SOURCE_FRAGMENT;
-	}
+	SourceFragment getOriginalSourceFragment();
 }

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -23,6 +23,7 @@ import spoon.support.DerivedProperty;
 import spoon.reflect.annotations.PropertyGetter;
 import spoon.reflect.annotations.PropertySetter;
 import spoon.support.Experimental;
+import spoon.support.sniper.internal.ElementSourceFragment;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -413,4 +414,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	@Experimental
 	String prettyprint();
 
+	// overriding the return type
+	@Override
+	ElementSourceFragment getOriginalSourceFragment();
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -14,9 +14,9 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtShadowable;
@@ -596,7 +596,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public ElementSourceFragment getOriginalSourceFragment() {
 		SourcePosition sp = this.getPosition();
-		CompilationUnit compilationUnit = sp.getCompilationUnit();
+		CtCompilationUnit compilationUnit = sp.getCompilationUnit();
 		if (compilationUnit != null) {
 			ElementSourceFragment rootFragment = compilationUnit.getOriginalSourceFragment();
 			return rootFragment.getSourceFragmentOf(this, sp.getSourceStart(), sp.getSourceEnd() + 1);

--- a/src/test/java/spoon/test/position/TestSourceFragment.java
+++ b/src/test/java/spoon/test/position/TestSourceFragment.java
@@ -39,6 +39,7 @@ import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
@@ -79,7 +80,17 @@ public class TestSourceFragment {
 	@Test
 	public void testSourcePositionFragment() {
 		SourcePosition sp = new SourcePositionImpl(DUMMY_COMPILATION_UNIT, 10, 20, null);
-		ElementSourceFragment sf = new ElementSourceFragment(() -> sp, null);
+		ElementSourceFragment sf = new ElementSourceFragment(new SourcePositionHolder() {
+			@Override
+			public SourcePosition getPosition() {
+				return sp;
+			}
+
+			@Override
+			public SourceFragment getOriginalSourceFragment() {
+				return null;
+			}
+		}, null);
 		assertEquals(10, sf.getStart());
 		assertEquals(21, sf.getEnd());
 		assertSame(sp, sf.getSourcePosition());
@@ -186,7 +197,17 @@ public class TestSourceFragment {
 	
 	private ElementSourceFragment createFragment(int start, int end) {
 		SourcePosition sp = new SourcePositionImpl(DUMMY_COMPILATION_UNIT, start, end - 1, null);
-		return new ElementSourceFragment(() -> sp, null);
+		return new ElementSourceFragment(new SourcePositionHolder() {
+			@Override
+			public SourcePosition getPosition() {
+				return sp;
+			}
+
+			@Override
+			public SourceFragment getOriginalSourceFragment() {
+				return null;
+			}
+		}, null);
 	}
 
 	@Test


### PR DESCRIPTION
it's a good design practice that interfaces only depends on other interfaces, not on concrete implementation classes, so `getOriginalSourceFragment` returns a `SourceFragment`

Plus this removes untestable code in `SourcePositionHolder`, see https://sonarqube.ow2.org/component_measures?id=fr.inria.gforge.spoon%3Aspoon-core&metric=coverage&view=list
