### PR TITLE
doc: Improve documentation for the DJPP get/setPreprocessors methods

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -2091,7 +2091,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	/**
-	 * @param preprocessors list of {@link CompilationUnitValidator}, which have to be used to validate and fix model before it's printing
+	 * Set preprocessors that the printer automatically runs on the model before printing it.
+	 * Typically, such preprocessors validate or adjust the model before printing.
+	 *
+	 * @param preprocessors list of processors to run on the model before printing
 	 */
 	public void setPreprocessors(List<Processor<CtElement>> preprocessors) {
 		this.preprocessors.clear();
@@ -2099,7 +2102,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	}
 
 	/**
-	 * @return list of {@link CompilationUnitValidator}, which are used to validate and fix model before it's printing
+	 * @return all processors currently set to run on the model before printing
 	 */
 	public List<Processor<CtElement>> getPreprocessors() {
 		return this.preprocessors;


### PR DESCRIPTION
The docs for DJPP get/setPreprocessors currently contain a broken link to some (probably very) old type that is no longer available, and aren't particularly clear about how DJPP actually uses the preprocessors. This PR removes the broken link and clarifies how the preprocessors are used.