### PR TITLE
refactor: Fix violation of Sonar rule 1444

### DIFF
--- a/src/main/java/spoon/LovecraftException.java
+++ b/src/main/java/spoon/LovecraftException.java
@@ -17,7 +17,7 @@ package spoon;
 public class LovecraftException extends SpoonException {
 	private static final long serialVersionUID = 1L;
 
-	public static String lovecraft =
+	public static final String lovecraft =
 		"It was from the artists and poets that the pertinent answers came, and I\n"
 		+ "know that panic would have broken loose had they been able to compare notes.\n"
 		+ "As it was, lacking their original letters, I half suspected the compiler of\n"


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 1444: '"public static" fields should be constant'](https://rules.sonarsource.com/java/RSPEC-1444).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 1444](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#public-static-fields-should-be-constant-sonar-rule-1444).