### PR TITLE
fix: correctly sniper-print type member comments after removal of all modifiers

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -10,7 +10,6 @@ package spoon.support.sniper.internal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Predicate;
 
 import spoon.SpoonException;
 import spoon.reflect.code.CtComment;
@@ -327,14 +326,10 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	 */
 	private boolean isUnprintedModifierCollectionFragment(int fragmentIndex, int lastPrintedIndex) {
 		SourceFragment fragment = childFragments.get(fragmentIndex);
-		if (!(fragment instanceof CollectionSourceFragment)) {
-			return false;
-		}
-
-		Predicate<SourceFragment> isModifierFragment = f -> f instanceof ElementSourceFragment
-				&& ((ElementSourceFragment) f).getRoleInParent() == CtRole.MODIFIER;
-		return ((CollectionSourceFragment) fragment).getItems().stream().anyMatch(isModifierFragment)
-				&& lastPrintedIndex < fragmentIndex;
+		return lastPrintedIndex < fragmentIndex
+				&& fragment instanceof CollectionSourceFragment
+				&& ((CollectionSourceFragment) fragment).getItems().stream()
+						.anyMatch(ElementSourceFragment::isModifierFragment);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -311,7 +311,7 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 			SourceFragment fragment = childFragments.get(i);
 			if (isSpaceFragment(fragment)
 					|| isCommentFragment(fragment)
-					|| isUnprintedModifierCollectionFragment(i, lastPrintedIndex)) {
+					|| isRecentlySkippedModifierCollectionFragment(i, lastPrintedIndex)) {
 				continue;
 			}
 			return i + 1;
@@ -320,11 +320,18 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	}
 
 	/**
+	 * Determines if the fragment at fragmentIndex is a "recently skipped" collection fragment
+	 * containing modifiers. "Recently skipped" entails that the modifier fragment has not been
+	 * printed, and that the last printed fragment occurs before the modifier fragment.
+	 *
+	 * It is necessary to detect such fragments as whitespace and comments may otherwise be lost
+	 * when completely removing modifier lists. See issue #3732 for details.
+	 *
 	 * @param fragmentIndex Index of the fragment.
 	 * @param lastPrintedIndex Index of the last printed fragment.
-	 * @return true if the fragment is a collection fragment that contains at least one modifier.
+	 * @return true if the fragment is a recently skipped collection fragment with modifiers.
 	 */
-	private boolean isUnprintedModifierCollectionFragment(int fragmentIndex, int lastPrintedIndex) {
+	private boolean isRecentlySkippedModifierCollectionFragment(int fragmentIndex, int lastPrintedIndex) {
 		SourceFragment fragment = childFragments.get(fragmentIndex);
 		return lastPrintedIndex < fragmentIndex
 				&& fragment instanceof CollectionSourceFragment

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -306,12 +306,12 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 		separatorActions.clear();
 	}
 
-	private int getLastNonSpaceNonCommentBefore(int index, int lastPrintedIndex) {
+	private int getLastNonSpaceNonCommentBefore(int index, int prevIndex) {
 		for (int i = index - 1; i >= 0; i--) {
 			SourceFragment fragment = childFragments.get(i);
 			if (isSpaceFragment(fragment)
 					|| isCommentFragment(fragment)
-					|| isRecentlySkippedModifierCollectionFragment(i, lastPrintedIndex)) {
+					|| isRecentlySkippedModifierCollectionFragment(i, prevIndex)) {
 				continue;
 			}
 			return i + 1;
@@ -320,20 +320,20 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 	}
 
 	/**
-	 * Determines if the fragment at fragmentIndex is a "recently skipped" collection fragment
+	 * Determines if the fragment at index is a "recently skipped" collection fragment
 	 * containing modifiers. "Recently skipped" entails that the modifier fragment has not been
 	 * printed, and that the last printed fragment occurs before the modifier fragment.
 	 *
 	 * It is necessary to detect such fragments as whitespace and comments may otherwise be lost
 	 * when completely removing modifier lists. See issue #3732 for details.
 	 *
-	 * @param fragmentIndex Index of the fragment.
-	 * @param lastPrintedIndex Index of the last printed fragment.
+	 * @param index Index of the fragment.
+	 * @param prevIndex Index of the last printed fragment.
 	 * @return true if the fragment is a recently skipped collection fragment with modifiers.
 	 */
-	private boolean isRecentlySkippedModifierCollectionFragment(int fragmentIndex, int lastPrintedIndex) {
-		SourceFragment fragment = childFragments.get(fragmentIndex);
-		return lastPrintedIndex < fragmentIndex
+	private boolean isRecentlySkippedModifierCollectionFragment(int index, int prevIndex) {
+		SourceFragment fragment = childFragments.get(index);
+		return prevIndex < index
 				&& fragment instanceof CollectionSourceFragment
 				&& ((CollectionSourceFragment) fragment).getItems().stream()
 						.anyMatch(ElementSourceFragment::isModifierFragment);

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -898,4 +898,11 @@ public class ElementSourceFragment implements SourceFragment {
 		return fragment instanceof ElementSourceFragment && ((ElementSourceFragment) fragment).getElement() instanceof CtComment;
 	}
 
+	/**
+	 * @return true if {@link SourceFragment} represents a modifier
+	 */
+	static boolean isModifierFragment(SourceFragment fragment) {
+		return fragment instanceof ElementSourceFragment
+				&& ((ElementSourceFragment) fragment).getRoleInParent() == CtRole.MODIFIER;
+	}
 }

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -436,6 +436,21 @@ public class TestSniperPrinter {
 	}
 
 	@Test
+	public void testFieldCommentDoesNotDisappearWhenAllModifiersAreRemoved() {
+		// contract: A comment on a field should not disappear when all of its modifiers are removed.
+
+		Consumer<CtType<?>> removeFieldModifiers = type -> {
+			CtField<?> field = type.getField("NON_FINAL_FIELD");
+			field.setModifiers(Collections.emptySet());
+		};
+
+		BiConsumer<CtType<?>, String> assertFieldCommentPrinted = (type, result) ->
+				assertThat(result, containsString("// field comment\n"));
+
+		testSniper("TypeMemberComments", removeFieldModifiers, assertFieldCommentPrinted);
+	}
+
+	@Test
 	public void testAddedImportStatementPlacedOnSeparateLineInFileWithoutPackageStatement() {
 		// contract: newline must be inserted between import statements when a new one is added
 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -445,7 +445,7 @@ public class TestSniperPrinter {
 		};
 
 		BiConsumer<CtType<?>, String> assertFieldCommentPrinted = (type, result) ->
-				assertThat(result, containsString("// field comment\n"));
+				assertThat(result, containsString("// field comment\n    int NON_FINAL_FIELD"));
 
 		testSniper("TypeMemberComments", removeFieldModifiers, assertFieldCommentPrinted);
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -60,6 +60,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -436,18 +437,24 @@ public class TestSniperPrinter {
 	}
 
 	@Test
-	public void testFieldCommentDoesNotDisappearWhenAllModifiersAreRemoved() {
+	public void testTypeMemberCommentDoesNotDisappearWhenAllModifiersAreRemoved() {
 		// contract: A comment on a field should not disappear when all of its modifiers are removed.
 
-		Consumer<CtType<?>> removeFieldModifiers = type -> {
-			CtField<?> field = type.getField("NON_FINAL_FIELD");
-			field.setModifiers(Collections.emptySet());
+		Consumer<CtType<?>> removeTypeMemberModifiers = type -> {
+			type.getField("NON_FINAL_FIELD").setModifiers(Collections.emptySet());
+			type.getMethodsByName("nonStaticMethod").get(0).setModifiers(Collections.emptySet());
+			type.getNestedType("NonStaticInnerClass").setModifiers(Collections.emptySet());
 		};
 
 		BiConsumer<CtType<?>, String> assertFieldCommentPrinted = (type, result) ->
-				assertThat(result, containsString("// field comment\n    int NON_FINAL_FIELD"));
+			assertThat(result, allOf(
+						containsString("// field comment\n    int NON_FINAL_FIELD"),
+						containsString("// method comment\n    void nonStaticMethod"),
+						containsString("// nested type comment\n    class NonStaticInnerClass")
+					)
+			);
 
-		testSniper("TypeMemberComments", removeFieldModifiers, assertFieldCommentPrinted);
+		testSniper("TypeMemberComments", removeTypeMemberModifiers, assertFieldCommentPrinted);
 	}
 
 	@Test


### PR DESCRIPTION
Fix #3732 

This PR fixes the bug described in #3732 by keeping track of the last printed element, and allowing the backwards search for previous whitespace to bypass modifier lists that have not been printed. To illustrate the effect of the fix, here's the initial test case file:

```java
public class TypeMemberComments {
    // field comment
    public static int NON_FINAL_FIELD = 42;

    // method comment
    public void nonStaticMethod() {

    }

    // nested type comment
    private class NonStaticInnerClass {

    }
}
```

The test case removes all of the modifiers from all of the type members. Before the fix, the sniper-printed result was the following:

```java
public class TypeMemberComments {
     int NON_FINAL_FIELD = 42;

     void nonStaticMethod() {

    }

     class NonStaticInnerClass {

    }
}
```

Note that the comments have disappeared and that the indentation of the type members is a bit off. After the fix, the result is like so:

```java
public class TypeMemberComments {
    // field comment
    int NON_FINAL_FIELD = 42;

    // method comment
    void nonStaticMethod() {

    }

    // nested type comment
    class NonStaticInnerClass {

    }
}
```

As it should!