### PR TITLE
chore: Use the kramdown Markdown processor for Spoon's website

### DIFF
--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -34,11 +34,8 @@ exclude:
 
 # same for all
 sidebar_accordion: true
-markdown: redcarpet
+markdown: kramdown
 theme_file: theme-mauve.css
-
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "tables", "with_toc_data"]
 
 highlighter: rouge
 


### PR DESCRIPTION
#3759 

The `redcarpet` processor isn't supported by Jekyll 4.0+, see https://github.com/jekyll/jekyll/issues/7838#issuecomment-537254511.