### PR TITLE
chore: update github action to use setup-java v2.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,15 +27,20 @@ jobs:
             java: 11
           - os: windows-latest
             java: 15
+
+
     env:
       MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      JAVA_DISTRIBUTION: adopt
+
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-      - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+      - uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2.0.0
         with:
           java-version: ${{ matrix.java }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
@@ -67,9 +72,10 @@ jobs:
     name: Test with coverage
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-      - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+      - uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2.0.0
         with:
           java-version: 15
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
@@ -100,9 +106,10 @@ jobs:
     name: Extra checks
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-      - uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+      - uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2.0.0
         with:
           java-version: 15
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
       - uses: actions/setup-python@41b7212b1668f5de9d65e9c82aa777e6bbedb3a8 # v2.1.4
         with:
           python-version: 3.6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      JAVA_DISTRIBUTION: 'zulu'
+      JAVA_DISTRIBUTION: adopt
 
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      JAVA_DISTRIBUTION: adopt
+      JAVA_DISTRIBUTION: 'zulu'
 
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      JAVA_DISTRIBUTION: adopt
     name: Test with coverage
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -103,6 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      JAVA_DISTRIBUTION: adopt
     name: Extra checks
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [1.8, 11, 15]
+        java: [8, 11, 15]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ on:
   schedule:
   - cron: "0 0 * * *"
 
+env:
+  JAVA_DISTRIBUTION: adopt
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -31,8 +34,6 @@ jobs:
 
     env:
       MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      JAVA_DISTRIBUTION: adopt
-
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
@@ -69,7 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      JAVA_DISTRIBUTION: adopt
     name: Test with coverage
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -104,7 +104,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      JAVA_DISTRIBUTION: adopt
     name: Extra checks
     steps:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4


### PR DESCRIPTION
Fix #3872 

This PR updates the Actions workflow to use the latest version of setup-java.