### PR TITLE
review: chore: Add daily cache of Maven dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,9 +43,7 @@ jobs:
         uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
         with:
           path: ~/.m2/repository
-          key: |
-            # date is used in the key ==> cache hits are never more than 24 hours old
-            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Use silent log config
@@ -74,9 +72,7 @@ jobs:
         uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
         with:
           path: ~/.m2/repository
-          key: |
-            # date is used in the key ==> cache hits are never more than 24 hours old
-            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Use silent log config
@@ -109,9 +105,7 @@ jobs:
         uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
         with:
           path: ~/.m2/repository
-          key: |
-            # date is used in the key ==> cache hits are never more than 24 hours old
-            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Use silent log config

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,20 @@ jobs:
       - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: 15
+
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: |
+            # date is used in the key ==> cache hits are never more than 24 hours old
+            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build and test
@@ -86,6 +100,20 @@ jobs:
       - uses: actions/setup-python@41b7212b1668f5de9d65e9c82aa777e6bbedb3a8 # v2.1.4
         with:
           python-version: 3.6
+
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: |
+            # date is used in the key ==> cache hits are never more than 24 hours old
+            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
+
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Run extra checks

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,15 +34,20 @@ jobs:
       - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: ${{ matrix.java }}
+
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
         run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
-      - uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+      - name: Use Maven dependency cache
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          key: |
+            # date is used in the key ==> cache hits are never more than 24 hours old
+            ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven-
+
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build and test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,15 @@ jobs:
       - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
         with:
           java-version: ${{ matrix.java }}
+      - name: Get date for cache # see https://github.com/actions/cache README
+        id: get-date
+        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        shell: bash
+      - uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Use silent log config
         run: mv chore/travis/logback.xml src/test/resources/
       - name: Build and test


### PR DESCRIPTION
Fix #3840

This PR adds a cache for Maven dependencies in the primary build matrix. The cache is dependent on the current date, and so will never be used for more than 24 hours. This makes the risk of stale dependencies causing trouble relatively small, and at worst the problem will go away the next day.

The speedup is significant, e.g. for `Tests with Java 1.8 on ubuntu-latest`:

* Before cache: [12m31s](https://github.com/INRIA/spoon/runs/2111403925)
* After cache: [9m9s](https://github.com/INRIA/spoon/pull/3842/checks?check_run_id=2111720116)

All-in-all, we see roughly a 3-minute reduction across all jobs individually, as well as the total wall time for CI (not counting CPU time, but actual time a developer has to wait), which is down from ~14 to ~11 minutes.

Unfortunately, I couldn't find a way to enable a "global" cache for all jobs, so the caching steps must be duplicated for each job that needs them. There's currently no mechanism in GitHub Actions to reuse steps, either. I think the speedup is well worth that complexity, and as we use caches that are at most 24 hours old, I think there's minimal risk of any noteworthy complications with caching.