### PR TITLE
feat: Add CtExecutable.addParameterAt

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtAnonymousExecutable.java
@@ -44,6 +44,10 @@ public interface CtAnonymousExecutable extends CtExecutable<Void>, CtTypeMember 
 
 	@Override
 	@UnsettableProperty
+	<T extends CtExecutable<Void>> T addParameterAt(int position, CtParameter<?> parameter);
+
+	@Override
+	@UnsettableProperty
 	<T extends CtExecutable<Void>> T addThrownType(CtTypeReference<? extends Throwable> throwType);
 
 }

--- a/src/main/java/spoon/reflect/declaration/CtExecutable.java
+++ b/src/main/java/spoon/reflect/declaration/CtExecutable.java
@@ -69,6 +69,16 @@ public interface CtExecutable<R> extends CtNamedElement, CtTypedElement<R>, CtBo
 	<T extends CtExecutable<R>> T addParameter(CtParameter<?> parameter);
 
 	/**
+	 * Add a parameter at a specific position in the executable.
+	 *
+	 * @param position index where the `parameter` needs to be inserted
+	 * @param parameter parameter to be inserted
+	 * @return an object or sub-type of {@link CtExecutable}
+	 */
+	@PropertySetter(role = PARAMETER)
+	<T extends CtExecutable<R>> T addParameterAt(int position, CtParameter<?> parameter);
+
+	/**
 	 * Remove a parameter for this executable
 	 *
 	 * @param parameter

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -188,6 +188,12 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@Override
 	public <C extends CtExecutable<T>> C addParameter(CtParameter<?> parameter) {
+		addParameterAt(parameters.size(), parameter);
+		return (C) this;
+	}
+
+	@Override
+	public <C extends CtExecutable<T>> C addParameterAt(int position, CtParameter<?> parameter) {
 		if (parameter == null) {
 			return (C) this;
 		}
@@ -196,7 +202,7 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 		}
 		parameter.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, PARAMETER, this.parameters, parameter);
-		parameters.add(parameter);
+		parameters.add(position, parameter);
 		return (C) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -118,6 +118,13 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 
 	@Override
 	@UnsettableProperty
+	public CtExecutable addParameterAt(int position, CtParameter parameter) {
+		// unsettable property
+		return this;
+	}
+
+	@Override
+	@UnsettableProperty
 	public boolean removeParameter(CtParameter parameter) {
 		return false;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtExecutableImpl.java
@@ -104,6 +104,12 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 
 	@Override
 	public <T extends CtExecutable<R>> T addParameter(CtParameter<?> parameter) {
+		addParameterAt(parameters.size(), parameter);
+		return (T) this;
+	}
+
+	@Override
+	public <T extends CtExecutable<R>> T addParameterAt(int position, CtParameter<?> parameter) {
 		if (parameter == null) {
 			return (T) this;
 		}
@@ -112,7 +118,7 @@ public abstract class CtExecutableImpl<R> extends CtNamedElementImpl implements 
 		}
 		parameter.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, PARAMETER, this.parameters, parameter);
-		parameters.add(parameter);
+		parameters.add(position, parameter);
 		return (T) this;
 	}
 

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -166,6 +166,7 @@ public class ConstructorTest {
 
 	@Test
 	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		// contract: the parameter should be added at the specified position
 		Factory factory = new Launcher().getFactory();
 
 		CtConstructor<?> constructor = factory.createConstructor();
@@ -194,6 +195,8 @@ public class ConstructorTest {
 
 	@Test
 	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		// contract: `addParameterAt` should throw an out of bounds exception when the specified position is out of
+		// bounds of the parameter collection
 		Factory factory = new Launcher().getFactory();
 		CtConstructor<?> constructor = factory.createConstructor();
 		CtParameter<?> paramater = factory.createParameter();

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -23,6 +23,7 @@ import spoon.SpoonAPI;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtIntersectionTypeReference;
@@ -35,12 +36,16 @@ import spoon.test.constructor.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -157,5 +162,43 @@ public class ConstructorTest {
 
 		assertEquals("Serializable", bounds.get(1).getSimpleName());
 		assertEquals(1, bounds.get(1).getAnnotations().size());
+	}
+
+	@Test
+	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		Factory factory = new Launcher().getFactory();
+
+		CtConstructor<?> constructor = factory.createConstructor();
+
+		CtParameter<?> first = factory.createParameter();
+		CtTypeReference<String> firstType = factory.Type().stringType();
+		first.setSimpleName("x");
+		first.setType((CtTypeReference) firstType);
+
+		CtParameter<?> second = factory.createParameter();
+		CtTypeReference<Integer> secondType = factory.Type().integerType();
+		second.setSimpleName("y");
+		second.setType((CtTypeReference) secondType);
+
+		CtParameter<?> third = factory.createParameter();
+		CtTypeReference<Boolean> thirdType = factory.Type().booleanType();
+		third.setSimpleName("z");
+		third.setType((CtTypeReference) thirdType);
+
+		constructor.addParameterAt(0, second);
+		constructor.addParameterAt(1, third);
+		constructor.addParameterAt(0, first);
+
+		assertThat(constructor.getParameters(), equalTo(Arrays.asList(first, second, third)));
+	}
+
+	@Test
+	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		Factory factory = new Launcher().getFactory();
+		CtConstructor<?> constructor = factory.createConstructor();
+		CtParameter<?> paramater = factory.createParameter();
+
+		assertThrows(IndexOutOfBoundsException.class,
+				() -> constructor.addParameterAt(2, paramater));
 	}
 }

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -170,20 +170,20 @@ public class ConstructorTest {
 
 		CtConstructor<?> constructor = factory.createConstructor();
 
-		CtParameter<?> first = factory.createParameter();
+		CtParameter<String> first = factory.createParameter();
 		CtTypeReference<String> firstType = factory.Type().stringType();
 		first.setSimpleName("x");
-		first.setType((CtTypeReference) firstType);
+		first.setType(firstType);
 
-		CtParameter<?> second = factory.createParameter();
+		CtParameter<Integer> second = factory.createParameter();
 		CtTypeReference<Integer> secondType = factory.Type().integerType();
 		second.setSimpleName("y");
-		second.setType((CtTypeReference) secondType);
+		second.setType(secondType);
 
-		CtParameter<?> third = factory.createParameter();
+		CtParameter<Boolean> third = factory.createParameter();
 		CtTypeReference<Boolean> thirdType = factory.Type().booleanType();
 		third.setSimpleName("z");
-		third.setType((CtTypeReference) thirdType);
+		third.setType(thirdType);
 
 		constructor.addParameterAt(0, second);
 		constructor.addParameterAt(1, third);

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -54,15 +54,19 @@ import spoon.test.lambda.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -535,5 +539,43 @@ public class LambdaTest {
 				fail();
 			}
 		}
+	}
+
+	@Test
+	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		Factory factory = new Launcher().getFactory();
+
+		CtLambda<?> lambda = factory.createLambda();
+
+		CtParameter<String> first = factory.createParameter();
+		CtTypeReference<String> firstType = factory.Type().stringType();
+		first.setSimpleName("x");
+		first.setType(firstType);
+
+		CtParameter<Integer> second = factory.createParameter();
+		CtTypeReference<Integer> secondType = factory.Type().integerType();
+		second.setSimpleName("y");
+		second.setType(secondType);
+
+		CtParameter<Boolean> third = factory.createParameter();
+		CtTypeReference<Boolean> thirdType = factory.Type().booleanType();
+		third.setSimpleName("z");
+		third.setType(thirdType);
+
+		lambda.addParameterAt(0, second);
+		lambda.addParameterAt(1, third);
+		lambda.addParameterAt(0, first);
+
+		assertThat(lambda.getParameters(), equalTo(Arrays.asList(first, second, third)));
+	}
+
+	@Test
+	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		Factory factory = new Launcher().getFactory();
+		CtLambda<?> lamda = factory.createLambda();
+		CtParameter<?> paramater = factory.createParameter();
+
+		assertThrows(IndexOutOfBoundsException.class,
+				() -> lamda.addParameterAt(2, paramater));
 	}
 }

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -543,6 +543,7 @@ public class LambdaTest {
 
 	@Test
 	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		// contract: the parameter should be added at the specified position
 		Factory factory = new Launcher().getFactory();
 
 		CtLambda<?> lambda = factory.createLambda();
@@ -571,6 +572,8 @@ public class LambdaTest {
 
 	@Test
 	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		// contract: `addParameterAt` should throw an out of bounds exception when the specified position is out of
+		// bounds of the parameter collection
 		Factory factory = new Launcher().getFactory();
 		CtLambda<?> lamda = factory.createLambda();
 		CtParameter<?> paramater = factory.createParameter();

--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -142,6 +142,7 @@ public class MethodTest {
 
 	@Test
 	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		// contract: the parameter should be added at the specified position
 		Factory factory = new Launcher().getFactory();
 
 		CtMethod<?> method = factory.createMethod();
@@ -170,6 +171,8 @@ public class MethodTest {
 
 	@Test
 	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		// contract: `addParameterAt` should throw an out of bounds exception when the specified position is out of
+		// bounds of the parameter collection
 		Factory factory = new Launcher().getFactory();
 		CtMethod<?> method = factory.createMethod();
 		CtParameter<?> paramater = factory.createParameter();

--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -20,20 +20,26 @@ import org.junit.Test;
 import spoon.Launcher;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.test.delete.testclasses.Adobada;
 import spoon.test.method.testclasses.Methods;
 import spoon.test.method.testclasses.Tacos;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
@@ -132,5 +138,43 @@ public class MethodTest {
 		}
 
 		assertTrue(compareFound);
+	}
+
+	@Test
+	public void test_addParameterAt_addsParameterToSpecifiedPosition() {
+		Factory factory = new Launcher().getFactory();
+
+		CtMethod<?> method = factory.createMethod();
+
+		CtParameter<?> first = factory.createParameter();
+		CtTypeReference<String> firstType = factory.Type().stringType();
+		first.setSimpleName("x");
+		first.setType((CtTypeReference) firstType);
+
+		CtParameter<?> second = factory.createParameter();
+		CtTypeReference<Integer> secondType = factory.Type().integerType();
+		second.setSimpleName("y");
+		second.setType((CtTypeReference) secondType);
+
+		CtParameter<?> third = factory.createParameter();
+		CtTypeReference<Boolean> thirdType = factory.Type().booleanType();
+		third.setSimpleName("z");
+		third.setType((CtTypeReference) thirdType);
+
+		method.addParameterAt(0, second);
+		method.addParameterAt(1, third);
+		method.addParameterAt(0, first);
+
+		assertThat(method.getParameters(), equalTo(Arrays.asList(first, second, third)));
+	}
+
+	@Test
+	public void test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds() {
+		Factory factory = new Launcher().getFactory();
+		CtMethod<?> method = factory.createMethod();
+		CtParameter<?> paramater = factory.createParameter();
+
+		assertThrows(IndexOutOfBoundsException.class,
+				() -> method.addParameterAt(2, paramater));
 	}
 }

--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -146,20 +146,20 @@ public class MethodTest {
 
 		CtMethod<?> method = factory.createMethod();
 
-		CtParameter<?> first = factory.createParameter();
+		CtParameter<String> first = factory.createParameter();
 		CtTypeReference<String> firstType = factory.Type().stringType();
 		first.setSimpleName("x");
-		first.setType((CtTypeReference) firstType);
+		first.setType(firstType);
 
-		CtParameter<?> second = factory.createParameter();
+		CtParameter<Integer> second = factory.createParameter();
 		CtTypeReference<Integer> secondType = factory.Type().integerType();
 		second.setSimpleName("y");
-		second.setType((CtTypeReference) secondType);
+		second.setType(secondType);
 
-		CtParameter<?> third = factory.createParameter();
+		CtParameter<Boolean> third = factory.createParameter();
 		CtTypeReference<Boolean> thirdType = factory.Type().booleanType();
 		third.setSimpleName("z");
-		third.setType((CtTypeReference) thirdType);
+		third.setType(thirdType);
 
 		method.addParameterAt(0, second);
 		method.addParameterAt(1, third);


### PR DESCRIPTION
#3884 

This PR provides an API to add a parameter in `CtExecutable`s at a specified position. Since there are few classed which inherit from `CtExecutableImpl`, we should test this API for all those classes.

- [x] CtConstructor
- [x] CtMethod
- [x] CtLambda
~- CtAnonymousExecutable~ (cannot add parameters to an anonymous class in Java)