### PR TITLE
fix: Fix violation of Sonar rule 2142

### DIFF
--- a/src/main/java/spoon/processing/AbstractParallelProcessor.java
+++ b/src/main/java/spoon/processing/AbstractParallelProcessor.java
@@ -156,6 +156,9 @@ public abstract class AbstractParallelProcessor<E extends CtElement> extends Abs
 			try {
 				job.get();
 			} catch (InterruptedException | ExecutionException e) {
+				if (e instanceof InterruptedException) {
+					Thread.currentThread().interrupt();
+				}
 				throw new SpoonException("failed to wait for parallel processor to finish", e);
 			}
 		}


### PR DESCRIPTION
Hi,

This PR fixes 1 violation of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

The concerned violation can viewed on the [OW2 SonarQube instance](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&issues=AXh4mEuvLwoiZThdxVl5&open=AXh4mEuvLwoiZThdxVl5), and is [the only new bug violation introduced in the past... long time](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&resolved=false&sinceLeakPeriod=true&types=BUG). By me. Oops. 