### PR TITLE
chore: Bump license-maven-plugin to version 4.0

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -59,11 +59,15 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <configuration>
-                        <header>LICENSE.txt</header>
-                        <basedir>src</basedir>
-                        <includes>
-                            <include>main/java/**</include>
-                        </includes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>LICENSE.txt</header>
+                                <basedir>src</basedir>
+                                <includes>
+                                    <include>main/java/**</include>
+                                </includes>
+                            </licenseSet>
+                        </licenseSets>
                     </configuration>
                     <executions>
                         <execution>

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/AllBranchesReturn.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/AllBranchesReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/BranchKind.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/BranchKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowEdge.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowEdge.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowGraph.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowGraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowNode.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ExceptionControlFlowStrategy.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ExceptionControlFlowStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/GraphVisPrettyPrinter.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/GraphVisPrettyPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/NaiveExceptionControlFlowStrategy.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/NaiveExceptionControlFlowStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/NotFoundException.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/NotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/TransferFunctionVisitor.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/TransferFunctionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/Value.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/Value.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/AbstractControlFlowVisitor.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/AbstractControlFlowVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitor.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitorBackwards.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitorBackwards.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitorForward.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/ControlFlowVisitorForward.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/InitializedVariables.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/InitializedVariables.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-control-flow/src/main/java/fr/inria/dataflow/UselessAssignmentAnalysis.java
+++ b/spoon-control-flow/src/main/java/fr/inria/dataflow/UselessAssignmentAnalysis.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/spoon-decompiler/src/main/java/spoon/DecompiledResource.java
+++ b/spoon-decompiler/src/main/java/spoon/DecompiledResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/JarLauncher.java
+++ b/spoon-decompiler/src/main/java/spoon/JarLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/CFRDecompiler.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/CFRDecompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/Decompiler.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/Decompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/FernflowerDecompiler.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/FernflowerDecompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/MultiTypeTransformer.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/MultiTypeTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/ProcyonDecompiler.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/ProcyonDecompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/SpoonClassFileTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-decompiler/src/main/java/spoon/decompiler/TypeTransformer.java
+++ b/spoon-decompiler/src/main/java/spoon/decompiler/TypeTransformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) 2006-2018 INRIA and contributors
  * Spoon - http://spoon.gforge.inria.fr/
  *

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -236,14 +236,18 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>4.0</version>
                     <configuration>
-                        <header>LICENSE-short.txt</header>
-                        <includes>
-                            <include>src/main/java/**</include>
-                            <!-- We also want to check the license in templates to generate files with the proper header -->
-                            <include>src/test/java/spoon/generating/clone/*</include>
-                        </includes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>LICENSE-short.txt</header>
+                                <includes>
+                                    <include>src/main/java/**</include>
+                                    <!-- We also want to check the license in templates to generate files with the proper header -->
+                                    <include>src/test/java/spoon/generating/clone/*</include>
+                                </includes>
+                            </licenseSet>
+                        </licenseSets>
                         <excludes>
 		            <!--  excluding the code coming from Javaparser -->
 		            <exclude>src/main/java/spoon/javadoc/internal/*</exclude>

--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -84,11 +84,15 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <configuration>
-                        <header>LICENSE.txt</header>
-                        <basedir>src</basedir>
-                        <includes>
-                            <include>main/java/**</include>
-                        </includes>
+                        <licenseSets>
+                            <licenseSet>
+                                <header>LICENSE.txt</header>
+                                <basedir>src</basedir>
+                                <includes>
+                                    <include>main/java/**</include>
+                                </includes>
+                            </licenseSet>
+                        </licenseSets>
                     </configuration>
                     <executions>
                         <execution>

--- a/spoon-smpl/src/main/java/spoon/smpl/AnchoredOperationsMap.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/AnchoredOperationsMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.smpl.operation.Operation;

--- a/spoon-smpl/src/main/java/spoon/smpl/CFGModel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/CFGModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import fr.inria.controlflow.BranchKind;

--- a/spoon-smpl/src/main/java/spoon/smpl/CombinationsGenerator.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/CombinationsGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/CommandlineApplication.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/CommandlineApplication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.declaration.CtClass;

--- a/spoon-smpl/src/main/java/spoon/smpl/DebugUtils.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/DebugUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.code.CtBlock;

--- a/spoon-smpl/src/main/java/spoon/smpl/Environment.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/Environment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.Arrays;

--- a/spoon-smpl/src/main/java/spoon/smpl/FormulaCompiler.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/FormulaCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import fr.inria.controlflow.BranchKind;

--- a/spoon-smpl/src/main/java/spoon/smpl/FormulaOptimizer.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/FormulaOptimizer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.smpl.formula.AllNext;

--- a/spoon-smpl/src/main/java/spoon/smpl/Label.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/Label.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.smpl.formula.Predicate;

--- a/spoon-smpl/src/main/java/spoon/smpl/LabelMatchResult.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/LabelMatchResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/LabelMatchResultImpl.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/LabelMatchResultImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/MethodHeaderModel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/MethodHeaderModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.code.CtFieldRead;

--- a/spoon-smpl/src/main/java/spoon/smpl/Model.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/Model.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.List;

--- a/spoon-smpl/src/main/java/spoon/smpl/ModelChecker.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/ModelChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.smpl.formula.AllNext;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLGrep.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLGrep.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLJavaDSL.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLJavaDSL.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.code.CtExpression;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLLexer.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLLexer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import fr.inria.controlflow.BranchKind;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLParser.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLProblemDetector.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLProblemDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLProcessor.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.Launcher;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLRule.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.declaration.CtExecutable;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLRuleImpl.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLRuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import org.apache.commons.lang3.NotImplementedException;

--- a/spoon-smpl/src/main/java/spoon/smpl/SpoonJavaParser.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SpoonJavaParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.Launcher;

--- a/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/Substitutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 

--- a/spoon-smpl/src/main/java/spoon/smpl/Transformer.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/Transformer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import fr.inria.controlflow.BranchKind;

--- a/spoon-smpl/src/main/java/spoon/smpl/TriConsumer.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/TriConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import java.util.Objects;

--- a/spoon-smpl/src/main/java/spoon/smpl/TypeAccessReplacer.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/TypeAccessReplacer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.code.CtExpression;

--- a/spoon-smpl/src/main/java/spoon/smpl/VariableUseScanner.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/VariableUseScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/AllNext.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/AllNext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/AllUntil.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/AllUntil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/And.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/And.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/BinaryConnective.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/BinaryConnective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Branch.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Branch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.code.CtIf;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/CodeElementPredicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/CodeElementPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsNext.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsNext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsUntil.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsUntil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsVar.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/ExistsVar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Expression.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Expression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Formula.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Formula.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/FormulaScanner.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/FormulaScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/FormulaVisitor.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/FormulaVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/InnerAnd.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/InnerAnd.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/MetadataPredicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/MetadataPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.Map;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/MetavariableConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/MetavariableConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/MethodHeaderPredicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/MethodHeaderPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtMethod;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Not.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Not.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Optional.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Optional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Or.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Or.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/ParameterizedPredicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/ParameterizedPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Predicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Predicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.Map;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Proposition.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Proposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.Map;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/SequentialOr.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/SequentialOr.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/SetEnv.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/SetEnv.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/Statement.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/Statement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/SubformulaCollector.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/SubformulaCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/True.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/True.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/UnaryConnective.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/UnaryConnective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/formula/VariableUsePredicate.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/formula/VariableUsePredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.formula;
 
 import java.util.Map;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/BranchLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/BranchLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 import spoon.reflect.code.CtIf;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/CodeElementLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/CodeElementLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/MetadataLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/MetadataLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 import spoon.smpl.Label;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/MethodHeaderLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/MethodHeaderLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 import spoon.reflect.declaration.CtExecutable;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/PropositionLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/PropositionLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 import spoon.smpl.Label;

--- a/spoon-smpl/src/main/java/spoon/smpl/label/StatementLabel.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/label/StatementLabel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.label;
 
 //import spoon.pattern.Match;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/ConstantConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/ConstantConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.code.CtExpression;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/ExpressionConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/ExpressionConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.code.CtExpression;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/IdentifierConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/IdentifierConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.code.CtVariableAccess;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/RegexConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/RegexConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/TypeConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/TypeConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.code.CtFieldRead;

--- a/spoon-smpl/src/main/java/spoon/smpl/metavars/TypedIdentifierConstraint.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/metavars/TypedIdentifierConstraint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.metavars;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/AppendOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/AppendOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.code.CtStatement;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/DeleteOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/DeleteOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.code.CtBlock;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/InsertIntoBlockOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/InsertIntoBlockOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.code.CtBlock;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/MethodHeaderReplaceOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/MethodHeaderReplaceOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/Operation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/Operation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/OperationCategory.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/OperationCategory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/PrependOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/PrependOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.code.CtStatement;

--- a/spoon-smpl/src/main/java/spoon/smpl/operation/ReplaceOperation.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/operation/ReplaceOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.operation;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/DotsExtPatternMatcher.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/DotsExtPatternMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import spoon.reflect.code.CtAbstractInvocation;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/ElemNode.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/ElemNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/ParamNode.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/ParamNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import spoon.reflect.code.CtAnnotationFieldAccess;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternMatcher.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import spoon.reflect.code.CtVariableAccess;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternNode.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternNodeVisitor.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/PatternNodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 /**

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/SubElemPatternCollector.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/SubElemPatternCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import java.util.ArrayList;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/SubElemPatternMatcher.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/SubElemPatternMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 import spoon.reflect.declaration.CtElement;

--- a/spoon-smpl/src/main/java/spoon/smpl/pattern/ValueNode.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/pattern/ValueNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -19,7 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
 package spoon.smpl.pattern;
 
 /**

--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/IncrementalLauncher.java
+++ b/src/main/java/spoon/IncrementalLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/LovecraftException.java
+++ b/src/main/java/spoon/LovecraftException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/OutputType.java
+++ b/src/main/java/spoon/OutputType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/SpoonAPI.java
+++ b/src/main/java/spoon/SpoonAPI.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/SpoonException.java
+++ b/src/main/java/spoon/SpoonException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/SpoonModelBuilder.java
+++ b/src/main/java/spoon/SpoonModelBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/InvalidClassPathException.java
+++ b/src/main/java/spoon/compiler/InvalidClassPathException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/ModelBuildingException.java
+++ b/src/main/java/spoon/compiler/ModelBuildingException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/SpoonFolder.java
+++ b/src/main/java/spoon/compiler/SpoonFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/SpoonResource.java
+++ b/src/main/java/spoon/compiler/SpoonResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/SpoonResourceHelper.java
+++ b/src/main/java/spoon/compiler/SpoonResourceHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/AdvancedOptions.java
+++ b/src/main/java/spoon/compiler/builder/AdvancedOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/AnnotationProcessingOptions.java
+++ b/src/main/java/spoon/compiler/builder/AnnotationProcessingOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/ClasspathOptions.java
+++ b/src/main/java/spoon/compiler/builder/ClasspathOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/ComplianceOptions.java
+++ b/src/main/java/spoon/compiler/builder/ComplianceOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/EncodingProvider.java
+++ b/src/main/java/spoon/compiler/builder/EncodingProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/JDTBuilder.java
+++ b/src/main/java/spoon/compiler/builder/JDTBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/JDTBuilderImpl.java
+++ b/src/main/java/spoon/compiler/builder/JDTBuilderImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/Options.java
+++ b/src/main/java/spoon/compiler/builder/Options.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/builder/SourceOptions.java
+++ b/src/main/java/spoon/compiler/builder/SourceOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/compiler/package-info.java
+++ b/src/main/java/spoon/compiler/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/experimental/CtUnresolvedImport.java
+++ b/src/main/java/spoon/experimental/CtUnresolvedImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/experimental/package-info.java
+++ b/src/main/java/spoon/experimental/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/Javadoc.java
+++ b/src/main/java/spoon/javadoc/internal/Javadoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocBlockTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/JavadocDescription.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocDescription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/JavadocDescriptionElement.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocDescriptionElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocSnippet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/legacy/NameFilter.java
+++ b/src/main/java/spoon/legacy/NameFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/legacy/package-info.java
+++ b/src/main/java/spoon/legacy/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/ConceptKind.java
+++ b/src/main/java/spoon/metamodel/ConceptKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/MMMethod.java
+++ b/src/main/java/spoon/metamodel/MMMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/MMMethodKind.java
+++ b/src/main/java/spoon/metamodel/MMMethodKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/Metamodel.java
+++ b/src/main/java/spoon/metamodel/Metamodel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/MetamodelConcept.java
+++ b/src/main/java/spoon/metamodel/MetamodelConcept.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/metamodel/package-info.java
+++ b/src/main/java/spoon/metamodel/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/package-info.java
+++ b/src/main/java/spoon/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/ConflictResolutionMode.java
+++ b/src/main/java/spoon/pattern/ConflictResolutionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/Generator.java
+++ b/src/main/java/spoon/pattern/Generator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
+++ b/src/main/java/spoon/pattern/InlinedStatementConfigurator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/Match.java
+++ b/src/main/java/spoon/pattern/Match.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/Pattern.java
+++ b/src/main/java/spoon/pattern/Pattern.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/PatternBuilderHelper.java
+++ b/src/main/java/spoon/pattern/PatternBuilderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/Quantifier.java
+++ b/src/main/java/spoon/pattern/Quantifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/DefaultGenerator.java
+++ b/src/main/java/spoon/pattern/internal/DefaultGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/PatternPrinter.java
+++ b/src/main/java/spoon/pattern/internal/PatternPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/ResultHolder.java
+++ b/src/main/java/spoon/pattern/internal/ResultHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/SubstitutionRequestProvider.java
+++ b/src/main/java/spoon/pattern/internal/SubstitutionRequestProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/ValueConvertor.java
+++ b/src/main/java/spoon/pattern/internal/ValueConvertor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/ValueConvertorImpl.java
+++ b/src/main/java/spoon/pattern/internal/ValueConvertorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/matcher/ChainOfMatchersImpl.java
+++ b/src/main/java/spoon/pattern/internal/matcher/ChainOfMatchersImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/matcher/Matchers.java
+++ b/src/main/java/spoon/pattern/internal/matcher/Matchers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/matcher/MatchingScanner.java
+++ b/src/main/java/spoon/pattern/internal/matcher/MatchingScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
+++ b/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/AbstractParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/ComputedParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ComputedParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/ListParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ListParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/MapParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/MapParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/ParameterComputer.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ParameterComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/ParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/ParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/SetParameterInfo.java
+++ b/src/main/java/spoon/pattern/internal/parameter/SetParameterInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/pattern/internal/parameter/SimpleNameOfTypeReferenceParameterComputer.java
+++ b/src/main/java/spoon/pattern/internal/parameter/SimpleNameOfTypeReferenceParameterComputer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/AbstractManualProcessor.java
+++ b/src/main/java/spoon/processing/AbstractManualProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/AbstractParallelProcessor.java
+++ b/src/main/java/spoon/processing/AbstractParallelProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/AbstractProcessor.java
+++ b/src/main/java/spoon/processing/AbstractProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/AnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AnnotationProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/FactoryAccessor.java
+++ b/src/main/java/spoon/processing/FactoryAccessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/FileGenerator.java
+++ b/src/main/java/spoon/processing/FileGenerator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/ProcessInterruption.java
+++ b/src/main/java/spoon/processing/ProcessInterruption.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/ProcessingManager.java
+++ b/src/main/java/spoon/processing/ProcessingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/Processor.java
+++ b/src/main/java/spoon/processing/Processor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/ProcessorProperties.java
+++ b/src/main/java/spoon/processing/ProcessorProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/ProcessorPropertiesImpl.java
+++ b/src/main/java/spoon/processing/ProcessorPropertiesImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/Property.java
+++ b/src/main/java/spoon/processing/Property.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/SpoonTagger.java
+++ b/src/main/java/spoon/processing/SpoonTagger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/TraversalStrategy.java
+++ b/src/main/java/spoon/processing/TraversalStrategy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/processing/package-info.java
+++ b/src/main/java/spoon/processing/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/AbstractRenameRefactoring.java
+++ b/src/main/java/spoon/refactoring/AbstractRenameRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtDeprecatedRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtDeprecatedRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtParameterRemoveRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtParameterRemoveRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtRenameGenericVariableRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtRenameGenericVariableRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtRenameLocalVariableRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtRenameLocalVariableRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/CtRenameRefactoring.java
+++ b/src/main/java/spoon/refactoring/CtRenameRefactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/MethodCallState.java
+++ b/src/main/java/spoon/refactoring/MethodCallState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/MethodInvocationSearch.java
+++ b/src/main/java/spoon/refactoring/MethodInvocationSearch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/Refactoring.java
+++ b/src/main/java/spoon/refactoring/Refactoring.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/refactoring/RefactoringException.java
+++ b/src/main/java/spoon/refactoring/RefactoringException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/CtModel.java
+++ b/src/main/java/spoon/reflect/CtModel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/CtModelImpl.java
+++ b/src/main/java/spoon/reflect/CtModelImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
+++ b/src/main/java/spoon/reflect/ModelElementContainerDefaultCapacities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/ModelStreamer.java
+++ b/src/main/java/spoon/reflect/ModelStreamer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/annotations/MetamodelPropertyField.java
+++ b/src/main/java/spoon/reflect/annotations/MetamodelPropertyField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/annotations/PropertyGetter.java
+++ b/src/main/java/spoon/reflect/annotations/PropertyGetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/annotations/PropertySetter.java
+++ b/src/main/java/spoon/reflect/annotations/PropertySetter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/BinaryOperatorKind.java
+++ b/src/main/java/spoon/reflect/code/BinaryOperatorKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CaseKind.java
+++ b/src/main/java/spoon/reflect/code/CaseKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtAbstractInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtAbstractSwitch.java
+++ b/src/main/java/spoon/reflect/code/CtAbstractSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtAnnotationFieldAccess.java
+++ b/src/main/java/spoon/reflect/code/CtAnnotationFieldAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtArrayAccess.java
+++ b/src/main/java/spoon/reflect/code/CtArrayAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtArrayRead.java
+++ b/src/main/java/spoon/reflect/code/CtArrayRead.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtArrayWrite.java
+++ b/src/main/java/spoon/reflect/code/CtArrayWrite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtAssert.java
+++ b/src/main/java/spoon/reflect/code/CtAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtAssignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtBinaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtBinaryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtBlock.java
+++ b/src/main/java/spoon/reflect/code/CtBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtBodyHolder.java
+++ b/src/main/java/spoon/reflect/code/CtBodyHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtBreak.java
+++ b/src/main/java/spoon/reflect/code/CtBreak.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtCFlowBreak.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCase.java
+++ b/src/main/java/spoon/reflect/code/CtCase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCatch.java
+++ b/src/main/java/spoon/reflect/code/CtCatch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCatchVariable.java
+++ b/src/main/java/spoon/reflect/code/CtCatchVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCodeElement.java
+++ b/src/main/java/spoon/reflect/code/CtCodeElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
+++ b/src/main/java/spoon/reflect/code/CtCodeSnippetStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtComment.java
+++ b/src/main/java/spoon/reflect/code/CtComment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtConditional.java
+++ b/src/main/java/spoon/reflect/code/CtConditional.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtConstructorCall.java
+++ b/src/main/java/spoon/reflect/code/CtConstructorCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtContinue.java
+++ b/src/main/java/spoon/reflect/code/CtContinue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtDo.java
+++ b/src/main/java/spoon/reflect/code/CtDo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtExecutableReferenceExpression.java
+++ b/src/main/java/spoon/reflect/code/CtExecutableReferenceExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtExpression.java
+++ b/src/main/java/spoon/reflect/code/CtExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtFieldAccess.java
+++ b/src/main/java/spoon/reflect/code/CtFieldAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtFieldRead.java
+++ b/src/main/java/spoon/reflect/code/CtFieldRead.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtFieldWrite.java
+++ b/src/main/java/spoon/reflect/code/CtFieldWrite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtFor.java
+++ b/src/main/java/spoon/reflect/code/CtFor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtForEach.java
+++ b/src/main/java/spoon/reflect/code/CtForEach.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtIf.java
+++ b/src/main/java/spoon/reflect/code/CtIf.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtInvocation.java
+++ b/src/main/java/spoon/reflect/code/CtInvocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtJavaDoc.java
+++ b/src/main/java/spoon/reflect/code/CtJavaDoc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtJavaDocTag.java
+++ b/src/main/java/spoon/reflect/code/CtJavaDocTag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
+++ b/src/main/java/spoon/reflect/code/CtLabelledFlowBreak.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtLambda.java
+++ b/src/main/java/spoon/reflect/code/CtLambda.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtLiteral.java
+++ b/src/main/java/spoon/reflect/code/CtLiteral.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtLocalVariable.java
+++ b/src/main/java/spoon/reflect/code/CtLocalVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtLoop.java
+++ b/src/main/java/spoon/reflect/code/CtLoop.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtNewArray.java
+++ b/src/main/java/spoon/reflect/code/CtNewArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtNewClass.java
+++ b/src/main/java/spoon/reflect/code/CtNewClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
+++ b/src/main/java/spoon/reflect/code/CtOperatorAssignment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtRHSReceiver.java
+++ b/src/main/java/spoon/reflect/code/CtRHSReceiver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtReturn.java
+++ b/src/main/java/spoon/reflect/code/CtReturn.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtStatement.java
+++ b/src/main/java/spoon/reflect/code/CtStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtStatementList.java
+++ b/src/main/java/spoon/reflect/code/CtStatementList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtSuperAccess.java
+++ b/src/main/java/spoon/reflect/code/CtSuperAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtSwitch.java
+++ b/src/main/java/spoon/reflect/code/CtSwitch.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtSwitchExpression.java
+++ b/src/main/java/spoon/reflect/code/CtSwitchExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtSynchronized.java
+++ b/src/main/java/spoon/reflect/code/CtSynchronized.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtTargetedExpression.java
+++ b/src/main/java/spoon/reflect/code/CtTargetedExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtTextBlock.java
+++ b/src/main/java/spoon/reflect/code/CtTextBlock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtThisAccess.java
+++ b/src/main/java/spoon/reflect/code/CtThisAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtThrow.java
+++ b/src/main/java/spoon/reflect/code/CtThrow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtTryWithResource.java
+++ b/src/main/java/spoon/reflect/code/CtTryWithResource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtTypeAccess.java
+++ b/src/main/java/spoon/reflect/code/CtTypeAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtUnaryOperator.java
+++ b/src/main/java/spoon/reflect/code/CtUnaryOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtVariableAccess.java
+++ b/src/main/java/spoon/reflect/code/CtVariableAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtVariableRead.java
+++ b/src/main/java/spoon/reflect/code/CtVariableRead.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtVariableWrite.java
+++ b/src/main/java/spoon/reflect/code/CtVariableWrite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtWhile.java
+++ b/src/main/java/spoon/reflect/code/CtWhile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/CtYieldStatement.java
+++ b/src/main/java/spoon/reflect/code/CtYieldStatement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/LiteralBase.java
+++ b/src/main/java/spoon/reflect/code/LiteralBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/UnaryOperatorKind.java
+++ b/src/main/java/spoon/reflect/code/UnaryOperatorKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/code/package-info.java
+++ b/src/main/java/spoon/reflect/code/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/CompilationUnit.java
+++ b/src/main/java/spoon/reflect/cu/CompilationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/SourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/SourcePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
+++ b/src/main/java/spoon/reflect/cu/SourcePositionHolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/package-info.java
+++ b/src/main/java/spoon/reflect/cu/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/position/BodyHolderSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/BodyHolderSourcePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/position/CompoundSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/CompoundSourcePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/position/DeclarationSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/DeclarationSourcePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtAnnotatedElementType.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotatedElementType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtAnnotation.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnnotationType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
+++ b/src/main/java/spoon/reflect/declaration/CtCodeSnippet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
+++ b/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtConstructor.java
+++ b/src/main/java/spoon/reflect/declaration/CtConstructor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtEnum.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtEnumValue.java
+++ b/src/main/java/spoon/reflect/declaration/CtEnumValue.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtField.java
+++ b/src/main/java/spoon/reflect/declaration/CtField.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtFormalTypeDeclarer.java
+++ b/src/main/java/spoon/reflect/declaration/CtFormalTypeDeclarer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtImport.java
+++ b/src/main/java/spoon/reflect/declaration/CtImport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtImportKind.java
+++ b/src/main/java/spoon/reflect/declaration/CtImportKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtInterface.java
+++ b/src/main/java/spoon/reflect/declaration/CtInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtModifiable.java
+++ b/src/main/java/spoon/reflect/declaration/CtModifiable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtModule.java
+++ b/src/main/java/spoon/reflect/declaration/CtModule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtModuleDirective.java
+++ b/src/main/java/spoon/reflect/declaration/CtModuleDirective.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtModuleRequirement.java
+++ b/src/main/java/spoon/reflect/declaration/CtModuleRequirement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtMultiTypedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtNamedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtNamedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtPackageDeclaration.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackageDeclaration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtPackageExport.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackageExport.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtProvidedService.java
+++ b/src/main/java/spoon/reflect/declaration/CtProvidedService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtShadowable.java
+++ b/src/main/java/spoon/reflect/declaration/CtShadowable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtTypeMember.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypeParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtTypedElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtTypedElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtUsedService.java
+++ b/src/main/java/spoon/reflect/declaration/CtUsedService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/CtVariable.java
+++ b/src/main/java/spoon/reflect/declaration/CtVariable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/ModifierKind.java
+++ b/src/main/java/spoon/reflect/declaration/ModifierKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/ParentNotInitializedException.java
+++ b/src/main/java/spoon/reflect/declaration/ParentNotInitializedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/declaration/package-info.java
+++ b/src/main/java/spoon/reflect/declaration/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/eval/PartialEvaluator.java
+++ b/src/main/java/spoon/reflect/eval/PartialEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/eval/package-info.java
+++ b/src/main/java/spoon/reflect/eval/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/AnnotationFactory.java
+++ b/src/main/java/spoon/reflect/factory/AnnotationFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/ClassFactory.java
+++ b/src/main/java/spoon/reflect/factory/ClassFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
+++ b/src/main/java/spoon/reflect/factory/CompilationUnitFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/ConstructorFactory.java
+++ b/src/main/java/spoon/reflect/factory/ConstructorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/CoreFactory.java
+++ b/src/main/java/spoon/reflect/factory/CoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/EnumFactory.java
+++ b/src/main/java/spoon/reflect/factory/EnumFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/EvalFactory.java
+++ b/src/main/java/spoon/reflect/factory/EvalFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/Factory.java
+++ b/src/main/java/spoon/reflect/factory/Factory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/FieldFactory.java
+++ b/src/main/java/spoon/reflect/factory/FieldFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/InterfaceFactory.java
+++ b/src/main/java/spoon/reflect/factory/InterfaceFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/MethodFactory.java
+++ b/src/main/java/spoon/reflect/factory/MethodFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/ModuleFactory.java
+++ b/src/main/java/spoon/reflect/factory/ModuleFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/QueryFactory.java
+++ b/src/main/java/spoon/reflect/factory/QueryFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/SubFactory.java
+++ b/src/main/java/spoon/reflect/factory/SubFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/factory/package-info.java
+++ b/src/main/java/spoon/reflect/factory/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/ContainerKind.java
+++ b/src/main/java/spoon/reflect/meta/ContainerKind.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/RoleHandler.java
+++ b/src/main/java/spoon/reflect/meta/RoleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/AbstractRoleHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/AbstractRoleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/ListHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/ListHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/MapHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/MapHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java
+++ b/src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/RoleHandlerHelper.java
+++ b/src/main/java/spoon/reflect/meta/impl/RoleHandlerHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/SetHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/SetHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/meta/impl/SingleHandler.java
+++ b/src/main/java/spoon/reflect/meta/impl/SingleHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/package-info.java
+++ b/src/main/java/spoon/reflect/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtElementPathBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtPath.java
+++ b/src/main/java/spoon/reflect/path/CtPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtPathBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtPathException.java
+++ b/src/main/java/spoon/reflect/path/CtPathException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/CtRole.java
+++ b/src/main/java/spoon/reflect/path/CtRole.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtNamedPathElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/CtPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtPathElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/CtPathImpl.java
+++ b/src/main/java/spoon/reflect/path/impl/CtPathImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtRolePathElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/path/impl/CtTypedNameElement.java
+++ b/src/main/java/spoon/reflect/path/impl/CtTypedNameElement.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtActualTypeContainer.java
+++ b/src/main/java/spoon/reflect/reference/CtActualTypeContainer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtArrayTypeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtCatchVariableReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtExecutableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtExecutableReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtFieldReference.java
+++ b/src/main/java/spoon/reflect/reference/CtFieldReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtIntersectionTypeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtLocalVariableReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtModuleReference.java
+++ b/src/main/java/spoon/reflect/reference/CtModuleReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtPackageReference.java
+++ b/src/main/java/spoon/reflect/reference/CtPackageReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtParameterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtReference.java
+++ b/src/main/java/spoon/reflect/reference/CtReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtTypeMemberWildcardImportReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeMemberWildcardImportReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeParameterReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtUnboundVariableReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtVariableReference.java
+++ b/src/main/java/spoon/reflect/reference/CtVariableReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/CtWildcardReference.java
+++ b/src/main/java/spoon/reflect/reference/CtWildcardReference.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/reference/package-info.java
+++ b/src/main/java/spoon/reflect/reference/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/AccessibleVariablesFinder.java
+++ b/src/main/java/spoon/reflect/visitor/AccessibleVariablesFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/AstParentConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/AstParentConsistencyChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CacheBasedConflictFinder.java
+++ b/src/main/java/spoon/reflect/visitor/CacheBasedConflictFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/Child.java
+++ b/src/main/java/spoon/reflect/visitor/Child.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtAbstractBiScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractBiScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtAbstractImportVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractImportVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtAbstractVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtBFSIterator.java
+++ b/src/main/java/spoon/reflect/visitor/CtBFSIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
+++ b/src/main/java/spoon/reflect/visitor/CtBiScannerDefault.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtDequeScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtDequeScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtImportVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtImportVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtInheritanceScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtIterator.java
+++ b/src/main/java/spoon/reflect/visitor/CtIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtVisitable.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/CtVisitor.java
+++ b/src/main/java/spoon/reflect/visitor/CtVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/DefaultImportComparator.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultImportComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/DefaultTokenWriter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultTokenWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/EarlyTerminatingScanner.java
+++ b/src/main/java/spoon/reflect/visitor/EarlyTerminatingScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/Filter.java
+++ b/src/main/java/spoon/reflect/visitor/Filter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceFullyQualifiedProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
+++ b/src/main/java/spoon/reflect/visitor/ForceImportProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ImportAnalyzer.java
+++ b/src/main/java/spoon/reflect/visitor/ImportAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
+++ b/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ImportScanner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
+++ b/src/main/java/spoon/reflect/visitor/ImportScannerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/JavaIdentifiers.java
+++ b/src/main/java/spoon/reflect/visitor/JavaIdentifiers.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/LexicalScope.java
+++ b/src/main/java/spoon/reflect/visitor/LexicalScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/LexicalScopeScanner.java
+++ b/src/main/java/spoon/reflect/visitor/LexicalScopeScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ListPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/ListPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/ModelConsistencyChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/NameScopeImpl.java
+++ b/src/main/java/spoon/reflect/visitor/NameScopeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/OperatorHelper.java
+++ b/src/main/java/spoon/reflect/visitor/OperatorHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/Parent.java
+++ b/src/main/java/spoon/reflect/visitor/Parent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/PrettyPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/PrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/PrinterHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/PrintingContext.java
+++ b/src/main/java/spoon/reflect/visitor/PrintingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/Query.java
+++ b/src/main/java/spoon/reflect/visitor/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/Root.java
+++ b/src/main/java/spoon/reflect/visitor/Root.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/RoundBracketAnalyzer.java
+++ b/src/main/java/spoon/reflect/visitor/RoundBracketAnalyzer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/TokenWriter.java
+++ b/src/main/java/spoon/reflect/visitor/TokenWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/TypeNameScope.java
+++ b/src/main/java/spoon/reflect/visitor/TypeNameScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtConsumableFunction.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtConsumableFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtConsumer.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtConsumer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtFunction.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryAware.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryable.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtScannerListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/QueryFailurePolicy.java
+++ b/src/main/java/spoon/reflect/visitor/chain/QueryFailurePolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/chain/ScanningMode.java
+++ b/src/main/java/spoon/reflect/visitor/chain/ScanningMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllMethodsSameSignatureFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AllTypeMembersFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/AnnotationFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AnnotationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/CatchVariableReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CatchVariableReferenceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/CatchVariableScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CatchVariableScopeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/CompositeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CompositeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/CtScannerFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/DirectReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/DirectReferenceFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ExecutableReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ExecutableReferenceFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/FieldAccessFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldAccessFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldReferenceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FieldScopeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/FilteringOperator.java
+++ b/src/main/java/spoon/reflect/visitor/filter/FilteringOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/InvocationFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/InvocationFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/LambdaFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LambdaFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/LineFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LineFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/LocalVariableReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LocalVariableReferenceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/LocalVariableScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/LocalVariableScopeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/NamedElementFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodQuery.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverriddenMethodQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/OverridingMethodFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ParameterReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParameterReferenceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ParameterScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParameterScopeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ParentFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ReferenceTypeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ReferenceTypeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/RegexFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/RegexFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/ReturnOrThrowFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/ReturnOrThrowFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/SameFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SameFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/SiblingsFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SiblingsFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubInheritanceHierarchyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/SubtypeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SubtypeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/TypeFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/TypeFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/VariableAccessFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/VariableReferenceFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/VariableReferenceFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/VariableScopeFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/VariableScopeFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/filter/package-info.java
+++ b/src/main/java/spoon/reflect/visitor/filter/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/package-info.java
+++ b/src/main/java/spoon/reflect/visitor/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/reflect/visitor/printer/CommentOffset.java
+++ b/src/main/java/spoon/reflect/visitor/printer/CommentOffset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/CompressionType.java
+++ b/src/main/java/spoon/support/CompressionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/DefaultOutputDestinationHandler.java
+++ b/src/main/java/spoon/support/DefaultOutputDestinationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/DerivedProperty.java
+++ b/src/main/java/spoon/support/DerivedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/Experimental.java
+++ b/src/main/java/spoon/support/Experimental.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/Internal.java
+++ b/src/main/java/spoon/support/Internal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/Level.java
+++ b/src/main/java/spoon/support/Level.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/OutputDestinationHandler.java
+++ b/src/main/java/spoon/support/OutputDestinationHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/QueueProcessingManager.java
+++ b/src/main/java/spoon/support/QueueProcessingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/RuntimeProcessingManager.java
+++ b/src/main/java/spoon/support/RuntimeProcessingManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/SerializationModelStreamer.java
+++ b/src/main/java/spoon/support/SerializationModelStreamer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/SpoonClassNotFoundException.java
+++ b/src/main/java/spoon/support/SpoonClassNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/UnsettableProperty.java
+++ b/src/main/java/spoon/support/UnsettableProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/comparator/CtLineElementComparator.java
+++ b/src/main/java/spoon/support/comparator/CtLineElementComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/comparator/FixedOrderBasedOnFileNameCompilationUnitComparator.java
+++ b/src/main/java/spoon/support/comparator/FixedOrderBasedOnFileNameCompilationUnitComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/comparator/QualifiedNameComparator.java
+++ b/src/main/java/spoon/support/comparator/QualifiedNameComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/comparator/SignatureComparator.java
+++ b/src/main/java/spoon/support/comparator/SignatureComparator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/FileSystemFile.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/FileSystemFolder.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/FilteringFolder.java
+++ b/src/main/java/spoon/support/compiler/FilteringFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/ProgressLogger.java
+++ b/src/main/java/spoon/support/compiler/ProgressLogger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/SnippetCompilationError.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/SpoonProgress.java
+++ b/src/main/java/spoon/support/compiler/SpoonProgress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/VirtualFile.java
+++ b/src/main/java/spoon/support/compiler/VirtualFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/VirtualFolder.java
+++ b/src/main/java/spoon/support/compiler/VirtualFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/ZipFile.java
+++ b/src/main/java/spoon/support/compiler/ZipFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/ZipFolder.java
+++ b/src/main/java/spoon/support/compiler/ZipFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/ASTPair.java
+++ b/src/main/java/spoon/support/compiler/jdt/ASTPair.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/CompilationUnitFilter.java
+++ b/src/main/java/spoon/support/compiler/jdt/CompilationUnitFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/CompilationUnitWrapper.java
+++ b/src/main/java/spoon/support/compiler/jdt/CompilationUnitWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/FactoryCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FactoryCompilerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
+++ b/src/main/java/spoon/support/compiler/jdt/FileCompilerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTSnippetCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderCompiler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/compiler/jdt/TreeBuilderRequestor.java
+++ b/src/main/java/spoon/support/compiler/jdt/TreeBuilderRequestor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/gui/SpoonModelTree.java
+++ b/src/main/java/spoon/support/gui/SpoonModelTree.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
+++ b/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/gui/SpoonTreeBuilder.java
+++ b/src/main/java/spoon/support/gui/SpoonTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/ActionBasedChangeListener.java
+++ b/src/main/java/spoon/support/modelobs/ActionBasedChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/ActionBasedChangeListenerImpl.java
+++ b/src/main/java/spoon/support/modelobs/ActionBasedChangeListenerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/EmptyModelChangeListener.java
+++ b/src/main/java/spoon/support/modelobs/EmptyModelChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/FineModelChangeListener.java
+++ b/src/main/java/spoon/support/modelobs/FineModelChangeListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
+++ b/src/main/java/spoon/support/modelobs/SourceFragmentCreator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/action/Action.java
+++ b/src/main/java/spoon/support/modelobs/action/Action.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/action/AddAction.java
+++ b/src/main/java/spoon/support/modelobs/action/AddAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/action/DeleteAction.java
+++ b/src/main/java/spoon/support/modelobs/action/DeleteAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/action/DeleteAllAction.java
+++ b/src/main/java/spoon/support/modelobs/action/DeleteAllAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/action/UpdateAction.java
+++ b/src/main/java/spoon/support/modelobs/action/UpdateAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/CollectionContext.java
+++ b/src/main/java/spoon/support/modelobs/context/CollectionContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/Context.java
+++ b/src/main/java/spoon/support/modelobs/context/Context.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/ListContext.java
+++ b/src/main/java/spoon/support/modelobs/context/ListContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/MapContext.java
+++ b/src/main/java/spoon/support/modelobs/context/MapContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/ObjectContext.java
+++ b/src/main/java/spoon/support/modelobs/context/ObjectContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/modelobs/context/SetContext.java
+++ b/src/main/java/spoon/support/modelobs/context/SetContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/package-info.java
+++ b/src/main/java/spoon/support/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtAnnotationFieldAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAnnotationFieldAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtArrayReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayReadImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtArrayWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtArrayWriteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssertImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtAssignmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBinaryOperatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBlockImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtBreakImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCaseImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCodeSnippetStatementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCommentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConditionalImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtContinueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtDoImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtDoImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExecutableReferenceExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtFieldReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldReadImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtFieldWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtFieldWriteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForEachImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtIfImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtIfImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtJavaDocTagImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLoopImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewArrayImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtNewClassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtOperatorAssignmentImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtReturnImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSuperAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtSwitchExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSwitchExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSwitchImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtSynchronizedImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTargetedExpressionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtTextBlockImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTextBlockImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtThisAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtThisAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtThrowImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtThrowImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryWithResourceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtUnaryOperatorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableAccessImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtVariableReadImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableReadImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtVariableWriteImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtVariableWriteImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtWhileImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/code/CtYieldStatementImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtYieldStatementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/CompilationUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/position/PartialSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/PartialSourcePositionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationMethodImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtConstructorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumValueImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumValueImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtImportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleRequirementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtNamedElementImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageDeclarationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageDeclarationImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageExportImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtProvidedServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/CtUsedServiceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtUsedServiceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/declaration/InvisibleArrayConstructorImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/InvisibleArrayConstructorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/eval/EvalHelper.java
+++ b/src/main/java/spoon/support/reflect/eval/EvalHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/eval/InlinePartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/InlinePartialEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/package-info.java
+++ b/src/main/java/spoon/support/reflect/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtCatchVariableReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtLocalVariableReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtModuleReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtPackageReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtParameterReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtTypeMemberWildcardImportReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeMemberWildcardImportReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtUnboundVariableReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtVariableReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
+++ b/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/CollectionSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/CollectionSourceFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/DefaultSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/DefaultSourceFragmentPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/ElementPrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementPrinterEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
+++ b/src/main/java/spoon/support/sniper/internal/IndentationDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/ModificationStatus.java
+++ b/src/main/java/spoon/support/sniper/internal/ModificationStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
+++ b/src/main/java/spoon/support/sniper/internal/MutableTokenWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/PrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/PrinterEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/SourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/SourceFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/SourceFragmentContextList.java
+++ b/src/main/java/spoon/support/sniper/internal/SourceFragmentContextList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/SourceFragmentContextNormal.java
+++ b/src/main/java/spoon/support/sniper/internal/SourceFragmentContextNormal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/SourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/SourceFragmentPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/TokenPrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenPrinterEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/TokenType.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/internal/TokenWriterProxy.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenWriterProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/sniper/package-info.java
+++ b/src/main/java/spoon/support/sniper/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/template/Parameters.java
+++ b/src/main/java/spoon/support/template/Parameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/template/UndefinedParameterException.java
+++ b/src/main/java/spoon/support/template/UndefinedParameterException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/template/package-info.java
+++ b/src/main/java/spoon/support/template/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/ByteSerialization.java
+++ b/src/main/java/spoon/support/util/ByteSerialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/EmptyClearableList.java
+++ b/src/main/java/spoon/support/util/EmptyClearableList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/EmptyClearableSet.java
+++ b/src/main/java/spoon/support/util/EmptyClearableSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/EmptyIterator.java
+++ b/src/main/java/spoon/support/util/EmptyIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/ImmutableMap.java
+++ b/src/main/java/spoon/support/util/ImmutableMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/ImmutableMapImpl.java
+++ b/src/main/java/spoon/support/util/ImmutableMapImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/ModelList.java
+++ b/src/main/java/spoon/support/util/ModelList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/ModelSet.java
+++ b/src/main/java/spoon/support/util/ModelSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/QualifiedNameBasedSortedSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/RtHelper.java
+++ b/src/main/java/spoon/support/util/RtHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/SignatureBasedSortedSet.java
+++ b/src/main/java/spoon/support/util/SignatureBasedSortedSet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/SortedList.java
+++ b/src/main/java/spoon/support/util/SortedList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/util/internal/MapUtils.java
+++ b/src/main/java/spoon/support/util/internal/MapUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/AbstractTypingContext.java
+++ b/src/main/java/spoon/support/visitor/AbstractTypingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
+++ b/src/main/java/spoon/support/visitor/GenericTypeAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/HashcodeVisitor.java
+++ b/src/main/java/spoon/support/visitor/HashcodeVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
+++ b/src/main/java/spoon/support/visitor/SubInheritanceHierarchyResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
+++ b/src/main/java/spoon/support/visitor/TypeReferenceScanner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/clone/CloneBuilder.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
+++ b/src/main/java/spoon/support/visitor/clone/CloneVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/equals/NotEqualException.java
+++ b/src/main/java/spoon/support/visitor/equals/NotEqualException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitor.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/AbstractRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/AbstractRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/AnnotationRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/AnnotationRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/ExecutableRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/ExecutableRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/RuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/RuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/TypeReferenceRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/TypeReferenceRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/TypeRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/TypeRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/internal/VariableRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/VariableRuntimeBuilderContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/java/reflect/RtParameter.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/InvalidReplaceException.java
+++ b/src/main/java/spoon/support/visitor/replace/InvalidReplaceException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/ReplaceListListener.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplaceListListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/ReplaceListener.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplaceListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/ReplaceMapListener.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplaceMapListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/ReplaceSetListener.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplaceSetListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
+++ b/src/main/java/spoon/support/visitor/replace/ReplacementVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/AbstractTemplate.java
+++ b/src/main/java/spoon/template/AbstractTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/BlockTemplate.java
+++ b/src/main/java/spoon/template/BlockTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/ExpressionTemplate.java
+++ b/src/main/java/spoon/template/ExpressionTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/ExtensionTemplate.java
+++ b/src/main/java/spoon/template/ExtensionTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/Local.java
+++ b/src/main/java/spoon/template/Local.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/Parameter.java
+++ b/src/main/java/spoon/template/Parameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/StatementTemplate.java
+++ b/src/main/java/spoon/template/StatementTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/Substitution.java
+++ b/src/main/java/spoon/template/Substitution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/Template.java
+++ b/src/main/java/spoon/template/Template.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/TemplateBuilder.java
+++ b/src/main/java/spoon/template/TemplateBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/TemplateException.java
+++ b/src/main/java/spoon/template/TemplateException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/TemplateMatcher.java
+++ b/src/main/java/spoon/template/TemplateMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/TemplateParameter.java
+++ b/src/main/java/spoon/template/TemplateParameter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/template/package-info.java
+++ b/src/main/java/spoon/template/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/AbstractAssert.java
+++ b/src/main/java/spoon/testing/AbstractAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/AbstractCtElementAssert.java
+++ b/src/main/java/spoon/testing/AbstractCtElementAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/AbstractCtPackageAssert.java
+++ b/src/main/java/spoon/testing/AbstractCtPackageAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/AbstractFileAssert.java
+++ b/src/main/java/spoon/testing/AbstractFileAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/Assert.java
+++ b/src/main/java/spoon/testing/Assert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/CtElementAssert.java
+++ b/src/main/java/spoon/testing/CtElementAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/CtPackageAssert.java
+++ b/src/main/java/spoon/testing/CtPackageAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/FileAssert.java
+++ b/src/main/java/spoon/testing/FileAssert.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/utils/Check.java
+++ b/src/main/java/spoon/testing/utils/Check.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/utils/ModelUtils.java
+++ b/src/main/java/spoon/testing/utils/ModelUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/main/java/spoon/testing/utils/ProcessorUtils.java
+++ b/src/main/java/spoon/testing/utils/ProcessorUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/test/java/spoon/generating/clone/CloneBuilderTemplate.java
+++ b/src/test/java/spoon/generating/clone/CloneBuilderTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/test/java/spoon/generating/clone/CloneVisitorTemplate.java
+++ b/src/test/java/spoon/generating/clone/CloneVisitorTemplate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/test/java/spoon/generating/clone/GetterTemplateMatcher.java
+++ b/src/test/java/spoon/generating/clone/GetterTemplateMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors

--- a/src/test/java/spoon/generating/clone/SetterTemplateMatcher.java
+++ b/src/test/java/spoon/generating/clone/SetterTemplateMatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * SPDX-License-Identifier: (MIT OR CECILL-C)
  *
  * Copyright (C) 2006-2019 INRIA and contributors


### PR DESCRIPTION
This PR does the same thing as #3868 in bumping the version of `license-maven-plugin`, but also fixes the errors. There are two fixes, apart from bumping the version:

1. Wrap the configuration in the `<licenseSets><licenseSet>` tags, which is mandatory for version 4.0
	- We might want to look at the new features for handling multiple licenses, that's what this is for! I think that's for a different PR, though.
2. Adopt the new default format (slashstar, header starts with `/*` as opposed to Javadoc `/**`).
    - I prefer this format, as linters such as the one in IntelliJ IDEA complain about "dangling Javadoc comment" when the Javadoc style is used for a header.

