### PR TITLE
WIP (Feature/printer): allow changing line separator

### DIFF
--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -440,15 +440,15 @@ public interface Environment {
 	void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations);
 
 	/**
-	 * Sets the line ending to the given value. See {@link spoon.compiler.Environment.LineEnding} for possible values.
-	 * @param lineEnding  lineEnding to use
+	 * Sets the line separator to the given value. See {@link spoon.compiler.Environment.PlatformLineSeparators} for possible values.
+	 * @param lineSeparator  lineEnding to use
 	 */
-	void setLineEndings(LineEnding lineEnding);
+	void setLineSeparators(PlatformLineSeparators lineSeparator);
 
 	/**
-	 * @return  the used line endings as a String.
+	 * @return  the used line separator as a String.
 	 */
-	String getLineEnding();
+	String getLineSeparators();
 	/** Drives how the model is pretty-printed to disk, or when {@link CtElement#prettyprint()} is called */
 	enum PRETTY_PRINTING_MODE {
 		/** direct in {@link spoon.reflect.visitor.DefaultJavaPrettyPrinter}, no preprocessors are applied to the model before pretty-printing }. */
@@ -461,10 +461,10 @@ public interface Environment {
 		FULLYQUALIFIED
 	}
 	/**
-	 * Defines different line endings for different platforms.
+	 * Defines different line separators for different platforms.
 	 * Windows is {@code \r\n}, UNIX {@code \n} and SYSTEM_DEFAULT uses {@link System#lineSeparator()}.
 	 */
-	enum LineEnding {
+	enum PlatformLineSeparators {
 		UNIX("\n"), WINDOWS("\r\n"), SYSTEM_DEFAULT(System.lineSeparator());
 		private String lineSeparator;
 		/**
@@ -473,7 +473,7 @@ public interface Environment {
 		public String getLineEndingString() {
 			return lineSeparator;
 		}
-		LineEnding(String lineSeparator) {
+		PlatformLineSeparators(String lineSeparator) {
 			this.lineSeparator = lineSeparator;
 		}
 	}

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -440,15 +440,15 @@ public interface Environment {
 	void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations);
 
 	/**
-	 * Sets the line separator to the given value. See {@link spoon.compiler.Environment.PlatformLineSeparators} for possible values.
+	 * Sets the line separator to the given value. See {@link spoon.compiler.Environment.PlatformLineSeparator} for possible values.
 	 * @param lineSeparator  lineEnding to use
 	 */
-	void setLineSeparators(PlatformLineSeparators lineSeparator);
+	void setLineSeparator(PlatformLineSeparator lineSeparator);
 
 	/**
 	 * @return  the used line separator as a String.
 	 */
-	String getLineSeparators();
+	String getLineSeparator();
 	/** Drives how the model is pretty-printed to disk, or when {@link CtElement#prettyprint()} is called */
 	enum PRETTY_PRINTING_MODE {
 		/** direct in {@link spoon.reflect.visitor.DefaultJavaPrettyPrinter}, no preprocessors are applied to the model before pretty-printing }. */
@@ -464,16 +464,16 @@ public interface Environment {
 	 * Defines different line separators for different platforms.
 	 * Windows is {@code \r\n}, UNIX {@code \n} and SYSTEM_DEFAULT uses {@link System#lineSeparator()}.
 	 */
-	enum PlatformLineSeparators {
+	enum PlatformLineSeparator {
 		UNIX("\n"), WINDOWS("\r\n"), SYSTEM_DEFAULT(System.lineSeparator());
 		private String lineSeparator;
 		/**
 		 * @return the lineEndingString as a String
 		 */
-		public String getLineEndingString() {
+		public String getLineSeparatorAsString() {
 			return lineSeparator;
 		}
-		PlatformLineSeparators(String lineSeparator) {
+		PlatformLineSeparator(String lineSeparator) {
 			this.lineSeparator = lineSeparator;
 		}
 	}

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -439,6 +439,16 @@ public interface Environment {
 	 */
 	void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations);
 
+	/**
+	 * Sets the line ending to the given value. See {@link spoon.compiler.Environment.LineEnding} for possible values.
+	 * @param lineEnding  lineEnding to use
+	 */
+	void setLineEndings(LineEnding lineEnding);
+
+	/**
+	 * @return  the used line endings as a String.
+	 */
+	String getLineEnding();
 	/** Drives how the model is pretty-printed to disk, or when {@link CtElement#prettyprint()} is called */
 	enum PRETTY_PRINTING_MODE {
 		/** direct in {@link spoon.reflect.visitor.DefaultJavaPrettyPrinter}, no preprocessors are applied to the model before pretty-printing }. */
@@ -449,5 +459,22 @@ public interface Environment {
 
 		/** force everything to be fully-qualified */
 		FULLYQUALIFIED
+	}
+	/**
+	 * Defines different line endings for different platforms.
+	 * Windows is {@code \r\n}, UNIX {@code \n} and SYSTEM_DEFAULT uses {@link System#lineSeparator()}.
+	 */
+	enum LineEnding {
+		UNIX("\n"), WINDOWS("\r\n"), SYSTEM_DEFAULT(System.lineSeparator());
+		private String lineSeparator;
+		/**
+		 * @return the lineEndingString as a String
+		 */
+		public String getLineEndingString() {
+			return lineSeparator;
+		}
+		LineEnding(String lineSeparator) {
+			this.lineSeparator = lineSeparator;
+		}
 	}
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -73,6 +73,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private boolean processingStopped = false;
 
+	private String lineEnding = LineEnding.SYSTEM_DEFAULT.getLineEndingString();
 	@Override
 	public PRETTY_PRINTING_MODE getPrettyPrintingMode() {
 		return prettyPrintingMode;
@@ -655,6 +656,7 @@ private transient  ClassLoader inputClassloader;
 		));
 		printer.setIgnoreImplicit(false);
 		printer.setPreprocessors(preprocessors);
+		printer.setLineSeparator(this.getLineEnding());
 		return printer;
 	}
 
@@ -668,6 +670,7 @@ private transient  ClassLoader inputClassloader;
 
 			if (PRETTY_PRINTING_MODE.DEBUG.equals(prettyPrintingMode)) {
 				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
+				printer.setLineSeparator(this.getLineEnding());
 				return printer;
 			}
 
@@ -683,6 +686,7 @@ private transient  ClassLoader inputClassloader;
 				));
 				printer.setIgnoreImplicit(false);
 				printer.setPreprocessors(preprocessors);
+				printer.setLineSeparator(this.getLineEnding());
 				return printer;
 			}
 
@@ -705,5 +709,15 @@ private transient  ClassLoader inputClassloader;
 	@Override
 	public void setIgnoreDuplicateDeclarations(boolean ignoreDuplicateDeclarations) {
 		this.ignoreDuplicateDeclarations = ignoreDuplicateDeclarations;
+	}
+
+	@Override
+	public void setLineEndings(LineEnding lineEnding) {
+		this.lineEnding = lineEnding.getLineEndingString();
+	}
+
+	@Override
+	public String getLineEnding() {
+		return lineEnding;
 	}
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -73,7 +73,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private boolean processingStopped = false;
 
-	private String lineEnding = LineEnding.SYSTEM_DEFAULT.getLineEndingString();
+	private String lineEnding = PlatformLineSeparators.SYSTEM_DEFAULT.getLineEndingString();
 	@Override
 	public PRETTY_PRINTING_MODE getPrettyPrintingMode() {
 		return prettyPrintingMode;
@@ -656,7 +656,7 @@ private transient  ClassLoader inputClassloader;
 		));
 		printer.setIgnoreImplicit(false);
 		printer.setPreprocessors(preprocessors);
-		printer.setLineSeparator(this.getLineEnding());
+		printer.setLineSeparator(this.getLineSeparators());
 		return printer;
 	}
 
@@ -670,7 +670,7 @@ private transient  ClassLoader inputClassloader;
 
 			if (PRETTY_PRINTING_MODE.DEBUG.equals(prettyPrintingMode)) {
 				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-				printer.setLineSeparator(this.getLineEnding());
+				printer.setLineSeparator(this.getLineSeparators());
 				return printer;
 			}
 
@@ -686,7 +686,7 @@ private transient  ClassLoader inputClassloader;
 				));
 				printer.setIgnoreImplicit(false);
 				printer.setPreprocessors(preprocessors);
-				printer.setLineSeparator(this.getLineEnding());
+				printer.setLineSeparator(this.getLineSeparators());
 				return printer;
 			}
 
@@ -712,12 +712,12 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public void setLineEndings(LineEnding lineEnding) {
+	public void setLineSeparators(PlatformLineSeparators lineEnding) {
 		this.lineEnding = lineEnding.getLineEndingString();
 	}
 
 	@Override
-	public String getLineEnding() {
+	public String getLineSeparators() {
 		return lineEnding;
 	}
 }

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -73,7 +73,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private boolean processingStopped = false;
 
-	private String lineEnding = PlatformLineSeparators.SYSTEM_DEFAULT.getLineEndingString();
+	private String lineSeparator = PlatformLineSeparator.SYSTEM_DEFAULT.getLineSeparatorAsString();
 	@Override
 	public PRETTY_PRINTING_MODE getPrettyPrintingMode() {
 		return prettyPrintingMode;
@@ -656,7 +656,7 @@ private transient  ClassLoader inputClassloader;
 		));
 		printer.setIgnoreImplicit(false);
 		printer.setPreprocessors(preprocessors);
-		printer.setLineSeparator(this.getLineSeparators());
+		printer.setLineSeparator(this.getLineSeparator());
 		return printer;
 	}
 
@@ -670,7 +670,7 @@ private transient  ClassLoader inputClassloader;
 
 			if (PRETTY_PRINTING_MODE.DEBUG.equals(prettyPrintingMode)) {
 				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-				printer.setLineSeparator(this.getLineSeparators());
+				printer.setLineSeparator(this.getLineSeparator());
 				return printer;
 			}
 
@@ -686,7 +686,7 @@ private transient  ClassLoader inputClassloader;
 				));
 				printer.setIgnoreImplicit(false);
 				printer.setPreprocessors(preprocessors);
-				printer.setLineSeparator(this.getLineSeparators());
+				printer.setLineSeparator(this.getLineSeparator());
 				return printer;
 			}
 
@@ -712,12 +712,12 @@ private transient  ClassLoader inputClassloader;
 	}
 
 	@Override
-	public void setLineSeparators(PlatformLineSeparators lineEnding) {
-		this.lineEnding = lineEnding.getLineEndingString();
+	public void setLineSeparator(PlatformLineSeparator lineSeparator) {
+		this.lineSeparator = lineSeparator.getLineSeparatorAsString();
 	}
 
 	@Override
-	public String getLineSeparators() {
-		return lineEnding;
+	public String getLineSeparator() {
+		return lineSeparator;
 	}
 }

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.junit.Test;
 
 import spoon.Launcher;
-import spoon.compiler.Environment.LineEnding;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtReturn;

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.junit.Test;
 
 import spoon.Launcher;
+import spoon.compiler.Environment.LineEnding;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtReturn;
@@ -192,8 +193,8 @@ public class FieldTest {
 
 	@Test
 	public void bugAfterRefactoringImports() {
-		assumeNotWindows(); // FIXME Make test case pass on Windows
 		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setLineEndings(LineEnding.UNIX);
 		Factory factory = launcher.getFactory();
 		final CtClass<?> klass = factory.createClass("foo.A");
 

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -193,8 +193,8 @@ public class FieldTest {
 
 	@Test
 	public void bugAfterRefactoringImports() {
+		assumeNotWindows(); // FIXME Make test case pass on Windows
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setLineEndings(LineEnding.UNIX);
 		Factory factory = launcher.getFactory();
 		final CtClass<?> klass = factory.createClass("foo.A");
 

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -579,7 +579,7 @@ public class DefaultPrettyPrinterTest {
 	public void testUnixLineEndings() {
 		// contract: setting line endings to unix style should produce \n line endings.
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setLineSeparators(Environment.PlatformLineSeparators.UNIX);
+		launcher.getEnvironment().setLineSeparator(Environment.PlatformLineSeparator.UNIX);
 		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.getEnvironment().setTabulationSize(4);
 		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));
@@ -592,7 +592,7 @@ public class DefaultPrettyPrinterTest {
 	public void testWindowsLineEndings() {
 		// contract: setting line endings to windows style should produce \r\n line endings.
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setLineSeparators(Environment.PlatformLineSeparators.WINDOWS);
+		launcher.getEnvironment().setLineSeparator(Environment.PlatformLineSeparator.WINDOWS);
 		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.getEnvironment().setTabulationSize(4);
 		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -1,18 +1,16 @@
 /**
- * Copyright (C) 2006-2018 INRIA and contributors
- * Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006-2018 INRIA and contributors Spoon - http://spoon.gforge.inria.fr/
  *
- * This software is governed by the CeCILL-C License under French law and
- * abiding by the rules of distribution of free software. You can use, modify
- * and/or redistribute the software under the terms of the CeCILL-C license as
- * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ * This software is governed by the CeCILL-C License under French law and abiding by the rules of
+ * distribution of free software. You can use, modify and/or redistribute the software under the
+ * terms of the CeCILL-C license as circulated by CEA, CNRS and INRIA at http://www.cecill.info.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * CeCILL-C License for more details.
  *
- * The fact that you are presently reading this means that you have had
- * knowledge of the CeCILL-C license and that you accept its terms.
+ * The fact that you are presently reading this means that you have had knowledge of the CeCILL-C
+ * license and that you accept its terms.
  */
 package spoon.test.prettyprinter;
 
@@ -36,6 +34,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.MavenLauncher;
+import spoon.OutputType;
 import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.Environment;
@@ -62,6 +61,7 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.JavaOutputProcessor;
 import spoon.support.compiler.SpoonPom;
+import spoon.support.compiler.VirtualFile;
 import spoon.test.imports.ImportTest;
 import spoon.test.prettyprinter.testclasses.AClass;
 import spoon.test.prettyprinter.testclasses.ClassUsingStaticMethod;
@@ -570,5 +570,32 @@ public class DefaultPrettyPrinterTest {
 		} catch (MavenInvocationException e) {
 			return false;
 		}
+	}
+
+
+	@Test
+	public void testUnixLineEndings() {
+		// contract: setting line endings to unix style should produce \n line endings.
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setLineEndings(Environment.LineEnding.UNIX);
+		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
+		launcher.getEnvironment().setTabulationSize(4);
+		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));
+		CtModel model = launcher.buildModel();
+		CtType<?> type = model.getAllTypes().iterator().next();
+		assertEquals("class a {\n    int c = 3;\n}", type.toString());
+	}
+
+	@Test
+	public void testWindowsLineEndings() {
+		// contract: setting line endings to windows style should produce \r\n line endings.
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setLineEndings(Environment.LineEnding.WINDOWS);
+		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
+		launcher.getEnvironment().setTabulationSize(4);
+		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));
+		CtModel model = launcher.buildModel();
+		CtType<?> type = model.getAllTypes().iterator().next();
+		assertEquals("class a {\r\n    int c = 3;\r\n}", type.toString());
 	}
 }

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -579,7 +579,7 @@ public class DefaultPrettyPrinterTest {
 	public void testUnixLineEndings() {
 		// contract: setting line endings to unix style should produce \n line endings.
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setLineEndings(Environment.LineEnding.UNIX);
+		launcher.getEnvironment().setLineSeparators(Environment.PlatformLineSeparators.UNIX);
 		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.getEnvironment().setTabulationSize(4);
 		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));
@@ -592,7 +592,7 @@ public class DefaultPrettyPrinterTest {
 	public void testWindowsLineEndings() {
 		// contract: setting line endings to windows style should produce \r\n line endings.
 		Launcher launcher = new Launcher();
-		launcher.getEnvironment().setLineEndings(Environment.LineEnding.WINDOWS);
+		launcher.getEnvironment().setLineSeparators(Environment.PlatformLineSeparators.WINDOWS);
 		launcher.getEnvironment().setOutputType(OutputType.NO_OUTPUT);
 		launcher.getEnvironment().setTabulationSize(4);
 		launcher.addInputResource(new VirtualFile("class a { int c = 3;}"));

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -1,16 +1,18 @@
 /**
- * Copyright (C) 2006-2018 INRIA and contributors Spoon - http://spoon.gforge.inria.fr/
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
  *
- * This software is governed by the CeCILL-C License under French law and abiding by the rules of
- * distribution of free software. You can use, modify and/or redistribute the software under the
- * terms of the CeCILL-C license as circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
- * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * CeCILL-C License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
  *
- * The fact that you are presently reading this means that you have had knowledge of the CeCILL-C
- * license and that you accept its terms.
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
  */
 package spoon.test.prettyprinter;
 


### PR DESCRIPTION
As discussed here #3752, we fix a lot of testcase by allowing to set line separator. This PRs adds a flag to `Environment` to allow easier usage, as the needed method is not exposed see [link](https://github.com/INRIA/spoon/issues/3752#issuecomment-762169344). The enum `PlatformLineSeparator` should allow easier usage with the 3 values, UNIX, WINDOWS, System_Default.  

Is there any need to support different not normal line separators? Could there be any printer/sniper related problems?
Edit: is there even a need for using `System.lineSeparator()` as default. I couldn't find any windows software that needs `\r\n`