### PR TITLE
fix: Fix NullPointerException when allowing duplicate classes

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -75,7 +75,8 @@ class JDTTreeBuilderQuery {
 		for (CompilationUnitDeclaration unitToProcess : unitsToProcess) {
 			if (unitToProcess.types != null) {
 				for (TypeDeclaration type : unitToProcess.types) {
-					if (qualifiedName.equals(CharOperation.toString(type.binding.compoundName))) {
+					if (type.binding != null
+							&& qualifiedName.equals(CharOperation.toString(type.binding.compoundName))) {
 						return type.binding;
 					}
 					if (type.memberTypes != null) {

--- a/src/test/resources/duplicates-in-submodules/README.md
+++ b/src/test/resources/duplicates-in-submodules/README.md
@@ -1,0 +1,1 @@
+Test files to replicate https://github.com/INRIA/spoon/issues/3707

--- a/src/test/resources/duplicates-in-submodules/moduleA/duplicates/Duplicate.java
+++ b/src/test/resources/duplicates-in-submodules/moduleA/duplicates/Duplicate.java
@@ -1,0 +1,3 @@
+package duplicates;
+
+public class Duplicate {}

--- a/src/test/resources/duplicates-in-submodules/moduleA/duplicates/Main.java
+++ b/src/test/resources/duplicates-in-submodules/moduleA/duplicates/Main.java
@@ -1,0 +1,9 @@
+package duplicates;
+
+import duplicates.WithNestedEnum.NestedEnum;
+
+public class Main {
+    public static void main(String[] args) {
+        System.out.println(NestedEnum.YES.name());
+    }
+}

--- a/src/test/resources/duplicates-in-submodules/moduleA/duplicates/WithNestedEnum.java
+++ b/src/test/resources/duplicates-in-submodules/moduleA/duplicates/WithNestedEnum.java
@@ -1,0 +1,7 @@
+package duplicates;
+
+class WithNestedEnum {
+    public enum NestedEnum {
+        YES;
+    }
+}

--- a/src/test/resources/duplicates-in-submodules/moduleB/duplicates/Duplicate.java
+++ b/src/test/resources/duplicates-in-submodules/moduleB/duplicates/Duplicate.java
@@ -1,0 +1,3 @@
+package duplicates;
+
+public class Duplicate {}


### PR DESCRIPTION
Fix #3707 

This crash occurs very rarely. The requirement is that there is a _package private_ class B with a nested type C, and have some other class A import B.C and then make an unqualified access to some member C.someMember. At the samie time, there must be a duplicated class in the same package and `setIgnoreDuplicateDeclarations(true)` must be active. The import + access in type A forces Spoon to search for type C with `JDTTreeBuilderQuery::searchTypeBinding`, in which a `NullPointerException` would occur if there was a duplicated class that was processed before finding the sought type. The reason is that a duplicated class will have `binding = null`.

This does not happen if Spoon is not ignoring duplicates, because then an appropriate error on finding duplicate declarations is raised much earlier.

In the test case provided with this PR, `WithNestedEnum` is type B, `NestedEnum` is type C, and `Main` is type A. There is also a duplicated class `Duplicated`.

Fixing the bug was trivial, replicating it was hard :)
