### PR TITLE
chore: Add website CNAME

### DIFF
--- a/doc/CNAME
+++ b/doc/CNAME
@@ -1,0 +1,1 @@
+spoon.gforge.inria.fr


### PR DESCRIPTION
#3759 

The CNAME record is required for the custom URL to work, and currently it has been added manually over in spoonlabs.github.io.

We could also generate the CNAME file in the deployment script, but it seems simpler to just have it in the repo.