### PR TITLE
fix(spoon-visualiser): bump Interacto to use the latest version on Central

### DIFF
--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>io.github.interacto</groupId>
             <artifactId>interacto-javafx</artifactId>
-            <version>3.4</version>
+            <version>4.3.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.openjfx</groupId>

--- a/spoon-visualisation/src/main/java/module-info.java
+++ b/spoon-visualisation/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module spoon.visualisation {
 	requires javafx.controls;
 	requires org.eclipse.jdt.core;
 	requires org.jetbrains.annotations;
+	requires java.desktop;
 
 	exports spoon.visualisation to javafx.graphics;
 	exports spoon.visualisation.instrument to javafx.fxml;

--- a/spoon-visualisation/src/main/java/spoon/visualisation/instrument/SpoonCodeInstrument.java
+++ b/spoon-visualisation/src/main/java/spoon/visualisation/instrument/SpoonCodeInstrument.java
@@ -92,7 +92,8 @@ public class SpoonCodeInstrument extends JfxInstrument implements Initializable 
 	@Override
 	protected void configureBindings() {
 		// On text change, the spoon tree is rebuilt
-		textInputBinder(i -> new UpdateSpoonTree(spoonAST, hideImplicit.isSelected(), "", treeLevel.getValue()))
+		textInputBinder()
+			.toProduce(i -> new UpdateSpoonTree(spoonAST, hideImplicit.isSelected(), "", treeLevel.getValue()))
 			.on(spoonCode)
 			.then((i, c) -> c.setCode(i.getWidget().getText()))
 			.bind();
@@ -101,17 +102,21 @@ public class SpoonCodeInstrument extends JfxInstrument implements Initializable 
 			() -> new UpdateSpoonTree(spoonAST, hideImplicit.isSelected(), spoonCode.getText(), treeLevel.getValue());
 
 		// Checking the checkbox hides or shows the implicit elements
-		checkboxBinder(cmdsupplier)
+		checkboxBinder()
+			.toProduce(cmdsupplier)
 			.on(hideImplicit)
 			.bind();
 
 		// Selecting an item of the combo box recomputes the spoon tree using the new analysis level
-		comboboxBinder(cmdsupplier)
+		comboboxBinder()
+			.toProduce(cmdsupplier)
 			.on(treeLevel)
 			.bind();
 
 		// Clicking on a tree item selects the corresponding Java code
-		nodeBinder(new Click(), i -> {
+		nodeBinder()
+			.usingInteraction(Click::new)
+			.toProduce(i -> {
 				final SpoonTreeItem item = i.getSrcObject()
 					.filter(o -> o.getParent() instanceof TreeCell)
 					.map(o -> ((SpoonTreeItem) ((TreeCell<?>) o.getParent()).getTreeItem()))
@@ -124,12 +129,15 @@ public class SpoonCodeInstrument extends JfxInstrument implements Initializable 
 
 		// Clicking in the text area (ie changing the caret position) selects (when relevant)
 		// the corresponding item in the Spoon tree
-		nodeBinder(new Click(), i -> new SelectCodeItem(spoonCode.getCaretPosition(), spoonAST))
+		nodeBinder()
+			.usingInteraction(Click::new)
+			.toProduce(i -> new SelectCodeItem(spoonCode.getCaretPosition(), spoonAST))
 			.on(spoonCode)
 			.bind();
 
 		// Clicking on the save button saves in a text file the text version of the Spoon tree
-		buttonBinder(i -> new SaveTreeText(getFileChooser().showSaveDialog(null), hideImplicit.isSelected(),
+		buttonBinder()
+			.toProduce(i -> new SaveTreeText(getFileChooser().showSaveDialog(null), hideImplicit.isSelected(),
 				spoonCode.getText(), treeLevel.getValue()))
 			.on(save)
 			.bind();

--- a/spoon-visualisation/src/main/java/spoon/visualisation/spoon/TreePrinter.java
+++ b/spoon-visualisation/src/main/java/spoon/visualisation/spoon/TreePrinter.java
@@ -22,6 +22,7 @@
 package spoon.visualisation.spoon;
 
 import io.github.interacto.command.library.OpenWebPage;
+import java.awt.Desktop;
 import java.net.URI;
 import java.util.List;
 import javafx.scene.control.Hyperlink;
@@ -72,8 +73,7 @@ public class TreePrinter extends SpoonElementVisitor {
 		// Clicking on the link opens the doc
 		// 'new Thread' because otherwise the app freezes (run in the UI thread)
 		classLink.setOnAction(evt -> new Thread(() -> {
-			final OpenWebPage cmd = new OpenWebPage();
-			cmd.setUri(URI.create(url));
+			final OpenWebPage cmd = new OpenWebPage(Desktop.getDesktop(), URI.create(url));
 			if(cmd.canDo()) {
 				cmd.doIt();
 			}

--- a/spoon-visualisation/src/test/java/spoon/visualisation/instrument/SpoonCodeInstrumentTest.java
+++ b/spoon-visualisation/src/test/java/spoon/visualisation/instrument/SpoonCodeInstrumentTest.java
@@ -1,8 +1,6 @@
 package spoon.visualisation.instrument;
 
-import io.github.interacto.command.CmdHandler;
 import io.github.interacto.command.CommandsRegistry;
-import io.github.interacto.command.library.OpenWebPage;
 import io.github.interacto.fsm.TimeoutTransition;
 import java.io.File;
 import java.io.IOException;
@@ -105,8 +103,7 @@ class SpoonCodeInstrumentTest {
 
 	@BeforeEach
 	void setUp(final FxRobot robot) {
-		CommandsRegistry.INSTANCE.clear();
-		CommandsRegistry.INSTANCE.removeAllHandlers();
+		CommandsRegistry.getInstance().clear();
 		spoonAST = robot.lookup("#spoonAST").query();
 		spoonCode = robot.lookup("#spoonCode").query();
 		treeLevel = robot.lookup("#treeLevel").query();
@@ -206,22 +203,6 @@ class SpoonCodeInstrumentTest {
 
 		AssertionsForClassTypes.assertThat(hyperlinks.size()).isEqualTo(2);
 	}
-
-	@Disabled("Does not work on headless server")
-	@Test
-	void testClickHyperlink(final FxRobot robot) {
-		robot.clickOn(spoonCode).write("class Foo { }");
-		waitForTimeoutTransitions();
-		final CmdHandler handler = Mockito.mock(CmdHandler.class);
-		CommandsRegistry.INSTANCE.addHandler(handler);
-		final Set<Node> hyperlinks = robot.lookup(CoreMatchers.instanceOf(Hyperlink.class)).queryAll();
-		robot.clickOn(hyperlinks.iterator().next());
-		WaitForAsyncUtils.waitForFxEvents();
-		waitForThread("OPEN_SPOON_DOC_THREAD");
-
-		Mockito.verify(handler, Mockito.times(1)).onCmdExecuted(Mockito.any(OpenWebPage.class));
-	}
-
 
 	@Disabled("Does not work on headless servers")
 	@Test


### PR DESCRIPTION
Related to #3860

Interacto is the graphical lib used by Spoon Visualiser.
Available on maven central since the 4.0 version (see https://search.maven.org/artifact/io.github.interacto/interacto-javafx/4.3.1/jar) it was before on the Inria Maven repo.
We have to update Interacto to its latest version to get from Maven Central.
This is the goal of this PR.