### PR TITLE
refactor: remove unused fields + corresponding architectural test

### DIFF
--- a/src/main/java/spoon/metamodel/MMMethod.java
+++ b/src/main/java/spoon/metamodel/MMMethod.java
@@ -29,7 +29,6 @@ public class MMMethod {
 	private final String signature;
 	private final MMMethodKind methodKind;
 
-	
 	/**
 	 * Creates a {@link MMMethod} of a {@link MetamodelProperty}
 	 * @param field a owner field

--- a/src/main/java/spoon/metamodel/MMMethod.java
+++ b/src/main/java/spoon/metamodel/MMMethod.java
@@ -29,6 +29,7 @@ public class MMMethod {
 	private final String signature;
 	private final MMMethodKind methodKind;
 
+	
 	/**
 	 * Creates a {@link MMMethod} of a {@link MetamodelProperty}
 	 * @param field a owner field

--- a/src/main/java/spoon/metamodel/MMMethodKind.java
+++ b/src/main/java/spoon/metamodel/MMMethodKind.java
@@ -77,13 +77,12 @@ public enum MMMethodKind {
 	private final Predicate<CtMethod<?>> detector;
 	private final int level;
 	private final boolean multi;
-	private final int valueParameterIndex;
 
 	MMMethodKind(int valueParameterIndex, boolean multi, int level, Predicate<CtMethod<?>> detector) {
 		this.multi = multi;
 		this.level = level;
 		this.detector = detector;
-		this.valueParameterIndex = valueParameterIndex;
+		// valueParameterindex is never used
 	}
 
 	/**

--- a/src/main/java/spoon/metamodel/MMMethodKind.java
+++ b/src/main/java/spoon/metamodel/MMMethodKind.java
@@ -22,16 +22,18 @@ public enum MMMethodKind {
 	 * Getter.
 	 * T get()
 	 */
-	GET(-1, false, 1, m -> m.getParameters().isEmpty() && (m.getSimpleName().startsWith("get") || m.getSimpleName().startsWith("is"))),
+	GET(false, 1, m -> m.getParameters().isEmpty()
+			&& (m.getSimpleName().startsWith("get") || m.getSimpleName().startsWith("is"))),
 	/**
 	 * Setter
 	 * void set(T)
 	 */
-	SET(0, false, 1, m -> m.getParameters().size() == 1 && m.getSimpleName().startsWith("set")),
+	SET(false, 1, m -> m.getParameters().size() == 1 && m.getSimpleName().startsWith("set")),
 	/**
 	 * void addFirst(T)
 	 */
-	ADD_FIRST(0, true, 10, m -> {
+	ADD_FIRST(true, 10, m ->
+		{
 		if (m.getParameters().size() == 1) {
 			if (m.getSimpleName().startsWith("add") || m.getSimpleName().startsWith("insert")) {
 				return m.getSimpleName().endsWith("AtTop") || m.getSimpleName().endsWith("Begin");
@@ -42,7 +44,8 @@ public enum MMMethodKind {
 	/**
 	 * void add(T)
 	 */
-	ADD_LAST(0, true,  1, m -> {
+	ADD_LAST(true, 1, m ->
+		{
 		if (m.getParameters().size() == 1) {
 			return m.getSimpleName().startsWith("add") || m.getSimpleName().startsWith("insert");
 		}
@@ -51,7 +54,8 @@ public enum MMMethodKind {
 	/**
 	 * void addOn(int, T)
 	 */
-	ADD_ON(1, true, 1, m -> {
+	ADD_ON(true, 1, m ->
+		{
 		if (m.getParameters().size() == 2 && "int".equals(m.getParameters().get(0).getType().getSimpleName())) {
 			return m.getSimpleName().startsWith("add") || m.getSimpleName().startsWith("insert");
 		}
@@ -60,29 +64,28 @@ public enum MMMethodKind {
 	/**
 	 * void remove(T)
 	 */
-	REMOVE(0, true, 1, m -> m.getParameters().size() == 1 && m.getSimpleName().startsWith("remove")),
+	REMOVE(true, 1, m -> m.getParameters().size() == 1 && m.getSimpleName().startsWith("remove")),
 
 	/**
 	 * Return element by its name
 	 * T get(String)
 	 */
-	GET_BY(-1, true, 1, m -> m.getSimpleName().startsWith("get")
+	GET_BY(true, 1, m -> m.getSimpleName().startsWith("get")
 			&& m.getParameters().size() == 1  && m.getParameters().get(0).getType().getQualifiedName().equals(String.class.getName())),
 
 	/**
 	 * The not matching method
 	 */
-	OTHER(-2, false, 0, m -> true);
+	OTHER(false, 0, m -> true);
 
 	private final Predicate<CtMethod<?>> detector;
 	private final int level;
 	private final boolean multi;
 
-	MMMethodKind(int valueParameterIndex, boolean multi, int level, Predicate<CtMethod<?>> detector) {
+	MMMethodKind(boolean multi, int level, Predicate<CtMethod<?>> detector) {
 		this.multi = multi;
 		this.level = level;
 		this.detector = detector;
-		// valueParameterindex is never used
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -27,8 +27,6 @@ import java.util.regex.Pattern;
  */
 public class CtPathStringBuilder {
 
-	private final Pattern pathPattern = Pattern.compile("([/.#])([^/.#\\[]+)(\\[([^/.#]*)\\])?");
-	private final Pattern argumentPattern = Pattern.compile("(\\w+)=([^=\\]]+)");
 
 
 	private Class load(String name) throws CtPathException {

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -52,7 +52,7 @@ public class PrinterHelper {
 	 * Not used yet, but this shows the advantage of encapsulating all sbf.append in calls to {@link #write(char)} or {@link #write(String)}.
 	 * This will be used for sniper mode later
 	 */
-	private int column = 1;
+	// private int column = 1;
 
 	/**
 	 * Mapping for line numbers.

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -47,12 +47,6 @@ public class PrinterHelper {
 	 */
 	private int line = 1;
 
-	/**
-	 * Current column number
-	 * Not used yet, but this shows the advantage of encapsulating all sbf.append in calls to {@link #write(char)} or {@link #write(String)}.
-	 * This will be used for sniper mode later
-	 */
-	// private int column = 1;
 
 	/**
 	 * Mapping for line numbers.
@@ -84,8 +78,6 @@ public class PrinterHelper {
 		sbf.setLength(0);
 		nbTabs = 0;
 		line = 1;
-		// Commented out, because unused but for feature reserved.
-		// column = 1;
 		shouldWriteTabs = true;
 		//create new map, because clients keeps reference to it
 		lineNumberMapping = new HashMap<>();
@@ -111,8 +103,6 @@ public class PrinterHelper {
 		if (c == '\r') {
 			sbf.append(c);
 			line++;
-			// reset the column index
-			// column = 1;
 			shouldWriteTabs = true;
 			lastCharWasCR = true;
 			return this;
@@ -126,8 +116,6 @@ public class PrinterHelper {
 				//increment line only once in sequence of \r\n.
 				//last was NOT \r, so do it now
 				line++;
-				// reset the column index. Commented out, because unused but for feature reserved.
-				// column = 1;
 				shouldWriteTabs = true;
 			}
 			lastCharWasCR = false;
@@ -135,8 +123,6 @@ public class PrinterHelper {
 		}
 		autoWriteTabs();
 		sbf.append(c);
-		// Commented out, because unused but for feature reserved.
-		// column += 1;
 		lastCharWasCR = false;
 		return this;
 	}
@@ -153,8 +139,6 @@ public class PrinterHelper {
 		for (int i = 0; i < nbTabs; i++) {
 			if (env != null && env.isUsingTabulations()) {
 				sbf.append('\t');
-				// Commented out, because unused but for feature reserved.
-				// column += 1;
 			} else {
 				int indentationSize = 2;
 				if (env != null) {
@@ -162,8 +146,6 @@ public class PrinterHelper {
 				}
 				for (int j = 0; j < indentationSize; j++) {
 					sbf.append(' ');
-					// Commented out, because unused but for feature reserved.
-					// column += 1;
 				}
 			}
 		}

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -84,7 +84,8 @@ public class PrinterHelper {
 		sbf.setLength(0);
 		nbTabs = 0;
 		line = 1;
-		column = 1;
+		// Commented out, because unused but for feature reserved.
+		// column = 1;
 		shouldWriteTabs = true;
 		//create new map, because clients keeps reference to it
 		lineNumberMapping = new HashMap<>();
@@ -111,7 +112,7 @@ public class PrinterHelper {
 			sbf.append(c);
 			line++;
 			// reset the column index
-			column = 1;
+			// column = 1;
 			shouldWriteTabs = true;
 			lastCharWasCR = true;
 			return this;
@@ -125,8 +126,8 @@ public class PrinterHelper {
 				//increment line only once in sequence of \r\n.
 				//last was NOT \r, so do it now
 				line++;
-				// reset the column index
-				column = 1;
+				// reset the column index. Commented out, because unused but for feature reserved.
+				// column = 1;
 				shouldWriteTabs = true;
 			}
 			lastCharWasCR = false;
@@ -134,7 +135,8 @@ public class PrinterHelper {
 		}
 		autoWriteTabs();
 		sbf.append(c);
-		column += 1;
+		// Commented out, because unused but for feature reserved.
+		// column += 1;
 		lastCharWasCR = false;
 		return this;
 	}
@@ -151,7 +153,8 @@ public class PrinterHelper {
 		for (int i = 0; i < nbTabs; i++) {
 			if (env != null && env.isUsingTabulations()) {
 				sbf.append('\t');
-				column += 1;
+				// Commented out, because unused but for feature reserved.
+				// column += 1;
 			} else {
 				int indentationSize = 2;
 				if (env != null) {
@@ -159,7 +162,8 @@ public class PrinterHelper {
 				}
 				for (int j = 0; j < indentationSize; j++) {
 					sbf.append(' ');
-					column += 1;
+					// Commented out, because unused but for feature reserved.
+					// column += 1;
 				}
 			}
 		}

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -124,8 +124,6 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private CompressionType compressionType = CompressionType.GZIP;
 
-	private boolean sniperMode = false;
-
 	private boolean ignoreDuplicateDeclarations = false;
 
 	private Supplier<PrettyPrinter> prettyPrinterCreator;

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -9,7 +9,6 @@ package spoon.support.compiler.jdt;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import spoon.SpoonException;
@@ -93,7 +92,6 @@ public class JDTCommentBuilder {
 		this.factory = factory;
 		this.sourceUnit = declarationUnit.compilationResult.compilationUnit;
 		this.contents = sourceUnit.getContents();
-		this.filePath = CharOperation.charToString(sourceUnit.getFileName());
 		this.spoonUnit = JDTTreeBuilder.getOrCreateCompilationUnit(declarationUnit, factory);
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -75,7 +75,6 @@ public class JDTCommentBuilder {
 	private static final Logger LOGGER = LogManager.getLogger();
 
 	private final CompilationUnitDeclaration declarationUnit;
-	private String filePath;
 	private CompilationUnit spoonUnit;
 	private Factory factory;
 	private ICompilationUnit sourceUnit;

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
@@ -31,7 +30,6 @@ import java.util.Set;
 class JDTImportBuilder {
 
 	private final CompilationUnitDeclaration declarationUnit;
-	private String filePath;
 	private CompilationUnit spoonUnit;
 	private ICompilationUnit sourceUnit;
 	private Factory factory;
@@ -41,7 +39,6 @@ class JDTImportBuilder {
 		this.declarationUnit = declarationUnit;
 		this.factory = factory;
 		this.sourceUnit = declarationUnit.compilationResult.compilationUnit;
-		this.filePath = CharOperation.charToString(sourceUnit.getFileName());
 		// get the CU: it has already been built during model building in JDTBasedSpoonCompiler
 		this.spoonUnit = JDTTreeBuilder.getOrCreateCompilationUnit(declarationUnit, factory);
 		this.imports = new HashSet<>();

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -788,7 +788,6 @@ public class ParentExiter extends CtInheritanceScanner {
 		return parent.type != null && parent.type.equals(childJDT);
 	}
 
-	private static final String KEYWORD_NEW = "new";
 
 	@Override
 	public <T> void visitCtNewClass(CtNewClass<T> newClass) {

--- a/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
@@ -17,5 +17,4 @@ import spoon.support.reflect.declaration.CtCompilationUnitImpl;
 public class CompilationUnitImpl extends CtCompilationUnitImpl implements CompilationUnit {
 	private static final long serialVersionUID = 2L;
 
-	private boolean autoImport = true;
 }

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -472,14 +472,17 @@ public class SpoonArchitectureEnforcerTest {
 		fields.removeIf(v -> !v.isPrivate());
 		// remove fields for serialization gods
 		fields.removeIf(v -> v.getSimpleName().equals("serialVersionUID"));
-
-		List<CtFieldRead<?>> fieldRead = model.getElements(new TypeFilter<>(CtFieldRead.class));
 		// some fieldReads have no variable declaration
+		List<CtFieldRead<?>> fieldRead = model.getElements(new TypeFilter<>(CtFieldRead.class));
 		fieldRead.removeIf(v -> v.getVariable().getFieldDeclaration() == null);
-
+		// convert to HashSet for faster lookup. We trade memory for lookup speed.
+		HashSet<CtField<?>> lookUp = fieldRead.stream()
+				.map(CtFieldRead::getVariable)
+				.map(v -> v.getFieldDeclaration())
+				.collect(Collectors.toCollection(HashSet::new));
 		List<CtField<?>> fieldsWithRead = fields.stream()
-		// every field must have a read
-		.filter(field -> fieldRead.stream().anyMatch(read -> read.getVariable().getFieldDeclaration().equals(field)))
+				// 	 every field must have a read
+				.filter(field -> lookUp.contains(field))
 		.collect(Collectors.toList());
 		fields.removeAll(fieldsWithRead);
 		assertEquals("Some Fields have no read/write", Collections.emptyList(), fields);


### PR DESCRIPTION
As discussed in #3628, here is a test case checking that every private field has a read. We dont need to check for writes, because a fieldRead without a fieldWrite before will never happen. Will writing this test case i found 8 unused fields. 
- One was a constructor parameter and i added a comment
- One is for later use and i commented it out
- 6 were simply unused.