### PR TITLE
fix: Fix 1 violation of Sonar rule 2142

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -546,6 +546,7 @@ public class SpoonPom implements SpoonResource {
 		} catch (IOException e) {
 			throw new SpoonException("Maven home detection has failed.");
 		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw new SpoonException("Maven home detection was interrupted.");
 		}
 		return mvnHome;


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).
