### PR TITLE
chore: Add job for sorald-buildbreaker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Sorald Buildbreaker
-        uses: SpoonLabs/sorald-buildbreaker@f3ce916e2a3f83cfbee20bf6fa743c565c2e3696 # dev version
+        uses: SpoonLabs/sorald-buildbreaker@70d81bc6aa8edfe64e2945ce64d485254e17aeec # dev version
         with:
           source: 'src/main/java'
           ratchet-from: 'origin/master'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,3 +132,17 @@ jobs:
         run: mv chore/logback.xml src/test/resources/
       - name: Run extra checks
         run: ./chore/ci-extra.sh
+
+  sorald-buildbreaker:
+    runs-on: ubuntu-latest
+    name: Run Sorald Buildbreaker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          fetch-depth: 0
+      - name: Run Sorald Buildbreaker
+        uses: SpoonLabs/sorald-buildbreaker@f3ce916e2a3f83cfbee20bf6fa743c565c2e3696 # dev version
+        with:
+          source: 'src/main/java'
+          ratchet-from: 'origin/master'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Sorald Buildbreaker
-        uses: SpoonLabs/sorald-buildbreaker@70d81bc6aa8edfe64e2945ce64d485254e17aeec # dev version
+        uses: SpoonLabs/sorald-buildbreaker@35c1a784848bd3182cfcc8a584cff90560fa6371 # dev version
         with:
           source: 'src/main/java'
           ratchet-from: 'origin/master'

--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -60,7 +60,6 @@ public class FluentLauncher {
 	 * Adds an input resource to be processed by Spoon (either a file or a folder).
 	 */
 	public FluentLauncher inputResource(Iterable<String> paths) {
-		int a = 2;
 		for (String path : paths) {
 			launcher.addInputResource(path);
 		}

--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -60,7 +60,7 @@ public class FluentLauncher {
 	 * Adds an input resource to be processed by Spoon (either a file or a folder).
 	 */
 	public FluentLauncher inputResource(Iterable<String> paths) {
-        int a = 2;
+		int a = 2;
 		for (String path : paths) {
 			launcher.addInputResource(path);
 		}

--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -33,6 +33,7 @@ public class FluentLauncher {
 	 *
 	 */
 	public FluentLauncher() {
+        int a = 2;
 		this.launcher = new Launcher();
 	}
 

--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -33,7 +33,6 @@ public class FluentLauncher {
 	 *
 	 */
 	public FluentLauncher() {
-        int a = 2;
 		this.launcher = new Launcher();
 	}
 
@@ -61,6 +60,7 @@ public class FluentLauncher {
 	 * Adds an input resource to be processed by Spoon (either a file or a folder).
 	 */
 	public FluentLauncher inputResource(Iterable<String> paths) {
+        int a = 2;
 		for (String path : paths) {
 			launcher.addInputResource(path);
 		}


### PR DESCRIPTION
Fix #3788 

This PR adds a workflow job that runs https://github.com/spoonlabs/sorald-buildbreaker on Spoon, and fails the build if the changed lines (relative to master) contains any repairable violations. Here's an example of where it finds a violation in the diff: https://github.com/INRIA/spoon/pull/3912/checks?check_run_id=2543019363#step:3:123. Note that the final commit in this PR, which just removes the artificial rule violation, causes the build to go green!

Currently, it's a separate job, but once we deem buildbreaker to be stable enough we can simply incorporate it into the `extras` job by adding this step:

```yml
      - name: Run Sorald Buildbreaker
        uses: SpoonLabs/sorald-buildbreaker@35c1a784848bd3182cfcc8a584cff90560fa6371 # dev version
        with:
          source: 'src/main/java'
          ratchet-from: 'origin/master'
```

**Next steps** are to improve the stability of buildbreaker, and also identify what else we want buildbreaker to do. How should it present rule violations (current presentation is cryptic to the uninitiated, to say the least)? Should it propose a patch to fix the violation? Etc, etc.

> **Important:** `sorald-buildbreaker` is very much experimental at this point. I would not exclude the possibility of spurious failures that have nothing to do with the PR. Please ping me if it fails on any PR such that I can investigate.