### PR TITLE
fix: fix a race condition in AbstractParallelProcessor

### DIFF
--- a/src/main/java/spoon/processing/AbstractParallelProcessor.java
+++ b/src/main/java/spoon/processing/AbstractParallelProcessor.java
@@ -7,10 +7,14 @@
  */
 package spoon.processing;
 
+import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
 
@@ -38,6 +42,9 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 	private ExecutorService service;
 	private ArrayBlockingQueue<Processor<E>> processorQueue;
 
+	// Maps each processor to its last submitted job to be able to wait for all processors to finish
+	private final Map<Processor<E>, Future<?>> lastSubmittedJob;
+
 	/**
 	 * Creates a new AbstractParallelProcessor from given iterable. The iterable is
 	 * fully consumed. Giving an endless iterable of processors will result in
@@ -54,6 +61,7 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 		processorQueue = new ArrayBlockingQueue<>(processorNumber);
 		processors.forEach(processorQueue::add);
 		service = Executors.newFixedThreadPool(processorNumber);
+		lastSubmittedJob = new IdentityHashMap<>();
 	}
 
 	/**
@@ -78,6 +86,7 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 			}
 			processorQueue.add(it.next());
 		}
+		lastSubmittedJob = new IdentityHashMap<>();
 	}
 
 	/**
@@ -100,13 +109,14 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 			});
 		}
 		service = Executors.newFixedThreadPool(numberOfProcessors);
+		lastSubmittedJob = new IdentityHashMap<>();
 	}
 
 	@Override
 	public final void process(E element) {
 		try {
 			Processor<E> currentProcessor = processorQueue.take();
-			service.execute(() -> {
+			Future<?> job = service.submit(() -> {
 				try {
 					currentProcessor.process(element);
 					processorQueue.put(currentProcessor);
@@ -121,8 +131,10 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 					throw e;
 				}
 			});
+			lastSubmittedJob.put(currentProcessor, job);
 		} catch (InterruptedException e) {
 			// because rethrow is not possible here.
+			awaitJobCompletion();
 			Thread.currentThread().interrupt();
 			e.printStackTrace();
 		}
@@ -133,7 +145,19 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 	 */
 	@Override
 	public void processingDone() {
+		// await termination of the latest jobs
+		awaitJobCompletion();
 		service.shutdown();
 		super.processingDone();
+	}
+
+	private void awaitJobCompletion() {
+		for (Future<?> job : lastSubmittedJob.values()) {
+			try {
+				job.get();
+			} catch (InterruptedException | ExecutionException e) {
+				throw new SpoonException("failed to wait for parallel processor to finish", e);
+			}
+		}
 	}
 }

--- a/src/test/java/spoon/test/processing/processors/ParallelProcessorTest.java
+++ b/src/test/java/spoon/test/processing/processors/ParallelProcessorTest.java
@@ -265,10 +265,10 @@ public class ParallelProcessorTest {
 		return new AbstractProcessor<CtElement>() {
 			@Override
 			public void process(CtElement element) {
-			    try {
+				try {
 					Thread.sleep(sleepTimeMs);
 				} catch (InterruptedException e) {
-			        Thread.currentThread().interrupt();
+					Thread.currentThread().interrupt();
 				}
 				counters.getAndUpdate(idx, i -> i + 1);
 			}


### PR DESCRIPTION
Fix #3806 

~Currently just a test to reproduce the problem. Want to see if it works on GitHub Actions machines, which I believe have 2 cores. So it should work.~

This PR fixes a race condition in AbstractParallelProcessor. 67c8aa3 introduces a test that reproduces the problem, and 40a9602 fixes the problem by keeping track of the last job submitted for each processor and then waiting (indefinitely) for these to terminate. We only need to keep track of the latest job, as each processor only handles one job at a time.

We could also busy-wait on the processors queue to fill back up, which is somewhat less complex, but less efficient and less explicit. I prefer the current solution.