### PR TITLE
ix: Fix unqualified type becoming qualified in union type catch

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1608,15 +1608,18 @@ public class JDTTreeBuilder extends ASTVisitor {
 			return true;
 		}
 		if (context.stack.peekFirst().node instanceof UnionTypeReference) {
+			CtTypeReference<?> typeReference;
+
 			if (singleTypeReference.resolvedType == null) {
-				CtTypeReference typeReference = factory.Type().createReference(singleTypeReference.toString());
+				typeReference = factory.Type().createReference(singleTypeReference.toString());
 				CtReference ref = references.getDeclaringReferenceFromImports(singleTypeReference.getLastToken());
 				references.setPackageOrDeclaringType(typeReference, ref);
-				context.enter(typeReference, singleTypeReference);
 			} else {
-				context.enter(references.<Throwable>getTypeReference(singleTypeReference.resolvedType), singleTypeReference);
+				typeReference = references.<Throwable>getTypeReference(singleTypeReference.resolvedType);
 			}
 
+			context.enter(typeReference, singleTypeReference);
+			typeReference.setSimplyQualified(true);
 			return true;
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
 			context.enter(helper.createCatchVariable(singleTypeReference, scope), singleTypeReference);

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -45,6 +45,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -348,5 +350,22 @@ public class TryCatchTest {
 		CtCatch targetCatch = catches.get(0);
 		CtTypeReference<?> catchParamType = targetCatch.getParameter().getType();
 		assertTrue(catchParamType.isSimplyQualified());
+	}
+
+	@Test
+	public void testCatchUnqualifiedReferenceMarkedSimplyQualifiedWhenMultipleTypesAreSpecified() throws Exception {
+		// contract: Unqualified type references should have implicit packages when there are
+		// multiple types in a single catcher
+
+		CtClass<?> clazz = build(
+				"spoon.test.trycatch.testclasses", "MultipleUnqualifiedTypesInSingleCatcher");
+		List<CtCatch> catches = clazz.getElements(e -> true);
+		assertEquals(1, catches.size());
+
+		CtCatch targetCatch = catches.get(0);
+		List<CtTypeReference<?>> paramTypes = targetCatch.getParameter().getMultiTypes();
+		assertThat(paramTypes.size(), equalTo(2));
+		assertTrue("first type reference is fully qualified", paramTypes.get(0).isSimplyQualified());
+		assertTrue("second type reference is fully qualified", paramTypes.get(1).isSimplyQualified());
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -367,5 +368,22 @@ public class TryCatchTest {
 		assertThat(paramTypes.size(), equalTo(2));
 		assertTrue("first type reference is fully qualified", paramTypes.get(0).isSimplyQualified());
 		assertTrue("second type reference is fully qualified", paramTypes.get(1).isSimplyQualified());
+	}
+
+	@Test
+	public void testCatchWithQualifiedAndUnqualifiedTypeReferencesInSameCatcher() throws Exception {
+		// contract: It should be possible for qualified and unqualified type references to exist in
+		// the same catcher
+
+		CtClass<?> clazz = build(
+				"spoon.test.trycatch.testclasses", "CatcherWithQualifiedAndUnqualifiedTypeRefs");
+		List<CtCatch> catches = clazz.getElements(e -> true);
+		assertEquals(1, catches.size());
+
+		CtCatch targetCatch = catches.get(0);
+		List<CtTypeReference<?>> paramTypes = targetCatch.getParameter().getMultiTypes();
+		assertThat(paramTypes.size(), equalTo(2));
+		assertTrue("first type reference should be unqualified", paramTypes.get(0).isSimplyQualified());
+		assertFalse("second type reference should be qualified", paramTypes.get(1).isSimplyQualified());
 	}
 }

--- a/src/test/java/spoon/test/trycatch/testclasses/CatcherWithQualifiedAndUnqualifiedTypeRefs.java
+++ b/src/test/java/spoon/test/trycatch/testclasses/CatcherWithQualifiedAndUnqualifiedTypeRefs.java
@@ -1,0 +1,11 @@
+package spoon.test.trycatch.testclasses;
+
+public class CatcherWithQualifiedAndUnqualifiedTypeRefs {
+    public static void main(String[] args) {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException | java.lang.RuntimeException e) {
+            // pass
+        }
+    }
+}

--- a/src/test/java/spoon/test/trycatch/testclasses/MultipleUnqualifiedTypesInSingleCatcher.java
+++ b/src/test/java/spoon/test/trycatch/testclasses/MultipleUnqualifiedTypesInSingleCatcher.java
@@ -1,0 +1,11 @@
+package spoon.test.trycatch.testclasses;
+
+class MultipleUnqualifiedTypesInSingleCatcher {
+    public static void main(String[] args) {
+        try {
+            throw new InterruptedException();
+        } catch (InterruptedException | RuntimeException e) {
+            // pass
+        }
+    }
+}


### PR DESCRIPTION
Fix #3917 

This PR fixes a problem where simply qualified type references in union types inside of catchers are parsed as fully qualified.