### PR TITLE
Review: Fix(CtCase): add fix for missing parents

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -93,6 +93,7 @@ public class CtCaseImpl<E> extends CtStatementImpl implements CtCase<E> {
 			setCaseExpression(caseExpression);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, CtRole.CASE, caseExpressions, this.caseExpressions);
+		caseExpression.setParent(this);
 		this.caseExpressions.add(caseExpression);
 		return (T) this;
 	}

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -112,6 +112,17 @@ public class SwitchCaseTest {
 				assertEquals(String.class.getName(), aCase.getCaseExpression().getType().getTypeDeclaration().getQualifiedName());
 			}
 		}
+		@DisplayName("Parent is set")
+		@Test
+		public void testParentInCaseExpressions() {
+				// contract: for all expressions in a case, the parent is set.
+				Launcher launcher = new Launcher();
+				launcher.getEnvironment().setComplianceLevel(14);
+				launcher.addInputResource(new VirtualFile("class A { { int x = switch(1) { case 1, 3 -> 0; default -> 1}; } }"));
+				launcher.buildModel();
+				List<CtLiteral<?>> caseStatement = launcher.getModel().getElements(new TypeFilter<>(CtLiteral.class));
+				assertTrue(caseStatement.stream().allMatch(CtLiteral::isParentInitialized));
+		}
 	}
 
 


### PR DESCRIPTION
Potential fix for #3680. I'm unsure why the problem lived for so long, but setting the parent in `addCaseExpression` should fix it. Is there any other place the parent should have been set?