### PR TITLE
fix: Search for packages in all available Java modules

### DIFF
--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -162,9 +162,15 @@ public class PackageFactory extends SubFactory {
 		return factory.getModel().getAllModules().stream()
 				.map(module -> getPackageFromModule(qualifiedName, module))
 				.filter(Objects::nonNull)
-				.findFirst().orElse(null);
+				.findFirst()
+				.orElse(null);
 	}
 
+	/**
+	 * @param qualifiedName Qualified name of a package.
+	 * @param module A module in which to search for the package.
+	 * @return The package if found in this module, otherwise null.
+	 */
 	private static CtPackage getPackageFromModule(String qualifiedName, CtModule module) {
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
 		CtPackage current = module.getRootPackage();

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.StringTokenizer;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -11,6 +11,8 @@ package spoon.reflect.factory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.StringTokenizer;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
@@ -157,13 +159,18 @@ public class PackageFactory extends SubFactory {
 		if (qualifiedName.contains(CtType.INNERTTYPE_SEPARATOR)) {
 			throw new RuntimeException("Invalid package name " + qualifiedName);
 		}
+
+		return factory.getModel().getAllModules().stream()
+				.map(module -> getPackageFromModule(qualifiedName, module))
+				.filter(Objects::nonNull)
+				.findFirst().orElse(null);
+	}
+
+	private static CtPackage getPackageFromModule(String qualifiedName, CtModule module) {
 		StringTokenizer token = new StringTokenizer(qualifiedName, CtPackage.PACKAGE_SEPARATOR);
-		CtPackage current = factory.getModel().getRootPackage();
-		if (token.hasMoreElements()) {
+		CtPackage current = module.getRootPackage();
+		while (token.hasMoreElements() && current != null) {
 			current = current.getPackage(token.nextToken());
-			while (token.hasMoreElements() && current != null) {
-				current = current.getPackage(token.nextToken());
-			}
 		}
 
 		return current;

--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -40,10 +40,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -131,6 +134,22 @@ public class TestCompilationUnit {
 			// do nothing
 		}
 	}
+
+	@Test
+	public void testCompilationUnitInNamedModuleHasDeclaredTypes() {
+		// contract: Compilation units in named modules should have the expected declared types
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
+		launcher.buildModel();
+
+		CtType<?> expectedType = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
+		CtCompilationUnit cu = launcher.getFactory().CompilationUnit().getOrCreate(expectedType);
+
+		assertThat(cu.getDeclaredTypes(), equalTo(Collections.singletonList(expectedType)));
+	}
+
 
 	@Test
 	public void testCompilationUnitSourcePosition() throws IOException {

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -37,6 +37,7 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.ctType.testclasses.X;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -47,6 +48,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -247,5 +249,22 @@ public class CtTypeTest {
 		model.getAllTypes().forEach(type -> {
 			type.getUsedTypes(false);
 			});
+	}
+
+	@Test
+	public void testTypeDeclarationToReferenceRoundTripInNamedModule() {
+		// contract: It's possible to go from a type declaration, to a reference, and back to the declaration
+		// when the declaration is contained within a named module
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
+		launcher.buildModel();
+
+		CtType<?> typeDecl = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
+		CtTypeReference<?> typeRef = typeDecl.getReference();
+		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
+
+		assertSame(reFetchedTypeDecl, typeDecl);
 	}
 }

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -41,7 +41,10 @@ import spoon.test.SpoonTestHelpers;
 import spoon.test.factory.testclasses.Foo;
 
 import java.lang.reflect.Method;
+import java.nio.file.Paths;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -169,6 +172,23 @@ public class FactoryTest {
 		});
 		assertEquals(0, model.getAllTypes().size());
 	}
+
+	@Test
+	public void testGetPackageFromNamedModule() {
+		// contract: It should be possible to get a package from a named module
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module_with_code");
+		launcher.buildModel();
+
+		String packageName = "fr.simplemodule.pack";
+		CtPackage packageInNamedModule = launcher.getFactory().Package().get(packageName);
+
+		assertNotNull(packageInNamedModule);
+		assertThat(packageInNamedModule.getQualifiedName(), equalTo(packageName));
+	}
+
 
 	public void testIncrementalModel() {
 

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -37,7 +37,6 @@ import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.factory.PackageFactory;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
@@ -50,7 +49,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -346,12 +344,9 @@ public class TestModule {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setComplianceLevel(9);
 		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
+		launcher.buildModel();
 
-		CtModel model = launcher.buildModel();
-		CtType<?> typeDecl = model.getAllTypes().stream()
-				.filter(t -> t.getQualifiedName().equals("fr.simplemodule.pack.SimpleClass"))
-				.findFirst()
-				.get();
+		CtType<?> typeDecl = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
 		CtTypeReference<?> typeRef = typeDecl.getReference();
 		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
 
@@ -364,14 +359,11 @@ public class TestModule {
 
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setComplianceLevel(9);
-		Path projectPath = Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code");
-		launcher.addInputResource(projectPath.toString());
+		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
+		launcher.buildModel();
 
-		CtModel model = launcher.buildModel();
-		Factory factory = launcher.getFactory();
-		CtModule namedModule = model.getAllModules().stream().filter(m -> !m.isUnnamedModule()).findFirst().get();
-		CtType<?> expectedType = factory.Type().get("fr.simplemodule.pack.SimpleClass");
-		CtCompilationUnit cu = namedModule.getFactory().CompilationUnit().getOrCreate(expectedType);
+		CtType<?> expectedType = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
+		CtCompilationUnit cu = launcher.getFactory().CompilationUnit().getOrCreate(expectedType);
 
 		assertThat(cu.getDeclaredTypes(), equalTo(Collections.singletonList(expectedType)));
 	}

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -36,6 +36,7 @@ import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.reference.CtModuleReference;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
@@ -43,6 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -327,6 +329,26 @@ public class TestModule {
 		CtPackage packBar = (CtPackage) barclass.getParent();
 
 		assertTrue(packBar.getParent() instanceof CtModule);
+	}
+
+	@Test
+	public void testTypeDeclarationToReferenceRoundTripInNamedModule() {
+		// contract: It's possible to go from a type declaration, to a reference, and back to the declaration
+		// when the declaration is contained within a named module
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
+
+		CtModel model = launcher.buildModel();
+		CtType<?> typeDecl = model.getAllTypes().stream()
+				.filter(t -> t.getQualifiedName().equals("fr.simplemodule.pack.SimpleClass"))
+				.findFirst()
+				.get();
+		CtTypeReference<?> typeRef = typeDecl.getReference();
+		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
+
+		assertSame(reFetchedTypeDecl, typeDecl);
 	}
 
 	@Test (expected = SpoonException.class)

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -27,7 +27,6 @@ import spoon.SpoonException;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtModuleDirective;
 import spoon.reflect.declaration.CtPackage;
@@ -36,9 +35,7 @@ import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
-import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtModuleReference;
-import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
@@ -46,13 +43,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
@@ -334,54 +327,6 @@ public class TestModule {
 		CtPackage packBar = (CtPackage) barclass.getParent();
 
 		assertTrue(packBar.getParent() instanceof CtModule);
-	}
-
-	@Test
-	public void testTypeDeclarationToReferenceRoundTripInNamedModule() {
-		// contract: It's possible to go from a type declaration, to a reference, and back to the declaration
-		// when the declaration is contained within a named module
-
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setComplianceLevel(9);
-		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
-		launcher.buildModel();
-
-		CtType<?> typeDecl = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
-		CtTypeReference<?> typeRef = typeDecl.getReference();
-		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
-
-		assertSame(reFetchedTypeDecl, typeDecl);
-	}
-
-	@Test
-	public void testCompilationUnitInNamedModuleHasDeclaredTypes() {
-		// contract: Compilation units in named modules should have the expected declared types
-
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setComplianceLevel(9);
-		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
-		launcher.buildModel();
-
-		CtType<?> expectedType = launcher.getFactory().Type().get("fr.simplemodule.pack.SimpleClass");
-		CtCompilationUnit cu = launcher.getFactory().CompilationUnit().getOrCreate(expectedType);
-
-		assertThat(cu.getDeclaredTypes(), equalTo(Collections.singletonList(expectedType)));
-	}
-
-	@Test
-	public void testGetPackageFromNamedModule() {
-		// contract: It should be possible to get a package from a named module
-
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setComplianceLevel(9);
-		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
-		launcher.buildModel();
-
-		String packageName = "fr.simplemodule.pack";
-		CtPackage packageInNamedModule = launcher.getFactory().Package().get(packageName);
-
-		assertNotNull(packageInNamedModule);
-		assertThat(packageInNamedModule.getQualifiedName(), equalTo(packageName));
 	}
 
 	@Test (expected = SpoonException.class)

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -37,6 +37,7 @@ import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.PackageFactory;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
@@ -373,6 +374,22 @@ public class TestModule {
 		CtCompilationUnit cu = namedModule.getFactory().CompilationUnit().getOrCreate(expectedType);
 
 		assertThat(cu.getDeclaredTypes(), equalTo(Collections.singletonList(expectedType)));
+	}
+
+	@Test
+	public void testGetPackageFromNamedModule() {
+		// contract: It should be possible to get a package from a named module
+
+		final Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource(Paths.get(MODULE_RESOURCES_PATH).resolve("simple_module_with_code").toString());
+		launcher.buildModel();
+
+		String packageName = "fr.simplemodule.pack";
+		CtPackage packageInNamedModule = launcher.getFactory().Package().get(packageName);
+
+		assertNotNull(packageInNamedModule);
+		assertThat(packageInNamedModule.getQualifiedName(), equalTo(packageName));
 	}
 
 	@Test (expected = SpoonException.class)


### PR DESCRIPTION
Fix #3769 

The issue describes the symptoms and the root cause of them. The tl;dr is that `PackageFactory.get(String)` only searches for packages in the unnamed module, causing type resolution in named modules to not work correctly. This PR fixes that by searching for packages in all modules.

As noted in #3769, there's probably a whole lot of code that assumes that there's only the unnamed module, and therefore use `CtModel.getRootPackage()` (which returns the root package of the unnamed module) as the definitive root package, which as of Java 9 is not appropriate.