### PR TITLE
WIP: feature: Add OFF log level to StandardEnvironment

### DIFF
--- a/src/main/java/spoon/support/Level.java
+++ b/src/main/java/spoon/support/Level.java
@@ -11,7 +11,7 @@ package spoon.support;
  * Enum for representing logging levels.
  */
 public enum Level {
-	ERROR(100), WARN(200), INFO(300), DEBUG(400), TRACE(500);
+	OFF(0), ERROR(100), WARN(200), INFO(300), DEBUG(400), TRACE(500);
 
 	private final int levelValue;
 

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -274,7 +274,7 @@ public class StandardEnvironment implements Serializable, Environment {
 	}
 
 	private void print(String message, Level messageLevel) {
-		if (messageLevel.toInt() <= this.level.toInt()) {
+		if (this.level.compareTo(Level.OFF) > 0 && messageLevel.toInt() <= this.level.toInt()) {
 			switch (messageLevel) {
 				case ERROR: logger.error(message);
 					break;


### PR DESCRIPTION
As discussed in  #3901, this PR adds a new logging level `OFF(0)` and modifies the printing logic in `StandardEnvironment` so that it is turned off if this new level is set.

I tagged this as a feature following the tag of the issue.
The contributing guidelines state that feature PR should have tests and corresponding documentation. I though this PR is maybe to small for that, but please let me know if you would like tests added and what should they cover.

