### PR TITLE
migrate namefiltertest to Junit 5

### DIFF
--- a/src/test/java/spoon/legacy/NameFilterTest.java
+++ b/src/test/java/spoon/legacy/NameFilterTest.java
@@ -1,0 +1,39 @@
+package spoon.legacy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.factory.Factory;
+import spoon.test.filters.testclasses.Foo;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static spoon.testing.utils.ModelUtils.build;
+
+class NameFilterTest {
+
+    private Factory factory;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        factory = build(Foo.class);
+    }
+
+    @Test
+    public void testNameFilter() throws Exception {
+        // contract: legacy NameFilter is tested and works
+        CtClass<?> foo = factory.Package().get("spoon.test.filters.testclasses").getType("Foo");
+        assertEquals("Foo", foo.getSimpleName());
+        List<CtNamedElement> elements = foo.getElements(new NameFilter<>("i"));
+        assertEquals(1, elements.size());
+    }
+
+    @Test()
+    public void testNameFilterThrowsException() {
+        CtClass<?> foo = factory.Package().get("spoon.test.filters.testclasses").getType("Foo");
+        assertThrows(IllegalArgumentException.class, () -> foo.getElements(new NameFilter<>(null)));
+    }
+}


### PR DESCRIPTION
Hi team, 

In this commit I have:

* migrated nameFilterTest from Junit 4 to Junit 5
* Restructured the nameFilterTest, where it should have been placed
* Added a testNameFilterThrowsException, to improve the line coverage from 56% to 66%.

Statistics of nameFilter class. 
![Screen Shot 2021-05-21 at 13 53 08-fullpage](https://user-images.githubusercontent.com/62026125/119106354-e7385e80-ba3b-11eb-8615-6497a8e068fb.png)

<img width="857" alt="Screenshot 2021-05-21 at 1 54 41 PM" src="https://user-images.githubusercontent.com/62026125/119106541-177ffd00-ba3c-11eb-900f-403f875c36dd.png">

I guess in the next commit the objective could be to improve the line coverage from 66% to 100% ?