### PR TITLE
fix: Fix NullPointerException in SniperJavaPrettyPrinter.printTypes

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import java.util.Optional;
 
 import spoon.OutputType;
 import spoon.SpoonException;
@@ -113,7 +112,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 
 	@Override
 	public String printTypes(CtType<?>... type) {
-	    CtCompilationUnit cu = getUnambiguousCompilationUnit(type);
+		CtCompilationUnit cu = getUnambiguousCompilationUnit(type);
 		calculate(cu, Arrays.asList(type));
 		return getResult();
 	}

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -8,6 +8,7 @@
 package spoon.support.sniper;
 
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
@@ -106,6 +107,16 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	 */
 	private TokenWriter createTokenWriterListener(TokenWriter tokenWriter) {
 		return new TokenWriterProxy(this, tokenWriter);
+	}
+
+	@Override
+	public String printTypes(CtType<?>... type) {
+		CtCompilationUnit cu = Arrays.stream(type)
+				.map(ctType -> ctType.getFactory().CompilationUnit().getOrCreate(ctType))
+				.findFirst()
+				.orElseThrow(IllegalArgumentException::new);
+		calculate(cu, Arrays.asList(type));
+		return getResult();
 	}
 
 	@Override

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -357,7 +357,7 @@ public class TestSniperPrinter {
 	 * @param resultChecker a code which checks that printed sources are as expected
 	 */
 	private void testSniper(String testClass, Consumer<CtType<?>> transformation, BiConsumer<CtType<?>, String> resultChecker) {
-	    Launcher launcher = createLauncherWithSniperPrinter();
+		Launcher launcher = createLauncherWithSniperPrinter();
 		launcher.addInputResource(getResourcePath(testClass));
 		launcher.buildModel();
 		Factory f = launcher.getFactory();

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -348,6 +348,26 @@ public class TestSniperPrinter {
 		});
 	}
 
+	@Test
+	public void testPrintTypesThrowsWhenPassedTypesFromMultipleCompilationUnits() {
+		// contract: printTypes() should raise an IllegalArgumentException if it is passed types
+		// from multiple CUs
+
+		Launcher launcher = createLauncherWithSniperPrinter();
+		// there is no particular reason for the choice of these two resources, other than that
+		// they are different from each other and existed at the time of writing this test
+		launcher.addInputResource(getResourcePath("visibility.YamlRepresenter"));
+		launcher.addInputResource(getResourcePath("spoon.test.variable.Tacos"));
+		CtType<?>[] types = launcher.buildModel().getAllTypes().toArray(new CtType<?>[0]);
+
+		try {
+			launcher.getEnvironment().createPrettyPrinter().printTypes(types);
+			fail("Expected an IllegalArgumentException");
+		} catch (IllegalArgumentException e) {
+		    // pass
+		}
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -328,6 +328,26 @@ public class TestSniperPrinter {
 		});
 	}
 
+	@Test
+	public void testPrintTypesProducesFullOutputForSingleTypeCompilationUnit() {
+		// contract: printTypes() should produce the same output as launcher.prettyprint() for a
+		// single-type compilation unit
+
+		// there is no particular reason for using the YamlRepresenter resource, it simply already
+		// existed and filled the role it needed to
+		String resourceName = "visibility.YamlRepresenter";
+		String inputPath = getResourcePath(resourceName);
+
+		Launcher printTypesLauncher = createLauncherWithSniperPrinter();
+		printTypesLauncher.addInputResource(inputPath);
+		printTypesLauncher.buildModel();
+		String printTypesString = printTypesLauncher.createPrettyPrinter().printTypes(printTypesLauncher.getModel().getAllTypes().toArray(new CtType[0]));
+
+		testSniper(resourceName, ctType -> {}, (type, prettyPrint) -> {
+			assertEquals(prettyPrint, printTypesString);
+		});
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,
@@ -337,20 +357,8 @@ public class TestSniperPrinter {
 	 * @param resultChecker a code which checks that printed sources are as expected
 	 */
 	private void testSniper(String testClass, Consumer<CtType<?>> transformation, BiConsumer<CtType<?>, String> resultChecker) {
-		Launcher launcher = new Launcher();
+	    Launcher launcher = createLauncherWithSniperPrinter();
 		launcher.addInputResource(getResourcePath(testClass));
-		launcher.getEnvironment().setPrettyPrinterCreator(() -> {
-			SniperJavaPrettyPrinter printer = new SniperJavaPrettyPrinter(launcher.getEnvironment());
-			printer.setPreprocessors(Collections.unmodifiableList(Arrays.<Processor<CtElement>>asList(
-					//remove unused imports first. Do not add new imports at time when conflicts are not resolved
-					new ImportCleaner().setCanAddImports(false),
-					//solve conflicts, the current imports are relevant too
-					new ImportConflictDetector(),
-					//compute final imports
-					new ImportCleaner()
-				)));
-			return printer;
-		});
 		launcher.buildModel();
 		Factory f = launcher.getFactory();
 
@@ -364,6 +372,23 @@ public class TestSniperPrinter {
 
 		//check the printed file
 		resultChecker.accept(ctClass, getContentOfPrettyPrintedClassFromDisk(ctClass));
+	}
+
+	private static Launcher createLauncherWithSniperPrinter() {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setPrettyPrinterCreator(() -> {
+			SniperJavaPrettyPrinter printer = new SniperJavaPrettyPrinter(launcher.getEnvironment());
+			printer.setPreprocessors(Collections.unmodifiableList(Arrays.<Processor<CtElement>>asList(
+					//remove unused imports first. Do not add new imports at time when conflicts are not resolved
+					new ImportCleaner().setCanAddImports(false),
+					//solve conflicts, the current imports are relevant too
+					new ImportConflictDetector(),
+					//compute final imports
+					new ImportCleaner()
+			)));
+			return printer;
+		});
+		return launcher;
 	}
 
 	private String getContentOfPrettyPrintedClassFromDisk(CtType<?> type) {

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -341,7 +341,8 @@ public class TestSniperPrinter {
 		Launcher printTypesLauncher = createLauncherWithSniperPrinter();
 		printTypesLauncher.addInputResource(inputPath);
 		printTypesLauncher.buildModel();
-		String printTypesString = printTypesLauncher.createPrettyPrinter().printTypes(printTypesLauncher.getModel().getAllTypes().toArray(new CtType[0]));
+		String printTypesString = printTypesLauncher.createPrettyPrinter()
+				.printTypes(printTypesLauncher.getModel().getAllTypes().toArray(new CtType[0]));
 
 		testSniper(resourceName, ctType -> {}, (type, prettyPrint) -> {
 			assertEquals(prettyPrint, printTypesString);


### PR DESCRIPTION
Fix #3675 

This PR fixes the problem explained in #3675 by overriding `printTypes` in `SniperJavaPrettyPrinter`, and trying to resolve a compilation unit from the types passed in. If no compilation unit can be found, or the types have mismatching compilation units, it raises an exception. Two new tests verify the behavior within a reasonable amount of certainty.