### PR TITLE
chore: Use ow2-nexus as the snapshot repository

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -27,7 +27,7 @@
 
     <repositories>
         <repository>
-            <id>ow2-nexus</id>
+            <id>ow2.org-snapshot</id>
             <name>Maven Repository for Spoon Snapshots</name>
             <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
         </repository>
@@ -89,7 +89,7 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
-            <id>ow2-nexus</id>
+            <id>ow2.org-snapshot</id>
             <name>Maven Repository for Spoon Snapshots</name>
             <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -27,9 +27,9 @@
 
     <repositories>
         <repository>
-            <id>maven.inria.fr-snapshot</id>
+            <id>ow2-nexus</id>
             <name>Maven Repository for Spoon Snapshots</name>
-            <url>https://maven.irisa.fr/artifactory/spoon-public-snapshot</url>
+            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
         </repository>
     </repositories>
 
@@ -89,9 +89,9 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
-            <id>maven.inria.fr-snapshot</id>
+            <id>ow2-nexus</id>
             <name>Maven Repository for Spoon Snapshots</name>
-            <url>http://maven.inria.fr/artifactory/spoon-public-snapshot</url>
+            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
         <site>
             <id>gforge.inria.fr-site</id>

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -229,9 +229,9 @@
 
     <repositories>
         <repository>
-            <id>ow2.org-snapshot</id>
-            <name>Maven Repository for Spoon Snapshots</name>
-            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+            <id>mavenInriaSnapshot</id>
+            <name>http://maven.inria.fr-snapshots</name>
+            <url>http://maven.inria.fr/artifactory/malai-public-snapshot</url>
             <snapshots><enabled>true</enabled></snapshots>
             <releases><enabled>false</enabled></releases>
         </repository>

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -229,9 +229,9 @@
 
     <repositories>
         <repository>
-            <id>mavenInriaSnapshot</id>
-            <name>http://maven.inria.fr-snapshots</name>
-            <url>http://maven.inria.fr/artifactory/malai-public-snapshot</url>
+            <id>ow2.org-snapshot</id>
+            <name>Maven Repository for Spoon Snapshots</name>
+            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
             <snapshots><enabled>true</enabled></snapshots>
             <releases><enabled>false</enabled></releases>
         </repository>


### PR DESCRIPTION
Fix #3648 

This also requires the credentials in the Jenkins Spoon-Snapshot-Deployer job to be updated with the OW2 credentials (hence titled as wip), but I think that should be all.

I'm not sure about the ID for the repository, is there some convention for that?