### PR TITLE
fix: more resilient wrt to errors during shadow class building

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -564,7 +564,11 @@ public class TypeFactory extends SubFactory {
 					newShadowClass = new JavaReflectionTreeBuilder(getShadowFactory()).scan((Class<T>) cl);
 				} catch (Throwable e) {
 					Launcher.LOGGER.warn("cannot create shadow class: {}", cl.getName(), e);
-					return null;
+
+					newShadowClass = getShadowFactory().Core().createClass();
+					newShadowClass.setSimpleName(cl.getSimpleName());
+					newShadowClass.setShadow(true);
+					getShadowFactory().Package().getOrCreate(cl.getPackage().getName()).addType(newShadowClass);
 				}
 				newShadowClass.setFactory(factory);
 				newShadowClass.accept(new CtScanner() {

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -34,7 +34,6 @@ import spoon.reflect.visitor.CtAbstractVisitor;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DefaultCoreFactory;
-import spoon.support.SpoonClassNotFoundException;
 import spoon.support.StandardEnvironment;
 import spoon.support.util.internal.MapUtils;
 import spoon.support.visitor.ClassTypingContext;

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -7,6 +7,7 @@
  */
 package spoon.reflect.factory;
 
+import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.cu.SourcePosition;
@@ -563,7 +564,8 @@ public class TypeFactory extends SubFactory {
 				try {
 					newShadowClass = new JavaReflectionTreeBuilder(getShadowFactory()).scan((Class<T>) cl);
 				} catch (Throwable e) {
-					throw new SpoonClassNotFoundException("cannot create shadow class: " + cl.getName(), e);
+					Launcher.LOGGER.warn("cannot create shadow class: {}", cl.getName(), e);
+					return null;
 				}
 				newShadowClass.setFactory(factory);
 				newShadowClass.accept(new CtScanner() {

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -296,7 +296,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 				CtLiteral<Object> defaultExpression = factory.createLiteral(field.get(null));
 				ctField.setDefaultExpression(defaultExpression);
 			}
-		} catch (Throwable e) {
+		} catch (IllegalAccessException | ExceptionInInitializerError | UnsatisfiedLinkError e) {
 			// ignore
 		}
 

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -296,7 +296,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 				CtLiteral<Object> defaultExpression = factory.createLiteral(field.get(null));
 				ctField.setDefaultExpression(defaultExpression);
 			}
-		} catch (IllegalAccessException e) {
+		} catch (Throwable e) {
 			// ignore
 		}
 

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -63,6 +63,7 @@ import spoon.support.reflect.declaration.CtEnumValueImpl;
 import spoon.support.reflect.declaration.CtFieldImpl;
 import spoon.support.visitor.equals.EqualsChecker;
 import spoon.support.visitor.equals.EqualsVisitor;
+import spoon.support.visitor.java.testclasses.NPEInStaticInit;
 import spoon.test.generics.testclasses3.ComparableComparatorBug;
 
 import java.io.File;
@@ -89,6 +90,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class JavaReflectionTreeBuilderTest {
@@ -681,5 +683,15 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals(true, ctClass.isAnonymous());
 		assertEquals(true, ctClass.isShadow());
 		assertEquals("foo", ctClass.getMethods().toArray(new CtMethod[0])[0].getSimpleName());
+	}
+
+	@Test
+	public void testExpectedExceptionInInitializerError() {
+		try {
+			new JavaReflectionTreeBuilder(createFactory()).scan(NPEInStaticInit.class);
+			fail();
+		}
+		catch (ExceptionInInitializerError expected) {
+		}
 	}
 }

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -63,7 +63,6 @@ import spoon.support.reflect.declaration.CtEnumValueImpl;
 import spoon.support.reflect.declaration.CtFieldImpl;
 import spoon.support.visitor.equals.EqualsChecker;
 import spoon.support.visitor.equals.EqualsVisitor;
-import spoon.support.visitor.java.testclasses.NPEInStaticInit;
 import spoon.test.generics.testclasses3.ComparableComparatorBug;
 
 import java.io.File;
@@ -688,7 +687,7 @@ public class JavaReflectionTreeBuilderTest {
 	@Test
 	public void testExpectedExceptionInInitializerError() {
 		try {
-			new JavaReflectionTreeBuilder(createFactory()).scan(NPEInStaticInit.class);
+			new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.NPEInStaticInit.class);
 			fail();
 		}
 		catch (ExceptionInInitializerError expected) {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -89,7 +89,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class JavaReflectionTreeBuilderTest {
@@ -685,12 +684,18 @@ public class JavaReflectionTreeBuilderTest {
 	}
 
 	@Test
-	public void testExpectedExceptionInInitializerError() {
-		try {
-			new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.NPEInStaticInit.class);
-			fail();
-		}
-		catch (ExceptionInInitializerError expected) {
-		}
+	public void testCannotGetDefaultExpressionBecauseOfException() {
+		/*
+		 * contract:
+		 * 				JavaReflectionTreeBuilder can't set defaultExpression for the field (public static primitive),
+		 * 				as Reflection API throws the exception ExceptionInInitializerError when attempting to get it.
+		 * 				{@link JavaReflectionTreeBuilder#visitField(Filed)} ignores any exceptions.
+		 */
+		CtType<spoon.support.visitor.java.testclasses.NPEInStaticInit> ctType =
+				new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.NPEInStaticInit.class);
+
+		CtField<?> value = ctType.getField("VALUE");
+		// should have gotten '1'
+		assertNull(value.getDefaultExpression());
 	}
 }

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -687,14 +687,25 @@ public class JavaReflectionTreeBuilderTest {
 	public void testCannotGetDefaultExpressionBecauseOfException() {
 		/*
 		 * contract:
-		 * 				JavaReflectionTreeBuilder can't set defaultExpression for the field (public static primitive),
-		 * 				as Reflection API throws the exception ExceptionInInitializerError when attempting to get it.
-		 * 				{@link JavaReflectionTreeBuilder#visitField(Filed)} ignores any exceptions.
+		 *    JavaReflectionTreeBuilder can't set defaultExpression for the field (public static primitive),
+		 *    as Reflection API throws the exception ExceptionInInitializerError when attempting to get it.
+		 *    {@link JavaReflectionTreeBuilder#visitField(Filed)} ignores this exception.
 		 */
-		CtType<spoon.support.visitor.java.testclasses.NPEInStaticInit> ctType =
-				new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.NPEInStaticInit.class);
+		CtType<?> ctType = new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.NPEInStaticInit.class);
 
 		CtField<?> value = ctType.getField("VALUE");
+		// should have gotten '1'
+		assertNull(value.getDefaultExpression());
+
+		/*
+		 * contract:
+		 *    JavaReflectionTreeBuilder can't set defaultExpression for the field (public static primitive),
+		 *    as Reflection API throws the exception UnsatisfiedLinkError when attempting to get it.
+		 *    {@link JavaReflectionTreeBuilder#visitField(Filed)} ignores this exception.
+		 */
+		ctType = new JavaReflectionTreeBuilder(createFactory()).scan(spoon.support.visitor.java.testclasses.UnsatisfiedLinkErrorInStaticInit.class);
+
+		value = ctType.getField("VALUE");
 		// should have gotten '1'
 		assertNull(value.getDefaultExpression());
 	}

--- a/src/test/java/spoon/support/visitor/java/testclasses/NPEInStaticInit.java
+++ b/src/test/java/spoon/support/visitor/java/testclasses/NPEInStaticInit.java
@@ -1,0 +1,20 @@
+package spoon.support.visitor.java.testclasses;
+
+public class NPEInStaticInit {
+
+  private static class InnerClass {
+    public void doSmt(){ }
+  }
+
+  public static int VALUE = 1; // because of this field
+  
+  static {
+    System.out.println("This text will be printed"); // NOTE
+  }
+
+  public static InnerClass someObject = null;
+  
+  static {
+    someObject.doSmt();      // NPE !!!
+  }
+}

--- a/src/test/java/spoon/support/visitor/java/testclasses/UnsatisfiedLinkErrorInStaticInit.java
+++ b/src/test/java/spoon/support/visitor/java/testclasses/UnsatisfiedLinkErrorInStaticInit.java
@@ -1,0 +1,10 @@
+package spoon.support.visitor.java.testclasses;
+
+public class UnsatisfiedLinkErrorInStaticInit {
+
+  public static int VALUE = 1; // because of this field
+  
+  static {
+    System.load("not found path!");
+  }
+}


### PR DESCRIPTION
Hello everyone,

We develop a static code analyzer and to do it we need to build models using Spoon for a lot of projects.

Some background information.

_This is how it was before:_

JDTImportBuilder::getOrLoadClass tried to get imported class through getClass().getClassLoader().loadClass(className) ... it didn't manage to find anything ('null', ClassNotFoundException, ...).
 This led to the situation when JDTImportBuilder::getOrLoadClass returned 'null'. We couldn't get it and that was OK.

_This is how it is now:_

Recently JDTImportBuilder::getOrLoadClass tries to load class using JDTImportBuilder::loadClass.
That is, if 'factory.getEnvironment().getInputClassLoader' existed, we tried to get it from there, otherwise we got class, same as before.
So through the factory environment you are able to get classes that, before the change, thrown with ClassNotFoundException.
But this modification led to the situation when TypeFactory::get(Class) couldn't get the shadowClass using JavaReflectionTreeBuilder (probably because reflection has not enough information). This leads to the SpoonClassNotFoundException exception that interrupts model building. Therefore we can't start the analysis niether.
There are a lot of reasons of program crash when launching JavaReflectionTreeBuilder:

```
    * Caused by: java.lang.ExceptionInInitializerError
    * Caused by: java.lang.TypeNotPresentException: Type org.jvnet.mimepull.Header not present
    * Caused by: java.lang.ArrayStoreException: sun.reflect.annotation.TypeNotPresentExceptionProxy
    * Caused by: java.lang.SecurityException: class "com.google.protobuf.GeneratedMessageV3$FieldAccessorTable"'s signer information does not match signer information of other classes in the same package
    * Caused by: java.lang.IncompatibleClassChangeError: com.google.common.collect.Interners and com.google.common.collect.Interners$InternerImpl disagree on InnerClasses attribute
    * ....
```

    
PR details:
I added logging 'cannot create shadow class' (just in case).
I think, returning 'null' makes more sense, as it was before. If you couldn't get it, that's OK (alas, something's missing).