### PR TITLE
test Disable failing test on Windows build

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -450,6 +450,7 @@ public class TestSniperPrinter {
 
 	@Test
 	public void testTypeMemberCommentDoesNotDisappearWhenAllModifiersAreRemoved() {
+		assumeNotWindows(); // FIXME Make test case pass on Windows
 		// contract: A comment on a field should not disappear when all of its modifiers are removed.
 
 		Consumer<CtType<?>> removeTypeMemberModifiers = type -> {


### PR DESCRIPTION
#3752 

A branch that was developed in parallel with the Windows build being added had a test that does not pass on Windows. This PR disables that test for Windows. It should be fixed along with the other failing sniper tests, they all likely suffer from the same or similar issues.