### PR TITLE
fix: Ensure that for init/update are registered in listeners

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -76,11 +76,11 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 
 	@Override
 	public <T extends CtFor> T setForInit(List<CtStatement> statements) {
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_INIT, this.forInit, new ArrayList<>(this.forInit));
 		if (statements == null || statements.isEmpty()) {
 			this.forInit = CtElementImpl.emptyList();
 			return (T) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_INIT, this.forInit, new ArrayList<>(this.forInit));
 		this.forInit.clear();
 		for (CtStatement stmt : statements) {
 			addForInit(stmt);

--- a/src/main/java/spoon/support/reflect/code/CtForImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtForImpl.java
@@ -118,11 +118,11 @@ public class CtForImpl extends CtLoopImpl implements CtFor {
 
 	@Override
 	public <T extends CtFor> T setForUpdate(List<CtStatement> statements) {
+		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_UPDATE, this.forUpdate, new ArrayList<>(this.forUpdate));
 		if (statements == null || statements.isEmpty()) {
 			this.forUpdate = CtElementImpl.emptyList();
 			return (T) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, FOR_UPDATE, this.forUpdate, new ArrayList<>(this.forUpdate));
 		this.forUpdate.clear();
 		for (CtStatement stmt : statements) {
 			addForUpdate(stmt);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -744,17 +744,31 @@ public class TestSniperPrinter {
 	}
 
 	@Test
-	void testSniperRespectsDeletionInForLoopHeader() {
-		// contract: The sniper printer should detect deletions in for loop headers as modifications
+	void testSniperRespectsDeletionInForInit() {
+		// contract: The sniper printer should detect deletions in for loop init as modifications
 		// and print the model accordingly.
 
         Consumer<CtType<?>> deleteForUpdate = type -> {
         	CtFor ctFor = type.filterChildren(CtFor.class::isInstance).first();
-        	ctFor.getForUpdate().forEach(CtElement::delete);
 			ctFor.getForInit().forEach(CtElement::delete);
 		};
 		BiConsumer<CtType<?>, String> assertNotStaticFindFirstIsEmpty = (type, result) ->
-            assertThat(result, containsString("for (; i < 10;)"));
+            assertThat(result, containsString("for (; i < 10; i++)"));
+
+		testSniper("ForLoop", deleteForUpdate, assertNotStaticFindFirstIsEmpty);
+	}
+
+	@Test
+	void testSniperRespectsDeletionInForUpdate() {
+		// contract: The sniper printer should detect deletions in for loop update as modifications
+		// and print the model accordingly.
+
+		Consumer<CtType<?>> deleteForUpdate = type -> {
+			CtFor ctFor = type.filterChildren(CtFor.class::isInstance).first();
+			ctFor.getForUpdate().forEach(CtElement::delete);
+		};
+		BiConsumer<CtType<?>, String> assertNotStaticFindFirstIsEmpty = (type, result) ->
+				assertThat(result, containsString("for (int i = 0; i < 10;)"));
 
 		testSniper("ForLoop", deleteForUpdate, assertNotStaticFindFirstIsEmpty);
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -753,9 +753,8 @@ public class TestSniperPrinter {
         	ctFor.getForUpdate().forEach(CtElement::delete);
 			ctFor.getForInit().forEach(CtElement::delete);
 		};
-		BiConsumer<CtType<?>, String> assertNotStaticFindFirstIsEmpty = (type, result) -> {
+		BiConsumer<CtType<?>, String> assertNotStaticFindFirstIsEmpty = (type, result) ->
             assertThat(result, containsString("for (; i < 10;)"));
-		};
 
 		testSniper("ForLoop", deleteForUpdate, assertNotStaticFindFirstIsEmpty);
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -16,6 +16,7 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
@@ -31,6 +32,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -62,6 +64,7 @@ import java.util.function.Consumer;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -738,6 +741,23 @@ public class TestSniperPrinter {
 		SniperJavaPrettyPrinter sniper = (SniperJavaPrettyPrinter) launcher.getEnvironment().createPrettyPrinter();
 
 		assertThrows(IllegalArgumentException.class, () -> sniper.calculate(cu, Collections.singletonList(primaryType)));
+	}
+
+	@Test
+	void testSniperRespectsDeletionInForLoopHeader() {
+		// contract: The sniper printer should detect deletions in for loop headers as modifications
+		// and print the model accordingly.
+
+        Consumer<CtType<?>> deleteForUpdate = type -> {
+        	CtFor ctFor = type.filterChildren(CtFor.class::isInstance).first();
+        	ctFor.getForUpdate().forEach(CtElement::delete);
+			ctFor.getForInit().forEach(CtElement::delete);
+		};
+		BiConsumer<CtType<?>, String> assertNotStaticFindFirstIsEmpty = (type, result) -> {
+            assertThat(result, containsString("for (; i < 10;)"));
+		};
+
+		testSniper("ForLoop", deleteForUpdate, assertNotStaticFindFirstIsEmpty);
 	}
 
 	/**

--- a/src/test/resources/ForLoop.java
+++ b/src/test/resources/ForLoop.java
@@ -1,0 +1,7 @@
+public class ForLoop {
+    public void forLoop() {
+        for (int i = 0; i < 10; i++) {
+            System.out.println(i);
+        }
+    }
+}


### PR DESCRIPTION
Fix #3940 

The `setForInit` and `setForUpdate` does not call change listeners if the value set was the empty list or null. Note that deleting the last element in a e.g. a for init is implemented such that `setForInit` is called with an empty list, and so the last deletion is not registered. This causes problems for the sniper printer, as a patch that only deletes the final element in a for update or init does not register any changes, and so the sniper just prints the original source code.

This PR simply moves the `onDeletAll()` call to the change listeners to the top of the `setForInit` and `setForUpdate` methods, such that they are always called. This is valid, as setting an empty list or `null` is equivalent to clearing the list.