### PR TITLE
fix: Fix unqualified type reference in catch block becoming qualified

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1509,7 +1509,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 			context.enter(reference, qualifiedTypeReference);
 			return true;
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
-			context.enter(helper.createCatchVariable(qualifiedTypeReference), qualifiedTypeReference);
+			context.enter(helper.createCatchVariable(qualifiedTypeReference, scope), qualifiedTypeReference);
 			return true;
 		}
 		context.enter(factory.Code().createTypeAccessWithoutCloningReference(references.buildTypeReference(qualifiedTypeReference, scope)), qualifiedTypeReference);
@@ -1593,7 +1593,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		if (!(context.stack.peekFirst().node instanceof Argument)) {
 			throw new SpoonException("UnionType is only supported for CtCatch.");
 		}
-		context.enter(helper.createCatchVariable(unionTypeReference), unionTypeReference);
+		context.enter(helper.createCatchVariable(unionTypeReference, scope), unionTypeReference);
 		return true;
 	}
 
@@ -1619,7 +1619,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 			return true;
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
-			context.enter(helper.createCatchVariable(singleTypeReference), singleTypeReference);
+			context.enter(helper.createCatchVariable(singleTypeReference, scope), singleTypeReference);
 			return true;
 		}
 		CtTypeReference<?> typeRef = references.buildTypeReference(singleTypeReference, scope);

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -21,7 +21,6 @@ import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ReferenceExpression;
 import org.eclipse.jdt.internal.compiler.ast.RequiresStatement;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
-import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.UnionTypeReference;

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.internal.compiler.ast.QualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ReferenceExpression;
 import org.eclipse.jdt.internal.compiler.ast.RequiresStatement;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
+import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.UnionTypeReference;
@@ -33,6 +34,7 @@ import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.VariableBinding;
@@ -117,7 +119,7 @@ public class JDTTreeBuilderHelper {
 	 * 		Corresponds to the exception type declared in the catch.
 	 * @return a catch variable.
 	 */
-	CtCatchVariable<Throwable> createCatchVariable(TypeReference typeReference) {
+	CtCatchVariable<Throwable> createCatchVariable(TypeReference typeReference, Scope scope) {
 		final Argument jdtCatch = (Argument) jdtTreeBuilder.getContextBuilder().stack.peekFirst().node;
 		final Set<CtExtendedModifier> modifiers = getModifiers(jdtCatch.modifiers, false, false);
 
@@ -127,12 +129,7 @@ public class JDTTreeBuilderHelper {
 			//do not set type of variable yet. It will be initialized later by visit of multiple types. Each call then ADDs one type
 			return result;
 		} else {
-			CtTypeReference ctTypeReference;
-			if (typeReference.resolvedType instanceof ProblemReferenceBinding) {
-				ctTypeReference = jdtTreeBuilder.getReferencesBuilder().buildTypeReference(typeReference, null);
-			} else {
-				ctTypeReference = jdtTreeBuilder.getReferencesBuilder().<Throwable>getTypeReference(typeReference.resolvedType);
-			}
+			CtTypeReference ctTypeReference = jdtTreeBuilder.getReferencesBuilder().buildTypeReference(typeReference, scope);
 			return result.<CtCatchVariable>setType(ctTypeReference);
 		}
 	}

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -336,4 +336,17 @@ public class TryCatchTest {
 		assertEquals("CustomException", caughtType.getSimpleName());
 		assertEquals("some.neat.pkg.CustomException", caughtType.getQualifiedName());
 	}
+
+	@Test
+	public void testCatchUnqualifiedReferenceHasPackageMarkedImplicit() throws Exception {
+		// contract: An unqualified type reference in a catch clause should have its package marked implicit
+
+        CtClass<?> clazz = build("spoon.test.trycatch.testclasses", "CatchWithUnqualifiedType");
+        List<CtCatch> catches = clazz.getElements(e -> true);
+        assertEquals(1, catches.size());
+
+        CtCatch targetCatch = catches.get(0);
+        CtTypeReference<?> catchParamType = targetCatch.getParameter().getType();
+        assertTrue(catchParamType.getPackage().isImplicit());
+	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -341,12 +341,12 @@ public class TryCatchTest {
 	public void testCatchUnqualifiedReferenceIsMarkedSimplyQualified() throws Exception {
 		// contract: An unqualified type reference in a catch clause should have its package marked implicit
 
-        CtClass<?> clazz = build("spoon.test.trycatch.testclasses", "CatchWithUnqualifiedType");
-        List<CtCatch> catches = clazz.getElements(e -> true);
-        assertEquals(1, catches.size());
+		CtClass<?> clazz = build("spoon.test.trycatch.testclasses", "CatchWithUnqualifiedType");
+		List<CtCatch> catches = clazz.getElements(e -> true);
+		assertEquals(1, catches.size());
 
-        CtCatch targetCatch = catches.get(0);
-        CtTypeReference<?> catchParamType = targetCatch.getParameter().getType();
-        assertTrue(catchParamType.isSimplyQualified());
+		CtCatch targetCatch = catches.get(0);
+		CtTypeReference<?> catchParamType = targetCatch.getParameter().getType();
+		assertTrue(catchParamType.isSimplyQualified());
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -338,7 +338,7 @@ public class TryCatchTest {
 	}
 
 	@Test
-	public void testCatchUnqualifiedReferenceHasPackageMarkedImplicit() throws Exception {
+	public void testCatchUnqualifiedReferenceIsMarkedSimplyQualified() throws Exception {
 		// contract: An unqualified type reference in a catch clause should have its package marked implicit
 
         CtClass<?> clazz = build("spoon.test.trycatch.testclasses", "CatchWithUnqualifiedType");
@@ -347,6 +347,6 @@ public class TryCatchTest {
 
         CtCatch targetCatch = catches.get(0);
         CtTypeReference<?> catchParamType = targetCatch.getParameter().getType();
-        assertTrue(catchParamType.getPackage().isImplicit());
+        assertTrue(catchParamType.isSimplyQualified());
 	}
 }

--- a/src/test/java/spoon/test/trycatch/testclasses/CatchWithUnqualifiedType.java
+++ b/src/test/java/spoon/test/trycatch/testclasses/CatchWithUnqualifiedType.java
@@ -1,0 +1,12 @@
+package spoon.test.trycatch.testclasses;
+
+import java.io.IOException;
+
+public class CatchWithUnqualifiedType {
+    public static void main(String[] args) {
+        try {
+            throw new IOException();
+        } catch (IOException e) {
+        }
+    }
+}


### PR DESCRIPTION
Fix #3799 

Fixes the problem by building the type reference with a higher-level method in the JDTTreeHelper, where this particular problem is already addressed. I had to adapt the signature of `JDTTreeBuilderHelper.createCatchVariable()` to also accept a scope for this, but I think this is more correct than it was previously.