### PR TITLE
WIP: (Doc) update doc to match unmodifiable behavior 

### DIFF
--- a/src/main/java/spoon/compiler/SpoonFolder.java
+++ b/src/main/java/spoon/compiler/SpoonFolder.java
@@ -15,7 +15,7 @@ import java.util.List;
 public interface SpoonFolder extends SpoonResource {
 
 	/**
-	 * Gets an unmodifiable view of all the files (excluding folders) in the folder.
+	 * Gets all the files (excluding folders) in the folder.
 	 */
 	List<SpoonFile> getFiles();
 
@@ -30,7 +30,7 @@ public interface SpoonFolder extends SpoonResource {
 	List<SpoonFile> getAllJavaFiles();
 
 	/**
-	 * Gets an unmodifiable view of subfolders in this folder.
+	 * Gets of subfolders in this folder.
 	 */
 	List<SpoonFolder> getSubFolders();
 

--- a/src/main/java/spoon/compiler/SpoonFolder.java
+++ b/src/main/java/spoon/compiler/SpoonFolder.java
@@ -15,7 +15,7 @@ import java.util.List;
 public interface SpoonFolder extends SpoonResource {
 
 	/**
-	 * Gets all the files (excluding folders) in the folder.
+	 * Gets an unmodifiable view of all the files (excluding folders) in the folder.
 	 */
 	List<SpoonFile> getFiles();
 
@@ -30,7 +30,7 @@ public interface SpoonFolder extends SpoonResource {
 	List<SpoonFile> getAllJavaFiles();
 
 	/**
-	 * Gets the subfolders in this folder.
+	 * Gets an unmodifiable view of subfolders in this folder.
 	 */
 	List<SpoonFolder> getSubFolders();
 

--- a/src/main/java/spoon/metamodel/MMMethod.java
+++ b/src/main/java/spoon/metamodel/MMMethod.java
@@ -107,7 +107,7 @@ public class MMMethod {
 	}
 
 	/**
-	 * @return {@link CtMethod}s, which are declared in the {@link MetamodelConcept} or in the hierarchy, that have the same role and {@link MMMethodKind}.
+	 * @return an unmodifiable view of {@link CtMethod}s, which are declared in the {@link MetamodelConcept} or in the hierarchy, that have the same role and {@link MMMethodKind}.
 	 */
 	public List<CtMethod<?>> getDeclaredMethods() {
 		return Collections.unmodifiableList(ownMethods);

--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -294,7 +294,7 @@ public class Metamodel {
 	}
 
 	/**
-	 * @return all {@link MetamodelConcept}s of spoon meta model
+	 * @return an unmodifiable view of all {@link MetamodelConcept}s of spoon meta model
 	 */
 	public Collection<MetamodelConcept> getConcepts() {
 		return Collections.unmodifiableCollection(nameToConcept.values());

--- a/src/main/java/spoon/metamodel/MetamodelConcept.java
+++ b/src/main/java/spoon/metamodel/MetamodelConcept.java
@@ -110,18 +110,18 @@ public class MetamodelConcept {
 	}
 
 	/**
-	 * @return map of {@link MetamodelProperty}s by their {@link CtRole}
+	 * @return an unmodifiable view of {@link MetamodelProperty}s by their {@link CtRole}
 	 */
 	public Map<CtRole, MetamodelProperty> getRoleToProperty() {
 		return Collections.unmodifiableMap(role2Property);
 	}
 
 	/**
-	 * @return Collection of all {@link MetamodelProperty} of current {@link MetamodelConcept}
+	 * @return an unmodifiable view of all {@link MetamodelProperty} of current {@link MetamodelConcept}
 	 * Note: actually is the order undefined
-	 * TODO: return List in the same order like it is scanned by CtScanner
 	 */
 	public Collection<MetamodelProperty> getProperties() {
+		// TODO: return List in the same order like it is scanned by CtScanner
 		return Collections.unmodifiableCollection(role2Property.values());
 	}
 

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -270,7 +270,7 @@ public class MetamodelProperty {
 
 	/**
 	 * @param kind {@link MMMethodKind}
-	 * @return methods of required `kind`
+	 * @return an unmodifiable view of methods of required `kind`
 	 */
 	public List<MMMethod> getMethods(MMMethodKind kind) {
 		List<MMMethod> ms = methodsByKind.get(kind);
@@ -278,7 +278,7 @@ public class MetamodelProperty {
 	}
 
 	/**
-	 * @return all methods which are accessing this property
+	 * @return an unmodifiable view of all methods which are accessing this property
 	 */
 	public Set<MMMethod> getMethods() {
 		Set<MMMethod> res = new HashSet<>();

--- a/src/main/java/spoon/pattern/Pattern.java
+++ b/src/main/java/spoon/pattern/Pattern.java
@@ -53,7 +53,7 @@ public class Pattern {
 	}
 
 	/**
-	 * @return Map of parameter names to {@link ParameterInfo} for each parameter of this {@link Pattern}
+	 * @return an unmodifiable view of the Map of parameter names to {@link ParameterInfo} for each parameter of this {@link Pattern}
 	 */
 	public Map<String, ParameterInfo> getParameterInfos() {
 		Map<String, ParameterInfo> parameters = new HashMap<>();

--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -446,7 +446,7 @@ public class PatternBuilder {
 	}
 
 	/**
-	 * @return a {@link CtElement}s which are the template model of this Pattern
+	 * @return an unmodifiable view of {@link CtElement}s which are the template model of this Pattern
 	 */
 	List<CtElement> getPatternModel() {
 		return patternModel;

--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -192,7 +192,9 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 		}
 		return false;
 	}
-
+	/**
+	 * @return an unmodifiable view of rootNode by metamodel property
+	 */
 	public Map<MetamodelProperty, RootNode> getRoleToNode() {
 		return roleToNode == null ? Collections.emptyMap() : Collections.unmodifiableMap(roleToNode);
 	}

--- a/src/main/java/spoon/pattern/internal/node/StringNode.java
+++ b/src/main/java/spoon/pattern/internal/node/StringNode.java
@@ -110,7 +110,7 @@ public class StringNode extends AbstractPrimitiveMatcher {
 	}
 
 	/**
-	 * @return {@link ParameterInfo} to replace marker map
+	 * @return an unmodifiable view of {@link ParameterInfo} to replace marker map
 	 */
 	public Map<String, ParameterInfo> getReplaceMarkers() {
 		return Collections.unmodifiableMap(tobeReplacedSubstrings);

--- a/src/main/java/spoon/reflect/CtModel.java
+++ b/src/main/java/spoon/reflect/CtModel.java
@@ -31,7 +31,7 @@ public interface CtModel extends Serializable, CtQueryable {
 	/** returns all top-level types of the model */
 	Collection<CtType<?>> getAllTypes();
 
-	/** returns all packages of the model */
+	/** returns an unmodifiable view of all packages of the model */
 	Collection<CtPackage> getAllPackages();
 
 	/**

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -103,7 +103,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	<T extends CtExpression> T getWrappedValue(String key);
 
 	/**
-	 * Returns this annotation's elements and their values. This is returned in
+	 * Returns an unmodifiable view of this annotation's elements and their values. This is returned in
 	 * the form of a map that associates element names with their corresponding
 	 * values. If you iterate over the map with entrySet(), the iteration order
 	 * complies with the order of annotation values in the source code.
@@ -114,7 +114,7 @@ public interface CtAnnotation<A extends Annotation> extends CtExpression<A>, CtS
 	@PropertyGetter(role = VALUE)
 	Map<String, CtExpression> getValues();
 
-	/** Get all values of {@link #getValues()}, plus the default ones defined in the annotation type. */
+	/** Get an unmodifiable view of all values of {@link #getValues()}, plus the default ones defined in the annotation type. */
 	@DerivedProperty
 	Map<String, CtExpression> getAllValues();
 

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -33,7 +33,7 @@ import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
  */
 public interface CtClass<T> extends CtType<T>, CtStatement {
 	/**
-	 * Returns the anonymous blocks of this class.
+	 * Returns an unmodifiable view of the anonymous blocks of this class.
 	 * Derived from {@link #getTypeMembers()}
 	 */
 	@DerivedProperty
@@ -50,7 +50,7 @@ public interface CtClass<T> extends CtType<T>, CtStatement {
 	CtConstructor<T> getConstructor(CtTypeReference<?>... parameterTypes);
 
 	/**
-	 * Returns the constructors of this class. This includes the default
+	 * Returns an unmodifiable view of the constructors of this class. This includes the default
 	 * constructor if this class has no constructors explicitly declared.
 	 *
 	 * Derived from {@link #getTypeMembers()}

--- a/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
+++ b/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
@@ -67,7 +67,7 @@ public interface CtCompilationUnit extends CtElement {
 	List<File> getBinaryFiles();
 
 	/**
-	 * Gets all the types declared in this compilation unit.
+	 * Gets an unmodifiable view of all the types declared in this compilation unit.
 	 */
 	@DerivedProperty
 	@PropertyGetter(role = CtRole.DECLARED_TYPE)

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -95,9 +95,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 
 
 	/**
-	 * Returns the annotations that are present on this element.
-	 *
-	 * For sake of encapsulation, the returned list is unmodifiable.
+	 * Returns an unmodifiable view of the annotations that are present on this element.
 	 */
 	@PropertyGetter(role = ANNOTATION)
 	List<CtAnnotation<? extends Annotation>> getAnnotations();
@@ -311,7 +309,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	Object getMetadata(String key);
 
 	/**
-	 * Retrieves all metadata stored in an element.
+	 * Retrieves an unmodifiable view of all metadata stored in an element.
 	 */
 	Map<String, Object> getAllMetadata();
 
@@ -327,7 +325,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	<E extends CtElement> E setComments(List<CtComment> comments);
 
 	/**
-	 * The list of comments
+	 * The list of comments as unmodifiable view
 	 * @return the list of comment
 	 */
 	@PropertyGetter(role = COMMENT)

--- a/src/main/java/spoon/reflect/declaration/CtEnum.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnum.java
@@ -57,7 +57,7 @@ public interface CtEnum<T extends Enum<?>> extends CtClass<T> {
 	CtEnumValue<?> getEnumValue(String name);
 
 	/**
-	 * Gets all enum values of the enumeration.
+	 * Gets all enum values of the enumeration as unmodifiable view
 	 *
 	 * @return All enum values.
 	 */

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -48,7 +48,7 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	CtBlock<R> getBody();
 
 	/**
-	 * Gets the parameters list.
+	 * Gets an unmodifiable view of the parameters list.
 	 */
 	@PropertyGetter(role = PARAMETER)
 	List<CtParameter<?>> getParameters();

--- a/src/main/java/spoon/reflect/declaration/CtModule.java
+++ b/src/main/java/spoon/reflect/declaration/CtModule.java
@@ -70,13 +70,17 @@ public interface CtModule extends CtNamedElement {
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
 	<T extends CtModule> T addModuleDirectiveAt(int position, CtModuleDirective moduleDirective);
-
+	/**
+	 * @return an unmodifiable view of module directives
+	 */
 	@PropertyGetter(role = MODULE_DIRECTIVE)
 	List<CtModuleDirective> getModuleDirectives();
 
 	@PropertySetter(role = MODULE_DIRECTIVE)
 	<T extends CtModule> T removeModuleDirective(CtModuleDirective moduleDirective);
-
+	/**
+	 * @return an unmodifiable view of used services
+	 */
 	@PropertyGetter(role = SERVICE_TYPE)
 	@DerivedProperty
 	List<CtUsedService> getUsedServices();
@@ -92,7 +96,9 @@ public interface CtModule extends CtNamedElement {
 	@PropertySetter(role = SERVICE_TYPE)
 	@DerivedProperty
 	<T extends CtModule> T removeUsedService(CtUsedService usedService);
-
+	/**
+	 * @return an unmodifiable view of exported packages
+	 */
 	@PropertyGetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
 	List<CtPackageExport> getExportedPackages();
@@ -108,7 +114,9 @@ public interface CtModule extends CtNamedElement {
 	@PropertySetter(role = EXPORTED_PACKAGE)
 	@DerivedProperty
 	<T extends CtModule> T removeExportedPackage(CtPackageExport exportedPackage);
-
+	/**
+	 * @return an unmodifiable view of opened packages
+	 */
 	@PropertyGetter(role = OPENED_PACKAGE)
 	@DerivedProperty
 	List<CtPackageExport> getOpenedPackages();
@@ -125,6 +133,9 @@ public interface CtModule extends CtNamedElement {
 	@DerivedProperty
 	<T extends CtModule> T removeOpenedPackage(CtPackageExport openedPackage);
 
+	/**
+	 * @return an unmodifiable view of required modules
+	 */
 	@PropertyGetter(role = REQUIRED_MODULE)
 	@DerivedProperty
 	List<CtModuleRequirement> getRequiredModules();
@@ -140,7 +151,9 @@ public interface CtModule extends CtNamedElement {
 	@PropertySetter(role = REQUIRED_MODULE)
 	@DerivedProperty
 	<T extends CtModule> T removeRequiredModule(CtModuleRequirement requiredModule);
-
+	/**
+	 * @return an unmodifiable view of provided services.
+	 */
 	@PropertyGetter(role = PROVIDED_SERVICE)
 	@DerivedProperty
 	List<CtProvidedService> getProvidedServices();

--- a/src/main/java/spoon/reflect/declaration/CtPackageExport.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackageExport.java
@@ -53,7 +53,9 @@ public interface CtPackageExport extends CtModuleDirective {
 
 	@PropertySetter(role = CtRole.PACKAGE_REF)
 	<T extends CtPackageExport> T setPackageReference(CtPackageReference packageReference);
-
+	/**
+	 * @return an unmodifiable view of exported packages.
+	 */
 	@PropertyGetter(role = CtRole.MODULE_REF)
 	List<CtModuleReference> getTargetExport();
 

--- a/src/main/java/spoon/reflect/declaration/CtProvidedService.java
+++ b/src/main/java/spoon/reflect/declaration/CtProvidedService.java
@@ -39,6 +39,9 @@ public interface CtProvidedService extends CtModuleDirective {
 	@PropertySetter(role = CtRole.SERVICE_TYPE)
 	<T extends CtProvidedService> T setServiceType(CtTypeReference providingType);
 
+	/**
+	 * @return an unmodifiable view of all implementation types.
+	 */
 	@PropertyGetter(role = CtRole.IMPLEMENTATION_TYPE)
 	List<CtTypeReference> getImplementationTypes();
 

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -230,7 +230,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	/**
 	 * Gets a method from its name and parameter types.
 	 *
-	 * @return null if does not exit
+	 * @return null if does not exist
 	 */
 	@PropertyGetter(role = METHOD)
 	<R> CtMethod<R> getMethod(String name, CtTypeReference<?>... parameterTypes);

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -77,7 +77,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	CtField<?> getField(String name);
 
 	/**
-	 * Returns the fields that are directly declared by this class or interface.
+	 * Returns an unmodifiable view of the fields that are directly declared by this class or interface.
 	 * Includes enum constants.
 	 *
 	 * Derived from {@link #getTypeMembers()}
@@ -93,7 +93,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	<N extends CtType<?>> N getNestedType(String name);
 
 	/**
-	 * Returns the declarations of the nested classes and interfaces that are
+	 * Returns an unmodifiable view of the declarations of the nested classes and interfaces that are
 	 * directly declared by this class or interface.
 	 */
 	@DerivedProperty
@@ -204,7 +204,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	void compileAndReplaceSnippets();
 
 	/**
-	 * Return all the methods that can be called on an instance of this type.
+	 * Return an unmodifiable view of all the methods that can be called on an instance of this type.
 	 * It recursively collects all methods (both concrete and abstract) from all super-classes and all super-interfaces.
 	 * It deduplicates methods with the same signature, which are defined several times somewhere in the type hierarchy.
 	 *
@@ -236,7 +236,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	<R> CtMethod<R> getMethod(String name, CtTypeReference<?>... parameterTypes);
 
 	/**
-	 * Returns the methods that are directly declared by this class or
+	 * Returns an unmodifiable view of the methods that are directly declared by this class or
 	 * interface.
 	 *
 	 * Derived from {@link #getTypeMembers()}
@@ -314,7 +314,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	<S> boolean removeSuperInterface(CtTypeReference<S> interfac);
 
 	/**
-	 * Gets all type members of the type like fields, methods, anonymous block, etc.
+	 * Gets an unmodifiable view of all type members of the type like fields, methods, anonymous block, etc.
 	 */
 	@PropertyGetter(role = TYPE_MEMBER)
 	List<CtTypeMember> getTypeMembers();

--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -30,7 +30,7 @@ import static spoon.reflect.path.CtRole.SUPER_TYPE;
  */
 public interface CtTypeInformation {
 	/**
-	 * Returns the interface types directly implemented by this class or
+	 * Returns an unmodifiable view of the interface types directly implemented by this class or
 	 * extended by this interface.
 	 */
 	@PropertyGetter(role = INTERFACE)
@@ -159,7 +159,7 @@ public interface CtTypeInformation {
 	CtFieldReference<?> getDeclaredOrInheritedField(String fieldName);
 
 	/**
-	 * Gets the executables declared by this type if applicable.
+	 * Gets an unmodifiable view of the executables declared by this type if applicable.
 	 */
 	@DerivedProperty
 	Collection<CtExecutableReference<?>> getDeclaredExecutables();

--- a/src/main/java/spoon/reflect/factory/ModuleFactory.java
+++ b/src/main/java/spoon/reflect/factory/ModuleFactory.java
@@ -68,7 +68,9 @@ public class ModuleFactory extends SubFactory {
 			}
 			return null;
 		}
-
+		/**
+		 * @return an unmodifiable view of all modules
+		 */
 		public Collection<CtModule> getAllModules() {
 			return Collections.unmodifiableCollection(allModules);
 		}

--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -81,7 +81,7 @@ public interface CtExecutableReference<T> extends CtReference, CtActualTypeConta
 	CtTypeReference<T> getType();
 
 	/**
-	 * Gets parameters of the executable.
+	 * Gets an unmodifiable view of the parameters of the executable.
 	 */
 	@PropertyGetter(role = CtRole.ARGUMENT_TYPE)
 	List<CtTypeReference<?>> getParameters();

--- a/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
@@ -19,7 +19,7 @@ import static spoon.reflect.path.CtRole.BOUND;
  */
 public interface CtIntersectionTypeReference<T> extends CtTypeReference<T> {
 	/**
-	 * Gets the bounds of the intersection type. Note that the first bound correspond to the current intersection type.
+	 * Gets an unmodifiable view the bounds of the intersection type. Note that the first bound correspond to the current intersection type.
 	 * <pre>
 	 *     T extends Interface1 &amp; Interface2 // CtTypeParameterReference#getBoundingType == Interface1 and getBounds().get(0) == Interface1
 	 * </pre>

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -261,7 +261,9 @@ public class PrinterHelper {
 	public void putLineNumberMapping(int valueLine) {
 		lineNumberMapping.put(this.line, valueLine);
 	}
-
+	/**
+	 * @return an unmodifiable view of the line mappings.
+	 */
 	public Map<Integer, Integer> getLineNumberMapping() {
 		return Collections.unmodifiableMap(lineNumberMapping);
 	}

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -149,7 +149,7 @@ public class SpoonPom implements SpoonResource {
 	}
 
 	/**
-	 * Get the list of modules defined in this POM
+	 * Get an unmodifiable view of the list of modules defined in this POM
 	 * @return the list of modules
 	 */
 	public List<SpoonPom> getModules() {

--- a/src/main/java/spoon/support/compiler/VirtualFolder.java
+++ b/src/main/java/spoon/support/compiler/VirtualFolder.java
@@ -53,7 +53,10 @@ public class VirtualFolder implements SpoonFolder {
 
 		return result;
 	}
-
+	/**
+	 * @{inheritDoc}
+	 * The result is an unmodifiable view.
+	 */
 	@Override
 	public List<SpoonFile> getFiles() {
 		return Collections.unmodifiableList(new ArrayList<>(files));
@@ -69,6 +72,10 @@ public class VirtualFolder implements SpoonFolder {
 		return null;
 	}
 
+		/**
+	 * @{inheritDoc}
+	 * The result is an unmodifiable view.
+	 */
 	@Override
 	public List<SpoonFolder> getSubFolders() {
 		List<SpoonFolder> result = new ArrayList<>();

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -661,7 +661,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 	}
 
 	/**
-	 * returns the list of current problems
+	 * returns an unmodifiable view of the list of current problems
 	 */
 	public List<CategorizedProblem> getProblems() {
 		return Collections.unmodifiableList(this.probs);

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -76,7 +76,7 @@ public class ChangeCollector {
 
 	/**
 	 * @param currentElement the {@link CtElement} whose changes has to be checked
-	 * @return set of {@link CtRole}s in direct children on of `currentElement` where something has changed since this {@link ChangeCollector} was attached
+	 * @return an unmodifiable view of the set of {@link CtRole}s in direct children on of `currentElement` where something has changed since this {@link ChangeCollector} was attached
 	 * The 'directly' means that value of attribute of `currentElement` was changed.
 	 * Use {@link #getChanges(CtElement)} to detect changes in child elements too
 	 */
@@ -89,7 +89,7 @@ public class ChangeCollector {
 	}
 
 	/**
-	 * Return the set of {@link CtRole}s for which children have changed from `currentElement`
+	 * Return an unmodifiable view of the set of {@link CtRole}s for which children have changed from `currentElement`
 	 * since this {@link ChangeCollector} was attached
 	 * Warning: change in IMPLICIT are ignored
 	 * @param currentElement the {@link CtElement} whose changes has to be checked

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -35,7 +35,9 @@ public class CtModifierHandler implements Serializable {
 	public Factory getFactory() {
 		return element.getFactory();
 	}
-
+	/**
+	 * @return an unmodifiable view of extended modifiers
+	 */
 	public Set<CtExtendedModifier> getExtendedModifiers() {
 		return Collections.unmodifiableSet(this.modifiers);
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -170,9 +170,6 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 
 	@Override
 	public List<CtAnnotation<? extends Annotation>> getAnnotations() {
-		if (this instanceof CtShadowable) {
-			CtShadowable shadowable = (CtShadowable) this;
-		}
 		return unmodifiableList(annotations);
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -19,7 +19,6 @@ import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
-import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -52,7 +52,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 		allMethods.addAll(getFactory().Type().get(Enum.class).getMethods());
 		allMethods.add(valuesMethod());
 		allMethods.add(valueOfMethod());
-		return allMethods;
+		return Collections.unmodifiableSet(allMethods);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -20,6 +20,7 @@ import spoon.support.util.QualifiedNameBasedSortedSet;
 import spoon.support.visitor.SignaturePrinter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -82,7 +83,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	@Override
 	public List<CtParameter<?>> getParameters() {
-		return parameters;
+		return Collections.unmodifiableList(parameters);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -849,7 +849,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 
 	@Override
 	public Set<CtTypeReference<?>> getSuperInterfaces() {
-		return interfaces;
+		return Collections.unmodifiableSet(interfaces);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -411,6 +411,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 				throw new SpoonException("Type not found " + getQualifiedName());
 			}
 		} else {
+			// no Collections.unmodifiable needed, because method already returns read only view
 			return t.getDeclaredExecutables();
 		}
 	}


### PR DESCRIPTION
As discussed in #3770 here are the doc changes.
Still missing is a second run through all interface implementations to fit their sometimes new contract and return an unmodifiable view too.
