### PR TITLE
perf: handle some concurrency in ModelSet

### DIFF
--- a/src/main/java/spoon/support/util/ModelSet.java
+++ b/src/main/java/spoon/support/util/ModelSet.java
@@ -10,6 +10,7 @@ package spoon.support.util;
 import java.io.Serializable;
 import java.util.AbstractSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -35,7 +36,7 @@ public abstract class ModelSet<T extends CtElement> extends AbstractSet<T> imple
 	private final Set<T> set;
 
 	protected ModelSet(Comparator<? super CtElement> comparator) {
-		set = new TreeSet<>(comparator);
+		set = Collections.synchronizedSet(new TreeSet<>(comparator));
 	}
 
 	protected abstract CtElement getOwner();


### PR DESCRIPTION
Reading the model sometimes leads to it's modification: for example, `CtTypeReferenceImpl.getTypeDeclaration()` may start building a shadow type which is then added to the model. This causes modification of the `types` ModelSet in CtPackageImpl, which is backed by a TreeSet (which is in turn backed by a TreeMap). Thus a TreeMap can be modified concurrently when multiple threads try to get a type declaration (or an executable declaration), which sometimes [causes an infinite loop](https://ivoanjo.me/blog/2018/07/21/writing-to-a-java-treemap-concurrently-can-lead-to-an-infinite-loop-during-reads/).

This fix is mostly "treating the symptoms" and it doesn't provide sufficient synchronization across the library so ConcurrentModificationException is still possible, but it at least prevents the infinite loop.

This fix doesn't seem to have too much impact on performance (at least in the "real-world scenario" of building the model by a Launcher and then reading it by multiple threads).