### PR TITLE
chore: Fix incorrect early exit in Javadoc quality script

### DIFF
--- a/chore/ci-checkstyle-javadoc.sh
+++ b/chore/ci-checkstyle-javadoc.sh
@@ -17,11 +17,6 @@ JAVADOC_CHECKSTYLE_CONFIG="__SPOON_CI_checkstyle-javadoc.xml"
 COMPARE_WITH_MASTER_ARG="COMPARE_WITH_MASTER"
 RELATED_ISSUE_URL="https://github.com/inria/spoon/issues/3923"
 
-if [[ $(git branch --show-current) == "$COMPARE_BRANCH" ]]; then
-    # nothing to compare, we're on the main branch
-    exit 0
-fi
-
 function cleanup() {
     if [ -f "$JAVADOC_CHECKSTYLE_CONFIG" ]; then
         rm "$JAVADOC_CHECKSTYLE_CONFIG"
@@ -105,6 +100,12 @@ if [ "$#" != 1 ]; then
 fi
 
 if [ "$1" == "$COMPARE_WITH_MASTER_ARG" ]; then
+    if [ $(git branch --show-current) == "$COMPARE_BRANCH" ]; then
+        # nothing to compare, we're on the main branch
+        echo "Already on branch $COMPARE_BRANCH, nothing to compare"
+        exit 0
+    fi
+
     main
 else
     grep "$1" <<< `run_checkstyle`


### PR DESCRIPTION
Related to #3923 

I had accidentally left an early exit at the top of the script causing it to be unusable if checked out to the master branch. That's not desirable as very likely, someone first looking into #3923 will be checkout out to the master branch, and may just give up as the script ostensibly doesn't work.

This PR just moves that early exit into the appropriate place (when running the compare command).