### PR TITLE
chore: Move Checkstyle config location into property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <sonar.coverage.exclusions>
         **/support/gui/*
     </sonar.coverage.exclusions>
+    <checkstyle.config.location>checkstyle.xml</checkstyle.config.location>
   </properties>
 
   <dependencies>
@@ -259,7 +260,6 @@
         <version>3.1.2</version>
         <configuration>
           <failsOnError>true</failsOnError>
-          <configLocation>checkstyle.xml</configLocation>
           <consoleOutput>true</consoleOutput>
           <!-- we exclude the generated files, see CtGenerationTest -->
           <excludes>spoon/support/visitor/clone/CloneBuilder.java</excludes>


### PR DESCRIPTION
Required to make #3907 green before merging, related to #3906

This PR moves the hard-coded Checkstyle config location into the [`checkstyle.config.location` property](https://maven.apache.org/plugins/maven-checkstyle-plugin/check-mojo.html#configLocation) (default user property for the `<configLocation>` element). This provides a default that can be overridden from the command line by specifying `-Dcheckstyle.config.location=path/to/some/checkstyle.xml`. This in turn is necessary for #3906 to be able to run with all the configuration in the pom for Checkstyle, but a different Checkstyle config.