### PR TITLE
review: chore: Remove snapshot repository from parent pom

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -25,14 +25,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>ow2.org-snapshot</id>
-            <name>Maven Repository for Spoon Snapshots</name>
-            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
 
         <!-- we all depend on Junit with scope=test -->

--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -19,6 +19,18 @@
         <version>1.0</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
+
+    <repositories>
+        <repository>
+            <!-- Required for spoon-control-flow SNAPSHOT -->
+            <id>ow2.org-snapshot</id>
+            <name>Maven Repository for Spoon Snapshots</name>
+            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+            <snapshots><enabled>true</enabled></snapshots>
+            <releases><enabled>false</enabled></releases>
+        </repository>
+    </repositories>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
#3216 

See my latest comments in #3216. I don't see any reason to declare the snapshot repository for anything but distribution management. In Jenkins jobs, we inject the snapshot repository into pom files of other projects.

If we agree to merge this, I'll (after merge) go over all Jenkins jobs and make sure that they correctly pull the latest snapshot (I already know of several that pull from the old snapshot repository).

EDIT: Apparently, `spoon-smpl` depends on a SNAPSHOT version of `spoon-control-flow`, so it does need the snapshot repository enabled by default. But that's the concern of `spoon-smpl`, and not _all_ of the Spoon Maven modules, and so we define it only in `spoon-smpl`.