### PR TITLE
chore: add SNAPSHOT tag to spoon-control-flow pom.xml artifact version

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-control-flow</artifactId>
-    <version>0.0.2</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
Change made by @monperrus. If I understood correctly it solves an issue with Maven repository deployment of spoon-control-flow.