### PR TITLE
chore: Improve ci-checkstyle-javadoc.sh usability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run extra checks
         run: ./chore/ci-extra.sh
       - name: Run Javadoc quality check
-        run: ./chore/ci-checkstyle-javadoc.sh RUN_CI_CHECK
+        run: ./chore/ci-checkstyle-javadoc.sh COMPARE_WITH_MASTER
 
   sorald-buildbreaker:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run extra checks
         run: ./chore/ci-extra.sh
       - name: Run Javadoc quality check
-        run: ./chore/ci-checkstyle-javadoc.sh
+        run: ./chore/ci-checkstyle-javadoc.sh RUN_CI_CHECK
 
   sorald-buildbreaker:
     runs-on: ubuntu-latest

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -15,6 +15,7 @@ COMPARE_BRANCH="master"
 JAVADOC_CHECKSTYLE_CONFIG="__SPOON_CI_checkstyle-javadoc.xml"
 
 COMPARE_WITH_MASTER_ARG="COMPARE_WITH_MASTER"
+RELATED_ISSUE_URL="https://github.com/inria/spoon/issues/3923"
 
 if [[ $(git branch --show-current) == "$COMPARE_BRANCH" ]]; then
     # nothing to compare, we're on the main branch
@@ -73,6 +74,7 @@ function main() {
     elif [[ $compare_num_errors < $current_num_errors ]]; then
         echo "Javadoc quality has deteriorated!"
         echo "Run the chore/ci-checkstyle-javadoc.sh script locally to find errors"
+        echo "See $RELATED_ISSUE_URL for details"
         exit 1
     else
         echo "Javadoc quality has not deteriorated"
@@ -87,6 +89,8 @@ function usage_and_exit() {
         branch with those on master and exit non-zero if the current branch has
         more errors. WARNING: Never run this with uncommitted changes, they
         will be lost!
+
+See $RELATED_ISSUE_URL for info related to using this script locally to improve Javadoc quality.
 
 To list all errors in a particular .java file, just run with '/<CLASS_NAME>.java' as the argument. For example:
 

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -23,7 +23,9 @@ if [[ $(git branch --show-current) == "$COMPARE_BRANCH" ]]; then
 fi
 
 function cleanup() {
-    rm -f "$JAVADOC_CHECKSTYLE_CONFIG"
+    if [ -f "$JAVADOC_CHECKSTYLE_CONFIG" ]; then
+        rm "$JAVADOC_CHECKSTYLE_CONFIG"
+    fi
 }
 
 trap cleanup EXIT

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -75,6 +75,7 @@ function main() {
         exit 1
     else
         echo "Javadoc quality has not deteriorated"
+        echo "Run the chore/ci-checkstyle-javadoc.sh script locally to find errors"
     fi
 }
 

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -72,10 +72,10 @@ function main() {
         exit 1;
     elif [[ $compare_num_errors < $current_num_errors ]]; then
         echo "Javadoc quality has deteriorated!"
+        echo "Run the chore/ci-checkstyle-javadoc.sh script locally to find errors"
         exit 1
     else
         echo "Javadoc quality has not deteriorated"
-        echo "Run the chore/ci-checkstyle-javadoc.sh script locally to find errors"
     fi
 }
 

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -84,13 +84,9 @@ function usage_and_exit() {
     <regex>: A regex to filter output lines by (typically just a file path)
     RUN_CI_CHECK: Run the continuous integration check
 
-Example use to list all errors in src/main/java/spoon/Launcher.java:
+To list all errors in a particular .java file, just run with '/<CLASS_NAME>.java' as the argument. For example:
 
-    \$ ./chore/ci-checkstyle-javadoc.sh src/main/java/spoon/Launcher.java
-
-Example use to count the errors in the same file:
-
-    \$ ./chore/ci-checkstyle-javadoc.sh src/main/java/spoon/Launcher.java | wc -l"
+    \$ ./chore/ci-checkstyle-javadoc.sh '/Launcher.java'"
     exit 1
 }
 

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -14,7 +14,7 @@ set -o pipefail
 COMPARE_BRANCH="master"
 JAVADOC_CHECKSTYLE_CONFIG="__SPOON_CI_checkstyle-javadoc.xml"
 
-RUN_CI_CHECK_ARG="RUN_CI_CHECK"
+COMPARE_WITH_MASTER_ARG="COMPARE_WITH_MASTER"
 
 if [[ $(git branch --show-current) == "$COMPARE_BRANCH" ]]; then
     # nothing to compare, we're on the main branch
@@ -80,10 +80,13 @@ function main() {
 }
 
 function usage_and_exit() {
-    echo "usage: ci-checkstyle-javadoc.sh [<regex>|$RUN_CI_CHECK_ARG]
+    echo "usage: ci-checkstyle-javadoc.sh [<regex>|$COMPARE_WITH_MASTER_ARG]
 
     <regex>: A regex to filter output lines by (typically just a file path)
-    RUN_CI_CHECK: Run the continuous integration check
+    $COMPARE_WITH_MASTER_ARG: Compare the amount of errors on the current
+        branch with those on master and exit non-zero if the current branch has
+        more errors. WARNING: Never run this with uncommitted changes, they
+        will be lost!
 
 To list all errors in a particular .java file, just run with '/<CLASS_NAME>.java' as the argument. For example:
 
@@ -95,7 +98,7 @@ if [[ "$#" != 1 ]]; then
     usage_and_exit
 fi
 
-if [[ "$1" == "$RUN_CI_CHECK_ARG" ]]; then
+if [[ "$1" == "$COMPARE_WITH_MASTER_ARG" ]]; then
     main
 else
     grep "$1" <<< `run_checkstyle`

--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -67,13 +67,13 @@ function main() {
     Current: $current_num_errors
     "
 
-    if [[ -z $compare_num_errors ]]; then
+    if [ -z $compare_num_errors ]; then
         echo "Failed to compute compare score";
         exit 1;
-    elif [[ -z $current_num_errors ]]; then
+    elif [ -z $current_num_errors ]; then
         echo "Failed to compute current score";
         exit 1;
-    elif [[ $compare_num_errors < $current_num_errors ]]; then
+    elif [ $compare_num_errors -lt $current_num_errors ]; then
         echo "Javadoc quality has deteriorated!"
         echo "Run the chore/ci-checkstyle-javadoc.sh script locally to find errors"
         echo "See $RELATED_ISSUE_URL for details"
@@ -100,11 +100,11 @@ To list all errors in a particular .java file, just run with '/<CLASS_NAME>.java
     exit 1
 }
 
-if [[ "$#" != 1 ]]; then
+if [ "$#" != 1 ]; then
     usage_and_exit
 fi
 
-if [[ "$1" == "$COMPARE_WITH_MASTER_ARG" ]]; then
+if [ "$1" == "$COMPARE_WITH_MASTER_ARG" ]; then
     main
 else
     grep "$1" <<< `run_checkstyle`


### PR DESCRIPTION
Fix #3922 

This PR improves the usability of the method Javadoc quality script, and links to the issue related to using it #3923. Additionally, non-POSIX-compliant comparisons have been removed to make the script compatible with more shells.

In terms of output, if the script failed in CI it would previously just print the amount of errors, but now ALSO prints this:

```
Run the chore/ci-checkstyle-javadoc.sh script locally to find errors
See https://github.com/inria/spoon/issues/3923 for details
```

Local use has also been improved, here's the help output:

```
$ ./chore/ci-checkstyle-javadoc.sh
usage: ci-checkstyle-javadoc.sh [<regex>|COMPARE_WITH_MASTER]

    <regex>: A regex to filter output lines by (typically just a file path)
    COMPARE_WITH_MASTER: Compare the amount of errors on the current
        branch with those on master and exit non-zero if the current branch has
        more errors. WARNING: Never run this with uncommitted changes, they
        will be lost!

See https://github.com/inria/spoon/issues/3923 for info related to using this script locally to improve Javadoc quality.

To list all errors in a particular .java file, just run with '/<CLASS_NAME>.java' as the argument. For example:

    $ ./chore/ci-checkstyle-javadoc.sh '/Launcher.java'
```

And, an example execution:

```java
./chore/ci-checkstyle-javadoc.sh '/Launcher.java'
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:103:42: Expected @param tag for 'args'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:180:52: Expected @param tag for 'resource'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:604: Expected @return tag. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:644: Expected @return tag. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:644:57: Expected @param tag for 'factory'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:644:86: Expected @param tag for 'inputSources'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:644:120: Expected @param tag for 'templateSources'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:660: Expected @return tag. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:660:69: Expected @param tag for 'inputSources'. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:873: Expected @return tag. [JavadocMethod]
[ERROR] /home/slarse/Documents/github/cdate/spoon-slarse/src/main/java/spoon/Launcher.java:873:52: Expected @param tag for 'code'. [JavadocMethod]
```

All-in-all, this makes the script actually useful for improving the docs!