### PR TITLE
WIP: Feature: allow lazy reference creation in TypeFactory creation

### DIFF
--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -203,7 +203,7 @@ public class MetamodelProperty {
 		if (valueType instanceof CtTypeParameterReference) {
 			valueType = ((CtTypeParameterReference) valueType).getBoundingType();
 			if (valueType == null) {
-				valueType = f.Type().OBJECT;
+				valueType = f.Type().OBJECT.get();
 			}
 		}
 		if (valueType.isImplicit()) {
@@ -342,8 +342,8 @@ public class MetamodelProperty {
 		CtTypeReference<?> returnType1 = methods.get(0).getActualCtMethod().getType();
 		CtTypeReference<?> returnType2 = methods.get(1).getActualCtMethod().getType();
 		Factory f = returnType1.getFactory();
-		boolean is1Iterable = returnType1.isSubtypeOf(f.Type().ITERABLE);
-		boolean is2Iterable = returnType2.isSubtypeOf(f.Type().ITERABLE);
+		boolean is1Iterable = returnType1.isSubtypeOf(f.Type().ITERABLE.get());
+		boolean is2Iterable = returnType2.isSubtypeOf(f.Type().ITERABLE.get());
 		if (is1Iterable != is2Iterable) {
 			// they are not some. Only one of them is iterable
 			if (is1Iterable) {
@@ -423,7 +423,7 @@ public class MetamodelProperty {
 		if (itemValueType instanceof CtTypeParameterReference) {
 			itemValueType = ((CtTypeParameterReference) itemValueType).getBoundingType();
 			if (itemValueType == null) {
-				itemValueType = valueType.getFactory().Type().OBJECT;
+				itemValueType = valueType.getFactory().Type().getDefaultBoundingType();
 			}
 		}
 		return itemValueType;
@@ -468,7 +468,7 @@ public class MetamodelProperty {
 	private CtTypeReference<?> getMapValueType(CtTypeReference<?> valueType) {
 		if (valueType != null) {
 			Factory f = valueType.getFactory();
-			if (valueType.isSubtypeOf(f.Type().MAP) && valueType.getActualTypeArguments().size() == 2) {
+			if (valueType.isSubtypeOf(f.Type().MAP.get()) && valueType.getActualTypeArguments().size() == 2) {
 				return valueType.getActualTypeArguments().get(1);
 			}
 		}

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -412,7 +412,7 @@ public class PatternParameterConfigurator {
 
 				CtTypeReference<?> paramType = paramField.getType();
 
-				if (paramType.isSubtypeOf(f.Type().ITERABLE) || paramType instanceof CtArrayTypeReference<?>) {
+				if (paramType.isSubtypeOf(f.Type().ITERABLE.get()) || paramType instanceof CtArrayTypeReference<?>) {
 					//parameter is a multivalue
 					// here we need to replace all named element and all references whose simpleName == stringMarker
 					parameter(parameterName).setContainerKind(ContainerKind.LIST).byNamedElement(stringMarker).byReferenceName(stringMarker);

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -127,7 +127,7 @@ public class ExecutableFactory extends SubFactory {
 			}
 		}
 		if (paramType == null) {
-			paramType = factory.Type().OBJECT;
+			paramType = factory.Type().OBJECT.get();
 		}
 		return paramType.clone();
 	}

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -3,9 +3,7 @@
  *
  * Copyright (C) 2006-2019 INRIA and contributors
  *
- * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the
- * Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms
- * under which to adopt Spoon.
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
  */
 package spoon.reflect.factory;
 

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -3,7 +3,9 @@
  *
  * Copyright (C) 2006-2019 INRIA and contributors
  *
- * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the
+ * Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms
+ * under which to adopt Spoon.
  */
 package spoon.reflect.factory;
 
@@ -65,35 +67,35 @@ public class TypeFactory extends SubFactory {
 					// TODO (leventov) it is questionable to me that nulltype should also be here
 					CtTypeReference.NULL_TYPE_NAME)));
 
-	public final CtTypeReference<?> NULL_TYPE = createReference(CtTypeReference.NULL_TYPE_NAME);
-	public final CtTypeReference<Void> VOID = createReference(Void.class);
-	public final CtTypeReference<String> STRING = createReference(String.class);
-	public final CtTypeReference<Boolean> BOOLEAN = createReference(Boolean.class);
-	public final CtTypeReference<Byte> BYTE = createReference(Byte.class);
-	public final CtTypeReference<Character> CHARACTER = createReference(Character.class);
-	public final CtTypeReference<Integer> INTEGER = createReference(Integer.class);
-	public final CtTypeReference<Long> LONG = createReference(Long.class);
-	public final CtTypeReference<Float> FLOAT = createReference(Float.class);
-	public final CtTypeReference<Double> DOUBLE = createReference(Double.class);
-	public final CtTypeReference<Void> VOID_PRIMITIVE = createReference(void.class);
-	public final CtTypeReference<Boolean> BOOLEAN_PRIMITIVE = createReference(boolean.class);
-	public final CtTypeReference<Byte> BYTE_PRIMITIVE = createReference(byte.class);
-	public final CtTypeReference<Character> CHARACTER_PRIMITIVE = createReference(char.class);
-	public final CtTypeReference<Integer> INTEGER_PRIMITIVE = createReference(int.class);
-	public final CtTypeReference<Long> LONG_PRIMITIVE = createReference(long.class);
-	public final CtTypeReference<Float> FLOAT_PRIMITIVE = createReference(float.class);
-	public final CtTypeReference<Double> DOUBLE_PRIMITIVE = createReference(double.class);
-	public final CtTypeReference<Short> SHORT = createReference(Short.class);
-	public final CtTypeReference<Short> SHORT_PRIMITIVE = createReference(short.class);
-	public final CtTypeReference<Date> DATE = createReference(Date.class);
-	public final CtTypeReference<Object> OBJECT = createReference(Object.class);
-	public final CtTypeReference<Iterable> ITERABLE = createReference(Iterable.class);
-	public final CtTypeReference<Collection> COLLECTION = createReference(Collection.class);
-	public final CtTypeReference<List> LIST = createReference(List.class);
-	public final CtTypeReference<Set> SET = createReference(Set.class);
-	public final CtTypeReference<Map> MAP = createReference(Map.class);
-	public final CtTypeReference<Enum> ENUM = createReference(Enum.class);
-	public final CtTypeReference<?> OMITTED_TYPE_ARG_TYPE = createReference(CtTypeReference.OMITTED_TYPE_ARG_NAME);
+	public final Supplier<CtTypeReference<?>> NULL_TYPE = lazily(() -> createReference(CtTypeReference.NULL_TYPE_NAME));
+	public final Supplier<CtTypeReference<Void>> VOID = lazily(() -> createReference(Void.class));
+	public final Supplier<CtTypeReference<String>> STRING = lazily(() -> createReference(String.class));
+	public final Supplier<CtTypeReference<Boolean>> BOOLEAN =	lazily(() -> createReference(Boolean.class));
+	public final Supplier<CtTypeReference<Byte>> BYTE = lazily(() -> createReference(Byte.class));
+	public final Supplier<CtTypeReference<Character>> CHARACTER =	lazily(() -> createReference(Character.class));
+	public final Supplier<CtTypeReference<Integer>> INTEGER =	lazily(() -> createReference(Integer.class));
+	public final Supplier<CtTypeReference<Long>> LONG = lazily(() -> createReference(Long.class));
+	public final Supplier<CtTypeReference<Float>> FLOAT = lazily(() -> createReference(Float.class));
+	public final Supplier<CtTypeReference<Double>> DOUBLE = lazily(() -> createReference(Double.class));
+	public final Supplier<CtTypeReference<Void>> VOID_PRIMITIVE = lazily(() -> createReference(void.class));
+	public final Supplier<CtTypeReference<Boolean>> BOOLEAN_PRIMITIVE = lazily(() -> createReference(boolean.class));
+	public final Supplier<CtTypeReference<Byte>> BYTE_PRIMITIVE =	lazily(() -> createReference(byte.class));
+	public final Supplier<CtTypeReference<Character>> CHARACTER_PRIMITIVE =	lazily(() -> createReference(char.class));
+	public final Supplier<CtTypeReference<Integer>> INTEGER_PRIMITIVE =	lazily(() -> createReference(int.class));
+	public final Supplier<CtTypeReference<Long>> LONG_PRIMITIVE =	lazily(() -> createReference(long.class));
+	public final Supplier<CtTypeReference<Float>> FLOAT_PRIMITIVE = lazily(() -> createReference(float.class));
+	public final Supplier<CtTypeReference<Double>> DOUBLE_PRIMITIVE = lazily(() -> createReference(double.class));
+	public final Supplier<CtTypeReference<Short>> SHORT = lazily(() -> createReference(Short.class));
+	public final Supplier<CtTypeReference<Short>> SHORT_PRIMITIVE =	lazily(() -> createReference(short.class));
+	public final Supplier<CtTypeReference<Date>> DATE = lazily(() -> createReference(Date.class));
+	public final Supplier<CtTypeReference<Object>> OBJECT =	lazily(() -> createReference(Object.class));
+	public final Supplier<CtTypeReference<Iterable>> ITERABLE = lazily(() -> createReference(Iterable.class));
+	public final Supplier<CtTypeReference<Collection>> COLLECTION = lazily(() -> createReference(Collection.class));
+	public final Supplier<CtTypeReference<List>> LIST = lazily(() -> createReference(List.class));
+	public final Supplier<CtTypeReference<Set>> SET = lazily(() -> createReference(Set.class));
+	public final Supplier<CtTypeReference<Map>> MAP = lazily(() -> createReference(Map.class));
+	public final Supplier<CtTypeReference<Enum>> ENUM = lazily(() -> createReference(Enum.class));
+	public final Supplier<CtTypeReference<?>> OMITTED_TYPE_ARG_TYPE =	lazily(() -> createReference(CtTypeReference.OMITTED_TYPE_ARG_NAME));
 
 	private final Map<Class<?>, CtType<?>> shadowCache = new ConcurrentHashMap<>();
 
@@ -101,154 +103,154 @@ public class TypeFactory extends SubFactory {
 	 * Returns a reference on the null type (type of null).
 	 */
 	public CtTypeReference<?> nullType() {
-		return NULL_TYPE.clone();
+		return NULL_TYPE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the void type.
 	 */
 	public CtTypeReference<Void> voidType() {
-		return VOID.clone();
+		return VOID.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the void primitive type.
 	 */
 	public CtTypeReference<Void> voidPrimitiveType() {
-		return VOID_PRIMITIVE.clone();
+		return VOID_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the string type.
 	 */
 	public CtTypeReference<String> stringType() {
-		return STRING.clone();
+		return STRING.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the boolean type.
 	 */
 	public CtTypeReference<Boolean> booleanType() {
-		return BOOLEAN.clone();
+		return BOOLEAN.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the boolean primitive type.
 	 */
 	public CtTypeReference<Boolean> booleanPrimitiveType() {
-		return BOOLEAN_PRIMITIVE.clone();
+		return BOOLEAN_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the byte type.
 	 */
 	public CtTypeReference<Byte> byteType() {
-		return BYTE.clone();
+		return BYTE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the byte primitive type.
 	 */
 	public CtTypeReference<Byte> bytePrimitiveType() {
-		return BYTE_PRIMITIVE.clone();
+		return BYTE_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the character type.
 	 */
 	public CtTypeReference<Character> characterType() {
-		return CHARACTER.clone();
+		return CHARACTER.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the character primitive type.
 	 */
 	public CtTypeReference<Character> characterPrimitiveType() {
-		return CHARACTER_PRIMITIVE.clone();
+		return CHARACTER_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the integer type.
 	 */
 	public CtTypeReference<Integer> integerType() {
-		return INTEGER.clone();
+		return INTEGER.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the integer primitive type.
 	 */
 	public CtTypeReference<Integer> integerPrimitiveType() {
-		return INTEGER_PRIMITIVE.clone();
+		return INTEGER_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the long type.
 	 */
 	public CtTypeReference<Long> longType() {
-		return LONG.clone();
+		return LONG.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the long primitive type.
 	 */
 	public CtTypeReference<Long> longPrimitiveType() {
-		return LONG_PRIMITIVE.clone();
+		return LONG_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the float type.
 	 */
 	public CtTypeReference<Float> floatType() {
-		return FLOAT.clone();
+		return FLOAT.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the float primitive type.
 	 */
 	public CtTypeReference<Float> floatPrimitiveType() {
-		return FLOAT_PRIMITIVE.clone();
+		return FLOAT_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the double type.
 	 */
 	public CtTypeReference<Double> doubleType() {
-		return DOUBLE.clone();
+		return DOUBLE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the double primitive type.
 	 */
 	public CtTypeReference<Double> doublePrimitiveType() {
-		return DOUBLE_PRIMITIVE.clone();
+		return DOUBLE_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the short type.
 	 */
 	public CtTypeReference<Short> shortType() {
-		return SHORT.clone();
+		return SHORT.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the short primitive type.
 	 */
 	public CtTypeReference<Short> shortPrimitiveType() {
-		return SHORT_PRIMITIVE.clone();
+		return SHORT_PRIMITIVE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the date type.
 	 */
 	public CtTypeReference<Date> dateType() {
-		return DATE.clone();
+		return DATE.get().clone();
 	}
 
 	/**
 	 * Returns a reference on the object type.
 	 */
 	public CtTypeReference<Object> objectType() {
-		return OBJECT.clone();
+		return OBJECT.get().clone();
 	}
 
 	/**
@@ -721,7 +723,7 @@ public class TypeFactory extends SubFactory {
 	 * Returns the default bounding type value
 	 */
 	public CtTypeReference getDefaultBoundingType() {
-		return OBJECT;
+		return OBJECT.get();
 	}
 
 	/**
@@ -749,5 +751,19 @@ public class TypeFactory extends SubFactory {
 		ctUnresolvedImport.setUnresolvedReference(reference);
 		ctUnresolvedImport.setStatic(isStatic);
 		return ctUnresolvedImport;
+	}
+
+	static <Z> Supplier<Z> lazily(Supplier<Z> supplier) {
+		return new Supplier<Z>() {
+			Z value; // = null
+
+			@Override
+			public Z get() {
+				if (value == null) {
+					value = supplier.get();
+				}
+				return value;
+			}
+		};
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
@@ -245,7 +245,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 				visitSuperInterfaces(typeRef, outputConsumer);
 				if (interfacesExtendObject) {
 					//last visit Object.class, because interface inherits all public type members of Object.class
-					sendResultWithListener(typeRef.getFactory().Type().OBJECT, isClass, outputConsumer, (ref) -> { });
+					sendResultWithListener(typeRef.getFactory().Type().getDefaultBoundingType(), isClass, outputConsumer, (ref) -> { });
 				}
 			} else {
 				//call visitSuperClasses only for input of type class. The contract of visitSuperClasses requires that
@@ -276,7 +276,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 		if (superClassRef == null) {
 			//only CtClasses extend object,
 			//this method is called only for classes (not for interfaces) so we know we can visit java.lang.Object now too
-			superClassRef = superTypeRef.getFactory().Type().OBJECT;
+			superClassRef = superTypeRef.getFactory().Type().OBJECT.get();
 		}
 		sendResultWithListener(superClassRef, true,
 				outputConsumer, (classRef) -> visitSuperClasses(classRef, outputConsumer, includingInterfaces));

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -97,7 +97,7 @@ public class SnippetCompilationHelper {
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st)
 			throws SnippetCompilationError {
-		return internalCompileStatement(st, st.getFactory().Type().VOID_PRIMITIVE);
+		return internalCompileStatement(st, st.getFactory().Type().voidType());
 	}
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st, CtTypeReference returnType)
@@ -140,7 +140,7 @@ public class SnippetCompilationHelper {
 	public static <T> CtExpression<T> compileExpression(
 			CtCodeSnippetExpression<T> expr) throws SnippetCompilationError {
 
-		CtReturn<T> ret = (CtReturn<T>) internalCompileStatement(expr, expr.getFactory().Type().OBJECT);
+		CtReturn<T> ret = (CtReturn<T>) internalCompileStatement(expr, expr.getFactory().Type().OBJECT.get());
 
 		CtExpression<T> returnedExpression = ret.getReturnedExpression();
 

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -97,7 +97,7 @@ public class SnippetCompilationHelper {
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st)
 			throws SnippetCompilationError {
-		return internalCompileStatement(st, st.getFactory().Type().voidType());
+		return internalCompileStatement(st, st.getFactory().Type().VOID_PRIMITIVE.get());
 	}
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st, CtTypeReference returnType)

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -430,7 +430,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				op.setKind(BinaryOperatorKind.PLUS);
 				op.setLeftHandOperand(operator.getRightHandOperand());
 				op.setRightHandOperand((CtExpression<?>) child);
-				op.setType((CtTypeReference) operator.getFactory().Type().STRING.clone());
+				op.setType((CtTypeReference) operator.getFactory().Type().STRING.get().clone());
 				operator.setRightHandOperand(op);
 				int[] lineSeparatorPositions = jdtTreeBuilder.getContextBuilder().getCompilationUnitLineSeparatorPositions();
 				SourcePosition leftPosition = op.getLeftHandOperand().getPosition();

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -601,7 +601,7 @@ public class ReferenceBuilder {
 		if (alloc.expectedType() == null || !(alloc.expectedType() instanceof ParameterizedTypeBinding)) {
 			// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
 			// method, or in a method that did not expect a parameterized argument
-			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.clone());
+			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.get().clone());
 		} else {
 			ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
 			// type arguments can be recovered from the expected type
@@ -1190,7 +1190,7 @@ public class ReferenceBuilder {
 			paramType = ((CtTypeParameterReference) paramType).getBoundingType();
 		}
 		if (paramType == null) {
-			paramType = param.getFactory().Type().OBJECT;
+			paramType = param.getFactory().Type().getDefaultBoundingType();
 		}
 		return paramType.clone();
 	}

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	public CtTypeReference<Void> getType() {
-		return (CtTypeReference<Void>) getFactory().Type().VOID_PRIMITIVE.clone().<CtTypeAccess>setParent(this);
+		return (CtTypeReference<Void>) getFactory().Type().VOID_PRIMITIVE.get().clone().<CtTypeAccess>setParent(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -164,7 +164,7 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	@Override
 	@DerivedProperty
 	public CtTypeReference<Void> getType() {
-		return factory.Type().VOID_PRIMITIVE;
+		return factory.Type().VOID_PRIMITIVE.get();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -188,7 +188,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 	public <R> CtMethod<R> getMethod(String name, CtTypeReference<?>... parameterTypes) {
 		if ("values".equals(name) && parameterTypes.length == 0) {
 			return valuesMethod();
-		} else if ("valueOf".equals(name) && parameterTypes.length == 1 && parameterTypes[0].equals(factory.Type().STRING)) {
+		} else if ("valueOf".equals(name) && parameterTypes.length == 1 && parameterTypes[0].equals(factory.Type().STRING.get())) {
 			return valueOfMethod();
 		} else {
 			return super.getMethod(name, parameterTypes);
@@ -203,7 +203,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 			return valuesMethod();
 		} else if ("valueOf".equals(name)
 			&& parameterTypes.length == 1
-			&& parameterTypes[0].equals(factory.Type().STRING)
+			&& parameterTypes[0].equals(factory.Type().STRING.get())
 			&& returnType.equals(factory.Type().createArrayReference(getReference()))) {
 			return valueOfMethod();
 		} else {

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -179,7 +179,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 			valueOfMethod.addThrownType(
 				getFactory().Type().createReference(IllegalArgumentException.class));
 			valueOfMethod.setType(getReference());
-			factory.Method().createParameter(valueOfMethod, factory.Type().STRING, "name");
+			factory.Method().createParameter(valueOfMethod, factory.Type().STRING.get(), "name");
 		}
 		return valueOfMethod;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -298,7 +298,7 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
 		CtTypeReference<?> bound = typeParam.getSuperclass();
 		if (bound == null) {
-			bound = typeParam.getFactory().Type().OBJECT;
+			bound = typeParam.getFactory().Type().OBJECT.get();
 		}
 		return bound;
 	}

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -314,7 +314,7 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 
 		if ((f != null) && f.getModifiers().contains(ModifierKind.FINAL)
 				// enum values have no meaningful default expression to be evaluated
-				&& !fieldAccess.getVariable().getDeclaringType().isSubtypeOf(fieldAccess.getFactory().Type().ENUM)
+				&& !fieldAccess.getVariable().getDeclaringType().isSubtypeOf(fieldAccess.getFactory().Type().ENUM.get())
 				) {
 			setResult(evaluate(f.getDefaultExpression()));
 			return;

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -382,7 +382,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 
 	@Override
 	public CtExecutableReference<?> getOverridingExecutable() {
-		CtTypeReference<Object> objectType = getFactory().Type().OBJECT;
+		CtTypeReference<Object> objectType = getFactory().Type().OBJECT.get();
 		CtTypeReference<?> declaringType = getDeclaringType();
 		if (declaringType == null) {
 			return getOverloadedExecutable(objectType, objectType);

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -79,7 +79,7 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	@Override
 	public CtTypeReference<?> getTypeErasure() {
 		if (bounds == null || bounds.isEmpty()) {
-			return getFactory().Type().OBJECT;
+			return getFactory().Type().OBJECT.get();
 		}
 		return bounds.get(0).getTypeErasure();
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.reflect.reference;
 
-import spoon.IdentifierVerifier;
 import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtComment;
@@ -25,7 +24,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static spoon.reflect.path.CtRole.NAME;

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -50,23 +50,16 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 
 	@Override
 	public <T extends CtReference> T setSimpleName(String simplename) {
-		String nameBefore = this.simplename;
-		this.simplename = simplename;
-		Optional<SpoonException> error = new IdentifierVerifier().checkIdentifier(this);
-		if (error.isPresent()) {
-			this.simplename = nameBefore;
-			if (!getFactory().getEnvironment().checksAreSkipped()) {
-			throw error.get();
-			}
-		}
 		Factory factory = getFactory();
+		checkIdentiferForJLSCorrectness(simplename);
 		if (factory == null) {
+			this.simplename = simplename;
 			return (T) this;
 		}
 		if (factory instanceof FactoryImpl) {
 			simplename = ((FactoryImpl) factory).dedup(simplename);
 		}
-		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simplename, nameBefore);
+		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, NAME, simplename, this.simplename);
 		this.simplename = simplename;
 		return (T) this;
 	}

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -586,14 +586,14 @@ public class ClassTypingContext extends AbstractTypingContext {
 		if (superArg instanceof CtWildcardReference) {
 			CtWildcardReference wr = (CtWildcardReference) superArg;
 			CtTypeReference<?> superBound = wr.getBoundingType();
-			if (superBound.equals(wr.getFactory().Type().OBJECT)) {
+			if (superBound.equals(wr.getFactory().Type().OBJECT.get())) {
 				//everything extends from object, nothing is super of Object
 				return wr.isUpper();
 			}
 			if (subArg instanceof CtWildcardReference) {
 				CtWildcardReference subWr = (CtWildcardReference) subArg;
 				CtTypeReference<?> subBound = subWr.getBoundingType();
-				if (subBound.equals(wr.getFactory().Type().OBJECT)) {
+				if (subBound.equals(wr.getFactory().Type().OBJECT.get())) {
 					//nothing is super of object
 					return false;
 				}

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -274,7 +274,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
 		CtTypeReference<?> bound = typeParam.getSuperclass();
 		if (bound == null) {
-			bound = typeParam.getFactory().Type().OBJECT;
+			bound = typeParam.getFactory().Type().OBJECT.get();
 		}
 		return bound;
 	}

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -382,7 +382,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 		if (contexts.contains(runtimeBuilderContext)) {
 			// we are in the case of a loop
 			exit();
-			enter(new TypeReferenceRuntimeBuilderContext(Object.class, factory.Type().OBJECT));
+			enter(new TypeReferenceRuntimeBuilderContext(Object.class, factory.Type().OBJECT.get()));
 			return;
 		}
 

--- a/src/test/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/test/java/spoon/generating/CloneVisitorGenerator.java
@@ -508,7 +508,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 			 * Check if the type is a subtype of CtElement.
 			 */
 			private boolean isSubTypeOfCtElement(CtTypeReference<?> type) {
-				if (!type.isPrimitive() && !type.equals(factory.Type().STRING)) {
+				if (!type.isPrimitive() && !type.equals(factory.Type().STRING.get())) {
 					if (type.isSubtypeOf(factory.Type().createReference(CtElement.class))) {
 						return true;
 					}

--- a/src/test/java/spoon/generating/RoleHandlersGenerator.java
+++ b/src/test/java/spoon/generating/RoleHandlersGenerator.java
@@ -133,7 +133,7 @@ public class RoleHandlersGenerator extends AbstractManualProcessor {
 	private CtTypeReference<?> fixMainValueType(CtTypeReference<?> valueType) {
 		valueType = fixValueType(valueType);
 		if (valueType instanceof CtWildcardReference) {
-			return getFactory().Type().OBJECT;
+			return getFactory().Type().OBJECT.get();
 		}
 		return valueType;
 	}

--- a/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
@@ -43,9 +43,9 @@ public class AnnotationLoopTest {
 		assertEquals("p", ((CtLocalVariable) aLoop.getForInit().get(1)).getSimpleName());
 		assertEquals("e", ((CtLocalVariable) aLoop.getForInit().get(2)).getSimpleName());
 
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(0)).getType());
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(1)).getType());
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(2)).getType());
+		assertEquals(aPozole.getFactory().Type().STRING.get(), ((CtLocalVariable) aLoop.getForInit().get(0)).getType());
+		assertEquals(aPozole.getFactory().Type().STRING.get(), ((CtLocalVariable) aLoop.getForInit().get(1)).getType());
+		assertEquals(aPozole.getFactory().Type().STRING.get(), ((CtLocalVariable) aLoop.getForInit().get(2)).getType());
 
 		final String nl = System.lineSeparator();
 		final String expected = "for (@java.lang.SuppressWarnings(\"rawtypes\")" + nl + "java.lang.String u = \"\", p = \"\", e = \"\"; u != e; u = p , p = \"\") {" + nl + "}";

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -126,7 +126,7 @@ public class AnnotationValuesTest {
 	public void testAnnotateWithEnum() {
 		final Factory factory = createFactory();
 		final CtClass<Object> target = factory.Class().create("org.example.Tacos");
-		final CtField<String> field = factory.Field().create(target, new HashSet<>(), factory.Type().STRING, "field");
+		final CtField<String> field = factory.Field().create(target, new HashSet<>(), factory.Type().STRING.get(), "field");
 		target.addField(field);
 
 		final CtAnnotation<BoundNumber> byteOrder = factory.Annotation().annotate(field, BoundNumber.class, "byteOrder", BoundNumber.ByteOrder.LittleEndian);

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -298,7 +298,7 @@ public class APITest {
 
 		final CtMethod aMethod = spoon.getFactory().Core().createMethod();
 		aMethod.setSimpleName("foo");
-		aMethod.setType(spoon.getFactory().Type().BOOLEAN_PRIMITIVE);
+		aMethod.setType(spoon.getFactory().Type().BOOLEAN_PRIMITIVE.get());
 		aMethod.setBody(spoon.getFactory().Core().createBlock());
 		aClass.addMethod(aMethod);
 

--- a/src/test/java/spoon/test/api/processors/AwesomeProcessor.java
+++ b/src/test/java/spoon/test/api/processors/AwesomeProcessor.java
@@ -18,7 +18,7 @@ public class AwesomeProcessor extends AbstractProcessor<CtClass<Bar>> {
 		// Creates new elements.
 		final CtMethod prepareMojito = element.getMethodsByName("doSomething").get(0);
 		prepareMojito.setSimpleName("prepareMojito");
-		prepareMojito.setType(getFactory().Type().VOID_PRIMITIVE);
+		prepareMojito.setType(getFactory().Type().VOID_PRIMITIVE.get());
 		final CtBlock<Object> block = getFactory().Core().createBlock();
 		block.addStatement(
 				getFactory().Code()

--- a/src/test/java/spoon/test/casts/CastTest.java
+++ b/src/test/java/spoon/test/casts/CastTest.java
@@ -105,7 +105,7 @@ public class CastTest {
 		assertEquals("T", getValueMethod.getType().getSimpleName());
 		assertEquals("T", getValueMethod.getParameters().get(0).getType().getActualTypeArguments().get(0).toString());
 
-		assertEquals(type.getFactory().Class().INTEGER, getValueInvocation.getType());
+		assertEquals(type.getFactory().Class().INTEGER.get(), getValueInvocation.getType());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -672,7 +672,7 @@ public class CommentTest {
 		CtMethod method = f.Core().createMethod();
 		method.setSimpleName("newMethod");
 		method.setBody(f.Core().createBlock());
-		method.setType(f.Type().VOID_PRIMITIVE);
+		method.setType(f.Type().VOID_PRIMITIVE.get());
 
 		type.addMethod(method);
 
@@ -686,7 +686,7 @@ public class CommentTest {
 
 		method.getBody().removeStatement(method.getBody().getStatement(0));
 
-		CtLocalVariable<Integer> i = f.Code().createLocalVariable(f.Type().INTEGER_PRIMITIVE, "i", null);
+		CtLocalVariable<Integer> i = f.Code().createLocalVariable(f.Type().INTEGER_PRIMITIVE.get(), "i", null);
 		i.addComment(createFakeComment(f, "comment local variable"));
 		method.getBody().addStatement(i);
 

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -116,7 +116,7 @@ public class ConstructorTest {
 
 	@Test
 	public void testTypeAnnotationOnExceptionDeclaredInConstructors() {
-		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT);
+		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT.get());
 
 		assertEquals(1, aConstructor.getThrownTypes().size());
 		Set<CtTypeReference<? extends Throwable>> thrownTypes = aConstructor.getThrownTypes();
@@ -128,7 +128,7 @@ public class ConstructorTest {
 
 	@Test
 	public void testTypeAnnotationWithConstructorsOnFormalType() {
-		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT);
+		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT.get());
 
 		assertEquals(1, aConstructor.getFormalCtTypeParameters().size());
 

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -92,7 +92,7 @@ public class CtClassTest {
 		// as long as we have not changed the signature, getConstructors, which is based on signatures,
 		// thinks there is one single constructor (and that's OK)
 		assertEquals(3, foo.getConstructors().size());
-		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().OBJECT));
+		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().OBJECT.get()));
 		// now that we have changed the signature we can call getConstructors safely
 		assertEquals(4, foo.getConstructors().size());
 		// we cloned the first constructor, so it has the same position, and comes before the 2nd and 3rd constructor

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -125,7 +125,7 @@ public class CtTypeTest {
 
 		CtType<?> oCtType = factory.Type().get("spoon.test.ctType.testclasses.O");
 		CtType<?> pCtType = factory.Type().get("spoon.test.ctType.testclasses.P");
-		CtTypeReference<?> objectCtTypeRef = factory.Type().OBJECT;
+		CtTypeReference<?> objectCtTypeRef = factory.Type().OBJECT.get();
 
 		List<CtTypeParameter> oTypeParameters = oCtType.getFormalCtTypeParameters();
 		assertTrue(oTypeParameters.size() == 1);

--- a/src/test/java/spoon/test/delete/DeleteTest.java
+++ b/src/test/java/spoon/test/delete/DeleteTest.java
@@ -165,7 +165,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE.get(), factory.Type().FLOAT_PRIMITIVE.get(), factory.Type().STRING.get());
 
 		int n = adobada.getMethods().size();
 
@@ -181,7 +181,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE.get(), factory.Type().FLOAT_PRIMITIVE.get(), factory.Type().STRING.get());
 		final CtParameter param = (CtParameter) method.getParameters().get(1);
 
 		assertEquals(3, method.getParameters().size());
@@ -239,7 +239,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE.get(), factory.Type().FLOAT_PRIMITIVE.get(), factory.Type().STRING.get());
 		final CtIf anIf = method.getElements(new TypeFilter<>(CtIf.class)).get(0);
 
 		assertNotNull(anIf.getCondition());
@@ -254,7 +254,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE.get(), factory.Type().FLOAT_PRIMITIVE.get(), factory.Type().STRING.get());
 		final CtAssignment chainOfAssignment = method.getElements(new TypeFilter<>(CtAssignment.class)).get(0);
 
 		assertNotNull(chainOfAssignment.getAssignment());

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -54,7 +54,7 @@ public class ExecutableTest {
 
 		for (CtAnonymousExecutable anonymousExecutable : anonymousExecutables) {
 			assertEquals("", anonymousExecutable.getSimpleName());
-			assertEquals(launcher.getFactory().Type().VOID_PRIMITIVE, anonymousExecutable.getType());
+			assertEquals(launcher.getFactory().Type().VOID_PRIMITIVE.get(), anonymousExecutable.getType());
 			assertEquals(0, anonymousExecutable.getParameters().size());
 			assertEquals(0, anonymousExecutable.getThrownTypes().size());
 		}

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -156,7 +156,7 @@ public class FactoryTest {
 		// if we change the implem, merge is impossible
 		CtField f = spoon.getFactory().Core().createField();
 		f.setSimpleName("foo");
-		f.setType(spoon.getFactory().Type().BYTE);
+		f.setType(spoon.getFactory().Type().BYTE.get());
 		p.getElements(new NamedElementFilter<>(CtPackage.class, "testclasses")).get(0).getType("Foo").addField(f);
 		try {
 			model.getRootPackage().addPackage(p);

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -97,9 +97,9 @@ public class FieldTest {
 
 		assertEquals(1, aClass.getFields().size());
 
-		final CtField<String> generated = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING, "generated");
+		final CtField<String> generated = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING.get(), "generated");
 		aClass.addFieldAtTop(generated);
-		final CtField<String> generated2 = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING, "generated2");
+		final CtField<String> generated2 = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING.get(), "generated2");
 		aClass.addFieldAtTop(generated2);
 
 		assertEquals(3, aClass.getFields().size());
@@ -125,7 +125,7 @@ public class FieldTest {
 	private CtField<Integer> createField(Factory factory, HashSet<ModifierKind> modifiers, String name) {
 		final CtField<Integer> first = factory.Core().createField();
 		first.setModifiers(modifiers);
-		first.setType(factory.Type().INTEGER_PRIMITIVE);
+		first.setType(factory.Type().INTEGER_PRIMITIVE.get());
 		first.setSimpleName(name);
 		return first;
 	}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -878,11 +878,11 @@ public class ImportTest {
 		assertTrue(result.contains(Object.class.getName()));
 
 		//contract: super type of Object is nothing
-		List<CtTypeReference<?>> typeResult = clientClass.getFactory().Type().OBJECT.map(new SuperInheritanceHierarchyFunction().includingSelf(false).returnTypeReferences(true)).list();
+		List<CtTypeReference<?>> typeResult = clientClass.getFactory().Type().OBJECT.get().map(new SuperInheritanceHierarchyFunction().includingSelf(false).returnTypeReferences(true)).list();
 		assertEquals(0, typeResult.size());
-		typeResult = clientClass.getFactory().Type().OBJECT.map(new SuperInheritanceHierarchyFunction().includingSelf(true).returnTypeReferences(true)).list();
+		typeResult = clientClass.getFactory().Type().OBJECT.get().map(new SuperInheritanceHierarchyFunction().includingSelf(true).returnTypeReferences(true)).list();
 		assertEquals(1, typeResult.size());
-		assertEquals(clientClass.getFactory().Type().OBJECT, typeResult.get(0));
+		assertEquals(clientClass.getFactory().Type().OBJECT.get(), typeResult.get(0));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -348,7 +348,7 @@ public class IntercessionTest {
 				nullLiteral.setType(factory.Type().nullType());
 
 				final CtBinaryOperator<Boolean> checkNull = factory.Code().createBinaryOperator(variableRead, nullLiteral, BinaryOperatorKind.EQ);
-				checkNull.setType(factory.Type().BOOLEAN_PRIMITIVE);
+				checkNull.setType(factory.Type().BOOLEAN_PRIMITIVE.get());
 
 				final CtMethod<Boolean> isEmptyMethod = ctParameter.getType().getTypeDeclaration().getMethod(factory.Type().booleanPrimitiveType(), "isEmpty");
 				final CtInvocation<Boolean> isEmpty = factory.Code().createInvocation(variableRead, isEmptyMethod.getReference());

--- a/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
+++ b/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
@@ -25,7 +25,7 @@ public class AnnotationPositionTest {
 		Factory factory = launcher.getFactory();
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnoUser.class);
 
-		CtMethod m1 = ctClass.getMethod("m1", factory.Type().STRING);
+		CtMethod m1 = ctClass.getMethod("m1", factory.Type().STRING.get());
 		CtParameter pm1 = (CtParameter) m1.getParameters().get(0);
 		SourcePosition paramPos1 = pm1.getType().getPosition();
 		SourcePosition typeRefPos1 = pm1.getType().getPosition();
@@ -33,7 +33,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos1,annoPos1));
 		assertTrue(contains(typeRefPos1,annoPos1));
 
-		CtMethod m2 = ctClass.getMethod("m2", factory.Type().STRING);
+		CtMethod m2 = ctClass.getMethod("m2", factory.Type().STRING.get());
 		CtParameter pm2 = (CtParameter) m2.getParameters().get(0);
 		SourcePosition paramPos2 = pm2.getPosition();
 		SourcePosition typeRefPos2 = pm2.getType().getPosition();
@@ -41,7 +41,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos2,annoPos2));
 		assertFalse(contains(typeRefPos2,annoPos2));
 
-		CtMethod m3 = ctClass.getMethod("m3", factory.Type().STRING);
+		CtMethod m3 = ctClass.getMethod("m3", factory.Type().STRING.get());
 		CtParameter pm3 = (CtParameter) m3.getParameters().get(0);
 		SourcePosition paramPos3 = pm3.getType().getPosition();
 		SourcePosition typeRefPos3 = pm3.getType().getPosition();
@@ -51,7 +51,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos3,annoPos32));
 		assertTrue(contains(typeRefPos3,annoPos32));
 
-		CtMethod m4 = ctClass.getMethod("m4", factory.Type().STRING);
+		CtMethod m4 = ctClass.getMethod("m4", factory.Type().STRING.get());
 		CtParameter pm4 = (CtParameter) m4.getParameters().get(0);
 		SourcePosition paramPos4 = pm4.getType().getPosition();
 		SourcePosition typeRefPos4 = pm4.getType().getPosition();
@@ -59,7 +59,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos4,annoPos4));
 		assertTrue(contains(typeRefPos4,annoPos4));
 
-		CtMethod m5 = ctClass.getMethod("m5", factory.Type().STRING);
+		CtMethod m5 = ctClass.getMethod("m5", factory.Type().STRING.get());
 		CtParameter pm5 = (CtParameter) m5.getParameters().get(0);
 		SourcePosition paramPos5 = pm5.getType().getPosition();
 		SourcePosition typeRefPos5 = pm5.getType().getPosition();
@@ -83,7 +83,7 @@ public class AnnotationPositionTest {
 
 
 
-		CtMethod m6 = ctClass.getMethod("m6", factory.Type().STRING);
+		CtMethod m6 = ctClass.getMethod("m6", factory.Type().STRING.get());
 		CtParameter pm6 = (CtParameter) m6.getParameters().get(0);
 
 		SourcePosition paramPos6 = pm6.getType().getPosition();

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -79,31 +79,31 @@ public class LiteralTest {
 		CtLiteral<?> literal = (CtLiteral<?>) ctType.getField("a").getDefaultExpression();
 		assertEquals(0, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.INTEGER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.INTEGER_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("b").getDefaultExpression();
 		assertEquals(0x0, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.INTEGER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.INTEGER_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("c").getDefaultExpression();
 		assertEquals(0f, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.FLOAT_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.FLOAT_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("d").getDefaultExpression();
 		assertEquals(0L, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.LONG_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.LONG_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("e").getDefaultExpression();
 		assertEquals(0d, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.DOUBLE_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.DOUBLE_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("f").getDefaultExpression();
@@ -115,12 +115,12 @@ public class LiteralTest {
 		literal = (CtLiteral<?>) ctType.getField("g").getDefaultExpression();
 		assertEquals("0", literal.getValue());
 		assertFalse(literal.getType().isPrimitive());
-		assertEquals(typeFactory.STRING, literal.getType());
+		assertEquals(typeFactory.STRING.get(), literal.getType());
 
 		literal = (CtLiteral<?>) ctType.getField("h").getDefaultExpression();
 		assertNull(literal.getValue());
 		assertFalse(literal.getType().isPrimitive());
-		assertEquals(typeFactory.NULL_TYPE, literal.getType());
+		assertEquals(typeFactory.NULL_TYPE.get(), literal.getType());
 
 	}
 

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -109,7 +109,7 @@ public class LiteralTest {
 		literal = (CtLiteral<?>) ctType.getField("f").getDefaultExpression();
 		assertEquals('0', literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.CHARACTER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.CHARACTER_PRIMITIVE.get(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("g").getDefaultExpression();

--- a/src/test/java/spoon/test/literal/UnicodeBugTest.java
+++ b/src/test/java/spoon/test/literal/UnicodeBugTest.java
@@ -32,7 +32,7 @@ public class UnicodeBugTest {
 	private class StringConcatProcessor extends AbstractProcessor<CtLiteral<?>> {
 		@Override
 		public boolean isToBeProcessed(CtLiteral<?> candidate) {
-			return candidate.getType().isSubtypeOf(getFactory().Type().STRING) &&
+			return candidate.getType().isSubtypeOf(getFactory().Type().STRING.get()) &&
 					candidate.getParent() instanceof CtBinaryOperator;
 		}
 

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -98,7 +98,7 @@ public class ParameterTest {
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(launcher.getFactory().Type().STRING, refType);
+			assertEquals(launcher.getFactory().Type().STRING.get(), refType);
 		}
 
 		// test integer parameters
@@ -109,7 +109,7 @@ public class ParameterTest {
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(launcher.getFactory().Type().INTEGER, refType);
+			assertEquals(launcher.getFactory().Type().INTEGER.get(), refType);
 		}
 
 		// test unknown parameters

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -235,7 +235,7 @@ public class ParentTest {
 		final CtMethod<?> aMethod = aTacos.getMethodsByName("m").get(0);
 
 		assertNotNull(aMethod.getType().getParent());
-		assertEquals(factory.Type().INTEGER_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().INTEGER_PRIMITIVE.get(), aMethod.getType());
 		assertEquals(aMethod, aMethod.getType().getParent());
 	}
 

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -395,11 +395,11 @@ public class ParentTest {
 			 */
 			private CtBinaryOperator<Boolean> createCheckNull(CtParameter<?> ctParameter) {
 				final CtLiteral nullLiteral = factory.Code().createLiteral(null);
-				nullLiteral.setType(factory.Type().NULL_TYPE.clone());
+				nullLiteral.setType(factory.Type().NULL_TYPE.get().clone());
 				final CtBinaryOperator<Boolean> operator = factory.Code().createBinaryOperator( //
 						factory.Code().createVariableRead(ctParameter.getReference(), true), //
 						nullLiteral, BinaryOperatorKind.EQ);
-				operator.setType(factory.Type().BOOLEAN_PRIMITIVE);
+				operator.setType(factory.Type().BOOLEAN_PRIMITIVE.get());
 				return operator;
 			}
 

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -177,7 +177,7 @@ public class PathTest {
 
 		CtLiteral<String> literal = factory.Core().createLiteral();
 		literal.setValue("salut");
-		literal.setType(literal.getFactory().Type().STRING);
+		literal.setType(literal.getFactory().Type().STRING.get());
 		equals(new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.toto#defaultExpression"), literal);
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -306,7 +306,7 @@ public class TestSniperPrinter {
 		testSniper(ToBeChanged.class.getName(), type -> {
 			Factory f = type.getFactory();
 			//create new type member
-			context.newField = f.createField(type, Collections.singleton(ModifierKind.PRIVATE), f.Type().DATE, "dateField");
+			context.newField = f.createField(type, Collections.singleton(ModifierKind.PRIVATE), f.Type().DATE.get(), "dateField");
 			type.addTypeMember(context.newField);
 		}, (type, printed) -> {
 			String lastMemberString = "new List<?>[7][];";

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -90,7 +90,7 @@ public class ProcessingTest {
 					constructor.getBody().getStatement(1).toString());
 		}
 
-		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE);
+		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE.get());
 		String myBeforeStatementAsString = "int before";
 		for (CtSwitch<?> ctSwitch : constructor.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class))) {
 			ctSwitch.insertBefore(type.getFactory().Code()
@@ -129,7 +129,7 @@ public class ProcessingTest {
 					constructor.getBody().getStatement(constructor.getBody().getStatements().size() - 1).toString());
 		}
 
-		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE);
+		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE.get());
 		String myBeforeStatementAsString = "int after";
 		for (CtSwitch<?> ctSwitch : constructor.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class))) {
 			ctSwitch.insertAfter(type.getFactory().Code()

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -525,20 +525,20 @@ public class TypeReferenceTest {
 		final CtWildcardReference reference = factory.createWildcardReference();
 		reference.setBoundingType(factory.Type().createReference(String.class));
 
-		assertEquals(factory.Type().STRING, reference.getBoundingType());
+		assertEquals(factory.Type().STRING.get(), reference.getBoundingType());
 
 		reference.setBoundingType(null);
 
-		assertEquals(factory.Type().OBJECT, reference.getBoundingType());
+		assertEquals(factory.Type().OBJECT.get(), reference.getBoundingType());
 		assertTrue(reference.isDefaultBoundingType());
 
 		reference.setBoundingType(factory.Type().createReference(String.class));
 
-		assertEquals(factory.Type().STRING, reference.getBoundingType());
+		assertEquals(factory.Type().STRING.get(), reference.getBoundingType());
 
 		reference.setBoundingType(factory.Type().objectType());
 
-		assertEquals(factory.Type().OBJECT, reference.getBoundingType());
+		assertEquals(factory.Type().OBJECT.get(), reference.getBoundingType());
 		assertTrue(reference.isDefaultBoundingType());
 	}
 

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -511,8 +511,8 @@ public class TypeReferenceTest {
 	@Test
 	public void testShortTypeReference() {
 
-		CtTypeReference<Short> aShort = createFactory().Type().SHORT;
-		CtTypeReference<Short> shortPrimitive = createFactory().Type().SHORT_PRIMITIVE;
+		CtTypeReference<Short> aShort = createFactory().Type().SHORT.get();
+		CtTypeReference<Short> shortPrimitive = createFactory().Type().SHORT_PRIMITIVE.get();
 
 		assertSame(Short.class, aShort.getActualClass());
 		assertSame(short.class, shortPrimitive.getActualClass());

--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -325,11 +325,11 @@ public class ReplaceTest {
 		final CtType<Tacos> aTacos = factory.Type().get(Tacos.class);
 		final CtMethod<?> aMethod = aTacos.getMethodsByName("m").get(0);
 
-		assertEquals(factory.Type().INTEGER_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().INTEGER_PRIMITIVE.get(), aMethod.getType());
 
 		aMethod.getType().replace(factory.Type().DOUBLE_PRIMITIVE.get());
 
-		assertEquals(factory.Type().DOUBLE_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().DOUBLE_PRIMITIVE.get(), aMethod.getType());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -327,7 +327,7 @@ public class ReplaceTest {
 
 		assertEquals(factory.Type().INTEGER_PRIMITIVE, aMethod.getType());
 
-		aMethod.getType().replace(factory.Type().DOUBLE_PRIMITIVE);
+		aMethod.getType().replace(factory.Type().DOUBLE_PRIMITIVE.get());
 
 		assertEquals(factory.Type().DOUBLE_PRIMITIVE, aMethod.getType());
 	}

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -115,7 +115,7 @@ public class SnippetTest {
 		// contract: a snippet with return can be compiled.
 		CtElement el = SnippetCompilationHelper.compileStatement(
 				factory.Code().createCodeSnippetStatement("return 3"),
-				factory.Type().INTEGER
+				factory.Type().INTEGER.get()
 		);
 		assertTrue(CtReturn.class.isAssignableFrom(el.getClass()));
 		assertEquals("return 3", el.toString());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -1047,7 +1047,7 @@ public class TemplateTest {
 		}
 		{
 			//contract: Type reference value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.get()).apply(factory.createClass());
 			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
 			//contract: the parameter of type string replaces substring in method name
 			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -796,7 +796,7 @@ public class TemplateTest {
 		Factory factory = spoon.getFactory();
 
 		CtClass<?> resultKlass = factory.Class().create("Result");
-		new InvocationTemplate(factory.Type().OBJECT, "hashCode").apply(resultKlass);
+		new InvocationTemplate(factory.Type().OBJECT.get(), "hashCode").apply(resultKlass);
 		CtMethod<?> templateMethod = (CtMethod<?>) resultKlass.getElements(new NamedElementFilter<>(CtMethod.class,"invoke")).get(0);
 		CtStatement templateRoot = (CtStatement) templateMethod.getBody().getStatement(0);
 		//iface.$method$() becomes iface.hashCode()
@@ -1036,7 +1036,7 @@ public class TemplateTest {
 		}
 		{
 			//contract: Type value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.get().getTypeDeclaration()).apply(factory.createClass());
 			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
 			//contract: the parameter of type string replaces substring in method name
 			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
@@ -1161,7 +1161,7 @@ public class TemplateTest {
 
 		//contract: String value is substituted in substring of literal, named element and reference
 		CtTypeReference<?> typeRef = factory.Type().createReference("spoon.test.template.TypeReferenceClassAccess$Example");
-		typeRef.addActualTypeArgument(factory.Type().DATE);
+		typeRef.addActualTypeArgument(factory.Type().DATE.get());
 		
 		final CtClass<?> result = (CtClass<?>) new TypeReferenceClassAccessTemplate(typeRef).apply(factory.Class().create("spoon.test.template.TypeReferenceClassAccess"));
 		spoon.prettyprint();

--- a/src/test/java/spoon/test/variable/VariableTest.java
+++ b/src/test/java/spoon/test/variable/VariableTest.java
@@ -69,10 +69,10 @@ public class VariableTest {
         TypeFactory typeFactory = launcher.getFactory().Type();
 
         assertTrue(localVariables.get(0).isInferred());
-        assertEquals(typeFactory.STRING, localVariables.get(0).getType());
+        assertEquals(typeFactory.STRING.get(), localVariables.get(0).getType());
 
         assertFalse(localVariables.get(1).isInferred());
-        assertEquals(typeFactory.STRING, localVariables.get(1).getType());
+        assertEquals(typeFactory.STRING.get(), localVariables.get(1).getType());
 
         assertTrue(localVariables.get(2).isInferred());
         assertEquals("java.io.FileReader", localVariables.get(2).getType().getQualifiedName());
@@ -81,16 +81,16 @@ public class VariableTest {
         assertEquals("java.io.FileReader", localVariables.get(3).getType().getQualifiedName());
 
         assertTrue(localVariables.get(4).isInferred());
-        assertEquals(typeFactory.BOOLEAN_PRIMITIVE, localVariables.get(4).getType());
+        assertEquals(typeFactory.BOOLEAN_PRIMITIVE.get(), localVariables.get(4).getType());
 
         assertFalse(localVariables.get(5).isInferred());
-        assertEquals(typeFactory.BOOLEAN_PRIMITIVE, localVariables.get(5).getType());
+        assertEquals(typeFactory.BOOLEAN_PRIMITIVE.get(), localVariables.get(5).getType());
 
         assertTrue(localVariables.get(6).isInferred());
-        assertEquals(typeFactory.INTEGER_PRIMITIVE, localVariables.get(6).getType());
+        assertEquals(typeFactory.INTEGER_PRIMITIVE.get(), localVariables.get(6).getType());
 
         assertFalse(localVariables.get(7).isInferred());
-        assertEquals(typeFactory.INTEGER_PRIMITIVE, localVariables.get(7).getType());
+        assertEquals(typeFactory.INTEGER_PRIMITIVE.get(), localVariables.get(7).getType());
     }
 
     @Test

--- a/src/test/java/spoon/testing/CtElementAssertTest.java
+++ b/src/test/java/spoon/testing/CtElementAssertTest.java
@@ -36,7 +36,7 @@ public class CtElementAssertTest {
 		final Factory factory = createFactory();
 		final CtField<Integer> expected = factory.Core().createField();
 		expected.setSimpleName("i");
-		expected.setType(factory.Type().INTEGER_PRIMITIVE);
+		expected.setType(factory.Type().INTEGER_PRIMITIVE.get());
 		expected.addModifier(ModifierKind.PUBLIC);
 		CtField<?> f = type.getField("i");
 		assertThat(f).isEqualTo(expected);
@@ -64,7 +64,7 @@ public class CtElementAssertTest {
 		}
 		final Factory build = buildNoClasspath(CtElementAssertTest.class);
 		final CtFieldAccess<Class<String>> actual = build.Code().createClassAccess(build.Type().<String>get(String.class).getReference());
-		final CtFieldAccess<Class<java.lang.String>> expected = createFactory().Code().createClassAccess(createFactory().Type().STRING);
+		final CtFieldAccess<Class<java.lang.String>> expected = createFactory().Code().createClassAccess(createFactory().Type().STRING.get());
 		assertThat(actual).isEqualTo(expected);
 	}
 }


### PR DESCRIPTION
While developing a visitor for checking correctness of identifiers, i came across a problem in `TypeFactory`. Currently everytime we create a new `TypeFactory` we create TypeReferences, but mostly dont use them. This change removes the reference creation to later time. It is implemented with a supplier doing lazy initializing and caching.
This change should increase the performance and shouldn't cost much memory. 
Before i fix all test errors, is there any reason why we have public fields and not methods hiding the implementation? For some types we even have them. I would like to make all fields private and use methods.
Wdyt?