### PR TITLE
chore(jdt): bump jdt version and fix testcase accordingly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.23.0</version>
+      <version>3.24.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -804,9 +804,8 @@ public class CommentTest {
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.getEnvironment().setCommentEnabled(true);
 
-		// TODO: Compliance level should be set at 15 and previews disabled
-		launcher.getEnvironment().setComplianceLevel(14);
-		launcher.getEnvironment().setPreviewFeaturesEnabled(true);
+		launcher.getEnvironment().setComplianceLevel(15);
+		// launcher.getEnvironment().setPreviewFeaturesEnabled(true);
 		
 		// interfaces.
 		launcher.addInputResource("./src/main/java/spoon/reflect/");


### PR DESCRIPTION
fixes #3731 
The fix was already as a todo there. JDT allows only for the latest java version preview features. Updating to version 15 and disabling preview features works for now. As soon as we implement java 15 preview features, we need to reenable them. 
As we discussed somewhere, some testhelpers could be super useful. 
```java
class JDTVersions {
/**
* Returns the latest jdt supported java version.
*/
String getLatestSupportedJavaVersion()

/**
* Checks if a jdt version supports preview features
*/
boolean String isPreviewSupported(String/int version)
}
```
This could remove a lot of hard coded versions from the test code. In many cases a latest version is what we want, but we simply write the latest current version. The supported jdt versions has some kind of api see [https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java#L3144](https://github.com/eclipse/eclipse.jdt.core/blob/master/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java#L3144) 
###  Location
I have no clue where testhelpers are placed inside the test folder. Any hints?
Currently SpoonTestHelpers is in spoon/test/ but maybe a clear folder inside /test for testhelpers is way more obvious to use?