### PR TITLE
fix: Fix violations of Sonar rule 2057

### DIFF
--- a/src/main/java/spoon/javadoc/internal/Javadoc.java
+++ b/src/main/java/spoon/javadoc/internal/Javadoc.java
@@ -34,6 +34,7 @@ import spoon.reflect.code.CtComment;
 * writing this comment does not contain any block tags (such as <code>@see AnotherClass</code>)
 */
 public class Javadoc implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private JavadocDescription description;
 	private List<JavadocBlockTag> blockTags;

--- a/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
@@ -27,6 +27,7 @@ import java.io.Serializable;
 * </code>
 */
 public class JavadocBlockTag implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private CtJavaDocTag.TagType type;
 	private JavadocDescription content;

--- a/src/main/java/spoon/javadoc/internal/JavadocDescription.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocDescription.java
@@ -22,6 +22,7 @@ package spoon.javadoc.internal;
 	* A javadoc text, potentially containing inline tags.
 	*/
 	public class JavadocDescription implements Serializable {
+	private static final long serialVersionUID = 1L;
 
 	private List<JavadocDescriptionElement> elements;
 

--- a/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 * <p>For example <code>{@link String}</code>
 */
 public class JavadocInlineTag implements JavadocDescriptionElement, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	/** Return the next word of the string, in other words it stops when a space is encountered. */
 	public static String nextWord(String string) {

--- a/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 * have two snippets: one before and one after the inline tag (<code>{@link String}</code>).
 */
 public class JavadocSnippet implements JavadocDescriptionElement, Serializable {
+	private static final long serialVersionUID = 1L;
 	private String text;
 
 	public JavadocSnippet(String text) {

--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -17,6 +17,7 @@ import spoon.reflect.declaration.CtElement;
  * source files.
  */
 public class CtLineElementComparator implements Comparator<CtElement>, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	/**
 	 * Returns 0 if o1 has the same position as o2, or both positions are invalid and o1.equals(o2).

--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
  * Compares based on a toString representation.
  */
 public class DeepRepresentationComparator implements Comparator<CtElement>, Serializable {
+	private static final long serialVersionUID = 1L;
 
 	@Override
 	public int compare(CtElement o1, CtElement o2) {

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
  * ModifierKind in kept for sake of full backward-compatibility.
  */
 public class CtExtendedModifier implements SourcePositionHolder, Serializable {
+	private static final long serialVersionUID = 1L;
 	private boolean implicit;
 	private ModifierKind kind;
 	private SourcePosition position;

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -213,6 +213,7 @@ public abstract class ModelList<T extends CtElement> extends AbstractList<T> imp
 	 * See https://docs.oracle.com/javase/7/docs/api/java/util/AbstractList.html#modCount
 	 */
 	private static class InternalList<T> extends ArrayList<T> {
+		private static final long serialVersionUID = 1L;
 		InternalList(int initialCapacity) {
 			super(initialCapacity);
 		}


### PR DESCRIPTION
Hi,

This PR fixes 9 violations of [Sonar Rule 2057: '"Serializable" classes should have a "serialVersionUID"'](https://rules.sonarsource.com/java/RSPEC-2057).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2057](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#serializable-classes-should-have-a-serialversionuidsonar-rule-2057).