### PR TITLE
fix: ParentNotInitializedException in AbstractTypingContext

### DIFF
--- a/src/main/java/spoon/support/visitor/AbstractTypingContext.java
+++ b/src/main/java/spoon/support/visitor/AbstractTypingContext.java
@@ -46,9 +46,12 @@ abstract class AbstractTypingContext implements GenericTypeAdapter {
 		if (!result.getActualTypeArguments().isEmpty()) {
 			//we have to adapt actual type arguments recursive too
 			if (isCopy == false) {
-				CtElement parent = result.getParent();
+				CtElement parent = result.isParentInitialized() ? result.getParent() : null;
 				result = result.clone();
-				result.setParent(parent);
+				if (parent != null) {
+					result.setParent(parent);
+				}
+
 				List<CtTypeReference<?>> actTypeArgs = new ArrayList<>(result.getActualTypeArguments());
 				for (int i = 0; i < actTypeArgs.size(); i++) {
 					CtTypeReference adaptedTypeArgs = adaptType(actTypeArgs.get(i));
@@ -72,7 +75,9 @@ abstract class AbstractTypingContext implements GenericTypeAdapter {
 
 	private CtTypeReference<?> adaptTypeParameterReferenceBoundingType(CtWildcardReference typeParamRef, CtTypeReference<?> boundingType) {
 		CtWildcardReference typeParamRefAdapted = typeParamRef.clone();
-		typeParamRefAdapted.setParent(typeParamRef.getParent());
+		if (typeParamRef.isParentInitialized()) {
+			typeParamRefAdapted.setParent(typeParamRef.getParent());
+		}
 		typeParamRefAdapted.setBoundingType(boundingType.equals(boundingType.getFactory().Type().getDefaultBoundingType()) ? boundingType.getFactory().Type().getDefaultBoundingType() : adaptType(boundingType));
 		return typeParamRefAdapted;
 	}


### PR DESCRIPTION
Semi-fix for #3734. Doesn't fix the cause of the issue, but at least fixes invalid element cloning logic. Though I'm not 100% sure whether no-parent elements should be handled or not. Anyway, in case they are supposed to be rejected there should be a separate check.