### PR TITLE
refactor: throw informative exception when sniper printing cannot be done

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -171,9 +171,9 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	}
 
 	private static <T> Set<T> toIdentityHashSet(Collection<T> items) {
-	    Set<T> idHashSet = Collections.newSetFromMap(new IdentityHashMap<>());
-	    idHashSet.addAll(items);
-	    return idHashSet;
+		Set<T> idHashSet = Collections.newSetFromMap(new IdentityHashMap<>());
+		idHashSet.addAll(items);
+		return idHashSet;
 	}
 
 	private static final String CR = "\r";

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -9,9 +9,13 @@ package spoon.support.sniper;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import spoon.OutputType;
@@ -130,6 +134,8 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 
 	@Override
 	public void calculate(CtCompilationUnit compilationUnit, List<CtType<?>> types) {
+		checkGivenTypesMatchDeclaredTypes(compilationUnit, types);
+
 		sourceCompilationUnit = compilationUnit;
 
 		//use line separator of origin source file
@@ -147,6 +153,27 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 		() -> {
 			super.calculate(sourceCompilationUnit, types);;
 		});
+	}
+
+	/** Throws an {@link IllegalArgumentException} if the given types do not exactly match the types of the CU. */
+	private static void checkGivenTypesMatchDeclaredTypes(CtCompilationUnit cu, List<CtType<?>> types) {
+		Set<CtType<?>> givenTypes = toIdentityHashSet(types);
+		Set<CtType<?>> declaredTypes = toIdentityHashSet(cu.getDeclaredTypes());
+		if (!givenTypes.equals(declaredTypes)) {
+			throw new IllegalArgumentException(
+					"Can only sniper print exactly all declared types of the compilation unit. Given types: "
+							+ toNameList(givenTypes) + ". Declared types: " + toNameList(declaredTypes));
+		}
+	}
+
+	private static List<String> toNameList(Collection<CtType<?>> types) {
+		return types.stream().map(CtType::getQualifiedName).collect(Collectors.toList());
+	}
+
+	private static <T> Set<T> toIdentityHashSet(Collection<T> items) {
+	    Set<T> idHashSet = Collections.newSetFromMap(new IdentityHashMap<>());
+	    idHashSet.addAll(items);
+	    return idHashSet;
 	}
 
 	private static final String CR = "\r";

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -634,7 +634,7 @@ public class TestSniperPrinter {
 
 	@Test
 	public void testThrowsWhenTryingToPrintSubsetOfCompilationUnitTypes() {
-	    // contract: Printing a subset of a compilation unit's types is a hassle to implement at the time of writing
+		// contract: Printing a subset of a compilation unit's types is a hassle to implement at the time of writing
 		// this, as a) DJPP will replace the compilation unit with a clone, and b) it makes it more difficult to
 		// match source code fragments. For now, we're lazy and simply don't allow it.
 

--- a/src/test/resources/MultipleTopLevelTypes.java
+++ b/src/test/resources/MultipleTopLevelTypes.java
@@ -1,0 +1,12 @@
+public class MultipleTopLevelTypes {
+    private int x;
+}
+
+class OtherTopLevelType {
+    private long z;
+}
+
+interface TopLevelInterface {
+    int getValue();
+}
+


### PR DESCRIPTION
Fix #3760 

See #3760 for a description of the problem. I think it's more work than it's worth to try to allow for sniper printing of a subset of a compilation unit's types. There's an initial problem in that DJPP clones the CU if it discovers that one is trying to print only a subset of the types (this is where the current crash described in #3760 comes from). Even working around that, there's still a bit of trickery involved in printing just a subset of the types. A couple more hours on this and I could _probably_ solve it, but I just don't think it's worth it.

This PR just throws a more informative exception that looks like this:

```
java.lang.IllegalArgumentException: Can only sniper print exactly all declared types of the compilation unit. Given types: [MultipleTopLevelTypes]. Declared types: [OtherTopLevelType, MultipleTopLevelTypes, TopLevelInterface]
```

I'm not quite sure if "fix" is the correct label for this PR, feel free to re-label.