### PR TITLE
fix: Fix crash on null type binding in nested type during search

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -75,13 +75,12 @@ class JDTTreeBuilderQuery {
 		for (CompilationUnitDeclaration unitToProcess : unitsToProcess) {
 			if (unitToProcess.types != null) {
 				for (TypeDeclaration type : unitToProcess.types) {
-					if (type.binding != null
-							&& qualifiedName.equals(CharOperation.toString(type.binding.compoundName))) {
+					if (qualifiedNameEqualsBindingCompoundName(qualifiedName, type)) {
 						return type.binding;
 					}
 					if (type.memberTypes != null) {
 						for (TypeDeclaration memberType : type.memberTypes) {
-							if (qualifiedName.equals(CharOperation.toString(memberType.binding.compoundName))) {
+							if (qualifiedNameEqualsBindingCompoundName(qualifiedName, memberType)) {
 								return type.binding;
 							}
 						}
@@ -90,6 +89,13 @@ class JDTTreeBuilderQuery {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Compare the qualified name to the type binding's compound name.
+	 */
+	private static boolean qualifiedNameEqualsBindingCompoundName(String qualifiedName, TypeDeclaration type) {
+		return type.binding != null && qualifiedName.equals(CharOperation.toString(type.binding.compoundName));
 	}
 
 	/**

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -197,7 +197,7 @@ public class TypeTest {
 		CtModel model = launcher.buildModel();
 
 		Set<String> expectedTypeNames = new HashSet<>(
-				Arrays.asList("duplicates.Duplicate", "duplicates.Main", "duplicates.WithNestedEnum"));
+				Arrays.asList("AlsoWithNestedEnum", "duplicates.Duplicate", "duplicates.Main", "duplicates.WithNestedEnum"));
 		Set<String> typeNames = model.getAllTypes().stream().map(CtType::getQualifiedName).collect(Collectors.toSet());
 
 		assertEquals(expectedTypeNames, typeNames);

--- a/src/test/resources/duplicates-in-submodules/moduleA/duplicates/AlsoWithNestedEnum.java
+++ b/src/test/resources/duplicates-in-submodules/moduleA/duplicates/AlsoWithNestedEnum.java
@@ -1,0 +1,16 @@
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+
+/**
+ * This class contains a nested type, is duplicated across the two modules in this project, and
+ * starts with an A, which places it at the top of the compilation units as these are sorted
+ * lexicographically for each module by JDT. At the time of writing this test file, this causes
+ * the nested type's type binding to be checked in
+ * {@link spoon.support.compiler.jdt.JDTTreeBuilderQuery#searchTypeBinding(String, CompilationUnitDeclaration[])},
+ * which if done without a null check causes a crash due to the type duplication making the binding
+ * null in one case.
+ */
+public class AlsoWithNestedEnum {
+    public enum SomeEnum {
+
+    }
+}

--- a/src/test/resources/duplicates-in-submodules/moduleB/duplicates/AlsoWithNestedEnum.java
+++ b/src/test/resources/duplicates-in-submodules/moduleB/duplicates/AlsoWithNestedEnum.java
@@ -1,0 +1,8 @@
+/**
+ * See the comment in ../moduleA/duplicates/AlsoWithNestedEnum.java.
+ */
+public class AlsoWithNestedEnum {
+    public enum SomeEnum {
+
+    }
+}


### PR DESCRIPTION
Fix #3950 
Fix #3572 

This PR fixes a crash that occurs when Spoon is forced to search for type bindings, and there's a _duplicated type with nested types that are also duplicated_. It's a very fringe thing that only occurs when running with `setIgnoreDuplicateDeclarations(true)`.
