### PR TITLE
perf: move code outside loop in FileCompilerConfig.initializeCompiler

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -42,6 +42,7 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 	public void initializeCompiler(JDTBatchCompiler compiler) {
 		JDTBasedSpoonCompiler jdtCompiler = compiler.getJdtCompiler();
 		List<CompilationUnit> cuList = new ArrayList<>();
+		Environment env = jdtCompiler.getEnvironment();
 
 		for (SpoonFile f : getFiles(compiler)) {
 
@@ -50,7 +51,6 @@ public class FileCompilerConfig implements SpoonModelBuilder.InputType {
 			}
 
 			String fName = f.isActualFile() ? f.getPath() : f.getName();
-			Environment env = jdtCompiler.getEnvironment();
 			cuList.add(new CompilationUnit(f.getContentChars(env), fName, env.getEncoding().displayName()));
 		}
 


### PR DESCRIPTION
Moved invariant variable outside of loop.  Will hopefully give performance boost on projects with lots of source files.