### PR TITLE
chore: Add script for SNAPSHOT version injection in CI

### DIFF
--- a/doc/jenkins/inject_spoon_snapshot.py
+++ b/doc/jenkins/inject_spoon_snapshot.py
@@ -24,6 +24,7 @@ MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0"
 NAMESPACES = {"": MAVEN_NAMESPACE}
 
 MAVEN_VERSIONS_COMMAND = "mvn -B -U versions:use-latest-versions -DallowSnapshots -Dincludes=fr.inria.gforge.spoon".split()
+PURGE_LOCAL_REPO_COMMAND = "mvn -B -U dependency:purge-local-repository -DmanualInclude='fr.inria.gforge.spoon:spoon-core' -DsnapshotsOnly=true".split()
 
 
 def main():
@@ -31,6 +32,7 @@ def main():
     pom_file = pathlib.Path("pom.xml")
     inject_snapshot_repo(pom_file)
     subprocess.run(MAVEN_VERSIONS_COMMAND, cwd=str(pom_file.parent))
+    subprocess.run(PURGE_LOCAL_REPO_COMMAND, cwd=str(pom_file.parent))
 
 
 def inject_snapshot_repo(pom_file: pathlib.Path) -> None:
@@ -54,6 +56,7 @@ def inject_snapshot_repo(pom_file: pathlib.Path) -> None:
 
     tree.write(str(pom_file))
 
+
 def in_maven_namespace(tag: str) -> str:
     """Wrap the tag in the default Maven namespace.
 
@@ -65,6 +68,7 @@ def in_maven_namespace(tag: str) -> str:
     This does not appear to work in Python 3.5
     """
     return "{{{}}}{}".format(MAVEN_NAMESPACE, tag)
+
 
 if __name__ == "__main__":
     main()

--- a/doc/jenkins/inject_spoon_snapshot.py
+++ b/doc/jenkins/inject_spoon_snapshot.py
@@ -1,44 +1,51 @@
 #! /bin/python3
 """Script for injecting the latest SNAPSHOT version of Spoon into all pom.xml
 files it finds in the curren tworking directory or any subdirectory.
+
+Requires the ``defusedxml`` package to be installed separately.
+
+This script is compatible with Python 3.5+
 """
 import xml.etree.ElementTree as ET
 import subprocess
 import pathlib
+
+from typing import Optional
 
 SPOON_SNAPSHOT_REPO = """
 <repository>
     <id>ow2.org-snapshot</id>
     <name>Maven Repository for Spoon Snapshots</name>
     <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
-    <snapshots/>
 </repository>
 """
 MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0"
 NAMESPACES = {"": MAVEN_NAMESPACE}
 
-MAVEN_VERSIONS_COMMAND = "mvn -B versions:use-latest-versions -DallowSnapshots -Dincludes=fr.inria.gforge.spoon".split()
+MAVEN_VERSIONS_COMMAND = "mvn -B -U versions:use-latest-versions -DallowSnapshots -Dincludes=fr.inria.gforge.spoon".split()
 
 
 def main():
     ET.register_namespace("", MAVEN_NAMESPACE)
-    for pom_file in pathlib.Path(".").rglob("pom.xml"):
-        inject_snapshot_repo(pom_file)
-        subprocess.run(MAVEN_VERSIONS_COMMAND)
+    pom_file = pathlib.Path("pom.xml")
+    inject_snapshot_repo(pom_file)
+    subprocess.run(MAVEN_VERSIONS_COMMAND, cwd=str(pom_file.parent))
 
 
 def inject_snapshot_repo(pom_file: pathlib.Path) -> None:
     tree = ET.parse(str(pom_file))
     root = tree.getroot()
 
-    repositories = root.find("repositories", NAMESPACES) or ET.SubElement(
-        root, "repositories"
-    )
+    repositories = root.find(in_maven_namespace("repositories"))
+    if not repositories:
+        repositories = ET.fromstring("<repositories></repositories>")
+        root.append(repositories)
+
     snapshot_repo = ET.fromstring(SPOON_SNAPSHOT_REPO)
     snapshot_repo_url = snapshot_repo.find("url").text
 
-    for repo in repositories.findall("repository", NAMESPACES):
-        url = repo.find("url", NAMESPACES).text
+    for repo in repositories.findall(in_maven_namespace("repository")):
+        url = repo.find(in_maven_namespace("url")).text
         if url == snapshot_repo_url:
             return
 
@@ -46,6 +53,17 @@ def inject_snapshot_repo(pom_file: pathlib.Path) -> None:
 
     tree.write(str(pom_file))
 
+def in_maven_namespace(tag: str) -> str:
+    """Wrap the tag in the default Maven namespace.
+
+    If porting this script to Python 3.6+, then this method can be removed and
+    one can instead search with a default namespace like so:
+
+    someElement.find(tag, namespaces={"": MAVEN_NAMESPACE})
+
+    This does not appear to work in Python 3.5
+    """
+    return "{{{}}}{}".format(MAVEN_NAMESPACE, tag)
 
 if __name__ == "__main__":
     main()

--- a/doc/jenkins/inject_spoon_snapshot.py
+++ b/doc/jenkins/inject_spoon_snapshot.py
@@ -17,6 +17,7 @@ SPOON_SNAPSHOT_REPO = """
     <id>ow2.org-snapshot</id>
     <name>Maven Repository for Spoon Snapshots</name>
     <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+    <snapshots/>
 </repository>
 """
 MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0"

--- a/doc/jenkins/inject_spoon_snapshot.py
+++ b/doc/jenkins/inject_spoon_snapshot.py
@@ -1,0 +1,51 @@
+#! /bin/python3
+"""Script for injecting the latest SNAPSHOT version of Spoon into all pom.xml
+files it finds in the curren tworking directory or any subdirectory.
+"""
+import xml.etree.ElementTree as ET
+import subprocess
+import pathlib
+
+SPOON_SNAPSHOT_REPO = """
+<repository>
+    <id>ow2.org-snapshot</id>
+    <name>Maven Repository for Spoon Snapshots</name>
+    <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
+    <snapshots/>
+</repository>
+"""
+MAVEN_NAMESPACE = "http://maven.apache.org/POM/4.0.0"
+NAMESPACES = {"": MAVEN_NAMESPACE}
+
+MAVEN_VERSIONS_COMMAND = "mvn -B versions:use-latest-versions -DallowSnapshots -Dincludes=fr.inria.gforge.spoon".split()
+
+
+def main():
+    ET.register_namespace("", MAVEN_NAMESPACE)
+    for pom_file in pathlib.Path(".").rglob("pom.xml"):
+        inject_snapshot_repo(pom_file)
+        subprocess.run(MAVEN_VERSIONS_COMMAND)
+
+
+def inject_snapshot_repo(pom_file: pathlib.Path) -> None:
+    tree = ET.parse(str(pom_file))
+    root = tree.getroot()
+
+    repositories = root.find("repositories", NAMESPACES) or ET.SubElement(
+        root, "repositories"
+    )
+    snapshot_repo = ET.fromstring(SPOON_SNAPSHOT_REPO)
+    snapshot_repo_url = snapshot_repo.find("url").text
+
+    for repo in repositories.findall("repository", NAMESPACES):
+        url = repo.find("url", NAMESPACES).text
+        if url == snapshot_repo_url:
+            return
+
+    repositories.append(snapshot_repo)
+
+    tree.write(str(pom_file))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a Python script that updates the Spoon version in a pom.xml file to the latest snapshot version. It does so by 1) injecting the snapshot repository into the pom file (if it's not already there), and 2) running `mvn versions:use-latest-versions` with snapshots enabled to update the version of Spoon, and 3) running `mvn dependency:purge-local-repository` to avoid using an old snapshot of the same version.

The script works with Python 3.5+ and requires the `defusedxml` package. We will use this for the smoke tests in the Jenkins pipeline where a project uses Spoon (i.e. Spoon is already a dependency), and we want to run its test suite with the latest snapshot.