### PR TITLE
test: Migrate CorrectIdentifierTest to JUnit5

### DIFF
--- a/src/test/java/spoon/generating/CorrectIdentifierTest.java
+++ b/src/test/java/spoon/generating/CorrectIdentifierTest.java
@@ -1,7 +1,7 @@
 package spoon.generating;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import spoon.FluentLauncher;
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -29,21 +29,21 @@ public class CorrectIdentifierTest {
 		assertThrows(SpoonException.class, () -> localVariableRef.setSimpleName(";tacos"));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void keyWord() {
 		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
 		assertThrows(SpoonException.class, () -> localVariableRef.setSimpleName("class"));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void keyWord2() {
 		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();
 		assertThrows(SpoonException.class, () -> localVariableRef.setSimpleName("null"));
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void keyWord3() {
 		CtLocalVariableReference<Object> localVariableRef = new Launcher().getFactory().createLocalVariableReference();


### PR DESCRIPTION
#3919

This PR just migrates CorrectIdentifierTest to Junit5, pure refactoring.

I have decided to do the migration sequentially hence, selected this test. I plan to migrate a lot of tests before the official start of the GSoC coding period.

I will be migrating sequentially but if org have priorities for some other tests, I will be happy to migrate them first : )