### PR TITLE
review: fix(sniper): Fix rounding error in indentation detection on single type member

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -79,9 +79,9 @@ public class IndentationDetector {
 			indentationSize = 1;
 		}
 
-		boolean usesTabs = wsPrecedingTypeMembers.stream()
+		boolean usesTabs = (double) wsPrecedingTypeMembers.stream()
 				.filter(s -> s.contains("\t"))
-				.count() >= wsPrecedingTypeMembers.size() / 2;
+				.count() >= (double) wsPrecedingTypeMembers.size() / 2;
 		return Pair.of(indentationSize, usesTabs);
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -420,7 +420,7 @@ public class TestSniperPrinter {
 	@Test
 	public void testAddedElementsIndentedWithAppropriateIndentationStyle() {
 		// contract: added elements in a source file should be indented with the same style of
-		// indentation as the rest of the file
+		// indentation as in the rest of the file
 
 		Consumer<CtType<?>> addElements = type -> {
 		    Factory fact = type.getFactory();

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -447,6 +447,29 @@ public class TestSniperPrinter {
 	}
 
 	@Test
+	public void testAddedElementsIndentedWithAppropriateIndentationStyleWhenOnlyOneTypeMemberExists() {
+		// contract: added elements in a source file should be indented with the same style of
+		// indentation as the single type member, when there is only one type member.
+
+		Consumer<CtType<?>> addElement = type -> {
+			Factory fact = type.getFactory();
+			fact.createField(type, new HashSet<>(), fact.Type().INTEGER_PRIMITIVE, "z", fact.createLiteral(2));
+		};
+		final String newField = "int z = 2;";
+
+		BiConsumer<CtType<?>, String> assertTabs = (type, result) ->
+				assertThat(result, containsString("\n\t" + newField));
+		BiConsumer<CtType<?>, String> assertTwoSpaces = (type, result) ->
+				assertThat(result, containsString("\n  " + newField));
+		BiConsumer<CtType<?>, String> assertFourSpaces = (type, result) ->
+				assertThat(result, containsString("\n    " + newField));
+
+		testSniper("indentation.singletypemember.Tabs", addElement, assertTabs);
+		testSniper("indentation.singletypemember.TwoSpaces", addElement, assertTwoSpaces);
+		testSniper("indentation.singletypemember.FourSpaces", addElement, assertFourSpaces);
+	}
+
+	@Test
 	public void testDefaultsToSingleTabIndentationWhenThereAreNoTypeMembers() {
 		// contract: if there are no type members in a compilation unit, the sniper printer defaults
 		// to indenting with 1 tab

--- a/src/test/resources/indentation/singletypemember/FourSpaces.java
+++ b/src/test/resources/indentation/singletypemember/FourSpaces.java
@@ -1,0 +1,5 @@
+package indentation.singletypemember;
+
+public class FourSpaces {
+    int x;
+}

--- a/src/test/resources/indentation/singletypemember/Tabs.java
+++ b/src/test/resources/indentation/singletypemember/Tabs.java
@@ -1,0 +1,5 @@
+package indentation.singletypemember;
+
+public class Tabs {
+	int x;
+}

--- a/src/test/resources/indentation/singletypemember/TwoSpaces.java
+++ b/src/test/resources/indentation/singletypemember/TwoSpaces.java
@@ -1,0 +1,5 @@
+package indentation.singletypemember;
+
+public class TwoSpaces {
+  int x;
+}


### PR DESCRIPTION
This fixes a rather silly rounding error in the indentation detection: if there's a single type member, `usesTabs = 1 / 2 = 0`. Therefore, a single type member will always be regarded as indented with tabs, regardless of actual indentation. It's extra silly because it affected the particular use case that I implemented the indentation detection for in the first place. Now explicitly uses doubles instead for the comparison.

Tiny rounding errors don't really matter here, in the general case there will either be 0 tabs or all tabs. It was just the massive rounding error of integer division of `1 / 2` that was problematic.