### PR TITLE
feat: add shortcut API to get or create the compilation unit

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -116,6 +116,11 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	String getDocComment();
 
 	/**
+	 * Gets the compilation unit in which the element resides or tries to create one corresponding to the element.
+	 */
+	CtCompilationUnit getOrCreateCompilationUnit();
+
+	/**
 	 * Build a short representation of any element.
 	 */
 	@DerivedProperty

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -9,6 +9,7 @@ package spoon.support.reflect.declaration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import spoon.SpoonException;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtBlock;
@@ -18,10 +19,13 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.factory.CompilationUnitFactory;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.FactoryImpl;
 import spoon.reflect.meta.RoleHandler;
@@ -184,6 +188,24 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 			}
 		}
 		return "";
+	}
+
+	public CtCompilationUnit getOrCreateCompilationUnit() {
+		CompilationUnitFactory cuFactory = getFactory().CompilationUnit();
+		if (this instanceof CtType<?>) {
+			return cuFactory.getOrCreate((CtType<?>) this);
+		} else if (this instanceof CtPackage) {
+			return cuFactory.getOrCreate((CtPackage) this);
+		} else if (this instanceof CtModule) {
+			return cuFactory.getOrCreate((CtModule) this);
+		} else {
+			CtType<?> enclosingType = getParent(CtType.class);
+			if (enclosingType != null) {
+				return cuFactory.getOrCreate(enclosingType);
+			} else {
+				throw new SpoonException(this.getShortRepresentation() + " does not belong to a compilation unit");
+			}
+		}
 	}
 
 	@Override

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -24,6 +24,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
@@ -266,5 +267,22 @@ public class CtTypeTest {
 		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
 
 		assertSame(reFetchedTypeDecl, typeDecl);
+	}
+
+	@Test
+	public void testGetOrCreateCompilationUnit() {
+		// contract: the compilation unit should be returned using the shortcut method
+		final Launcher launcher = new Launcher();
+		final Factory factory = launcher.getFactory();
+
+		// create the elements required
+		CtCompilationUnit expectedCu = factory.createCompilationUnit();
+		CtClass<?> klass = factory.createClass("CompilationUnit");
+
+		// modify the elements according to the contract
+		expectedCu.addDeclaredType(klass);
+		CtCompilationUnit actualCu = klass.getOrCreateCompilationUnit();
+
+		assertEquals(expectedCu, actualCu);
 	}
 }


### PR DESCRIPTION
Fixes #3942 

The changes add `getOrCreateCompilationUnit()` API which would serve as a shortcut to get the compilation unit. This API needs to be tested with the following elements.

- [ ] CtType
   - [x] CtClass
   - [ ] CtInterface 
- [ ] CtModule
- [ ] CtPackage