### PR TITLE
WIP: Discussion: (chore): add generated serialVersionUID and fix sonarlint rule 

### DIFF
--- a/src/main/java/spoon/javadoc/internal/Javadoc.java
+++ b/src/main/java/spoon/javadoc/internal/Javadoc.java
@@ -35,6 +35,8 @@ import spoon.reflect.code.CtComment;
 */
 public class Javadoc implements Serializable {
 
+
+	private static final long serialVersionUID = 753616734061711345L;
 	private JavadocDescription description;
 	private List<JavadocBlockTag> blockTags;
 

--- a/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 */
 public class JavadocBlockTag implements Serializable {
 
+	private static final long serialVersionUID = 8385157251800755037L;
 	private CtJavaDocTag.TagType type;
 	private JavadocDescription content;
 	private String name = "";

--- a/src/main/java/spoon/javadoc/internal/JavadocDescription.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocDescription.java
@@ -23,6 +23,8 @@ package spoon.javadoc.internal;
 	*/
 	public class JavadocDescription implements Serializable {
 
+
+	private static final long serialVersionUID = -103777997692627654L;
 	private List<JavadocDescriptionElement> elements;
 
 	public JavadocDescription() {

--- a/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 */
 public class JavadocInlineTag implements JavadocDescriptionElement, Serializable {
 
+	private static final long serialVersionUID = 1934780794454717951L;
+
 	/** Return the next word of the string, in other words it stops when a space is encountered. */
 	public static String nextWord(String string) {
 		int index = 0;

--- a/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 * have two snippets: one before and one after the inline tag (<code>{@link String}</code>).
 */
 public class JavadocSnippet implements JavadocDescriptionElement, Serializable {
+
+	private static final long serialVersionUID = -8967626164555785453L;
 	private String text;
 
 	public JavadocSnippet(String text) {

--- a/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
@@ -12,12 +12,11 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.support.reflect.cu.CompilationUnitImpl;
 
 import java.io.File;
-import java.io.Serializable;
 
 /**
  * This class represents the position of a program element in a source file.
  */
-public class NoSourcePosition implements SourcePosition, Serializable {
+public class NoSourcePosition implements SourcePosition {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -18,6 +18,8 @@ import spoon.reflect.declaration.CtElement;
  */
 public class CtLineElementComparator implements Comparator<CtElement>, Serializable {
 
+	private static final long serialVersionUID = -6784439592249504942L;
+
 	/**
 	 * Returns 0 if o1 has the same position as o2, or both positions are invalid and o1.equals(o2).
 	 * Returns -1 if o1 is before o2 in the file, or o1 has no valid position or both positions are invalid !o1.equals(o2).

--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -17,6 +17,8 @@ import java.util.Comparator;
  */
 public class DeepRepresentationComparator implements Comparator<CtElement>, Serializable {
 
+	private static final long serialVersionUID = 4852935760298043152L;
+
 	@Override
 	public int compare(CtElement o1, CtElement o2) {
 		if (o1.getPosition().isValidPosition() == false) {

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
  * ModifierKind in kept for sake of full backward-compatibility.
  */
 public class CtExtendedModifier implements SourcePositionHolder, Serializable {
+
+	private static final long serialVersionUID = -5285887802718811650L;
 	private boolean implicit;
 	private ModifierKind kind;
 	private SourcePosition position;

--- a/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
@@ -10,14 +10,13 @@ package spoon.support.reflect.cu.position;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.position.BodyHolderSourcePosition;
 
-import java.io.Serializable;
 
 /**
  * This class represents the position of a Java program element in a source
  * file.
  */
 public class BodyHolderSourcePositionImpl extends DeclarationSourcePositionImpl
-		implements BodyHolderSourcePosition, Serializable {
+		implements BodyHolderSourcePosition {
 
 	private static final long serialVersionUID = 1L;
 	private int bodyStart;

--- a/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
@@ -10,14 +10,13 @@ package spoon.support.reflect.cu.position;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.position.CompoundSourcePosition;
 
-import java.io.Serializable;
 
 /**
  * This class represents the position of a named Java program element in a source
  * file.
  */
 public class CompoundSourcePositionImpl extends SourcePositionImpl
-		implements CompoundSourcePosition, Serializable {
+		implements CompoundSourcePosition {
 
 	private static final long serialVersionUID = 1L;
 	private int declarationSourceStart;

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -15,14 +15,13 @@ import spoon.reflect.cu.position.DeclarationSourcePosition;
 import spoon.reflect.cu.position.NoSourcePosition;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Arrays;
 
 /**
  * This immutable class represents the position of a Java program element in a source
  * file.
  */
-public class SourcePositionImpl implements SourcePosition, Serializable {
+public class SourcePositionImpl implements SourcePosition {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -55,7 +55,6 @@ import spoon.support.visitor.equals.CloneHelper;
 import spoon.support.visitor.equals.EqualsVisitor;
 import spoon.support.visitor.replace.ReplacementVisitor;
 
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -73,7 +72,7 @@ import static spoon.reflect.visitor.CommentHelper.printComment;
  * Contains the default implementation of most CtElement methods.
  *
  */
-public abstract class CtElementImpl implements CtElement, Serializable {
+public abstract class CtElementImpl implements CtElement {
 	private static final long serialVersionUID = 1L;
 	protected static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	public static final String ERROR_MESSAGE_TO_STRING = "Error in printing the node. One parent isn't initialized!";

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -18,7 +18,6 @@ import spoon.reflect.visitor.CtVisitor;
 import spoon.support.UnsettableProperty;
 import spoon.support.reflect.declaration.CtElementImpl;
 
-import java.io.Serializable;
 import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 import java.util.HashSet;
@@ -28,7 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import static spoon.reflect.path.CtRole.NAME;
 
-public abstract class CtReferenceImpl extends CtElementImpl implements CtReference, Serializable {
+public abstract class CtReferenceImpl extends CtElementImpl implements CtReference {
 
 	private static final long serialVersionUID = 1L;
 	private static Collection<String> keywords = fillWithKeywords();


### PR DESCRIPTION
Rule: 'Extensions and implementations should not be redundant' see https://rules.sonarsource.com/java/RSPEC-1939?search=redundant
We had the situation that some class implemented Serializable even if there parent already did that. The implement clause was redundant and is removed now. There were a lot of serialVersionUID missing. We should either simple generate them or start using 1L and increment for every breaking change.