### PR TITLE
chore: break build if a class is not covered 

### DIFF
--- a/chore/travis/travis-jdk10.sh
+++ b/chore/travis/travis-jdk10.sh
@@ -9,4 +9,5 @@ chmod +x install-jdk.sh
 # Use the default (the one present in the base container) collection of trusted certificate authority (CA) certificates for java
 source ./install-jdk.sh -f 10 -c
 
-mvn  -Djava.src.version=1.10 test
+# install also does verify goals
+mvn  -Djava.src.version=1.10 clean install

--- a/chore/travis/travis-jdk8.sh
+++ b/chore/travis/travis-jdk8.sh
@@ -10,4 +10,4 @@ unzip -qq apache-maven-3.3.9-bin.zip
 export M2_HOME=$PWD/apache-maven-3.3.9
 
 $M2_HOME/bin/mvn --version
-$M2_HOME/bin/mvn clean install
+$M2_HOME/bin/mvn clean test

--- a/pom.xml
+++ b/pom.xml
@@ -190,19 +190,19 @@
                     <goal>check</goal>
                   </goals>
                   <configuration>
+                    <excludes>
+                      <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
+                      <exclude>**/support/gui/*</exclude>
+                    </excludes>
                     <rules>
                     <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <excludes>
-                        <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
-                        <exclude>**/support/gui/*</exclude>
-                      </excludes>
                       <element>BUNDLE</element>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
                           <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
-                          <maximum>1</maximum>
+                          <maximum>10</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,8 @@
                         <limit implementation="org.jacoco.report.check.Limit">
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
-                          <maximum>0</maximum>
+                          <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
+                          <maximum>1</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -189,28 +189,28 @@
                     <goals>
                         <goal>report</goal>
                     </goals>
-                  </execution>
+                </execution>
                 <execution>
-              <id>check-coverage</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <rules>
-              <rule implementation="org.jacoco.maven.RuleConfiguration">
-                <element>BUNDLE</element>
-                <limits>
-                  <limit implementation="org.jacoco.report.check.Limit">
-                    <counter>CLASS</counter>
-                    <value>MISSEDCOUNT</value>
-                    <maximum>0</maximum>
-                  </limit>
-                </limits>
-              </rule>
-              </rules>
-              </configuration>
-              </execution>
-        </executions>
+                  <id>check-coverage</id>
+                  <goals>
+                    <goal>check</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                    <rule implementation="org.jacoco.maven.RuleConfiguration">
+                      <element>BUNDLE</element>
+                      <limits>
+                        <limit implementation="org.jacoco.report.check.Limit">
+                          <counter>CLASS</counter>
+                          <value>MISSEDCOUNT</value>
+                          <maximum>0</maximum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
+                  </configuration>
+                </execution>
+          </executions>
       </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -265,3 +265,4 @@
     </plugins>
   </build>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
                           <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
-                          <maximum>10</maximum>
+                          <maximum>1</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -171,12 +171,6 @@
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>0.8.6</version>
-            <configuration>
-                <excludes>
-                    <!-- we exclude the GUI classes, because we don't want Swing GUI tests in Travis and SonarQube--> 
-                    <exclude>**/support/gui/*</exclude>
-                </excludes>
-            </configuration>
             <executions>
                 <execution>
                     <goals>
@@ -198,6 +192,10 @@
                   <configuration>
                     <rules>
                     <rule implementation="org.jacoco.maven.RuleConfiguration">
+                      <excludes>
+                        <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
+                        <exclude>**/support/gui/*</exclude>
+                      </excludes>
                       <element>BUNDLE</element>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,8 @@
                       <excludes>
                         <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
                         <exclude>spoon.support.gui.*</exclude>
+                        <!-- we exclude the generated inner classes of ReplacementVisitor -->
+                        <exclude>spoon.support.visitor.replace.ReplacementVisitor.*</exclude>
                       </excludes>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">

--- a/pom.xml
+++ b/pom.xml
@@ -185,23 +185,27 @@
                     </goals>
                 </execution>
                 <execution>
+                  <!-- reference: 
+                  * https://www.jacoco.org/jacoco/trunk/doc/check-mojo.html
+                  * https://stackoverflow.com/questions/41891739/how-to-fail-a-maven-build-if-junit-coverage-falls-below-certain-threshold
+                  -->
                   <id>check-coverage</id>
                   <goals>
                     <goal>check</goal>
                   </goals>
                   <configuration>
-                    <excludes>
-                      <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
-                      <exclude>**/support/gui/*</exclude>
-                    </excludes>
                     <rules>
                     <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>CLASS</element>
+                      <element>PACKAGE</element>
+                      <excludes>
+                        <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
+                        <exclude>**/support/gui/*</exclude>
+                      </excludes>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>LINE</counter>
+                          <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
-                          <maximum>3</maximum>
+                          <maximum>0</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -189,9 +189,29 @@
                     <goals>
                         <goal>report</goal>
                     </goals>
-                </execution>
-            </executions>
-        </plugin>
+                  </execution>
+                <execution>
+              <id>check-coverage</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <rules>
+              <rule implementation="org.jacoco.maven.RuleConfiguration">
+                <element>BUNDLE</element>
+                <limits>
+                  <limit implementation="org.jacoco.report.check.Limit">
+                    <counter>CLASS</counter>
+                    <value>MISSEDCOUNT</value>
+                    <maximum>0</maximum>
+                  </limit>
+                </limits>
+              </rule>
+              </rules>
+              </configuration>
+              </execution>
+        </executions>
+      </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -196,16 +196,16 @@
                   <configuration>
                     <rules>
                     <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>PACKAGE</element>
+                      <element>CLASS</element>
                       <excludes>
                         <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI --> 
-                        <exclude>**/support/gui/*</exclude>
+                        <exclude>spoon.support.gui.*</exclude>
                       </excludes>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>CLASS</counter>
-                          <value>MISSEDCOUNT</value>
-                          <maximum>0</maximum>
+                          <counter>LINE</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>0.1</minimum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
                           <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
-                          <maximum>1</maximum>
+                          <maximum>5</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -196,13 +196,12 @@
                     </excludes>
                     <rules>
                     <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>BUNDLE</element>
+                      <element>CLASS</element>
                       <limits>
                         <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>CLASS</counter>
+                          <counter>LINE</counter>
                           <value>MISSEDCOUNT</value>
-                          <!-- some classes are not covered in Travis, and I haven't found the way to list them -Martin -->
-                          <maximum>6</maximum>
+                          <maximum>3</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
                           <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
-                          <maximum>5</maximum>
+                          <maximum>7</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
                         <limit implementation="org.jacoco.report.check.Limit">
                           <counter>CLASS</counter>
                           <value>MISSEDCOUNT</value>
-                          <!-- in theory we would like to have MISSEDCOUNT=0 but in some cases, Jacoco counts one phantom missed instruction, so ze go for one -->
-                          <maximum>7</maximum>
+                          <!-- some classes are not covered in Travis, and I haven't found the way to list them -Martin -->
+                          <maximum>6</maximum>
                         </limit>
                       </limits>
                     </rule>

--- a/src/main/java/Foo.java
+++ b/src/main/java/Foo.java
@@ -1,0 +1,5 @@
+public class Foo {
+void f() {
+int i=1+3;
+}
+}

--- a/src/main/java/Foo.java
+++ b/src/main/java/Foo.java
@@ -1,5 +1,0 @@
-public class Foo {
-void f() {
-int i=1+3;
-}
-}


### PR DESCRIPTION
We should break the build if a class is not covered.

According to https://sonarqube.ow2.org/component_measures?id=fr.inria.gforge.spoon%3Aspoon-core&metric=coverage&view=list all classes are covered.

Yet, here Jacoco says that 8 classes are not covered: https://travis-ci.com/github/monperrus/spoon/jobs/396558655

    check (check-coverage) on project spoon-core: Coverage checks have not been met. See log for details

which ones?