### PR TITLE
doc: update spoon-smpl README and related docs

### DIFF
--- a/doc/spoon_smpl.md
+++ b/doc/spoon_smpl.md
@@ -62,10 +62,10 @@ $ java -cp <classpath> spoon.smpl.CommandlineApplication
 Due in large to the prototypical nature of the current implementation there is a lack of clear
 specification and documentation. The most helpful resources currently available are:
 
-1. [smpl_grammar.txt](https://github.com/mkforsb/spoon/blob/smpl/spoon-smpl/smpl_grammar.txt): covers parts of the currently supported grammar.
-2. [Test cases](https://github.com/mkforsb/spoon/tree/smpl/spoon-smpl/src/test/resources/endtoend): contains easy-to-read test cases that reveal both supported patch language features and supported Java elements.
-3. [PatternBuilder.java](https://github.com/mkforsb/spoon/blob/smpl/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java): shows the set of matchable Java elements, but can be cumbersome to read.
-4. [Substitutor.java](https://github.com/mkforsb/spoon/blob/smpl/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java): shows the set of transformable Java elements, but can be cumbersome to read.
+1. [smpl_grammar.txt](https://github.com/INRIA/spoon/blob/master/spoon-smpl/smpl_grammar.txt): covers parts of the currently supported grammar.
+2. [Test cases](https://github.com/INRIA/spoon/tree/master/spoon-smpl/src/test/resources/endtoend): contains easy-to-read test cases that reveal both supported patch language features and supported Java elements.
+3. [PatternBuilder.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java): shows the set of matchable Java elements, but can be cumbersome to read.
+4. [Substitutor.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java): shows the set of transformable Java elements, but can be cumbersome to read.
 
 ### Basic usage
 

--- a/spoon-smpl/README.md
+++ b/spoon-smpl/README.md
@@ -13,12 +13,39 @@ expression E;
 + ContextCompat.getColor(ctx , E)
 ``` 
 
+## Supported SmPL Features
+
+The following table shows some of the currently supported SmPL syntax/features:
+
+| Syntax                | Description                                             |
+|-----------------------|---------------------------------------------------------|
+| `@@ identifier x; @@` | Identifier metavariable.                                |
+| `@@ type x; @@`       | Arbitrary type name metavariable.                       |
+| `@@ SomeType x; @@`   | Specific type name metavariable.                        |
+| `@@ constant x; @@`   | Constant metavariable.                                  |
+| `@@ expression x; @@` | Expression metavariable.                                |
+| `  statement`         | Context match.                                          |
+| `- statement`         | Match and deletion.                                     |
+| `+ statement`         | Addition.                                               |
+| `...`                 | Computation path wildcard operator.                     |
+| `... when != expr`    | &nbsp;&nbsp; " &nbsp;&nbsp; with match constraint.      |
+| `... when exists`     | &nbsp;&nbsp; " &nbsp;&nbsp; with constraint relaxation. |
+| `... when any`        | &nbsp;&nbsp; " &nbsp;&nbsp; with constraint relaxation. |
+| `<... P ...>`         | Computation path wildcard with optional match of `P`.   |
+| `  f(...)`            | Argument or parameter list wildcard match.              |
+
+Additional helpful resources currently available are:
+
+1. [smpl_grammar.txt](https://github.com/INRIA/spoon/blob/master/spoon-smpl/smpl_grammar.txt): covers parts of the currently supported grammar.
+2. [Test cases](https://github.com/INRIA/spoon/tree/master/spoon-smpl/src/test/resources/endtoend): contains easy-to-read test cases that reveal both supported patch language features and supported Java elements.
+3. [PatternBuilder.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java): shows the set of matchable Java elements, but can be cumbersome to read.
+4. [Substitutor.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java): shows the set of transformable Java elements, but can be cumbersome to read.
+
 Spoon-SmPL's initial version has been implemented by Mikael Forsberg as part of his master's thesis ["Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology"](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226).
 
 References:
 * [SmPL: A Domain-Specific Language for Specifying Collateral Evolutions in Linux Device Drivers](http://coccinelle.lip6.fr/papers/ercim.pdf)
 * [A Foundation for Flow-Based Program Matching Using Temporal Logic and Model Checking](http://coccinelle.lip6.fr/papers/popl09.pdf)
-* [Semantic Patches for Java Program Transformation](https://drops.dagstuhl.de/opus/volltexte/2019/10814/pdf/LIPIcs-ECOOP-2019-22.pdf)
 * [Semantic Patches for Java Program Transformation](https://drops.dagstuhl.de/opus/volltexte/2019/10814/pdf/LIPIcs-ECOOP-2019-22.pdf)
 * [Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226)
  

--- a/spoon-smpl/README.md
+++ b/spoon-smpl/README.md
@@ -13,6 +13,14 @@ expression E;
 + ContextCompat.getColor(ctx , E)
 ``` 
 
+Spoon-SmPL's initial version has been implemented by Mikael Forsberg as part of his master's thesis ["Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology"](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226).
+
+References:
+* [SmPL: A Domain-Specific Language for Specifying Collateral Evolutions in Linux Device Drivers](http://coccinelle.lip6.fr/papers/ercim.pdf)
+* [A Foundation for Flow-Based Program Matching Using Temporal Logic and Model Checking](http://coccinelle.lip6.fr/papers/popl09.pdf)
+* [Semantic Patches for Java Program Transformation](https://drops.dagstuhl.de/opus/volltexte/2019/10814/pdf/LIPIcs-ECOOP-2019-22.pdf)
+* [Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226)
+
 ## Supported SmPL Features
 
 The following table shows some of the currently supported SmPL syntax/features:
@@ -41,14 +49,6 @@ Additional helpful resources currently available are:
 3. [PatternBuilder.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java): shows the set of matchable Java elements, but can be cumbersome to read.
 4. [Substitutor.java](https://github.com/INRIA/spoon/blob/master/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java): shows the set of transformable Java elements, but can be cumbersome to read.
 
-Spoon-SmPL's initial version has been implemented by Mikael Forsberg as part of his master's thesis ["Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology"](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226).
-
-References:
-* [SmPL: A Domain-Specific Language for Specifying Collateral Evolutions in Linux Device Drivers](http://coccinelle.lip6.fr/papers/ercim.pdf)
-* [A Foundation for Flow-Based Program Matching Using Temporal Logic and Model Checking](http://coccinelle.lip6.fr/papers/popl09.pdf)
-* [Semantic Patches for Java Program Transformation](https://drops.dagstuhl.de/opus/volltexte/2019/10814/pdf/LIPIcs-ECOOP-2019-22.pdf)
-* [Design and Implementation of Semantic Patch Support for the Spoon Java Transformation Engine' at KTH Royal Institute of Technology](http://urn.kb.se/resolve?urn=urn:nbn:se:kth:diva-291226)
- 
 ## Architecture Notes
 
 * Parsing SMPL: see SmPLLexer

--- a/spoon-smpl/smpl_grammar.txt
+++ b/spoon-smpl/smpl_grammar.txt
@@ -23,7 +23,6 @@ TODO: markdownify this file
     metatype ::= identifier
                | type
                | expression
-               | statement
                | constant
                | JavaType
     


### PR DESCRIPTION
Adds a table listing some of the currently supported SmPL features to the spoon-smpl README and fixes minor issues in related docs.