### PR TITLE
refactor: add support for malformed files through inheritance

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -596,7 +596,7 @@ public class Launcher implements SpoonAPI {
 	 * 		the factory this compiler works on
 	 */
 	public SpoonModelBuilder createCompiler(Factory factory) {
-		SpoonModelBuilder comp = new JDTBasedSpoonCompiler(factory);
+		SpoonModelBuilder comp = getCompilerInstance(factory);
 		Environment env = getEnvironment();
 		// building
 		comp.setBinaryOutputDirectory(jsapActualArgs.getFile("destination"));
@@ -612,6 +612,17 @@ public class Launcher implements SpoonAPI {
 		env.debugMessage("template classpath: " + Arrays.toString(comp.getTemplateClasspath()));
 
 		return comp;
+	}
+
+	/**
+	 * Instantiates the compiler. This method is invoked by {@link #createCompiler(Factory)} to retrieve
+	 * an empty compiler instance. Clients can override this method to use their custom compiler implementation.
+	 * @param factory the factory to pass on to the compiler.
+	 * @return a new compiler.
+	 * @see #createCompiler(Factory)
+	 */
+	protected SpoonModelBuilder getCompilerInstance(Factory factory) {
+		return new JDTBasedSpoonCompiler(factory);
 	}
 
 	public SpoonModelBuilder createCompiler(Factory factory, List<SpoonResource> inputSources) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -472,8 +472,8 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 	}
 
 	/**
-	 * Invokes the traversal of the given compilation unit declaration using the given builder as visitor.
-	 * This method must invoke {@link CompilationUnitDeclaration#traverse(ASTVisitor, CompilationUnitScope)})} )}
+	 * Invokes the traversal of the given compilation unit declaration using the given builder as a visitor.
+	 * Overriders of this method must invoke {@link CompilationUnitDeclaration#traverse(ASTVisitor, CompilationUnitScope)})} )}
 	 * @param builder the builder to use to traverse the unit.
 	 * @param unitDeclaration the unit declaration.
 	 */

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -14,9 +14,7 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
-import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
-import org.eclipse.jdt.internal.core.CompilationUnit;
 import spoon.OutputType;
 import spoon.SpoonException;
 import spoon.compiler.Environment;
@@ -473,11 +471,12 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 
 	/**
 	 * Invokes the traversal of the given compilation unit declaration using the given builder as a visitor.
-	 * Overriders of this method must invoke {@link CompilationUnitDeclaration#traverse(ASTVisitor, CompilationUnitScope)})} )}
+	 * Overriders of this method must either invoke {@link CompilationUnitDeclaration#traverse(ASTVisitor, CompilationUnitScope)})} )}
+	 * or this method before returning.
 	 * @param builder the builder to use to traverse the unit.
 	 * @param unitDeclaration the unit declaration.
 	 */
-	protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration){
+	protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration) {
 		unitDeclaration.traverse(builder, unitDeclaration.scope);
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -11,8 +11,12 @@ import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Level;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
+import org.eclipse.jdt.internal.core.CompilationUnit;
 import spoon.OutputType;
 import spoon.SpoonException;
 import spoon.compiler.Environment;
@@ -432,7 +436,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 
 		forEachCompilationUnit(unitList, SpoonProgress.Process.MODEL, unit -> {
 			// we need first to go through the whole model before getting the right reference for imports
-			unit.traverse(builder, unit.scope);
+			traverseUnitDeclaration(builder, unit);
 		});
 		//we need first imports before we can place comments. Mainly comments on imports need that
 		forEachCompilationUnit(unitList, SpoonProgress.Process.IMPORT, unit -> {
@@ -459,17 +463,24 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			if (unit.isModuleInfo() || !unit.isEmpty()) {
 				final String unitPath = new String(unit.getFileName());
 				if (canProcessCompilationUnit(unitPath)) {
-					try {
-						consumer.accept(unit);
-					} catch (Exception e) {
-						getEnvironment().report(null, Level.ERROR, "An error occurred while processing a unit in " + String.valueOf(unit.getFileName()) + ", some units may be missing in the model: " + e.getMessage());
-					}
+					consumer.accept(unit);
 				}
-					getEnvironment().getSpoonProgress().step(process, unitPath, ++i, unitList.size());
+				getEnvironment().getSpoonProgress().step(process, unitPath, ++i, unitList.size());
 			}
 		}
-			getEnvironment().getSpoonProgress().end(process);
+		getEnvironment().getSpoonProgress().end(process);
 	}
+
+	/**
+	 * Invokes the traversal of the given compilation unit declaration using the given builder as visitor.
+	 * This method must invoke {@link CompilationUnitDeclaration#traverse(ASTVisitor, CompilationUnitScope)})} )}
+	 * @param builder the builder to use to traverse the unit.
+	 * @param unitDeclaration the unit declaration.
+	 */
+	protected void traverseUnitDeclaration(JDTTreeBuilder builder, CompilationUnitDeclaration unitDeclaration){
+		unitDeclaration.traverse(builder, unitDeclaration.scope);
+	}
+
 
 	private boolean canProcessCompilationUnit(String unitPath) {
 		for (final CompilationUnitFilter cuf : compilationUnitFilters) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -459,7 +459,11 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 			if (unit.isModuleInfo() || !unit.isEmpty()) {
 				final String unitPath = new String(unit.getFileName());
 				if (canProcessCompilationUnit(unitPath)) {
-					consumer.accept(unit);
+					try {
+						consumer.accept(unit);
+					} catch (Exception e) {
+						getEnvironment().report(null, Level.ERROR, "An error occurred while processing a unit in " + String.valueOf(unit.getFileName()) + ", some units may be missing in the model: " + e.getMessage());
+					}
 				}
 					getEnvironment().getSpoonProgress().step(process, unitPath, ++i, unitList.size());
 			}


### PR DESCRIPTION
A common issue that I get while analysing big projects is that the analysis fails just because a few files contain issues, or special characters that are not allowed by the Java compiler: like for example archetype resource files:

```Java
#set( $symbol_pound = '#' )
#set( $symbol_dollar = '$' )
#set( $symbol_escape = '\' )

import ${package}.path.to.Clazz;
```

This very simple modification ensures that Spoon provides a best-effort attempt at parsing a certain project without failing just because of one malformed file. In case an error occurs, a message is printed on the console, so the user is notified.

I am not very practical of Spoon's internals, so there might be better solutions to this. If that's the case, pointers on how to implement a better one are welcome :)