### PR TITLE
test(DefaultPrettyPrinter): Check that DefaultPrettyPrinter is checkstyle compliant

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -516,7 +516,7 @@ public class SpoonPom implements SpoonResource {
 		return classpathElements.toArray(new String[0]);
 	}
 
-	private static String guessMavenHome() {
+	public static String guessMavenHome() {
 		String mvnHome = null;
 		try {
 			String[] cmd;

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -516,6 +516,10 @@ public class SpoonPom implements SpoonResource {
 		return classpathElements.toArray(new String[0]);
 	}
 
+	/**
+	 * Try to guess Maven home when none is provided.
+	 * @return the path toward maven install on the local machine.
+	 */
 	public static String guessMavenHome() {
 		String mvnHome = null;
 		try {

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -459,7 +459,7 @@ public class DefaultPrettyPrinterTest {
 	 * used as unit test.
 	 * Note that this test can be reused to check the compliance of any pretty printer with any set of styling rules.
 	*/
-	@Ignore
+	@Ignore // ignored as long as 1) it is too long 2) we don't implement a SpoonCompliantPrettyPrinter
 	@Test
 	public void testCheckstyleCompliance() throws IOException, XmlPullParserException {
 		File tmpDir = new File("./target/tmp-checkstyle");

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -452,6 +452,13 @@ public class DefaultPrettyPrinterTest {
 		assertEquals(expected, result);
 	}
 
+	/**
+	 * This test parses Spoon sources (src/main/java) and pretty prints them in a temporary directory 
+	 * to check the compliance of the pretty printer to the set of checkstyle rules used by the Spoon repo.
+	 * As the test takes a long time to run, it is only meant to detect exemples of violation that can, then, be
+	 * used as unit test.
+	 * Note that this test can be reused to check the compliance of any pretty printer with any set of styling rules.
+	*/
 	@Ignore
 	@Test
 	public void testCheckstyleCompliance() throws IOException, XmlPullParserException {
@@ -491,7 +498,6 @@ public class DefaultPrettyPrinterTest {
 			writer.write(new FileOutputStream(tmpPom), model);
 
 			//run checkstyle
-
 			//contract: PrettyPrinted sources should not contain errors
 			assertTrue(runCheckstyle(new File(SpoonPom.guessMavenHome()),tmpPom));
 


### PR DESCRIPTION
Related to #3623 .

This test check that spoon sources parsed by spoon and pretty printed with the DefaultPrettyPrinter passes the rules from `checkstyle.xml`. 

Note that it is simple to define a different rule set if we want to.

This test is probably not meant to be run with the rest of unit tests (too slow) but can help to isolate more precise violations.

Output:

```
Violations: 
V: [WhitespaceAfter] -> 77
   Ex: src/main/java/spoon/testing/utils/ModelUtils.java:23:59:
V: [NoWhitespaceBefore] -> 99
   Ex: src/main/java/spoon/support/gui/SpoonModelTree.java:9:94:
V: [RightCurly] -> 2
   Ex: src/main/java/spoon/metamodel/MetamodelProperty.java:391:17:
V: [ParenPad] -> 167
   Ex: src/main/java/spoon/refactoring/MethodInvocationSearch.java:38:37:
V: [WhitespaceAround] -> 61
   Ex: src/main/java/spoon/refactoring/CtParameterRemoveRefactoring.java:149:17:
V: [RegexpSingleline] -> 230
   Ex: src/main/java/spoon/refactoring/CtDeprecatedRefactoring.java:71:
V: [RegexpSinglelineJava] -> 57432
   Ex:src/main/java/spoon/SpoonAPI.java:13:
V: [NewlineAtEndOfFile] -> 661
   Ex: src/main/java/spoon/SpoonAPI.java:1:
V: [UnusedImports] -> 1
   Ex: src/main/java/spoon/refactoring/CtDeprecatedRefactoring.java:13:8:
```