### PR TITLE
WIP: feature: add flag for skipping deleted types in printing

### DIFF
--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -450,6 +450,7 @@ public interface Environment {
 		/** force everything to be fully-qualified */
 		FULLYQUALIFIED
 	}
+
 	/**
 	 * Sets the printer to skip printing empty Types.
 	 * A type is empty if it has no inner classes and no members.
@@ -459,7 +460,7 @@ public interface Environment {
 
 	/**
 	 * Returns if empty types are printed.
-   * A type is empty if it has no inner classes and no members.
+	 * A type is empty if it has no inner classes and no members.
 	 * Empty interfaces are not skipped, because they could be marker interfaces.
 	 * @return true if empty types are not printed, false otherwise
 	 */

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -452,18 +452,14 @@ public interface Environment {
 	}
 
 	/**
-	 * Sets the printer to skip printing empty Types.
-	 * A type is empty if it has no inner classes and no members.
-	 * Empty interfaces are not skipped, because they could be marker interfaces.
+	 * Sets the printer to skip printing deleted types.
 	 */
-	void skipEmptyTypePrinting();
+	void omitDeletedTypes();
 
 	/**
-	 * Returns if empty types are printed.
-	 * A type is empty if it has no inner classes and no members.
-	 * Empty interfaces are not skipped, because they could be marker interfaces.
-	 * @return true if empty types are not printed, false otherwise
+	 * Returns if deleted types are printed.
+	 * @return true if deleted types are not printed, false otherwise.
 	 */
-	boolean isSkipEmptyTypePrinting();
+	boolean isOmitDeletedTypes();
 
 }

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -450,4 +450,19 @@ public interface Environment {
 		/** force everything to be fully-qualified */
 		FULLYQUALIFIED
 	}
+	/**
+	 * Sets the printer to skip printing empty Types.
+	 * A type is empty if it has no inner classes and no members.
+	 * Empty interfaces are not skipped, because they could be marker interfaces.
+	 */
+	void skipEmptyTypePrinting();
+
+	/**
+	 * Returns if empty types are printed.
+   * A type is empty if it has no inner classes and no members.
+	 * Empty interfaces are not skipped, because they could be marker interfaces.
+	 * @return true if empty types are not printed, false otherwise
+	 */
+	boolean isSkipEmptyTypePrinting();
+
 }

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -355,4 +355,10 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 * A new unique method name is given for each copy, and this method can be called several times.
 	 */
 	CtType<?> copyType();
+
+	/**
+	 * Returns the state of a type. If a type is removed, top level and omitDeletedTypes is on, it isn't printed.
+	 * @return true if the type is removed, false otherwise.
+	 */
+	boolean isRemoved();
 }

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -102,8 +102,7 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 	 */
 	public void createJavaFile(CtType<?> element) {
 		Path typePath = getElementPath(element);
-		if (hasOnlyDefaultConstructor(element) && getFactory().getEnvironment().isSkipEmptyTypePrinting()) {
-			// 1 means only default constructor
+		if (element.isRemoved() && getEnvironment().isOmitDeletedTypes()) {
 			return;
 		}
 		// we only create a file for top-level classes
@@ -138,13 +137,6 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 			getEnvironment().getSpoonProgress().step(SpoonProgress.Process.PRINT, element.getQualifiedName());
 	}
 
-	private boolean hasOnlyDefaultConstructor(CtType<?> element) {
-		if (element.getTypeMembers().size() == 1) {
-			// now we check if the element is implicit => it is the default ctor
-			return element.getTypeMembers().get(0).isImplicit();
-		}
-		return false;
-	}
 
 	@Override
 	public boolean isToBeProcessed(CtNamedElement candidate) {

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -102,7 +102,10 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 	 */
 	public void createJavaFile(CtType<?> element) {
 		Path typePath = getElementPath(element);
-
+		if (hasOnlyDefaultConstructor(element) && getFactory().getEnvironment().isSkipEmptyTypePrinting()) {
+			// 1 means only default constructor
+			return;
+		}
 		// we only create a file for top-level classes
 		if (!element.isTopLevel()) {
 			throw new IllegalArgumentException();
@@ -133,6 +136,14 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 			Launcher.LOGGER.error(e.getMessage(), e);
 		}
 			getEnvironment().getSpoonProgress().step(SpoonProgress.Process.PRINT, element.getQualifiedName());
+	}
+
+	private boolean hasOnlyDefaultConstructor(CtType<?> element) {
+		if (element.getTypeMembers().size() == 1) {
+			// now we check if the element is implicit => it is the default ctor
+			return element.getTypeMembers().get(0).isImplicit();
+		}
+		return false;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -130,7 +130,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private Supplier<PrettyPrinter> prettyPrinterCreator;
 
-	private boolean skipPrintingEmptyTypes;
+	private boolean omitDeletedTypes;
 	/**
 	 * Creates a new environment with a <code>null</code> default file
 	 * generator.
@@ -711,12 +711,12 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public void skipEmptyTypePrinting() {
-		skipPrintingEmptyTypes = true;
+	public void omitDeletedTypes() {
+		omitDeletedTypes = true;
 	}
 
 	@Override
-	public boolean isSkipEmptyTypePrinting() {
-		return skipPrintingEmptyTypes;
+	public boolean isOmitDeletedTypes() {
+		return omitDeletedTypes;
 	}
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -130,6 +130,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private Supplier<PrettyPrinter> prettyPrinterCreator;
 
+	private boolean skipPrintingEmptyTypes;
 	/**
 	 * Creates a new environment with a <code>null</code> default file
 	 * generator.
@@ -707,5 +708,15 @@ private transient  ClassLoader inputClassloader;
 	@Override
 	public void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations) {
 		this.ignoreDuplicateDeclarations = ignoreDuplicateDeclarations;
+	}
+
+	@Override
+	public void skipEmptyTypePrinting() {
+		skipPrintingEmptyTypes = true;
+	}
+
+	@Override
+	public boolean isSkipEmptyTypePrinting() {
+		return skipPrintingEmptyTypes;
 	}
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -35,7 +35,6 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
 import spoon.reflect.visitor.Query;

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -16,6 +16,7 @@ import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
@@ -34,6 +35,7 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.EarlyTerminatingScanner;
 import spoon.reflect.visitor.Query;
@@ -80,6 +82,8 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@MetamodelPropertyField(role = {CtRole.TYPE_MEMBER, CtRole.FIELD, CtRole.CONSTRUCTOR, CtRole.ANNONYMOUS_EXECUTABLE, CtRole.METHOD, CtRole.NESTED_TYPE})
 	List<CtTypeMember> typeMembers = emptyList();
+
+	private boolean isRemoved;
 
 	public CtTypeImpl() {
 	}
@@ -1002,4 +1006,22 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		cu.addDeclaredType(this);
 		return printer.printCompilationUnit(cu);
 	}
+
+	@Override
+	public boolean isRemoved() {
+		return isRemoved;
+	}
+
+	@Override
+	public void delete() {
+		isRemoved = true;
+		super.delete();
+	}
+
+	@Override
+	public <E extends CtElement> E setParent(E parent) {
+		isRemoved = false;
+		return super.setParent(parent);
+	}
+
 }

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -83,7 +83,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@MetamodelPropertyField(role = {CtRole.TYPE_MEMBER, CtRole.FIELD, CtRole.CONSTRUCTOR, CtRole.ANNONYMOUS_EXECUTABLE, CtRole.METHOD, CtRole.NESTED_TYPE})
 	List<CtTypeMember> typeMembers = emptyList();
 
-	private boolean isRemoved;
+	private transient boolean isRemoved;
 
 	public CtTypeImpl() {
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -493,7 +493,7 @@ public class TestSniperPrinter {
 	}
 
 	@Test
-	public void testtestOmitDeletedTypesModeReadd() throws IOException {
+	public void testOmitDeletedTypesModeReadd() throws IOException {
 		// contract: if not omitDeletedTypesMode deleted types, here ABCQ, are printed
 		File outputFolder = folder.newFolder();
 		Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -55,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -471,61 +472,43 @@ public class TestSniperPrinter {
 		testToStringWithSniperPrinter("src/test/java/spoon/test/prettyprinter/testclasses/ElementScan.java");
 	}
 
+
 	@Test
-	public void testSkipEmptyTypeMode() throws IOException {
-		// contract: in skipEmptyTypeMode empty types, here ABCQ, are not printed
+	public void testOmitDeletedTypesModeDelete() throws IOException {
+		// contract: if omitDeletedTypes ddeleted types, here ABCQ, are printed
 		File outputFolder = folder.newFolder();
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(new VirtualFile("class ABCQ {}"));
-		launcher.getEnvironment().skipEmptyTypePrinting();
 		launcher.setSourceOutputDirectory(outputFolder.getPath().toString());
-		launcher.run();
+		launcher.getEnvironment().omitDeletedTypes();
+		CtModel model = launcher.buildModel();
+		// remove all types
+		Collection<CtType<?>> types = model.getAllTypes();
+		types.forEach(CtElement::delete);
+		// run process and print output
+		launcher.process();
+		launcher.prettyprint();
+		// now the type shouldn't be printed
 		assertTrue(outputFolder.list((dir, name) -> name.equals("ABCQ.java")).length == 0);
 	}
 
 	@Test
-	public void testNoSkipEmptyTypeMode() throws IOException {
-		// contract: if not skipEmptyTypeMode empty types, here ABCQ, are printed
+	public void testtestOmitDeletedTypesModeReadd() throws IOException {
+		// contract: if not omitDeletedTypesMode deleted types, here ABCQ, are printed
 		File outputFolder = folder.newFolder();
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(new VirtualFile("class ABCQ {}"));
 		launcher.setSourceOutputDirectory(outputFolder.getPath().toString());
-		launcher.run();
-		assertTrue(outputFolder.list((dir, name) -> name.equals("ABCQ.java")).length == 1);
-	}
-
-	@Test
-	public void testNoSkipEmptyTypeModeWithMember() throws IOException {
-		// contract: if not skipEmptyTypeMode empty types, here ABCQ, are printed
-		File outputFolder = folder.newFolder();
-		Launcher launcher = new Launcher();
-		launcher.addInputResource(new VirtualFile("class ABCQ {int a;}"));
-		launcher.setSourceOutputDirectory(outputFolder.getPath().toString());
-		launcher.run();
-		assertTrue(outputFolder.list((dir, name) -> name.equals("ABCQ.java")).length == 1);
-	}
-
-	@Test
-	public void testnoSkipEmptyTypeModeWithMemberInConstructor() throws IOException {
-		// contract: if not skipEmptyTypeMode empty types, here ABCQ, are printed
-		File outputFolder = folder.newFolder();
-		Launcher launcher = new Launcher();
-		launcher.addInputResource(new VirtualFile("class ABCQ {ABCQ(){int a = 3;}}"));
-		launcher.setSourceOutputDirectory(outputFolder.getPath().toString());
-		launcher.getEnvironment().skipEmptyTypePrinting();
-		launcher.run();
-		assertTrue(outputFolder.list((dir, name) -> name.equals("ABCQ.java")).length == 1);
-	}
-
-	@Test
-	public void testSkipEmptyTypeModeWithInnerType() throws IOException {
-		// contract: in skipEmptyTypeMode empty types, here ABCQ, are not printed. But if a type has a inner type we print it.
-		File outputFolder = folder.newFolder();
-		Launcher launcher = new Launcher();
-		launcher.addInputResource(new VirtualFile("class ABCQ {class ABCD{}}"));
-		launcher.getEnvironment().skipEmptyTypePrinting();
-		launcher.setSourceOutputDirectory(outputFolder.getPath().toString());
-		launcher.run();
+		launcher.getEnvironment().omitDeletedTypes();
+		CtModel model = launcher.buildModel();
+		// remove all types and readd them
+		Collection<CtType<?>> types = model.getAllTypes();
+		types.forEach(CtElement::delete);
+		types.forEach(model.getRootPackage()::addType);
+		// run process and print output
+		launcher.process();
+		launcher.prettyprint();
+		// now the type should be printed
 		assertTrue(outputFolder.list((dir, name) -> name.equals("ABCQ.java")).length == 1);
 	}
 }


### PR DESCRIPTION
As described in #3183 this is the first iteration for the feature. There are some design decisions and printer specific questions. Do we add printer modes like this with flags in environment or is there a better place? Adding a method to an interface could be a breaking change, but we could add a default implementation to the method if we want to avoid this.


#### Remove file is source/input folder = outputFolder
> To do it really nicely, we can do a rm or even git rm from Spoon if the source folder is the same as the target folder.

I would avoid using shell comands like `git rm,` but we could implement (and document) deleting types if sourceFolder = outputFolder. Assuming we implement this, do we want a flag to enable/disable this behavior, because removing source code as a result of a bad configuration is pretty bad experience for a user. We need to keep in mind not every project is part of a git repository and the code is not always restorable.   


### Open Work
There is still some work missing. These are more Printer specific topics.
#### Documenting
How and where should we document a new printer flag? Is there some manuell where I need to add it?
#### Naming
Some good idea for naming the flag? 
=> resolved `omitDeletedTypes`
#### Setter
Do we need to allow deactivating the flag after activating it?
#### Default mode
Maybe a topic we should discuss after heavy testing, but shall the mode be on as default?
