### PR TITLE
fix: fix NPE in ReferenceBuilder#tryRecoverTypeArguments

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -598,19 +598,22 @@ public class ReferenceBuilder {
 		}
 
 		AllocationExpression alloc = (AllocationExpression) stack.peek().node;
-		if (alloc.expectedType() == null || !(alloc.expectedType() instanceof ParameterizedTypeBinding)) {
-			// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
-			// method, or in a method that did not expect a parameterized argument
-			type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.clone());
-		} else {
+		if (alloc.expectedType() instanceof ParameterizedTypeBinding) {
 			ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
-			// type arguments can be recovered from the expected type
-			for (TypeBinding binding : expectedType.typeArguments()) {
-				CtTypeReference<?> typeArgRef = getTypeReference(binding);
-				typeArgRef.setImplicit(true);
-				type.addActualTypeArgument(typeArgRef);
+			if (expectedType.typeArguments() != null) {
+				// type arguments can be recovered from the expected type
+				for (TypeBinding binding : expectedType.typeArguments()) {
+					CtTypeReference<?> typeArgRef = getTypeReference(binding);
+					typeArgRef.setImplicit(true);
+					type.addActualTypeArgument(typeArgRef);
+				}
 			}
+			return;
 		}
+
+		// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
+		// method, or in a method that did not expect a parameterized argument
+		type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.clone());
 	}
 
 	/**

--- a/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
+++ b/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
@@ -175,6 +175,11 @@ public class MethodReferenceTest {
 	}
 
 	@Test
+	public void testTryRecoverTypeArgumentsHandlesNullTypeArguments() {
+		canBeBuilt("./src/test/resources/ReferenceBuilder-null-pointer/", 8);
+	}
+
+	@Test
 	public void testNoClasspathExecutableReferenceExpression() {
 		final Launcher launcher = new Launcher();
 		launcher.run(new String[] {

--- a/src/test/resources/ReferenceBuilder-null-pointer/Foo.java
+++ b/src/test/resources/ReferenceBuilder-null-pointer/Foo.java
@@ -1,0 +1,10 @@
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class Foo {
+	public void accept(Collection y) {}
+
+	public void doSomething(Collection x) {
+		accept(new ArrayList<>(x));
+	}
+}


### PR DESCRIPTION
`ReferenceBuilder#tryRecoverTypeArguments` doesn't check whether `expectedType.typeArguments()` is null and crashes with an NPE. Could be a bug in JDT, but the check nevertheless should be there - [ParameterizedTypeBinding](https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.tests.model/workspace/Compiler/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java) has a lot of null-checks for this field.