### PR TITLE
review: feat: Make sniper printer infer indentation style of compilation unit

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -169,7 +169,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	}
 
 	private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> typeFragments) {
-		List<String> spacePrecedingTypeMember = new ArrayList<>();
+		List<String> wsPrecedingTypeMembers = new ArrayList<>();
 
 		for (ElementSourceFragment typeSource : typeFragments) {
 			assert typeSource.getRoleInParent() == CtRole.DECLARED_TYPE;
@@ -181,13 +181,17 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 					TokenSourceFragment cur = (TokenSourceFragment) children.get(i);
 					ElementSourceFragment next = (ElementSourceFragment) children.get(i + 1);
 					if (cur.getType() == TokenType.SPACE && next.getRoleInParent() == CtRole.TYPE_MEMBER) {
-						spacePrecedingTypeMember.add(cur.getSourceCode().replace("\n", ""));
+						wsPrecedingTypeMembers.add(cur.getSourceCode().replace("\n", ""));
 					}
 				}
 			}
 		}
 
-		double avgIndent = spacePrecedingTypeMember.stream()
+		return guessIndentationStyle(wsPrecedingTypeMembers);
+	}
+
+	private static Pair<Integer, Boolean> guessIndentationStyle(List<String> wsPrecedingTypeMembers) {
+		double avgIndent = wsPrecedingTypeMembers.stream()
 				.map(String::length)
 				.map(Double::valueOf)
 				.reduce((acc, next) -> (acc + next) / 2).orElse(4d);
@@ -203,10 +207,9 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 			indentationSize = 1;
 		}
 
-		boolean usesTabs = spacePrecedingTypeMember.stream()
+		boolean usesTabs = wsPrecedingTypeMembers.stream()
 				.filter(s -> s.contains("\t"))
-				.count() >= spacePrecedingTypeMember.size() / 2;
-
+				.count() >= wsPrecedingTypeMembers.size() / 2;
 		return Pair.of(indentationSize, usesTabs);
 	}
 

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -8,12 +8,10 @@
 package spoon.support.sniper;
 
 import java.util.ArrayDeque;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import spoon.OutputType;
@@ -48,7 +46,6 @@ import spoon.support.sniper.internal.SourceFragmentContextList;
 import spoon.support.sniper.internal.SourceFragmentContextNormal;
 import spoon.support.sniper.internal.DefaultSourceFragmentPrinter;
 import spoon.support.sniper.internal.TokenPrinterEvent;
-import spoon.support.sniper.internal.TokenSourceFragment;
 import spoon.support.sniper.internal.TokenType;
 import spoon.support.sniper.internal.TokenWriterProxy;
 import spoon.support.util.ModelList;

--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -24,7 +24,8 @@ public class IndentationDetector {
 	}
 
 	/**
-	 * Detect the indentation style of the given compilation unit as 1, 2 or 4 spaces or tabs.
+	 * Detect the indentation style of the given compilation unit as 1, 2 or 4 spaces or tabs by
+	 * inspecting the whitespace preceding type members of top-level type declarations.
 	 *
 	 * @param cu A compilation unit.
 	 * @return A pair on the form (indentationSize, isTabs)

--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -1,0 +1,90 @@
+/**
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
+ *
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.support.sniper.internal;
+
+import org.apache.commons.lang3.tuple.Pair;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.path.CtRole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class for detecting the indentation style used in a compilation unit.
+ */
+public class IndentationDetector {
+
+    /**
+     * Detect the indentation style of the given compilation unit as 1, 2 or 4 spaces or tabs.
+     *
+     * @param cu A compilation unit.
+     * @return A pair on the form (indentationSize, isTabs)
+     */
+    public static Pair<Integer, Boolean> detectIndentation(CtCompilationUnit cu) {
+        List<ElementSourceFragment> typeFragments = cu.getOriginalSourceFragment()
+                .getGroupedChildrenFragments().stream()
+                .filter(fragment -> fragment instanceof CollectionSourceFragment)
+                .flatMap(fragment -> extractTypeFragments((CollectionSourceFragment) fragment).stream())
+                .collect(Collectors.toList());
+        return detectIndentation(typeFragments);
+    }
+
+    private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> typeFragments) {
+        List<String> wsPrecedingTypeMembers = new ArrayList<>();
+
+        for (ElementSourceFragment typeSource : typeFragments) {
+            assert typeSource.getRoleInParent() == CtRole.DECLARED_TYPE;
+            List<SourceFragment> children = typeSource.getChildrenFragments();
+            for (int i = 0; i < children.size() - 1; i++) {
+                if (children.get(i) instanceof TokenSourceFragment
+                        && children.get(i + 1) instanceof ElementSourceFragment) {
+
+                    TokenSourceFragment cur = (TokenSourceFragment) children.get(i);
+                    ElementSourceFragment next = (ElementSourceFragment) children.get(i + 1);
+                    if (cur.getType() == TokenType.SPACE && next.getRoleInParent() == CtRole.TYPE_MEMBER) {
+                        wsPrecedingTypeMembers.add(cur.getSourceCode().replace("\n", ""));
+                    }
+                }
+            }
+        }
+
+        return guessIndentationStyle(wsPrecedingTypeMembers);
+    }
+
+    private static Pair<Integer, Boolean> guessIndentationStyle(List<String> wsPrecedingTypeMembers) {
+        double avgIndent = wsPrecedingTypeMembers.stream()
+                .map(String::length)
+                .map(Double::valueOf)
+                .reduce((acc, next) -> (acc + next) / 2).orElse(4d);
+
+        double diff1 = Math.abs(1d - avgIndent);
+        double diff2 = Math.abs(2d - avgIndent);
+        double diff4 = Math.abs(4d - avgIndent);
+
+        int indentationSize;
+        if (diff1 > diff2) {
+            indentationSize = diff2 > diff4 ? 4 : 2;
+        } else {
+            indentationSize = 1;
+        }
+
+        boolean usesTabs = wsPrecedingTypeMembers.stream()
+                .filter(s -> s.contains("\t"))
+                .count() > wsPrecedingTypeMembers.size() / 2;
+        return Pair.of(indentationSize, usesTabs);
+    }
+
+    private static List<ElementSourceFragment> extractTypeFragments(CollectionSourceFragment collection) {
+        return collection.getItems().stream()
+                .filter(fragment -> fragment instanceof ElementSourceFragment)
+                .map(fragment -> (ElementSourceFragment) fragment)
+                .filter(fragment -> fragment.getRoleInParent() == CtRole.DECLARED_TYPE)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -16,76 +16,79 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Class for detecting the indentation style used in a compilation unit.
+ * Utility class for detecting the indentation style used in a compilation unit.
  */
 public class IndentationDetector {
 
-    /**
-     * Detect the indentation style of the given compilation unit as 1, 2 or 4 spaces or tabs.
-     *
-     * @param cu A compilation unit.
-     * @return A pair on the form (indentationSize, isTabs)
-     */
-    public static Pair<Integer, Boolean> detectIndentation(CtCompilationUnit cu) {
-        List<ElementSourceFragment> typeFragments = cu.getOriginalSourceFragment()
-                .getGroupedChildrenFragments().stream()
-                .filter(fragment -> fragment instanceof CollectionSourceFragment)
-                .flatMap(fragment -> extractTypeFragments((CollectionSourceFragment) fragment).stream())
-                .collect(Collectors.toList());
-        return detectIndentation(typeFragments);
-    }
+	private IndentationDetector() {
+	}
 
-    private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> topLevelTypeFragments) {
-        List<String> wsPrecedingTypeMembers = new ArrayList<>();
+	/**
+	 * Detect the indentation style of the given compilation unit as 1, 2 or 4 spaces or tabs.
+	 *
+	 * @param cu A compilation unit.
+	 * @return A pair on the form (indentationSize, isTabs)
+	 */
+	public static Pair<Integer, Boolean> detectIndentation(CtCompilationUnit cu) {
+		List<ElementSourceFragment> typeFragments = cu.getOriginalSourceFragment()
+				.getGroupedChildrenFragments().stream()
+				.filter(fragment -> fragment instanceof CollectionSourceFragment)
+				.flatMap(fragment -> extractTypeFragments((CollectionSourceFragment) fragment).stream())
+				.collect(Collectors.toList());
+		return detectIndentation(typeFragments);
+	}
 
-        for (ElementSourceFragment typeSource : topLevelTypeFragments) {
-            assert typeSource.getRoleInParent() == CtRole.DECLARED_TYPE;
+	private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> topLevelTypeFragments) {
+		List<String> wsPrecedingTypeMembers = new ArrayList<>();
 
-            List<SourceFragment> children = typeSource.getChildrenFragments();
-            for (int i = 0; i < children.size() - 1; i++) {
-                if (children.get(i) instanceof TokenSourceFragment
-                        && children.get(i + 1) instanceof ElementSourceFragment) {
+		for (ElementSourceFragment typeSource : topLevelTypeFragments) {
+			assert typeSource.getRoleInParent() == CtRole.DECLARED_TYPE;
 
-                    TokenSourceFragment cur = (TokenSourceFragment) children.get(i);
-                    ElementSourceFragment next = (ElementSourceFragment) children.get(i + 1);
-                    if (cur.getType() == TokenType.SPACE && next.getRoleInParent() == CtRole.TYPE_MEMBER) {
-                        wsPrecedingTypeMembers.add(cur.getSourceCode().replace("\n", ""));
-                    }
-                }
-            }
-        }
+			List<SourceFragment> children = typeSource.getChildrenFragments();
+			for (int i = 0; i < children.size() - 1; i++) {
+				if (children.get(i) instanceof TokenSourceFragment
+						&& children.get(i + 1) instanceof ElementSourceFragment) {
 
-        return guessIndentationStyle(wsPrecedingTypeMembers);
-    }
+					TokenSourceFragment cur = (TokenSourceFragment) children.get(i);
+					ElementSourceFragment next = (ElementSourceFragment) children.get(i + 1);
+					if (cur.getType() == TokenType.SPACE && next.getRoleInParent() == CtRole.TYPE_MEMBER) {
+						wsPrecedingTypeMembers.add(cur.getSourceCode().replace("\n", ""));
+					}
+				}
+			}
+		}
 
-    private static Pair<Integer, Boolean> guessIndentationStyle(List<String> wsPrecedingTypeMembers) {
-        double avgIndent = wsPrecedingTypeMembers.stream()
-                .map(String::length)
-                .map(Double::valueOf)
-                .reduce((acc, next) -> (acc + next) / 2).orElse(1d);
+		return guessIndentationStyle(wsPrecedingTypeMembers);
+	}
 
-        double diff1 = Math.abs(1d - avgIndent);
-        double diff2 = Math.abs(2d - avgIndent);
-        double diff4 = Math.abs(4d - avgIndent);
+	private static Pair<Integer, Boolean> guessIndentationStyle(List<String> wsPrecedingTypeMembers) {
+		double avgIndent = wsPrecedingTypeMembers.stream()
+				.map(String::length)
+				.map(Double::valueOf)
+				.reduce((acc, next) -> (acc + next) / 2).orElse(1d);
 
-        int indentationSize;
-        if (diff1 > diff2) {
-            indentationSize = diff2 > diff4 ? 4 : 2;
-        } else {
-            indentationSize = 1;
-        }
+		double diff1 = Math.abs(1d - avgIndent);
+		double diff2 = Math.abs(2d - avgIndent);
+		double diff4 = Math.abs(4d - avgIndent);
 
-        boolean usesTabs = wsPrecedingTypeMembers.stream()
-                .filter(s -> s.contains("\t"))
-                .count() >= wsPrecedingTypeMembers.size() / 2;
-        return Pair.of(indentationSize, usesTabs);
-    }
+		int indentationSize;
+		if (diff1 > diff2) {
+			indentationSize = diff2 > diff4 ? 4 : 2;
+		} else {
+			indentationSize = 1;
+		}
 
-    private static List<ElementSourceFragment> extractTypeFragments(CollectionSourceFragment collection) {
-        return collection.getItems().stream()
-                .filter(fragment -> fragment instanceof ElementSourceFragment)
-                .map(fragment -> (ElementSourceFragment) fragment)
-                .filter(fragment -> fragment.getRoleInParent() == CtRole.DECLARED_TYPE)
-                .collect(Collectors.toList());
-    }
+		boolean usesTabs = wsPrecedingTypeMembers.stream()
+				.filter(s -> s.contains("\t"))
+				.count() >= wsPrecedingTypeMembers.size() / 2;
+		return Pair.of(indentationSize, usesTabs);
+	}
+
+	private static List<ElementSourceFragment> extractTypeFragments(CollectionSourceFragment collection) {
+		return collection.getItems().stream()
+				.filter(fragment -> fragment instanceof ElementSourceFragment)
+				.map(fragment -> (ElementSourceFragment) fragment)
+				.filter(fragment -> fragment.getRoleInParent() == CtRole.DECLARED_TYPE)
+				.collect(Collectors.toList());
+	}
 }

--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -35,11 +35,12 @@ public class IndentationDetector {
         return detectIndentation(typeFragments);
     }
 
-    private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> typeFragments) {
+    private static Pair<Integer, Boolean> detectIndentation(List<ElementSourceFragment> topLevelTypeFragments) {
         List<String> wsPrecedingTypeMembers = new ArrayList<>();
 
-        for (ElementSourceFragment typeSource : typeFragments) {
+        for (ElementSourceFragment typeSource : topLevelTypeFragments) {
             assert typeSource.getRoleInParent() == CtRole.DECLARED_TYPE;
+
             List<SourceFragment> children = typeSource.getChildrenFragments();
             for (int i = 0; i < children.size() - 1; i++) {
                 if (children.get(i) instanceof TokenSourceFragment
@@ -61,7 +62,7 @@ public class IndentationDetector {
         double avgIndent = wsPrecedingTypeMembers.stream()
                 .map(String::length)
                 .map(Double::valueOf)
-                .reduce((acc, next) -> (acc + next) / 2).orElse(4d);
+                .reduce((acc, next) -> (acc + next) / 2).orElse(1d);
 
         double diff1 = Math.abs(1d - avgIndent);
         double diff2 = Math.abs(2d - avgIndent);
@@ -76,7 +77,7 @@ public class IndentationDetector {
 
         boolean usesTabs = wsPrecedingTypeMembers.stream()
                 .filter(s -> s.contains("\t"))
-                .count() > wsPrecedingTypeMembers.size() / 2;
+                .count() >= wsPrecedingTypeMembers.size() / 2;
         return Pair.of(indentationSize, usesTabs);
     }
 

--- a/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
+++ b/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
@@ -48,7 +48,9 @@ public class MutableTokenWriter implements TokenWriter {
 			int setTabulationSize = env.getTabulationSize();
 			env.useTabulations(originSourceUsesTabulations);
 			env.setTabulationSize(originSourceTabulationSize);
+
 			super.autoWriteTabs();
+
 			env.setTabulationSize(setTabulationSize);
 			env.useTabulations(true);
 		}

--- a/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
+++ b/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
@@ -22,8 +22,36 @@ public class MutableTokenWriter implements TokenWriter {
 	private final TokenWriter delegate;
 	private boolean muted = false;
 
+	// indentation style to use for new elements
+	private boolean originSourceUsesTabulations;
+	private int originSourceTabulationSize;
+
 	public MutableTokenWriter(Environment env) {
-		this.delegate = new DefaultTokenWriter(new PrinterHelper(env));
+		this.delegate = new DefaultTokenWriter(new SniperPrinterHelper(env));
+		originSourceUsesTabulations = true;
+		originSourceTabulationSize = 1;
+	}
+
+	private class SniperPrinterHelper extends PrinterHelper {
+		private final Environment env;
+
+		SniperPrinterHelper(Environment env) {
+			super(env);
+			this.env = env;
+		}
+
+		/**
+		 * We override this method to use the correct style of indentation for new elements.
+		 */
+		@Override
+		protected void autoWriteTabs() {
+			int setTabulationSize = env.getTabulationSize();
+			env.useTabulations(originSourceUsesTabulations);
+			env.setTabulationSize(originSourceTabulationSize);
+			super.autoWriteTabs();
+			env.setTabulationSize(setTabulationSize);
+			env.useTabulations(true);
+		}
 	}
 
 	/**
@@ -38,6 +66,14 @@ public class MutableTokenWriter implements TokenWriter {
 	 */
 	public void setMuted(boolean muted) {
 		this.muted = muted;
+	}
+
+	public void setOriginSourceUsesTabulations(boolean originSourceUsesTabulations) {
+		this.originSourceUsesTabulations = originSourceUsesTabulations;
+	}
+
+	public void setOriginSourceTabulationSize(int originSourceTabulationSize) {
+		this.originSourceTabulationSize = originSourceTabulationSize;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
+++ b/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
@@ -68,10 +68,16 @@ public class MutableTokenWriter implements TokenWriter {
 		this.muted = muted;
 	}
 
+	/**
+	 * @param originSourceUsesTabulations whether or not the origin source uses tabs for indentation.
+	 */
 	public void setOriginSourceUsesTabulations(boolean originSourceUsesTabulations) {
 		this.originSourceUsesTabulations = originSourceUsesTabulations;
 	}
 
+	/**
+	 * @param originSourceTabulationSize the amount of indentation used in the origin source.
+	 */
 	public void setOriginSourceTabulationSize(int originSourceTabulationSize) {
 		this.originSourceTabulationSize = originSourceTabulationSize;
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -446,6 +446,20 @@ public class TestSniperPrinter {
 		testSniper("indentation.FourSpaces", addElements, assertFourSpaces);
 	}
 
+	@Test
+	public void testDefaultsToSingleTabIndentationWhenThereAreNoTypeMembers() {
+		// contract: if there are no type members in a compilation unit, the sniper printer defaults
+		// to indenting with 1 tab
+
+		Consumer<CtType<?>> addField = type -> {
+			Factory fact = type.getFactory();
+			fact.createField(type, new HashSet<>(), fact.Type().INTEGER_PRIMITIVE, "z", fact.createLiteral(3));
+		};
+		testSniper("indentation.NoTypeMembers", addField, (type, result) -> {
+			assertThat(result, containsString("\n\tint z = 3;"));
+		});
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/resources/indentation/FourSpaces.java
+++ b/src/test/resources/indentation/FourSpaces.java
@@ -1,0 +1,10 @@
+package indentation;
+
+public class FourSpaces {
+    private int x = 1;
+    private int y = 2;
+
+    public int sum() {
+        return x + y;
+    }
+}

--- a/src/test/resources/indentation/NoTypeMembers.java
+++ b/src/test/resources/indentation/NoTypeMembers.java
@@ -1,0 +1,4 @@
+package indentation;
+
+public class NoTypeMembers {
+}

--- a/src/test/resources/indentation/Tabs.java
+++ b/src/test/resources/indentation/Tabs.java
@@ -1,0 +1,10 @@
+package indentation;
+
+public class Tabs {
+	private int x = 1;
+	private int y = 2;
+
+	public int sum() {
+		return x + y;
+	}
+}

--- a/src/test/resources/indentation/TwoSpaces.java
+++ b/src/test/resources/indentation/TwoSpaces.java
@@ -1,0 +1,10 @@
+package indentation;
+
+public class TwoSpaces {
+  private int x = 1;
+  private int y = 2;
+
+  public int sum() {
+    return x + y;
+  }
+}


### PR DESCRIPTION
Fix #3715 

This PR introduces indentation style inference to the sniper printer. It's simple in principle: look at the whitespace preceding the top-level type members and make a best guess as to what the indentation style is out of 1, 2 or 4 spaces/tabs. The original set of source code fragments are used to detect indentation.

If for any given compilation unit no top-level elements can be found, indentation detection defaults to tabs.

We will start using this ASAP in Sorald, preferably with the new beta release this Saturday if we can get it merged by then. Therefore, we should be able to detect any obvious issues this might introduce relatively quickly.

Note: This will crash and burn if you try to sniper print a compilation unit that does not have an origin source (e.g. if you add a CU through the Spoon API). That appears to be the case before this addition as well. Just thought I'd make note of it.