### PR TITLE
feat: Add CtAbstractInvocation.addArgumentAt method

### DIFF
--- a/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
@@ -40,6 +40,16 @@ public interface CtAbstractInvocation<T> extends CtElement {
 	<C extends CtAbstractInvocation<T>> C addArgument(CtExpression<?> argument);
 
 	/**
+	 * Adds an argument expression to the invocation at the specified position.
+	 *
+	 * @param position position to add the argument at.
+	 * @param argument argument to add.
+	 * @return the receiver.
+	 */
+	@PropertySetter(role = ARGUMENT)
+	<C extends CtAbstractInvocation<T>> C addArgumentAt(int position, CtExpression<?> argument);
+
+	/**
 	 * Removes an argument expression from the invocation.
 	 */
 	@PropertySetter(role = ARGUMENT)

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -124,6 +124,11 @@ public class CtConstructorCallImpl<T> extends CtTargetedExpressionImpl<T, CtExpr
 	}
 
 	@Override
+	public <C extends CtAbstractInvocation<T>> C addArgumentAt(int position, CtExpression<?> argument) {
+		return addArgument(position, argument);
+	}
+
+	@Override
 	public void removeArgument(CtExpression<?> argument) {
 		if (arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			return;

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -70,6 +70,11 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 	}
 
 	@Override
+	public <C extends CtAbstractInvocation<T>> C addArgumentAt(int position, CtExpression<?> argument) {
+		return addArgument(position, argument);
+	}
+
+	@Override
 	public void removeArgument(CtExpression<?> argument) {
 		if (arguments == CtElementImpl.<CtExpression<?>>emptyList()) {
 			return;

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -199,11 +199,11 @@ public class ConstructorCallTest {
 		// arguments a bit haphazardly
 
 		// 10
-		newLinkedHashMap.addArgumentAt(0, factory.createCodeSnippetExpression("10").compile());
-		// 10, true
-		newLinkedHashMap.addArgumentAt(1, factory.createCodeSnippetExpression("true").compile());
-		// 10, 1.4, true
-		newLinkedHashMap.addArgumentAt(1, factory.createCodeSnippetExpression("1.4").compile());
+		newLinkedHashMap.addArgumentAt(0, factory.createLiteral(10))
+			// 10, true
+			.addArgumentAt(1, factory.createLiteral(true))
+			// 10, 1.4, true
+			.addArgumentAt(1, factory.createLiteral(1.4));
 
 		// assert
 		assertThat(newLinkedHashMap.toString(), equalTo("new LinkedHashMap(10, 1.4, true)"));

--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -177,6 +179,34 @@ public class ConstructorCallTest {
 		String sourceFile = "./src/test/resources/noclasspath/GenericTypeEmptyDiamond.java";
 		CtTypeReference<?> executableType = getConstructorCallTypeFrom("ArrayList", sourceFile);
 		assertTrue(executableType.isParameterized());
+	}
+
+	@Test
+	public void test_addArgumentAt_addsArgumentToSpecifiedPosition() {
+		// contract: addArgumentAt should add arguments to the specified position.
+
+		// arrange
+		Factory factory = new Launcher().getFactory();
+		factory.getEnvironment().setAutoImports(true);
+		CtConstructorCall<?> newLinkedHashMap = (CtConstructorCall<?>) factory
+                // make it raw on purpose to simplify assertion
+				.createCodeSnippetExpression("new java.util.LinkedHashMap()")
+				.compile();
+
+		// act
+		// LinkedHashMap has multiple constructors, we're going for:
+		// LinkedHashMap(int initialCapacity, float loadFactor, boolean accessOrder) by adding
+		// arguments a bit haphazardly
+
+		// 10
+		newLinkedHashMap.addArgumentAt(0, factory.createCodeSnippetExpression("10").compile());
+		// 10, true
+		newLinkedHashMap.addArgumentAt(1, factory.createCodeSnippetExpression("true").compile());
+		// 10, 1.4, true
+		newLinkedHashMap.addArgumentAt(1, factory.createCodeSnippetExpression("1.4").compile());
+
+		// assert
+		assertThat(newLinkedHashMap.toString(), equalTo("new LinkedHashMap(10, 1.4, true)"));
 	}
 
 	private CtTypeReference<?> getConstructorCallTypeFrom(String simpleName, String sourceFile) {

--- a/src/test/java/spoon/test/invocations/InvocationTest.java
+++ b/src/test/java/spoon/test/invocations/InvocationTest.java
@@ -119,15 +119,15 @@ public class InvocationTest {
 		// order, but we do it haphazardly with addArgumentAt.
 
 		// AL
-		addAllInv.addArgumentAt(0, factory.createCodeSnippetExpression("new java.util.ArrayList<Integer>()").compile());
-		// AL, 99
-		addAllInv.addArgumentAt(1, factory.createLiteral(99));
-		// AL, 99, -2
-		addAllInv.addArgumentAt(2, factory.createLiteral(-2));
-		// AL, 4, 99, -2
-		addAllInv.addArgumentAt(1, factory.createLiteral(4));
-		// AL, 4, 99, 7, -2
-		addAllInv.addArgumentAt(3, factory.createLiteral(7));
+		addAllInv.addArgumentAt(0, factory.createCodeSnippetExpression("new java.util.ArrayList<Integer>()").compile())
+			// AL, 99
+			.addArgumentAt(1, factory.createLiteral(99))
+			// AL, 99, -2
+			.addArgumentAt(2, factory.createLiteral(-2))
+			// AL, 4, 99, -2
+			.addArgumentAt(1, factory.createLiteral(4))
+			// AL, 4, 99, 7, -2
+			.addArgumentAt(3, factory.createLiteral(7));
 
 		// assert
 		assertThat(addAllInv.toString(), equalTo("Collections.addAll(new ArrayList<Integer>(), 4, 99, 7, -2)"));

--- a/src/test/java/spoon/test/invocations/InvocationTest.java
+++ b/src/test/java/spoon/test/invocations/InvocationTest.java
@@ -25,6 +25,7 @@ import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.filter.AbstractFilter;
@@ -32,9 +33,12 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.invocations.testclasses.Bar;
 import spoon.test.invocations.testclasses.Foo;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertNotNull;
@@ -96,5 +100,36 @@ public class InvocationTest {
 		assertEquals(1, executables.size());
 		final CtExecutable exe = executables.get(0);
 		assertNotNull(exe.getReference().getDeclaration());
+	}
+
+	@Test
+	public void test_addArgumentAt_addsArgumentAtSpecifiedPosition() {
+		// contract: addArgumentAt should add arguments to the specified position.
+
+		// arrange
+		Factory factory = new Launcher().getFactory();
+		factory.getEnvironment().setAutoImports(true);;
+		CtType<?> collections = factory.Type().get(Collections.class);
+		CtInvocation<?> addAllInv = factory.createInvocation(
+				factory.createTypeAccess(collections.getReference()),
+				collections.getMethodsByName("addAll").get(0).getReference());
+
+		// act
+		// want to add the arguments new ArrayList<Integer>, 4, 99, 7, -2 s.t. they end up in that
+		// order, but we do it haphazardly with addArgumentAt.
+
+		// AL
+		addAllInv.addArgumentAt(0, factory.createCodeSnippetExpression("new java.util.ArrayList<Integer>()").compile());
+		// AL, 99
+		addAllInv.addArgumentAt(1, factory.createLiteral(99));
+		// AL, 99, -2
+		addAllInv.addArgumentAt(2, factory.createLiteral(-2));
+		// AL, 4, 99, -2
+		addAllInv.addArgumentAt(1, factory.createLiteral(4));
+		// AL, 4, 99, 7, -2
+		addAllInv.addArgumentAt(3, factory.createLiteral(7));
+
+		// assert
+		assertThat(addAllInv.toString(), equalTo("Collections.addAll(new ArrayList<Integer>(), 4, 99, 7, -2)"));
 	}
 }


### PR DESCRIPTION
#3884

This PR adds the method `CtAbstractInvocation.addArgumentAt(int, CtExpression<?>)` to the public API, as discussed in #3884.

This PR will determine whether we go with the `addX` naming convention, or the `addXAt` naming convention. Both are already present in the project, but we should adopt one as the predominant style. I favor `addXAt(int,CtElement)` because it makes it easier to see that the method is distinct, but `addX(int,CtElement)` is also valid as that is a common overload in the Java standard library collections.