### PR TITLE
fix: Prevent ImportCleaner from importing inherited static methods

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -171,7 +171,6 @@ public class ImportCleaner extends ImportAnalyzer<ImportCleaner.Context> {
 				// we would like to add an import, but we don't know to where
 				return;
 			}
-
 			CtTypeReference<?> topLevelTypeRef = typeRef.getTopLevelType();
 			if (typeRefQNames.contains(topLevelTypeRef.getQualifiedName())) {
 				//it is reference to a type of this CompilationUnit. Do not add it

--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -192,7 +192,10 @@ public class ImportCleaner extends ImportAnalyzer<ImportCleaner.Context> {
 			}
 			if (isStaticExecutableRef(ref)
 					&& inheritsFrom(ref.getParent(CtType.class).getReference(), typeRef)) {
-				// Static method is inherited from parent class
+				// Static method is inherited from parent class. At worst, importing an inherited
+				// static method results in a compile error, if the static method is defined in
+				// the default package (not allowed to import methods from default package).
+				// At best, it's pointless. So we skip it.
 				return;
 			}
 			String importRefID = getImportRefID(ref);

--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -185,13 +185,11 @@ public class ImportCleaner extends ImportAnalyzer<ImportCleaner.Context> {
 				//java.lang is always imported implicitly. Ignore it
 				return;
 			}
-			if (Objects.equals(packageQName, packageRef.getQualifiedName())
-					&& !isStaticExecutableRef(ref)) {
+			if (Objects.equals(packageQName, packageRef.getQualifiedName()) && !isStaticExecutableRef(ref)) {
 				//it is reference to a type of the same package. Do not add it
 				return;
 			}
-			if (isStaticExecutableRef(ref)
-					&& inheritsFrom(ref.getParent(CtType.class).getReference(), typeRef)) {
+			if (isStaticExecutableRef(ref) && inheritsFrom(ref.getParent(CtType.class).getReference(), typeRef)) {
 				// Static method is inherited from parent class. At worst, importing an inherited
 				// static method results in a compile error, if the static method is defined in
 				// the default package (not allowed to import methods from default package).

--- a/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
+++ b/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
@@ -35,6 +35,26 @@ public class ImportCleanerTest {
 		assertThat(importsAfter, equalTo(importsBefore));
 	}
 
+	@Test
+	public void testDoesNotImportInheritedStaticMethod() {
+		// contract: The import cleaner should not import static attributes that are inherited
+
+		// arrange
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("./src/test/resources/inherit-static-method");
+		CtModel model = launcher.buildModel();
+		CtType<?> derivedType = model.getUnnamedModule().getFactory().Type().get("Derived");
+		CtCompilationUnit cu = derivedType.getFactory().CompilationUnit().getOrCreate(derivedType);
+		List<String> importsBefore = getTextualImports(cu);
+
+		// act
+		new ImportCleaner().process(cu);
+
+		// assert
+		List<String> importsAfter = getTextualImports(cu);
+		assertThat(importsAfter, equalTo(importsBefore));
+	}
+
 	private static List<String> getTextualImports(CtCompilationUnit cu) {
 		return cu.getImports().stream()
 				.map(CtImport::toString)

--- a/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
+++ b/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
@@ -1,6 +1,5 @@
 package spoon.reflect.visitor;
 
-import org.apache.maven.model.Model;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -9,7 +8,6 @@ import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtType;
 
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;

--- a/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
+++ b/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
@@ -1,5 +1,6 @@
 package spoon.reflect.visitor;
 
+import org.apache.maven.model.Model;
 import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -8,6 +9,7 @@ import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtType;
 
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -18,32 +20,25 @@ public class ImportCleanerTest {
 	@Test
 	public void testDoesNotDuplicateUnresolvedImports() {
 	    // contract: The import cleaner should not duplicate unresolved imports
-
-		// arrange
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/unresolved/UnresolvedImport.java");
-		CtModel model = launcher.buildModel();
-		CtType<?> type = model.getAllTypes().stream().findFirst().get();
-		CtCompilationUnit cu = type.getFactory().CompilationUnit().getOrCreate(type);
-		List<String> importsBefore = getTextualImports(cu);
-
-		// act
-		new ImportCleaner().process(cu);
-
-		// assert
-		List<String> importsAfter = getTextualImports(cu);
-		assertThat(importsAfter, equalTo(importsBefore));
+		testImportCleanerDoesNotAlterImports("./src/test/resources/unresolved/UnresolvedImport.java", "UnresolvedImport");
 	}
 
 	@Test
 	public void testDoesNotImportInheritedStaticMethod() {
 		// contract: The import cleaner should not import static attributes that are inherited
+		testImportCleanerDoesNotAlterImports("./src/test/resources/inherit-static-method", "Derived");
+	}
 
+	/**
+	 * Test that processing the target class' compilation unit with the import cleaner does not
+	 * alter the imports.
+	 */
+	private static void testImportCleanerDoesNotAlterImports(String source, String targetClassQualname) {
 		// arrange
 		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/inherit-static-method");
+		launcher.addInputResource(source);
 		CtModel model = launcher.buildModel();
-		CtType<?> derivedType = model.getUnnamedModule().getFactory().Type().get("Derived");
+		CtType<?> derivedType = model.getUnnamedModule().getFactory().Type().get(targetClassQualname);
 		CtCompilationUnit cu = derivedType.getFactory().CompilationUnit().getOrCreate(derivedType);
 		List<String> importsBefore = getTextualImports(cu);
 

--- a/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
+++ b/src/test/java/spoon/reflect/visitor/ImportCleanerTest.java
@@ -36,8 +36,8 @@ public class ImportCleanerTest {
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(source);
 		CtModel model = launcher.buildModel();
-		CtType<?> derivedType = model.getUnnamedModule().getFactory().Type().get(targetClassQualname);
-		CtCompilationUnit cu = derivedType.getFactory().CompilationUnit().getOrCreate(derivedType);
+		CtType<?> type = model.getUnnamedModule().getFactory().Type().get(targetClassQualname);
+		CtCompilationUnit cu = type.getFactory().CompilationUnit().getOrCreate(type);
 		List<String> importsBefore = getTextualImports(cu);
 
 		// act

--- a/src/test/resources/inherit-static-method/Base.java
+++ b/src/test/resources/inherit-static-method/Base.java
@@ -1,0 +1,5 @@
+public class Base {
+    public static int getMeaning() {
+        return 42;
+    }
+}

--- a/src/test/resources/inherit-static-method/Base.java
+++ b/src/test/resources/inherit-static-method/Base.java
@@ -1,5 +1,3 @@
-package pkg;
-
 public class Base {
     public static int getMeaning() {
         return 42;

--- a/src/test/resources/inherit-static-method/Derived.java
+++ b/src/test/resources/inherit-static-method/Derived.java
@@ -1,0 +1,7 @@
+// this class uses a static method from its parent class, which previously caused the ImportCleaner
+// to statically import the method, even though it's inherited.
+public class Derived extends Base {
+    public static void main(String[] args) {
+        System.out.println(getMeaning());
+    }
+}

--- a/src/test/resources/inherit-static-method/Derived.java
+++ b/src/test/resources/inherit-static-method/Derived.java
@@ -1,6 +1,3 @@
-// important that Base is packaged, as static method imports from the default package are not allowed
-import pkg.Base;
-
 // this class uses a static method from its parent class, which previously caused the ImportCleaner
 // to statically import the method, even though it's inherited.
 public class Derived extends Base {

--- a/src/test/resources/inherit-static-method/Derived.java
+++ b/src/test/resources/inherit-static-method/Derived.java
@@ -1,3 +1,6 @@
+// important that Base is packaged, as static method imports from the default package are not allowed
+import pkg.Base;
+
 // this class uses a static method from its parent class, which previously caused the ImportCleaner
 // to statically import the method, even though it's inherited.
 public class Derived extends Base {

--- a/src/test/resources/inherit-static-method/pkg/Base.java
+++ b/src/test/resources/inherit-static-method/pkg/Base.java
@@ -1,3 +1,5 @@
+package pkg;
+
 public class Base {
     public static int getMeaning() {
         return 42;


### PR DESCRIPTION
Fix #3797 

This PR prevents the ImportCleaner from importing static methods that are inherited from a parent class. Such imports cause compile errors if the static method is defined in a class in the default package. At best, they do absolutely nothing.