### PR TITLE
fix: Fix infinite loop on type parameter in qualified name

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -64,6 +64,7 @@ import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.support.reflect.CtExtendedModifier;
@@ -521,6 +522,9 @@ public class JDTTreeBuilderHelper {
 					 */
 					return;
 					//throw new SpoonException("Unexpected type reference simple name: \"" + token + "\" expected: \"" + typeRef.getSimpleName() + "\"");
+				} else if (typeRef instanceof CtTypeParameterReference) {
+					// if a type parameter is part of a qualified name, it's never implicit
+					return;
 				}
 				CtTypeReference<?> declTypeRef = typeRef.getDeclaringType();
 				if (declTypeRef != null) {

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.ctClass;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 
 import static org.hamcrest.core.Is.is;
@@ -362,6 +363,8 @@ public class CtClassTest {
 				// Here we add a field with type `T.Entry`, i.e. T is used in a qualified type name
 				+ "T.Entry<String, String> entry; }");
 
-		assertThat(cls.getField("entry"), is(notNullValue()));
+		CtField<?> field = cls.getField("entry");
+		assertThat(field.getType().getQualifiedName(), equalTo("T$Entry"));
+		assertThat(field.getType().isSimplyQualified(), is(false));
 	}
 }

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -350,7 +350,6 @@ public class CtClassTest {
 		assertEquals(newClassInvocation.toString(), newClassInvocationCloned.toString());
 	}
 
-
 	@Test(timeout = 5000L)
 	public void test_buildParameterizedClass_withTypeParameterUsedAsQualifier() {
 		// contract: It should be possible to build a generic class when one of the type parameters

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -349,4 +349,20 @@ public class CtClassTest {
 
 		assertEquals(newClassInvocation.toString(), newClassInvocationCloned.toString());
 	}
+
+
+	@Test(timeout = 5000L)
+	public void test_buildParameterizedClass_withTypeParameterUsedAsQualifier() {
+		// contract: It should be possible to build a generic class when one of the type parameters
+		// is used in the qualified name of another type.
+        //
+		// See https://github.com/INRIA/spoon/issues/3903
+
+		CtClass<?> cls = Launcher.parseClass(
+				"public class Main<T extends java.util.Map<String, String>> { "
+				// Here we add a field with type `T.Entry`, i.e. T is used in a qualified type name
+				+ "T.Entry<String, String> entry; }");
+
+		assertThat(cls.getField("entry"), is(notNullValue()));
+	}
 }

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -352,7 +352,7 @@ public class CtClassTest {
 	}
 
 	@Test(timeout = 5000L)
-	public void test_buildParameterizedClass_withTypeParameterUsedAsQualifier() {
+	public void test_buildParameterizedClass_withTypeParameterUsedInQualifiedName() {
 		// contract: It should be possible to build a generic class when one of the type parameters
 		// is used in the qualified name of another type.
         //


### PR DESCRIPTION
Fix #3903 

This PR fixes the infinite loop described in #3903 by assuming that any qualified name that contains a type parameter reference is fully qualified. I'm pretty sure that assumption is valid, as one can only reference a type parameter from within the class or method that defines it.

In any case, it's better than an infinite loop :)