### PR TITLE
chore: bump to jdt 3.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.20.0</version>
+      <version>3.23.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -803,8 +803,6 @@ public class CommentTest {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);
-		launcher.getEnvironment().setComplianceLevel(13);
-		launcher.getEnvironment().setPreviewFeaturesEnabled(true);
 		// interfaces.
 		launcher.addInputResource("./src/main/java/spoon/reflect/");
 		launcher.addInputResource("./src/main/java/spoon/support/reflect/");

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -803,6 +803,7 @@ public class CommentTest {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);
+		launcher.getEnvironment().setComplianceLevel(14);
 		// interfaces.
 		launcher.addInputResource("./src/main/java/spoon/reflect/");
 		launcher.addInputResource("./src/main/java/spoon/support/reflect/");

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -52,8 +52,6 @@ public class SwitchCaseTest {
 	}
 	private static CtModel createModelFromString(String code) {
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setComplianceLevel(13);
-		launcher.getEnvironment().setPreviewFeaturesEnabled(true);
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.addInputResource(new VirtualFile(code));
 		return launcher.buildModel();

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -52,6 +52,7 @@ public class SwitchCaseTest {
 	}
 	private static CtModel createModelFromString(String code) {
 		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(14);
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.addInputResource(new VirtualFile(code));
 		return launcher.buildModel();


### PR DESCRIPTION
Some testcase needed a small fix before updating the jdt version. Mostly removing the preview flag for java13.