### PR TITLE
chore: Make URL to apidocs site relative

### DIFF
--- a/doc/_data/sidebar_doc.yml
+++ b/doc/_data/sidebar_doc.yml
@@ -47,7 +47,7 @@ entries:
           version: all
 
         - title: Javadoc
-          external_url: http://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs
+          external_url: /mvnsites/spoon-core/apidocs
           audience: writers, designers
           platform: all
           product: all


### PR DESCRIPTION
#3759 

Changes the URL to the apidocs to be site-relative, rather than absolute. This makes it easier to do local development of the site.

I don't quite understand why it has to be an `external_url`, but if you try just `url` all of the forward slashes are filtered out and the url ends up being `<DOMAIN>/mvnsitesspoon-coreapidocs`, which isn't what we want. I was unable to find any relevant documentation about this on the Jekyll website, so I just went with what works: a site-relative URL defined as `external_url`.