### PR TITLE
doc: Correct doc about getTypeDeclaration returning null

### DIFF
--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -65,7 +65,7 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 * reference or <code>null</code> if the type declaration is not in the
 	 * analyzed source files,
 	 *
-	 * {@link #getTypeDeclaration()} is a newer and better alternative that never returns null.
+	 * {@link #getTypeDeclaration()} is a newer and better alternative that less often returns null.
 	 *
 	 * @return the referenced element or <code>null</code> if the type
 	 * declaration is not the analyzed source files.


### PR DESCRIPTION
`CtTypeReference.getDeclaration()` says that `CtTypeReference.getTypeDeclaration()` is great because it _never returns null_. That's actually not the case: `getTypeDeclaration()` does return null if the referenced type is neither in the input source nor on the classpath. It even says so in the doc for `getTypeDeclaration()`. For completeness, here's a way to make that happen:

```java
Launcher launcher = new Launcher();
CtTypeReference<?> ref = launcher.getFactory().Type().createReference("SomeType");
assert ref.getTypeDeclaration() == null;
```

This PR simply changes "never" to "less often". The reason I'm changing this is because I ran into some (to me) inexplicable `NullPointerException`s due to a method I thought would never return null :)