### PR TITLE
fix(CtLineElementComparator): one can add two values to an annotation

### DIFF
--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -19,14 +19,14 @@ import spoon.reflect.declaration.CtElement;
 public class CtLineElementComparator implements Comparator<CtElement>, Serializable {
 
 	/**
-	 * Returns 0 if o1 has the same position as o2, or both positions are invalid.
-	 * Returns -1 if o1 is before o2 in the file, or o1 has no valid position.
+	 * Returns 0 if o1 has the same position as o2, or both positions are invalid and o1.equals(o2).
+	 * Returns -1 if o1 is before o2 in the file, or o1 has no valid position or both positions are invalid !o1.equals(o2).
 	 * Returns 1 if o2 is after o1 in the file, or o2 has no valid position.
 	 */
 	@Override
 	public int compare(CtElement o1, CtElement o2) {
 		if (!o1.getPosition().isValidPosition() && !o2.getPosition().isValidPosition()) {
-			return 0;
+			return o1.equals(o2) ? 0 : -1;
 		}
 		if (!o1.getPosition().isValidPosition()) {
 			return -1;

--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -26,7 +26,7 @@ public class CtLineElementComparator implements Comparator<CtElement>, Serializa
 	@Override
 	public int compare(CtElement o1, CtElement o2) {
 		if (!o1.getPosition().isValidPosition() && !o2.getPosition().isValidPosition()) {
-			return o1.equals(o2) ? 0 : (o1.hashCode() < o2.hashCode() : -1 : 1);
+			return o1.equals(o2) ? 0 : ((o1.hashCode() < o2.hashCode()) ? -1 : 1);
 		}
 		if (!o1.getPosition().isValidPosition()) {
 			return -1;

--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -26,7 +26,7 @@ public class CtLineElementComparator implements Comparator<CtElement>, Serializa
 	@Override
 	public int compare(CtElement o1, CtElement o2) {
 		if (!o1.getPosition().isValidPosition() && !o2.getPosition().isValidPosition()) {
-			return o1.equals(o2) ? 0 : -1;
+			return o1.equals(o2) ? 0 : (o1.hashCode() < o2.hashCode() : -1 : 1);
 		}
 		if (!o1.getPosition().isValidPosition()) {
 			return -1;

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -34,6 +34,7 @@ import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.reflect.code.CtExpressionImpl;
 import spoon.support.reflect.eval.EvalHelper;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
@@ -43,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -34,7 +34,6 @@ import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.reflect.code.CtExpressionImpl;
 import spoon.support.reflect.eval.EvalHelper;
 
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
@@ -44,7 +43,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -219,8 +219,6 @@ public class AnnotationValuesTest {
 		annotation.addValue("title", "First summary");
 		annotation.addValue("date", "2020-10-05");
 
-		Set set =annotation.getAllValues().entrySet();
-
 		//contract: All added values are added to the annotations
 		assertEquals(2, annotation.getAllValues().size());
 		assertTrue(annotation.getAllValues().containsKey("title"));

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -18,6 +18,7 @@ package spoon.test.annotation;
 
 import org.junit.Test;
 import spoon.Launcher;
+import spoon.SpoonAPI;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -30,12 +31,15 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.annotation.testclasses.AnnotationValues;
 import spoon.test.annotation.testclasses.BoundNumber;
+import spoon.test.annotation.testclasses.Summary;
 
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -142,8 +146,10 @@ public class AnnotationValuesTest {
 		launcher.getEnvironment().setCommentEnabled(false); // avoid getting the comment for the equals
 		launcher.buildModel();
 
-		assertEquals(strCtClassOracle,
-				launcher.getFactory().Class().getAll().get(0).getElements(new TypeFilter<>(CtClass.class)).get(2).toString());
+		assertEquals(
+				strCtClassOracle,
+				launcher.getFactory().Class().getAll().get(0).getElements(new TypeFilter<>(CtClass.class)).get(2).toString()
+		);
 	}
 
 	private static final String nl = System.lineSeparator();
@@ -201,5 +207,25 @@ public class AnnotationValuesTest {
 			assertEquals(0, element.getAnnotations().size());
 			return myself;
 		}
+	}
+
+	@Test
+	public void testIssue3639() {
+		SpoonAPI spoon = new Launcher();
+
+		CtTypeReference<Summary> typeRef = spoon.getFactory().createCtTypeReference(Summary.class);
+		CtAnnotation<Summary> annotation = spoon.getFactory().createAnnotation(typeRef);
+
+		annotation.addValue("title", "First summary");
+		annotation.addValue("date", "2020-10-05");
+
+		Set set =annotation.getAllValues().entrySet();
+
+		//contract: All added values are added to the annotations
+		assertEquals(2, annotation.getAllValues().size());
+		assertTrue(annotation.getAllValues().containsKey("title"));
+		assertTrue(annotation.getAllValues().containsKey("date"));
+		assertEquals("\"First summary\"", annotation.getAllValues().get("title").toString());
+		assertEquals("\"2020-10-05\"", annotation.getAllValues().get("date").toString());
 	}
 }

--- a/src/test/java/spoon/test/annotation/testclasses/Summary.java
+++ b/src/test/java/spoon/test/annotation/testclasses/Summary.java
@@ -1,0 +1,6 @@
+package spoon.test.annotation.testclasses;
+
+public @interface Summary {
+	String title();
+	String date();
+}


### PR DESCRIPTION
fix #3639 .

I seems that the entry set of the values contained an CtAnnotationImpl are ordered based on their source position. The issue is that so far `CtLineElementComparator#compare()` returns 0 if both element have `NoSourcePosition`. But this is the case when both elements are constructed programmatically. Hence the entry set arbitrarily retains only one of them.

My proposed solution is to make `CtLineElementComparator#compare()` returns 0 only if both elements have the same exact position or if both elements have `NoSourcePosition` and are equals. Otherwise we return -1 (i.e. order them aribtrarily). This way our entry set is pseudo order but does not delete unequals elements.