### PR TITLE
fix: Fix sniper printing of comments when changing modifiers

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -197,7 +197,7 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 
 						if (childAtIdxIsModifiedCollectionSourceFragment(i + 1)) {
 							// This is typically when the next child is a modified modifier list.
-						    // We must forcibly print a linefeed in this case, as the linefeed
+							// We must forcibly print a linefeed in this case, as the linefeed
 							// is part of the collection fragment and will thus not be printed with
 							// the comment, nor with the collection fragment itself due to corner
 							// case of entering the collection fragment "too late".
@@ -231,8 +231,8 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	}
 
 	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
-		SourceFragment nextElement = idx < childFragments.size() ?
-				childFragments.get(idx) : null;
+		SourceFragment nextElement = idx < childFragments.size()
+				? childFragments.get(idx) : null;
 		return nextElement instanceof CollectionSourceFragment
 				&& isFragmentModified(nextElement) != ModificationStatus.NOT_MODIFIED;
 	}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -194,6 +194,7 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 							//comment is not modified write origin sources
 							mutableTokenWriter.write(fragment.getSourceCode());
 						}
+						//we printed the comment, so we can print next space too
 						canPrintSpace = true;
 					} else {
 						//comment was remove

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -41,8 +41,6 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	//If next element is new, then run collected separator actions to print DJPP separators
 	protected final List<Runnable> separatorActions = new ArrayList<>();
 
-	private List<Integer> commentFragmentsToBePrinted = new ArrayList<>();
-
 	protected AbstractSourceFragmentPrinter(MutableTokenWriter mutableTokenWriter, ChangeResolver changeResolver, List<SourceFragment> childFragments) {
 		this.mutableTokenWriter = mutableTokenWriter;
 		this.changeResolver = changeResolver;
@@ -103,10 +101,6 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			//note: DJPP sends comments in wrong order/wrong place.
 			//so skip printing of this comment
 			//comment will be printed at place where it belongs to - together with spaces
-
-			// sometimes when the element directly succeeding the comment is deleted, the comment is lost,
-			// and so we must keep track of all comments to be printed
-			commentFragmentsToBePrinted.add(fragmentIndex);
 			return -1;
 		} else if (event.getRole() == CtRole.DECLARED_IMPORT && fragmentIndex == 0) {
 			// this is the first pre-existing import statement, and so we must print all newline
@@ -182,13 +176,10 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	 * @param toIndex index of first not processed fragment.
 	 */
 	protected void printOriginSpacesUntilFragmentIndex(int fromIndex, int toIndex) {
-		int adjustedFromIndex = Math.min(commentFragmentsToBePrinted.isEmpty() ?
-				fromIndex : commentFragmentsToBePrinted.get(0), fromIndex);
-
 		//print all not yet printed comments which still exist in parent
 		boolean canPrintSpace = true;
 		boolean skipSpaceAfterDeletedElement = false;
-		for (int i = adjustedFromIndex; i < toIndex; i++) {
+		for (int i = fromIndex; i < toIndex; i++) {
 			SourceFragment fragment = childFragments.get(i);
 			if (fragment instanceof ElementSourceFragment) {
 				ElementSourceFragment sourceFragment = (ElementSourceFragment) fragment;
@@ -229,7 +220,6 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			}
 		}
 		separatorActions.clear();
-		commentFragmentsToBePrinted.clear();
 	}
 
 	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
@@ -335,16 +325,6 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			return i + 1;
 		}
 		return 0;
-	}
-
-	private boolean elementExists(SourceFragment fragment) {
-		if (fragment instanceof ElementSourceFragment) {
-			return changeResolver.isElementExists(((ElementSourceFragment) fragment).getElement());
-		} else if (fragment instanceof CollectionSourceFragment) {
-			return ((CollectionSourceFragment) fragment).getItems().stream().anyMatch(this::elementExists);
-		} else {
-			return true;
-		}
 	}
 
 	@Override

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -182,8 +182,8 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	 * @param toIndex index of first not processed fragment.
 	 */
 	protected void printOriginSpacesUntilFragmentIndex(int fromIndex, int toIndex) {
-		int adjustedFromIndex = Math.min(commentFragmentsToBePrinted.isEmpty()
-				? fromIndex : commentFragmentsToBePrinted.get(0), fromIndex);
+		int adjustedFromIndex = Math.min(commentFragmentsToBePrinted.isEmpty() ?
+				fromIndex : commentFragmentsToBePrinted.get(0), fromIndex);
 
 		//print all not yet printed comments which still exist in parent
 		boolean canPrintSpace = true;
@@ -233,8 +233,8 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	}
 
 	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
-		SourceFragment nextElement = idx < childFragments.size()
-				? childFragments.get(idx) : null;
+		SourceFragment nextElement = idx < childFragments.size() ?
+				childFragments.get(idx) : null;
 		return nextElement instanceof CollectionSourceFragment
 				&& isFragmentModified(nextElement) != ModificationStatus.NOT_MODIFIED;
 	}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -193,6 +193,9 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 						} else {
 							//comment is not modified write origin sources
 							mutableTokenWriter.write(fragment.getSourceCode());
+							if (childAtIdxIsModifiedCollectionSourceFragment(i + 1)) {
+								mutableTokenWriter.directPrint("\n");
+							}
 						}
 						//we printed the comment, so we can print next space too
 						canPrintSpace = true;
@@ -217,6 +220,13 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			}
 		}
 		separatorActions.clear();
+	}
+
+	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
+		SourceFragment nextElement = idx < childFragments.size() ?
+				childFragments.get(idx) : null;
+		return nextElement instanceof CollectionSourceFragment
+				&& isFragmentModified(nextElement) != ModificationStatus.NOT_MODIFIED;
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -193,12 +193,18 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 						} else {
 							//comment is not modified write origin sources
 							mutableTokenWriter.write(fragment.getSourceCode());
-							if (childAtIdxIsModifiedCollectionSourceFragment(i + 1)) {
-								mutableTokenWriter.directPrint("\n");
-							}
 						}
-						//we printed the comment, so we can print next space too
-						canPrintSpace = true;
+
+						if (childAtIdxIsModifiedCollectionSourceFragment(i + 1)) {
+							// This is typically when the next child is a modified modifier list.
+						    // We must forcibly print a linefeed in this case, as the linefeed
+							// is part of the collection fragment and will thus not be printed with
+							// the comment, nor with the collection fragment itself due to corner case.
+							mutableTokenWriter.directPrint("\n");
+						} else {
+							//we printed the comment, so we can print next space too
+							canPrintSpace = true;
+						}
 					} else {
 						//comment was remove
 						//avoid printing of spaces between removed comments

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -182,8 +182,8 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	 * @param toIndex index of first not processed fragment.
 	 */
 	protected void printOriginSpacesUntilFragmentIndex(int fromIndex, int toIndex) {
-		int adjustedFromIndex = Math.min(commentFragmentsToBePrinted.isEmpty() ?
-				fromIndex : commentFragmentsToBePrinted.get(0), fromIndex);
+		int adjustedFromIndex = Math.min(commentFragmentsToBePrinted.isEmpty()
+				? fromIndex : commentFragmentsToBePrinted.get(0), fromIndex);
 
 		//print all not yet printed comments which still exist in parent
 		boolean canPrintSpace = true;
@@ -233,8 +233,8 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	}
 
 	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
-		SourceFragment nextElement = idx < childFragments.size() ?
-				childFragments.get(idx) : null;
+		SourceFragment nextElement = idx < childFragments.size()
+				? childFragments.get(idx) : null;
 		return nextElement instanceof CollectionSourceFragment
 				&& isFragmentModified(nextElement) != ModificationStatus.NOT_MODIFIED;
 	}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -194,19 +194,7 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 							//comment is not modified write origin sources
 							mutableTokenWriter.write(fragment.getSourceCode());
 						}
-
-						if (childAtIdxIsModifiedCollectionSourceFragment(i + 1)) {
-							// This is typically when the next child is a modified modifier list.
-							// We must forcibly print a linefeed in this case, as the linefeed
-							// is part of the collection fragment and will thus not be printed with
-							// the comment, nor with the collection fragment itself due to corner
-							// case of entering the collection fragment "too late".
-							String lineSep = mutableTokenWriter.getPrinterHelper().getLineSeparator();
-							mutableTokenWriter.directPrint(lineSep);
-						} else {
-							//we printed the comment, so we can print next space too
-							canPrintSpace = true;
-						}
+						canPrintSpace = true;
 					} else {
 						//comment was remove
 						//avoid printing of spaces between removed comments
@@ -228,13 +216,6 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			}
 		}
 		separatorActions.clear();
-	}
-
-	private boolean childAtIdxIsModifiedCollectionSourceFragment(int idx) {
-		SourceFragment nextElement = idx < childFragments.size()
-				? childFragments.get(idx) : null;
-		return nextElement instanceof CollectionSourceFragment
-				&& isFragmentModified(nextElement) != ModificationStatus.NOT_MODIFIED;
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -199,8 +199,10 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 							// This is typically when the next child is a modified modifier list.
 						    // We must forcibly print a linefeed in this case, as the linefeed
 							// is part of the collection fragment and will thus not be printed with
-							// the comment, nor with the collection fragment itself due to corner case.
-							mutableTokenWriter.directPrint("\n");
+							// the comment, nor with the collection fragment itself due to corner
+							// case of entering the collection fragment "too late".
+							String lineSep = mutableTokenWriter.getPrinterHelper().getLineSeparator();
+							mutableTokenWriter.directPrint(lineSep);
 						} else {
 							//we printed the comment, so we can print next space too
 							canPrintSpace = true;

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -500,7 +500,7 @@ public class ElementSourceFragment implements SourceFragment {
 				foundRoles.add(checkNotNull(esf.getRoleInParent()));
 				List<SourceFragment> childrenInSameCollection = new ArrayList<>();
 				//but first include prefix whitespace
-				SourceFragment spaceChild = removeSuffixSpace(result);
+				SourceFragment spaceChild = removeNonCommentSuffixSpace(result);
 				if (spaceChild != null) {
 					childrenInSameCollection.add(spaceChild);
 				}
@@ -540,10 +540,16 @@ public class ElementSourceFragment implements SourceFragment {
 		return result;
 	}
 
-	private SourceFragment removeSuffixSpace(List<SourceFragment> list) {
+	/**
+	 * Remove any suffix space, except if it follows directly after a comment. As comments are
+	 * treated as whitespace, the suffix space must be considered part of the comment, or we
+	 * sometimes fail to print it.
+	 */
+	private SourceFragment removeNonCommentSuffixSpace(List<SourceFragment> list) {
 		if (list.size() > 0) {
 			SourceFragment lastChild = list.get(list.size() - 1);
-			if (isSpaceFragment(lastChild)) {
+			SourceFragment secondLastChild = list.size() > 1 ? list.get(list.size() - 2) : null;
+			if (isSpaceFragment(lastChild) && !isCommentFragment(secondLastChild)) {
 				list.remove(list.size() - 1);
 				return lastChild;
 			}

--- a/src/test/java/spoon/test/position/TestSourceFragment.java
+++ b/src/test/java/spoon/test/position/TestSourceFragment.java
@@ -235,8 +235,8 @@ public class TestSourceFragment {
 		checkElementFragments(foo.getMethodsByName("m3").get(0),
 				"/**\n" + 
 				"	 * c0\n" + 
-				"	 */", 
-				group("\n\t", "public", "\n\t", "@Deprecated", " ", "//c1 ends with tab and space\t ", "\n\t", "static"), " ", "/*c2*/", " ",
+				"	 */", "\n\t",
+				group("public", "\n\t", "@Deprecated", " ", "//c1 ends with tab and space\t ", "\n\t", "static"), " ", "/*c2*/", " ",
 				"<", group("T", ",", " ", "U"), ">",
 				" ", "T", " ", "m3", "(", group("U param", ",", " ", "@Deprecated int p2"), ")", " ", "{\n" + 
 						"		return null;\n" + 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -59,20 +59,13 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.isA;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TestSniperPrinter {
 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -58,6 +58,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
@@ -375,22 +376,22 @@ public class TestSniperPrinter {
 
 	@Test
 	public void testNewlineInsertedBetweenCommentAndTypeMemberWithAddedModifier() {
-		// contract: newline must be inserted after comment when a succeeding field has had a
+		// contract: newline must be inserted after comment when a succeeding type member has had a
 		// modifier added to it
 
-		Consumer<CtType<?>> addFinalModifier = type -> {
+		Consumer<CtType<?>> addModifiers = type -> {
 			type.getField("NON_FINAL_FIELD")
 					.addModifier(ModifierKind.FINAL);
 			type.getMethod("nonStaticMethod").addModifier(ModifierKind.STATIC);
 			type.getNestedType("NonStaticInnerClass").addModifier(ModifierKind.STATIC);
 		};
-		BiConsumer<CtType<?>, String> assertFieldCorrectlyPrinted = (type, result) -> {
+		BiConsumer<CtType<?>, String> assertCommentsCorrectlyPrinted = (type, result) -> {
 		    assertThat(result, containsString("// field comment\n"));
 			assertThat(result, containsString("// method comment\n"));
 			assertThat(result, containsString("// nested type comment\n"));
 		};
 
-		testSniper("TypeMemberComments", addFinalModifier, assertFieldCorrectlyPrinted);
+		testSniper("TypeMemberComments", addModifiers, assertCommentsCorrectlyPrinted);
 	}
 
 	@Test
@@ -398,7 +399,7 @@ public class TestSniperPrinter {
 		// contract: newline must be inserted after comment when a succeeding field has had a
 		// modifier removed from it
 
-		Consumer<CtType<?>> addFinalModifier = type -> {
+		Consumer<CtType<?>> removeModifier = type -> {
 			// we only test removing a modifier from the field in this test, as removing the
 			// last modifier leads to a different corner case where the comment disappears
 			// altogether
@@ -406,11 +407,32 @@ public class TestSniperPrinter {
 					.removeModifier(ModifierKind.PUBLIC);
 		};
 
-		BiConsumer<CtType<?>, String> assertFieldCorrectlyPrinted = (type, result) -> {
+		BiConsumer<CtType<?>, String> assertCommentCorrectlyPrinted = (type, result) -> {
 			assertThat(result, containsString("// field comment\n"));
 		};
 
-		testSniper("TypeMemberComments", addFinalModifier, assertFieldCorrectlyPrinted);
+		testSniper("TypeMemberComments", removeModifier, assertCommentCorrectlyPrinted);
+	}
+
+	@Test
+	public void testNewlineInsertedBetweenModifiedCommentAndTypeMemberWithAddedModifier() {
+		// contract: newline must be inserted after modified comment when a succeeding type member
+		// has had its modifier list modified. We test modified comments separately from
+		// non-modified comments as they are handled differently in the printer.
+
+		final String commentContent = "modified comment";
+
+		Consumer<CtType<?>> enactModifications = type -> {
+			CtField<?> field = type.getField("NON_FINAL_FIELD");
+			field.addModifier(ModifierKind.FINAL);
+			field.getComments().get(0).setContent(commentContent);
+		};
+
+		BiConsumer<CtType<?>, String> assertCommentCorrectlyPrinted = (type, result) -> {
+			assertThat(result, containsString("// " + commentContent + "\n"));
+		};
+
+		testSniper("TypeMemberComments", enactModifications, assertCommentCorrectlyPrinted);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -399,16 +399,15 @@ public class TestSniperPrinter {
 		// modifier removed from it
 
 		Consumer<CtType<?>> addFinalModifier = type -> {
+			// we only test removing a modifier from the field in this test, as removing the
+			// last modifier leads to a different corner case where the comment disappears
+			// altogether
 			type.getField("NON_FINAL_FIELD")
 					.removeModifier(ModifierKind.PUBLIC);
-			type.getMethod("nonStaticMethod").removeModifier(ModifierKind.PUBLIC);
-			type.getNestedType("NonStaticInnerClass").removeModifier(ModifierKind.PRIVATE);
 		};
 
 		BiConsumer<CtType<?>, String> assertFieldCorrectlyPrinted = (type, result) -> {
 			assertThat(result, containsString("// field comment\n"));
-			assertThat(result, containsString("// method comment\n"));
-			assertThat(result, containsString("// nested type comment\n"));
 		};
 
 		testSniper("TypeMemberComments", addFinalModifier, assertFieldCorrectlyPrinted);

--- a/src/test/resources/TypeMemberComments.java
+++ b/src/test/resources/TypeMemberComments.java
@@ -1,0 +1,14 @@
+public class TypeMemberComments {
+    // field comment
+    public static int NON_FINAL_FIELD = 42;
+
+    // method comment
+    public void nonStaticMethod() {
+
+    }
+
+    // nested type comment
+    private class NonStaticInnerClass {
+
+    }
+}


### PR DESCRIPTION
Fix #3697 

~This is heavily WIP, I don't have a fix yet. The problems are thoroughly described in #3697~

This PR introduces a fix for the problem of disappearing whitespace between comments and type members with modified modifier lists. For example, given the following commented type member:

```java
// this is a type member
private static int number = 2;
```

Adding a `final` modifier to the modifier list would result in the following print-out:

```java
// this is a type memberprivate static int number = 2;
```

The source fragments will look something like so:

```
"// this is a type member"
["\n\t", "private", "static"]
...
```
Where the comment is a normal `ElementSourceFragment` and the list is a `CollectionSourceFragment`. The reason the whitespace isn't printed is that the it becomes part of the `CollectionSourceFragment`. The problem with this is that the modifier list is only entered when the first modifier is encountered, in this case `private`, and then the preceeding whitespace is printed. But as the `CollectionSourceFragment` hasn't been entered, the only preceeding whitespace is the comment (which is treated as whitespace).

The fix this PR does is to make the whitespace its own separate source fragment, like so.

```
"// this is a type member"
"\n\t"
["private", "static"]
```

This fix is only applied when the whitespace preceding a `CollectionSourceFragment` is the suffix whitespace of a comment. This is the only case where I've found it to be necessary.

Ps. This explanation may seem overly long, but I'm documenting this mostly for myself if this causes a bug tomorrow, and I've forgotten all about it.