### PR TITLE
refactor(ArchitectureEnforcer): replace treeSet with hashset

### DIFF
--- a/spoon-decompiler/src/test/java/spoon/decompiler/test/architecture/DecompilerArchitectureTest.java
+++ b/spoon-decompiler/src/test/java/spoon/decompiler/test/architecture/DecompilerArchitectureTest.java
@@ -146,7 +146,7 @@ public class DecompilerArchitectureTest {
 		// contract: when a pull-request introduces a new package, it is made explicit during code review
 		// when a pull-request introduces a new package, this test fails and the author has to explicitly declare the new package here
 
-		Set<String> officialPackages = new TreeSet<>();
+		Set<String> officialPackages = new HashSet<>();
 		officialPackages.add("spoon.decompiler");
 		officialPackages.add("spoon");
 		officialPackages.add(""); // root package
@@ -154,7 +154,7 @@ public class DecompilerArchitectureTest {
 		SpoonAPI spoon = new Launcher();
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
-		final Set<String> currentPackages = new TreeSet<>();
+		final Set<String> currentPackages = new HashSet<>();
 		spoon.getModel().processWith(new AbstractProcessor<CtPackage>() {
 			@Override
 			public void process(CtPackage element) {

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -363,7 +363,7 @@ public class SpoonArchitectureEnforcerTest {
 		// contract: when a pull-request introduces a new package, it is made explicit during code review
 		// when a pull-request introduces a new package, this test fails and the author has to explicitly declare the new package here
 
-		Set<String> officialPackages = new TreeSet<>();
+		Set<String> officialPackages = new HashSet<>();
 		officialPackages.add("spoon.compiler.builder");
 		officialPackages.add("spoon.compiler");
 		officialPackages.add("spoon.javadoc");
@@ -431,7 +431,7 @@ public class SpoonArchitectureEnforcerTest {
 		SpoonAPI spoon = new Launcher();
 		spoon.addInputResource("src/main/java/");
 		spoon.buildModel();
-		final Set<String> currentPackages = new TreeSet<>();
+		final Set<String> currentPackages = new HashSet<>();
 		spoon.getModel().processWith(new AbstractProcessor<CtPackage>() {
 			@Override
 			public void process(CtPackage element) {


### PR DESCRIPTION
A few lines above the code states: 
// contract: Spoon's code never uses TreeSet constructor, because they implicitly depend on Comparable (no static check, only dynamic checks)
So lets fulfil the contract. Simply TreeSet -> HashSet. Shouldn't change anything.
