### PR TITLE
review: chore: Clean up output in GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,8 @@ jobs:
             java: 11
           - os: windows-latest
             java: 15
+    env:
+      MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
@@ -36,9 +38,9 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
-      - name: Build and test
-        env:
-          MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      - name: Build
+        run: mvn -B install -DskipTests
+      - name: Test
         run: mvn test
 
   coverage:
@@ -53,7 +55,9 @@ jobs:
           java-version: 15
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
-      - name: Build and test
+      - name: Build
+        run: mvn -B install -DskipTests
+      - name: Test with coverage
         run: mvn -Pcoveralls test jacoco:report coveralls:report -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER --fail-never
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,13 +40,11 @@ jobs:
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
         run: |
-          mvn -B dependency:go-offline
-          mvn test-compile
+          mvn -B test-compile
       - name: Fetch final dependencies
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
-          # this is a hack to download the final test dependencies, that for
-          # some reason aren't downloaded by dependency:go-offline
+          # this is a hack to download the final test dependencies required to actually run the tests
           timeout 20 mvn -B test || echo "Done fetching dependencies"
       - name: Test
         run: mvn test
@@ -65,8 +63,7 @@ jobs:
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
         run: |
-          mvn -B dependency:go-offline
-          mvn test-compile
+          mvn -B test-compile
       - name: Test with coverage
         run: mvn -Pcoveralls test jacoco:report coveralls:report -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER --fail-never
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,12 @@ jobs:
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
         run: |
-          mvn -B test-compile -DskipTests
           mvn -B dependency:go-offline
+          mvn test-compile
+
+          # this is a hack to download the final test dependencies, that for
+          # some reason aren't donwloaded by dependency:go-offline
+          timeout 10 mvn -B test || echo "Done fetching dependencies"
       - name: Test
         run: mvn test
 
@@ -59,8 +63,12 @@ jobs:
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
         run: |
-          mvn -B test-compile -DskipTests
           mvn -B dependency:go-offline
+          mvn test-compile
+
+          # this is a hack to download the final test dependencies, that for
+          # some reason aren't donwloaded by dependency:go-offline
+          timeout 10 mvn -B test || echo "Done fetching dependencies"
       - name: Test with coverage
         run: mvn -Pcoveralls test jacoco:report coveralls:report -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER --fail-never
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
-        run: mvn -B install -DskipTests
+        run: |
+          mvn -B test-compile -DskipTests
+          mvn -B dependency:go-offline
       - name: Test
         run: mvn test
 
@@ -56,7 +58,9 @@ jobs:
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build
-        run: mvn -B install -DskipTests
+        run: |
+          mvn -B test-compile -DskipTests
+          mvn -B dependency:go-offline
       - name: Test with coverage
         run: mvn -Pcoveralls test jacoco:report coveralls:report -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER --fail-never
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,10 +42,9 @@ jobs:
         run: |
           mvn -B test-compile
       - name: Fetch final dependencies
-        if: ${{ matrix.os != 'windows-latest' }}
-        run: |
-          # this is a hack to download the final test dependencies required to actually run the tests
-          timeout 20 mvn -B test || echo "Done fetching dependencies"
+        # this is a hack to download the final test dependencies required to actually run the tests
+        run: timeout 20 mvn -B test || echo "Done fetching dependencies"
+        shell: bash
       - name: Test
         run: mvn test
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
           mvn -B dependency:go-offline
           mvn test-compile
       - name: Fetch final dependencies
-        if: ${{ matrix.os != "windows-latest" }}
+        if: ${{ matrix.os != 'windows-latest' }}
         run: |
           # this is a hack to download the final test dependencies, that for
           # some reason aren't downloaded by dependency:go-offline

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,10 +42,12 @@ jobs:
         run: |
           mvn -B dependency:go-offline
           mvn test-compile
-
+      - name: Fetch final dependencies
+        if: ${{ matrix.os != "windows-latest" }}
+        run: |
           # this is a hack to download the final test dependencies, that for
-          # some reason aren't donwloaded by dependency:go-offline
-          timeout 10 mvn -B test || echo "Done fetching dependencies"
+          # some reason aren't downloaded by dependency:go-offline
+          timeout 20 mvn -B test || echo "Done fetching dependencies"
       - name: Test
         run: mvn test
 
@@ -65,10 +67,6 @@ jobs:
         run: |
           mvn -B dependency:go-offline
           mvn test-compile
-
-          # this is a hack to download the final test dependencies, that for
-          # some reason aren't donwloaded by dependency:go-offline
-          timeout 10 mvn -B test || echo "Done fetching dependencies"
       - name: Test with coverage
         run: mvn -Pcoveralls test jacoco:report coveralls:report -DrepoToken=$GITHUB_TOKEN -DserviceName=github -DpullRequest=$PR_NUMBER --fail-never
         env:


### PR DESCRIPTION
Fix #3839 

This PR significantly cleans up the CI output of the primary build matrix by building the project and fetching dependencies in a separate step, before running the tests. Fetching _all_ test dependencies requires a little hack (start running tests, then abort after 20 seconds), because no matter what you do Maven will not fetch certain dependencies needed for test execution before-hand. Even when using something like `dependency:go-offline`.

If you have a look at the [test step of the current build (NOTE: You may need to refresh after clicking this link)](https://github.com/INRIA/spoon/pull/3838/checks?check_run_id=2111450564#step:7:1), the output actually starts with tests, and not with thousands of lines of "download progress", as was previously the case.