### PR TITLE
chore: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Fix #3933 

This PR adds a configuration for [GitHub-native Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/), which replaces the Dependabot Preview application.

Dependabot is supposed to support [Multi-module Maven projects](https://dependabot.com/blog/multimodule-maven-files/) by pointing it at the parent pom. So, if I'm not mistaken, we should be able to get updates for spoon-core and all subprojects by pointing dependabot to the `/spoon-pom/pom.xml` file.

@monperrus any reason not to try that?