### PR TITLE
fix: Use self-defined logging level instead of org.slf4j.event.Level

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -35,7 +35,7 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.JavaOutputProcessor;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.support.StandardEnvironment;
 import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
@@ -237,7 +237,7 @@ public class Launcher implements SpoonAPI {
 			opt2.setLongFlag("level");
 			opt2.setHelp("Level of the ouput messages about what spoon is doing.");
 			opt2.setStringParser(JSAP.STRING_PARSER);
-			opt2.setDefault(LogLevel.ERROR.toString());
+			opt2.setDefault(Level.ERROR.toString());
 			jsap.registerParameter(opt2);
 
 			// Auto-import
@@ -525,7 +525,7 @@ public class Launcher implements SpoonAPI {
 				try {
 					modelBuilder.addTemplateSource(SpoonResourceHelper.createResource(new File(s)));
 				} catch (FileNotFoundException e) {
-					environment.report(null, LogLevel.ERROR, "Unable to add template file: " + e.getMessage());
+					environment.report(null, Level.ERROR, "Unable to add template file: " + e.getMessage());
 					LOGGER.error(e.getMessage(), e);
 				}
 			}
@@ -541,7 +541,7 @@ public class Launcher implements SpoonAPI {
 
 	protected void reportClassPathMode() {
 		String cpmode = jsapActualArgs.getString("cpmode").toUpperCase();
-		factory.getEnvironment().report(null, LogLevel.INFO, "Running in " + cpmode + " mode (doc: http://spoon.gforge.inria.fr/launcher.html).");
+		factory.getEnvironment().report(null, Level.INFO, "Running in " + cpmode + " mode (doc: http://spoon.gforge.inria.fr/launcher.html).");
 	}
 
 	/**

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -17,7 +17,6 @@ import com.martiansoftware.jsap.stringparsers.FileStringParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.event.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spoon.SpoonModelBuilder.InputType;
@@ -36,6 +35,7 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.JavaOutputProcessor;
+import spoon.support.LogLevel;
 import spoon.support.StandardEnvironment;
 import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
@@ -237,7 +237,7 @@ public class Launcher implements SpoonAPI {
 			opt2.setLongFlag("level");
 			opt2.setHelp("Level of the ouput messages about what spoon is doing.");
 			opt2.setStringParser(JSAP.STRING_PARSER);
-			opt2.setDefault(Level.ERROR.toString());
+			opt2.setDefault(LogLevel.ERROR.toString());
 			jsap.registerParameter(opt2);
 
 			// Auto-import
@@ -525,7 +525,7 @@ public class Launcher implements SpoonAPI {
 				try {
 					modelBuilder.addTemplateSource(SpoonResourceHelper.createResource(new File(s)));
 				} catch (FileNotFoundException e) {
-					environment.report(null, Level.ERROR, "Unable to add template file: " + e.getMessage());
+					environment.report(null, LogLevel.ERROR, "Unable to add template file: " + e.getMessage());
 					LOGGER.error(e.getMessage(), e);
 				}
 			}
@@ -541,7 +541,7 @@ public class Launcher implements SpoonAPI {
 
 	protected void reportClassPathMode() {
 		String cpmode = jsapActualArgs.getString("cpmode").toUpperCase();
-		factory.getEnvironment().report(null, Level.INFO, "Running in " + cpmode + " mode (doc: http://spoon.gforge.inria.fr/launcher.html).");
+		factory.getEnvironment().report(null, LogLevel.INFO, "Running in " + cpmode + " mode (doc: http://spoon.gforge.inria.fr/launcher.html).");
 	}
 
 	/**

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -17,7 +17,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.support.CompressionType;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.support.OutputDestinationHandler;
 import spoon.support.compiler.SpoonProgress;
 import spoon.support.modelobs.FineModelChangeListener;
@@ -117,7 +117,7 @@ public interface Environment {
 	 * @param message
 	 *            The message to report
 	 */
-	void report(Processor<?> processor, LogLevel level, CtElement element, String message);
+	void report(Processor<?> processor, Level level, CtElement element, String message);
 
 	/**
 	 * This method should be called to print out a message during the
@@ -130,7 +130,7 @@ public interface Environment {
 	 * @param message
 	 *            The message to report
 	 */
-	void report(Processor<?> processor, LogLevel level, String message);
+	void report(Processor<?> processor, Level level, String message);
 
 	/**
 	 * This method should be called to report the end of the processing.
@@ -292,7 +292,7 @@ public interface Environment {
 	/**
 	 * Gets the level of loggers asked by the user.
 	 */
-	LogLevel getLevel();
+	Level getLevel();
 
 	/**
 	 * Sets the level of loggers asked by the user.

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -7,7 +7,6 @@
  */
 package spoon.compiler;
 
-import org.slf4j.event.Level;
 import spoon.OutputType;
 import spoon.compiler.builder.EncodingProvider;
 import spoon.processing.FileGenerator;
@@ -18,6 +17,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.support.CompressionType;
+import spoon.support.LogLevel;
 import spoon.support.OutputDestinationHandler;
 import spoon.support.compiler.SpoonProgress;
 import spoon.support.modelobs.FineModelChangeListener;
@@ -117,7 +117,7 @@ public interface Environment {
 	 * @param message
 	 *            The message to report
 	 */
-	void report(Processor<?> processor, Level level, CtElement element, String message);
+	void report(Processor<?> processor, LogLevel level, CtElement element, String message);
 
 	/**
 	 * This method should be called to print out a message during the
@@ -130,7 +130,7 @@ public interface Environment {
 	 * @param message
 	 *            The message to report
 	 */
-	void report(Processor<?> processor, Level level, String message);
+	void report(Processor<?> processor, LogLevel level, String message);
 
 	/**
 	 * This method should be called to report the end of the processing.
@@ -292,7 +292,7 @@ public interface Environment {
 	/**
 	 * Gets the level of loggers asked by the user.
 	 */
-	Level getLevel();
+	LogLevel getLevel();
 
 	/**
 	 * Sets the level of loggers asked by the user.

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -7,11 +7,11 @@
  */
 package spoon.processing;
 
-import org.slf4j.event.Level;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
+import spoon.support.LogLevel;
 import spoon.testing.utils.ProcessorUtils;
 
 import java.lang.reflect.Method;
@@ -86,7 +86,7 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 		try {
 			props = p.getFactory().getEnvironment().getProcessorProperties(p.getClass().getName());
 		} catch (Exception e) {
-			p.getFactory().getEnvironment().report(p, Level.ERROR,
+			p.getFactory().getEnvironment().report(p, LogLevel.ERROR,
 					"unable to get properties for processor '" + p.getClass().getName() + "': " + e.getMessage());
 			Launcher.LOGGER.error(e.getMessage(), e);
 		}

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -11,7 +11,7 @@ import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.testing.utils.ProcessorUtils;
 
 import java.lang.reflect.Method;
@@ -86,7 +86,7 @@ public abstract class AbstractProcessor<E extends CtElement> implements Processo
 		try {
 			props = p.getFactory().getEnvironment().getProcessorProperties(p.getClass().getName());
 		} catch (Exception e) {
-			p.getFactory().getEnvironment().report(p, LogLevel.ERROR,
+			p.getFactory().getEnvironment().report(p, Level.ERROR,
 					"unable to get properties for processor '" + p.getClass().getName() + "': " + e.getMessage());
 			Launcher.LOGGER.error(e.getMessage(), e);
 		}

--- a/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
@@ -7,10 +7,10 @@
  */
 package spoon.reflect.visitor;
 
-import org.slf4j.event.Level;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.support.LogLevel;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -59,7 +59,7 @@ public class ModelConsistencyChecker extends CtScanner {
 					element.setParent(stack.peek());
 				} else {
 					final String name = element instanceof CtNamedElement ? " - " + ((CtNamedElement) element).getSimpleName() : "";
-					environment.report(null, Level.WARN,
+					environment.report(null, LogLevel.WARN,
 							(element.isParentInitialized() ? "inconsistent" : "null") + " parent for " + element.getClass() + name + " - " + element.getPosition() + " - " + stack.peek()
 									.getPosition());
 					dumpStack();

--- a/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
@@ -10,7 +10,7 @@ package spoon.reflect.visitor;
 import spoon.compiler.Environment;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtNamedElement;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -59,7 +59,7 @@ public class ModelConsistencyChecker extends CtScanner {
 					element.setParent(stack.peek());
 				} else {
 					final String name = element instanceof CtNamedElement ? " - " + ((CtNamedElement) element).getSimpleName() : "";
-					environment.report(null, LogLevel.WARN,
+					environment.report(null, Level.WARN,
 							(element.isParentInitialized() ? "inconsistent" : "null") + " parent for " + element.getClass() + name + " - " + element.getPosition() + " - " + stack.peek()
 									.getPosition());
 					dumpStack();

--- a/src/main/java/spoon/support/Level.java
+++ b/src/main/java/spoon/support/Level.java
@@ -7,12 +7,12 @@
  */
 package spoon.support;
 
-public enum LogLevel {
+public enum Level {
 	ERROR(100), WARN(200), INFO(300), DEBUG(400), TRACE(500);
 
 	private final int levelValue;
 
-	LogLevel(int levelValue) {
+	Level(int levelValue) {
 		this.levelValue = levelValue;
 	}
 

--- a/src/main/java/spoon/support/Level.java
+++ b/src/main/java/spoon/support/Level.java
@@ -7,6 +7,9 @@
  */
 package spoon.support;
 
+/**
+ * Enum for representing logging levels.
+ */
 public enum Level {
 	ERROR(100), WARN(200), INFO(300), DEBUG(400), TRACE(500);
 

--- a/src/main/java/spoon/support/LogLevel.java
+++ b/src/main/java/spoon/support/LogLevel.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
+ *
+ * Copyright (C) 2006-2019 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.support;
+
+public enum LogLevel {
+	ERROR(100), WARN(200), INFO(300), DEBUG(400), TRACE(500);
+
+	private final int levelValue;
+
+	LogLevel(int levelValue) {
+		this.levelValue = levelValue;
+	}
+
+	/**
+	 * The ordinal representation of this logging level. The higher this value, the more logging
+	 * output is provided (i.e. the value increases with decreasing specificity).
+	 *
+	 * @return The ordinal logging level.
+	 */
+	public int toInt() {
+		return levelValue;
+	}
+}

--- a/src/main/java/spoon/support/RuntimeProcessingManager.java
+++ b/src/main/java/spoon/support/RuntimeProcessingManager.java
@@ -7,7 +7,6 @@
  */
 package spoon.support;
 
-import org.slf4j.event.Level;
 import spoon.processing.ProcessInterruption;
 import spoon.processing.ProcessingManager;
 import spoon.processing.Processor;
@@ -54,7 +53,7 @@ public class RuntimeProcessingManager implements ProcessingManager {
 			p.init();
 			addProcessor(p);
 		} catch (Exception e) {
-			factory.getEnvironment().report(null, Level.ERROR, "Unable to instantiate processor \"" + type.getName() + "\" - Your processor should have a constructor with no arguments");
+			factory.getEnvironment().report(null, LogLevel.ERROR, "Unable to instantiate processor \"" + type.getName() + "\" - Your processor should have a constructor with no arguments");
 		}
 	}
 
@@ -70,7 +69,7 @@ public class RuntimeProcessingManager implements ProcessingManager {
 		try {
 			addProcessor((Class<? extends Processor<?>>) getFactory().getEnvironment().getInputClassLoader().loadClass(qualifiedName));
 		} catch (ClassNotFoundException e) {
-			factory.getEnvironment().report(null, Level.ERROR, "Unable to load processor \"" + qualifiedName + "\" - Check your classpath.");
+			factory.getEnvironment().report(null, LogLevel.ERROR, "Unable to load processor \"" + qualifiedName + "\" - Check your classpath.");
 		}
 	}
 

--- a/src/main/java/spoon/support/RuntimeProcessingManager.java
+++ b/src/main/java/spoon/support/RuntimeProcessingManager.java
@@ -53,7 +53,7 @@ public class RuntimeProcessingManager implements ProcessingManager {
 			p.init();
 			addProcessor(p);
 		} catch (Exception e) {
-			factory.getEnvironment().report(null, LogLevel.ERROR, "Unable to instantiate processor \"" + type.getName() + "\" - Your processor should have a constructor with no arguments");
+			factory.getEnvironment().report(null, Level.ERROR, "Unable to instantiate processor \"" + type.getName() + "\" - Your processor should have a constructor with no arguments");
 		}
 	}
 
@@ -69,7 +69,7 @@ public class RuntimeProcessingManager implements ProcessingManager {
 		try {
 			addProcessor((Class<? extends Processor<?>>) getFactory().getEnvironment().getInputClassLoader().loadClass(qualifiedName));
 		} catch (ClassNotFoundException e) {
-			factory.getEnvironment().report(null, LogLevel.ERROR, "Unable to load processor \"" + qualifiedName + "\" - Check your classpath.");
+			factory.getEnvironment().report(null, Level.ERROR, "Unable to load processor \"" + qualifiedName + "\" - Check your classpath.");
 		}
 	}
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -8,7 +8,6 @@
 package spoon.support;
 
 
-import org.slf4j.event.Level;
 import org.slf4j.Logger;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -98,7 +97,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private transient  Logger logger = Launcher.LOGGER;
 
-	private Level level = Level.ERROR;
+	private LogLevel level = LogLevel.ERROR;
 
 	private boolean shouldCompile = false;
 
@@ -137,7 +136,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	@Override
 	public void debugMessage(String message) {
-		print(message, Level.DEBUG);
+		print(message, LogLevel.DEBUG);
 	}
 
 	@Override
@@ -160,7 +159,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	@Override
-	public Level getLevel() {
+	public LogLevel getLevel() {
 		return this.level;
 	}
 
@@ -189,15 +188,15 @@ public class StandardEnvironment implements Serializable, Environment {
 		skipSelfChecks = true;
 	}
 
-	private Level toLevel(String level) {
+	private LogLevel toLevel(String level) {
 		if (level == null || level.isEmpty()) {
 			throw new SpoonException("Wrong level given at Spoon.");
 		}
-		Level levelEnum;
+		LogLevel levelEnum;
 		try {
-			levelEnum = Level.valueOf(level);
+			levelEnum = LogLevel.valueOf(level);
 		} catch (IllegalArgumentException e) {
-			return Level.TRACE;
+			return LogLevel.TRACE;
 		}
 		return levelEnum;
 	}
@@ -227,18 +226,18 @@ public class StandardEnvironment implements Serializable, Environment {
 		return processingStopped;
 	}
 
-	private void prefix(StringBuilder buffer, Level level) {
-		if (level == Level.ERROR) {
+	private void prefix(StringBuilder buffer, LogLevel level) {
+		if (level == LogLevel.ERROR) {
 			buffer.append("error: ");
 			errorCount++;
-		} else if (level == Level.WARN) {
+		} else if (level == LogLevel.WARN) {
 			buffer.append("warning: ");
 			warningCount++;
 		}
 	}
 
 	@Override
-	public void report(Processor<?> processor, Level level, CtElement element, String message) {
+	public void report(Processor<?> processor, LogLevel level, CtElement element, String message) {
 		StringBuilder buffer = new StringBuilder();
 
 		prefix(buffer, level);
@@ -269,7 +268,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	@Override
-	public void report(Processor<?> processor, Level level, String message) {
+	public void report(Processor<?> processor, LogLevel level, String message) {
 		StringBuilder buffer = new StringBuilder();
 
 		prefix(buffer, level);
@@ -278,8 +277,8 @@ public class StandardEnvironment implements Serializable, Environment {
 		print(buffer.toString(), level);
 	}
 
-	private void print(String message, Level messageLevel) {
-		if (messageLevel.toInt() >= this.level.toInt()) {
+	private void print(String message, LogLevel messageLevel) {
+		if (messageLevel.toInt() <= this.level.toInt()) {
 			switch (messageLevel) {
 				case ERROR: logger.error(message);
 					break;
@@ -299,32 +298,32 @@ public class StandardEnvironment implements Serializable, Environment {
 	 */
 	@Override
 	public void reportEnd() {
-		print("end of processing: ", Level.INFO);
+		print("end of processing: ", LogLevel.INFO);
 		if (warningCount > 0) {
-			print(warningCount + " warning", Level.INFO);
+			print(warningCount + " warning", LogLevel.INFO);
 			if (warningCount > 1) {
-				print("s", Level.INFO);
+				print("s", LogLevel.INFO);
 			}
 			if (errorCount > 0) {
-				print(", ", Level.INFO);
+				print(", ", LogLevel.INFO);
 			}
 		}
 		if (errorCount > 0) {
-			print(errorCount + " error", Level.INFO);
+			print(errorCount + " error", LogLevel.INFO);
 			if (errorCount > 1) {
-				print("s", Level.INFO);
+				print("s", LogLevel.INFO);
 			}
 		}
 		if ((errorCount + warningCount) > 0) {
-			print("\n", Level.INFO);
+			print("\n", LogLevel.INFO);
 		} else {
-			print("no errors, no warnings", Level.INFO);
+			print("no errors, no warnings", LogLevel.INFO);
 		}
 	}
 
 	@Override
 	public void reportProgressMessage(String message) {
-		print(message, Level.INFO);
+		print(message, LogLevel.INFO);
 	}
 
 	public void setDebug(boolean debug) {
@@ -487,9 +486,9 @@ private transient  ClassLoader inputClassloader;
 				SpoonFolder tmp = new FileSystemFolder(classOrJarFolder);
 				List<SpoonFile> javaFiles = tmp.getAllJavaFiles();
 				if (!javaFiles.isEmpty()) {
-					print("You're trying to give source code in the classpath, this should be given to " + "addInputSource " + javaFiles, Level.WARN);
+					print("You're trying to give source code in the classpath, this should be given to " + "addInputSource " + javaFiles, LogLevel.WARN);
 				}
-				print("You specified the directory " + classOrJarFolder.getPath() + " in source classpath, please note that only class files will be considered. Jars and subdirectories will be ignored.", Level.WARN);
+				print("You specified the directory " + classOrJarFolder.getPath() + " in source classpath, please note that only class files will be considered. Jars and subdirectories will be ignored.", LogLevel.WARN);
 			} else if (classOrJarFolder.getName().endsWith(".class")) {
 				throw new InvalidClassPathException(".class files are not accepted in source classpath.");
 			}
@@ -576,7 +575,7 @@ private transient  ClassLoader inputClassloader;
 			this.outputDestinationHandler = new DefaultOutputDestinationHandler(directory.getCanonicalFile(),
 					this);
 		} catch (IOException e) {
-			print(e.getMessage(), Level.WARN);
+			print(e.getMessage(), LogLevel.WARN);
 			throw new SpoonException(e);
 		}
 	}

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -97,7 +97,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	private transient  Logger logger = Launcher.LOGGER;
 
-	private LogLevel level = LogLevel.ERROR;
+	private Level level = Level.ERROR;
 
 	private boolean shouldCompile = false;
 
@@ -136,7 +136,7 @@ public class StandardEnvironment implements Serializable, Environment {
 
 	@Override
 	public void debugMessage(String message) {
-		print(message, LogLevel.DEBUG);
+		print(message, Level.DEBUG);
 	}
 
 	@Override
@@ -159,7 +159,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	@Override
-	public LogLevel getLevel() {
+	public Level getLevel() {
 		return this.level;
 	}
 
@@ -188,15 +188,15 @@ public class StandardEnvironment implements Serializable, Environment {
 		skipSelfChecks = true;
 	}
 
-	private LogLevel toLevel(String level) {
+	private Level toLevel(String level) {
 		if (level == null || level.isEmpty()) {
 			throw new SpoonException("Wrong level given at Spoon.");
 		}
-		LogLevel levelEnum;
+		Level levelEnum;
 		try {
-			levelEnum = LogLevel.valueOf(level);
+			levelEnum = Level.valueOf(level);
 		} catch (IllegalArgumentException e) {
-			return LogLevel.TRACE;
+			return Level.TRACE;
 		}
 		return levelEnum;
 	}
@@ -226,18 +226,18 @@ public class StandardEnvironment implements Serializable, Environment {
 		return processingStopped;
 	}
 
-	private void prefix(StringBuilder buffer, LogLevel level) {
-		if (level == LogLevel.ERROR) {
+	private void prefix(StringBuilder buffer, Level level) {
+		if (level == Level.ERROR) {
 			buffer.append("error: ");
 			errorCount++;
-		} else if (level == LogLevel.WARN) {
+		} else if (level == Level.WARN) {
 			buffer.append("warning: ");
 			warningCount++;
 		}
 	}
 
 	@Override
-	public void report(Processor<?> processor, LogLevel level, CtElement element, String message) {
+	public void report(Processor<?> processor, Level level, CtElement element, String message) {
 		StringBuilder buffer = new StringBuilder();
 
 		prefix(buffer, level);
@@ -268,7 +268,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	@Override
-	public void report(Processor<?> processor, LogLevel level, String message) {
+	public void report(Processor<?> processor, Level level, String message) {
 		StringBuilder buffer = new StringBuilder();
 
 		prefix(buffer, level);
@@ -277,7 +277,7 @@ public class StandardEnvironment implements Serializable, Environment {
 		print(buffer.toString(), level);
 	}
 
-	private void print(String message, LogLevel messageLevel) {
+	private void print(String message, Level messageLevel) {
 		if (messageLevel.toInt() <= this.level.toInt()) {
 			switch (messageLevel) {
 				case ERROR: logger.error(message);
@@ -298,32 +298,32 @@ public class StandardEnvironment implements Serializable, Environment {
 	 */
 	@Override
 	public void reportEnd() {
-		print("end of processing: ", LogLevel.INFO);
+		print("end of processing: ", Level.INFO);
 		if (warningCount > 0) {
-			print(warningCount + " warning", LogLevel.INFO);
+			print(warningCount + " warning", Level.INFO);
 			if (warningCount > 1) {
-				print("s", LogLevel.INFO);
+				print("s", Level.INFO);
 			}
 			if (errorCount > 0) {
-				print(", ", LogLevel.INFO);
+				print(", ", Level.INFO);
 			}
 		}
 		if (errorCount > 0) {
-			print(errorCount + " error", LogLevel.INFO);
+			print(errorCount + " error", Level.INFO);
 			if (errorCount > 1) {
-				print("s", LogLevel.INFO);
+				print("s", Level.INFO);
 			}
 		}
 		if ((errorCount + warningCount) > 0) {
-			print("\n", LogLevel.INFO);
+			print("\n", Level.INFO);
 		} else {
-			print("no errors, no warnings", LogLevel.INFO);
+			print("no errors, no warnings", Level.INFO);
 		}
 	}
 
 	@Override
 	public void reportProgressMessage(String message) {
-		print(message, LogLevel.INFO);
+		print(message, Level.INFO);
 	}
 
 	public void setDebug(boolean debug) {
@@ -486,9 +486,9 @@ private transient  ClassLoader inputClassloader;
 				SpoonFolder tmp = new FileSystemFolder(classOrJarFolder);
 				List<SpoonFile> javaFiles = tmp.getAllJavaFiles();
 				if (!javaFiles.isEmpty()) {
-					print("You're trying to give source code in the classpath, this should be given to " + "addInputSource " + javaFiles, LogLevel.WARN);
+					print("You're trying to give source code in the classpath, this should be given to " + "addInputSource " + javaFiles, Level.WARN);
 				}
-				print("You specified the directory " + classOrJarFolder.getPath() + " in source classpath, please note that only class files will be considered. Jars and subdirectories will be ignored.", LogLevel.WARN);
+				print("You specified the directory " + classOrJarFolder.getPath() + " in source classpath, please note that only class files will be considered. Jars and subdirectories will be ignored.", Level.WARN);
 			} else if (classOrJarFolder.getName().endsWith(".class")) {
 				throw new InvalidClassPathException(".class files are not accepted in source classpath.");
 			}
@@ -575,7 +575,7 @@ private transient  ClassLoader inputClassloader;
 			this.outputDestinationHandler = new DefaultOutputDestinationHandler(directory.getCanonicalFile(),
 					this);
 		} catch (IOException e) {
-			print(e.getMessage(), LogLevel.WARN);
+			print(e.getMessage(), Level.WARN);
 			throw new SpoonException(e);
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -40,7 +40,7 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.Query;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.support.QueueProcessingManager;
 import spoon.support.comparator.FixedOrderBasedOnFileNameCompilationUnitComparator;
 import spoon.support.compiler.SnippetCompilationError;
@@ -445,7 +445,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				try {
 					new JDTCommentBuilder(unit, aFactory).build();
 				} catch (Exception e) {
-					getEnvironment().report(null, LogLevel.ERROR, "JDTCommentBuilder crashed with the error, some comments may be missing in the model: " + e.toString());
+					getEnvironment().report(null, Level.ERROR, "JDTCommentBuilder crashed with the error, some comments may be missing in the model: " + e.toString());
 				}
 			});
 		}
@@ -614,7 +614,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				if (problem.isError()) {
 					throw new SnippetCompilationError(message);
 				} else {
-					environment.report(null, LogLevel.WARN, message);
+					environment.report(null, Level.WARN, message);
 				}
 			}
 		}
@@ -653,7 +653,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				int problemId = problem.getID();
 				if (problemId != IProblem.UndefinedType && problemId != IProblem.UndefinedName
 						&& problemId != IProblem.ImportNotFound) {
-					environment.report(null, LogLevel.WARN, message);
+					environment.report(null, Level.WARN, message);
 				}
 			}
 		}

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -8,7 +8,6 @@
 package spoon.support.compiler.jdt;
 
 import org.apache.commons.io.IOUtils;
-import org.slf4j.event.Level;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
@@ -41,6 +40,7 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.Filter;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.Query;
+import spoon.support.LogLevel;
 import spoon.support.QueueProcessingManager;
 import spoon.support.comparator.FixedOrderBasedOnFileNameCompilationUnitComparator;
 import spoon.support.compiler.SnippetCompilationError;
@@ -445,7 +445,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				try {
 					new JDTCommentBuilder(unit, aFactory).build();
 				} catch (Exception e) {
-					getEnvironment().report(null, Level.ERROR, "JDTCommentBuilder crashed with the error, some comments may be missing in the model: " + e.toString());
+					getEnvironment().report(null, LogLevel.ERROR, "JDTCommentBuilder crashed with the error, some comments may be missing in the model: " + e.toString());
 				}
 			});
 		}
@@ -614,7 +614,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				if (problem.isError()) {
 					throw new SnippetCompilationError(message);
 				} else {
-					environment.report(null, Level.WARN, message);
+					environment.report(null, LogLevel.WARN, message);
 				}
 			}
 		}
@@ -653,7 +653,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				int problemId = problem.getID();
 				if (problemId != IProblem.UndefinedType && problemId != IProblem.UndefinedName
 						&& problemId != IProblem.ImportNotFound) {
-					environment.report(null, Level.WARN, message);
+					environment.report(null, LogLevel.WARN, message);
 				}
 			}
 		}

--- a/src/test/java/spoon/test/logging/LogTest.java
+++ b/src/test/java/spoon/test/logging/LogTest.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.slf4j.event.Level;
 import spoon.Launcher;
 import spoon.MavenLauncher;
+import spoon.support.LogLevel;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
@@ -40,15 +40,15 @@ public class LogTest {
 		@Parameterized.Parameters
 		public static Collection<Object[]> data() {
 			return Arrays.asList(new Object[][] {
-					{Level.DEBUG, 6 },
-					{Level.INFO, 2 },
-					{Level.WARN, 0 },
-					{Level.ERROR, 0 }
+					{LogLevel.DEBUG, 6 },
+					{LogLevel.INFO, 2 },
+					{LogLevel.WARN, 0 },
+					{LogLevel.ERROR, 0 }
 			});
 		}
 
 		@Parameterized.Parameter(0)
-		public Level level;
+		public LogLevel level;
 
 		@Parameterized.Parameter(1)
 		public int nbLogMessagesMinimum;

--- a/src/test/java/spoon/test/logging/LogTest.java
+++ b/src/test/java/spoon/test/logging/LogTest.java
@@ -22,7 +22,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import spoon.Launcher;
 import spoon.MavenLauncher;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
@@ -40,15 +40,15 @@ public class LogTest {
 		@Parameterized.Parameters
 		public static Collection<Object[]> data() {
 			return Arrays.asList(new Object[][] {
-					{LogLevel.DEBUG, 6 },
-					{LogLevel.INFO, 2 },
-					{LogLevel.WARN, 0 },
-					{LogLevel.ERROR, 0 }
+					{Level.DEBUG, 6 },
+					{Level.INFO, 2 },
+					{Level.WARN, 0 },
+					{Level.ERROR, 0 }
 			});
 		}
 
 		@Parameterized.Parameter(0)
-		public LogLevel level;
+		public Level level;
 
 		@Parameterized.Parameter(1)
 		public int nbLogMessagesMinimum;

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -35,7 +35,7 @@ import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.test.processing.processors.RenameProcessor;
 import spoon.test.processing.processors.CtClassProcessor;
@@ -173,7 +173,7 @@ public class ProcessingTest {
 		/* throw correctly an exception when trying to use a processor with constructor with args */
 
 		Launcher l = new Launcher();
-		l.getEnvironment().setLevel(LogLevel.ERROR.toString());
+		l.getEnvironment().setLevel(Level.ERROR.toString());
 		l.buildModel();
 		try {
 			new JDTBasedSpoonCompiler(l.getFactory()).instantiateAndProcess(Collections.singletonList("spoon.test.processing.ProcessingTest$WrongProcessor"));

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -18,7 +18,6 @@ package spoon.test.processing;
 
 import com.google.common.io.Files;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.event.Level;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -36,6 +35,7 @@ import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.LogLevel;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.test.processing.processors.RenameProcessor;
 import spoon.test.processing.processors.CtClassProcessor;
@@ -173,7 +173,7 @@ public class ProcessingTest {
 		/* throw correctly an exception when trying to use a processor with constructor with args */
 
 		Launcher l = new Launcher();
-		l.getEnvironment().setLevel(Level.ERROR.toString());
+		l.getEnvironment().setLevel(LogLevel.ERROR.toString());
 		l.buildModel();
 		try {
 			new JDTBasedSpoonCompiler(l.getFactory()).instantiateAndProcess(Collections.singletonList("spoon.test.processing.ProcessingTest$WrongProcessor"));

--- a/src/test/java/spoon/test/processing/processors/TestProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/TestProcessor.java
@@ -18,13 +18,13 @@ package spoon.test.processing.processors;
 
 import java.util.Date;
 
-import org.slf4j.event.Level;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtTypedElement;
+import spoon.support.LogLevel;
 import spoon.template.Substitution;
 import spoon.test.template.testclasses.constructors.TemplateWithConstructor;
 
@@ -38,13 +38,13 @@ public class TestProcessor extends AbstractProcessor<CtElement> {
 
 	public void process(CtElement element) {
 		if ((!(element instanceof CtPackage)) && !element.isParentInitialized()) {
-			getEnvironment().report(this, Level.ERROR, element,
+			getEnvironment().report(this, LogLevel.ERROR, element,
 					"Element's parent is null (" + element + ")");
 			throw new RuntimeException("uninitialized parent detected");
 		}
 		if (element instanceof CtTypedElement) {
 			if (((CtTypedElement<?>) element).getType() == null) {
-				getEnvironment().report(this, Level.WARN, element,
+				getEnvironment().report(this, LogLevel.WARN, element,
 						"Element's type is null (" + element + ")");
 			}
 		}

--- a/src/test/java/spoon/test/processing/processors/TestProcessor.java
+++ b/src/test/java/spoon/test/processing/processors/TestProcessor.java
@@ -24,7 +24,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtTypedElement;
-import spoon.support.LogLevel;
+import spoon.support.Level;
 import spoon.template.Substitution;
 import spoon.test.template.testclasses.constructors.TemplateWithConstructor;
 
@@ -38,13 +38,13 @@ public class TestProcessor extends AbstractProcessor<CtElement> {
 
 	public void process(CtElement element) {
 		if ((!(element instanceof CtPackage)) && !element.isParentInitialized()) {
-			getEnvironment().report(this, LogLevel.ERROR, element,
+			getEnvironment().report(this, Level.ERROR, element,
 					"Element's parent is null (" + element + ")");
 			throw new RuntimeException("uninitialized parent detected");
 		}
 		if (element instanceof CtTypedElement) {
 			if (((CtTypedElement<?>) element).getType() == null) {
-				getEnvironment().report(this, LogLevel.WARN, element,
+				getEnvironment().report(this, Level.WARN, element,
 						"Element's type is null (" + element + ")");
 			}
 		}


### PR DESCRIPTION
#3775 

This PR introduces a self-defined `LogLevel` enum that can be used to get or set the logging level. The reason we need this is that `org.slf4j.event.Level` makes Spoon backwards-incompatible with libraries that uses `slf4j-api < 1.7.15`. Which is not good. I've tested this locally and it fixes the test errors in Casper, as mentioned in #3775.

**This is a breaking change**, as the return type of `Environment.getLevel()` is changed. #I purposefully changed the name of the type from `Level` to `LogLevel` to make this more evident. #3755 was in fact also breaking, as the `org.slf4j.event.Level` is not the same as the previous `Level` type from `log4j`. With this change, however, we won't have breakage again, as we now define the type ourselves.

I have two more thoughts on this.

1. Do we want to implement this breaking change now, or should we wait for Spoon 9? If we don't want to do it now, we must also revert #3755.
2. As we're breaking the API anyway, we may also want to consider renaming `Environment.get/setLevel()` to `Environment.get/setLogLevel()`. These names are more descriptive ("level" is obvious in a logging framework, but not in a metaprogramming library), and also make the breaking change more obvious.