### PR TITLE
fix Jar execution on Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,9 @@
                     <manifest>
                         <mainClass>spoon.Launcher</mainClass>
                     </manifest>
+                    <manifestEntries>
+                      <Multi-Release>true</Multi-Release>
+                    </manifestEntries>
                 </archive>
                 <descriptorRefs>
                     <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
### Problem

One cannot use the Jar in Java 11, this crashes as follows, see [bug report](https://github.com/INRIA/spoon/issues/3514#issuecomment-667580825) from @layornos

```
$ java -jar target/spoon-core-8.4.0-SNAPSHOT-jar-with-dependencies.jar 
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/logging/log4j/util/StackLocator$FqcnCallerLocator
	at org.apache.logging.log4j.util.StackLocator.<clinit>(StackLocator.java:37)
	at org.apache.logging.log4j.util.StackLocatorUtil.<clinit>(StackLocatorUtil.java:33)
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:588)
	at spoon.Launcher.<clinit>(Launcher.java:589)
Caused by: java.lang.ClassNotFoundException: org.apache.logging.log4j.util.StackLocator$FqcnCallerLocator
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 4 more
```

### Root cause

Log4J works poorly on Java 11, and requires a multi-release mode, see https://stackoverflow.com/questions/53049346/is-log4j2-compatible-with-java-11

## Fix

add the multi-release info in the manifest

Thougts: we may want to move away from Log4J.
