### PR TITLE
fix: Fix crash on handling parameterized ProblemReferenceBinding

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -922,14 +922,18 @@ public class ReferenceBuilder {
 			ref = this.jdtTreeBuilder.getFactory().Type().objectType();
 		} else if (binding instanceof ProblemReferenceBinding) {
 			// Spoon is able to analyze also without the classpath
+			String readableName = String.valueOf(binding.readableName());
 			if (isParameterizedProblemReferenceBinding(binding)) {
+				// on some rare occasions, such as the one explained in #3951, the name of the problem
+				// binding contains type arguments. We currently ignore the type arguments themselves
+				// as parsing them is a massive pain, but we must strip them from the name.
+				readableName = readableName.substring(0, readableName.indexOf('<'));
 				jdtTreeBuilder.getFactory().getEnvironment().report(
 						null,
 						Level.WARN,
 						"Ignoring type parameters for problem binding: " + binding);
 			}
 
-			String readableName = stripTypeParametersFromTypeReference(String.valueOf(binding.readableName()));
 			String simpleName = readableName.substring(Math.max(0, readableName.lastIndexOf('.') + 1));
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			ref.setSimpleName(simpleName);
@@ -952,14 +956,6 @@ public class ReferenceBuilder {
 	private static boolean isParameterizedProblemReferenceBinding(TypeBinding binding) {
 		String sourceName = String.valueOf(binding.sourceName());
 		return binding instanceof ProblemReferenceBinding && typeRefContainsTypeArgs(sourceName);
-	}
-
-	private static String stripTypeParametersFromTypeReference(String typeReference) {
-		if (typeRefContainsTypeArgs(typeReference)) {
-			return typeReference.substring(0, typeReference.indexOf('<'));
-		} else {
-			return typeReference;
-		}
 	}
 
 	private static boolean typeRefContainsTypeArgs(String typeRef) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -949,34 +949,11 @@ public class ReferenceBuilder {
 		return (CtTypeReference<T>) ref;
 	}
 
-	private CompilationUnitDeclaration[] getCompilationUnitDeclarations() {
-		return ((TreeBuilderCompiler) jdtTreeBuilder
-				.getContextBuilder()
-				.compilationunitdeclaration
-				.scope
-				.environment
-				.typeRequestor).unitsToProcess;
-	}
-
 	private static boolean isParameterizedProblemReferenceBinding(TypeBinding binding) {
 		String sourceName = String.valueOf(binding.sourceName());
 		return binding instanceof ProblemReferenceBinding
 				&& !sourceName.startsWith("<")
 				&& sourceName.endsWith(">");
-	}
-
-	/**
-	 * Search for the actual type binding for this problem reference binding.
-	 *
-	 * @param binding An unresolved reference binding.
-	 * @return A type binding to the actual referenced type, or null if the type can't be found.
-	 */
-	private TypeBinding searchForActualBinding(ProblemReferenceBinding binding) {
-		if (isParameterizedProblemReferenceBinding(binding)) {
-			return getActualTypeBindingOfParameterizedProblemReferenceBinding(binding);
-		} else {
-			return null;
-		}
 	}
 
 	private String stripTypeParametersFromTypeReference(String typeReference) {
@@ -989,31 +966,6 @@ public class ReferenceBuilder {
 
 	private boolean typeRefContainsTypeArgs(String typeRef) {
 		return !typeRef.startsWith("<") && typeRef.endsWith(">");
-	}
-
-	/**
-	 * In some rare noclasspath cases, JDT parses a parameterized type reference to a
-	 * ProblemReferenceBinding * (as opposed to a ParameterizedTypeBinding). This makes it very
-	 * difficult to extract the * parameterized types as it essentially requires full-on parsing of
-	 * the type arguments.
-	 *
-	 * Currently, we try to extract the actual type binding of the generic type, but ignore the type
-	 * arguments as they * are too much effort to parse for this very, very rare case.
-	 *
-	 * See https://github.com/inria/spoon/issues/3951 for more details.
-	 *
-	 * @param binding A problem binding that contains type arguments in the compound name.
-	 * @return The actual type binding if it can be found by searching compilation units,
-	 * otherwise null.
-	 */
-	private TypeBinding getActualTypeBindingOfParameterizedProblemReferenceBinding(ProblemReferenceBinding binding) {
-		String nameWithTypeArgs = CharOperation.toString(binding.compoundName);
-		int typeArgsStart = nameWithTypeArgs.indexOf('<');
-
-		final CompilationUnitDeclaration[] units = getCompilationUnitDeclarations();
-		String qualname = nameWithTypeArgs.substring(0, typeArgsStart);
-
-		return searchTypeBinding(qualname, units);
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -951,12 +951,10 @@ public class ReferenceBuilder {
 
 	private static boolean isParameterizedProblemReferenceBinding(TypeBinding binding) {
 		String sourceName = String.valueOf(binding.sourceName());
-		return binding instanceof ProblemReferenceBinding
-				&& !sourceName.startsWith("<")
-				&& sourceName.endsWith(">");
+		return binding instanceof ProblemReferenceBinding && typeRefContainsTypeArgs(sourceName);
 	}
 
-	private String stripTypeParametersFromTypeReference(String typeReference) {
+	private static String stripTypeParametersFromTypeReference(String typeReference) {
 		if (typeRefContainsTypeArgs(typeReference)) {
 			return typeReference.substring(0, typeReference.indexOf('<'));
 		} else {
@@ -964,7 +962,7 @@ public class ReferenceBuilder {
 		}
 	}
 
-	private boolean typeRefContainsTypeArgs(String typeRef) {
+	private static boolean typeRefContainsTypeArgs(String typeRef) {
 		return !typeRef.startsWith("<") && typeRef.endsWith(">");
 	}
 

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -389,11 +389,13 @@ public class TryCatchTest {
 	}
 
 	@Test
-	public void testNonCloseableGenericTypeInTryWithResources() throws Exception {
+	public void testNonCloseableGenericTypeInTryWithResources() {
 		// contract: When a non-closeable generic type is used in a try-with-resources, it's type
 		// becomes a problem type in JDT, with the type parameters included in the compound name.
 		// This is as opposed to a parameterized type, so we need to take special care in parsing
 		// these problem types to make sure they are properly identified as parameterized types.
+		//
+		// Currently, we do NOT extract type references to type arguments for such bindings.
 		//
 		// This previously caused a crash, see https://github.com/INRIA/spoon/issues/3951
 
@@ -404,6 +406,8 @@ public class TryCatchTest {
 		CtLocalVariableReference<?> varRef = model.filterChildren(CtLocalVariableReference.class::isInstance).first();
 
 		assertThat(varRef.getType().getSimpleName(), equalTo("GenericType"));
-		assertThat(varRef.getType().getActualTypeArguments().size(), equalTo(2));
+
+		// We don't extract the type arguments
+		assertThat(varRef.getType().getActualTypeArguments().size(), equalTo(0));
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -23,7 +23,6 @@ import spoon.SpoonModelBuilder;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
-import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.declaration.CtClass;

--- a/src/test/resources/NonClosableGenericInTryWithResources.java
+++ b/src/test/resources/NonClosableGenericInTryWithResources.java
@@ -6,7 +6,7 @@ https://github.com/INRIA/spoon/issues/3951
 public class NonClosableGenericInTryWithResources {
     public static void main(String[] args) {
         // we use a non-closeable generic type in a try-with-resources, causing it to become a
-        // ProblemTypeBinding in JDT with a compound name of GenericType<Integer, String>
+        // ProblemReferenceBinding in JDT with a compound name of GenericType<Integer, String>
         try (GenericType<Integer, String> gen = new GenericType<>()) {
             // referencing the gen variable to force creation of a variable access, which
             // previously caused a crash

--- a/src/test/resources/NonClosableGenericInTryWithResources.java
+++ b/src/test/resources/NonClosableGenericInTryWithResources.java
@@ -1,0 +1,24 @@
+/*
+Using a non-closeable generic type in a try-with-resources previously caused a crash, see
+https://github.com/INRIA/spoon/issues/3951
+ */
+
+public class NonClosableGenericInTryWithResources {
+    public static void main(String[] args) {
+        // we use a non-closeable generic type in a try-with-resources, causing it to become a
+        // ProblemTypeBinding in JDT with a compound name of GenericType<Integer, String>
+        try (GenericType<Integer, String> gen = new GenericType<>()) {
+            // referencing the gen variable to force creation of a variable access, which
+            // previously caused a crash
+            gen.toString();
+        }
+
+    }
+
+    /**
+     * Class that definitely does not implement Closeable.
+     */
+    public static class GenericType<K, V> {
+
+    }
+}


### PR DESCRIPTION
Fix #3951 

The problem is described in the issue. It's very rare for JDT to parse a parameterized type reference to a ProblemReferenceBinding (even when the actual referenced type can't be resolved). In the particular case of error code 15 (using a type that isn't closable on a try-with-resources), it does however resolve the reference to a ProblemReferenceBinding with type parameters in the name, which caused the crash.

This PR does _not_ attempt to parse the type arguments, it only fixes the crash and lets the pre-existing logic for creating type references from problem bindings do its thing. In other words, a type reference is created with the correct simple name, and that's about it. A warning that the type arguments are ignored is also issued.

I found a way to actually resolve the correct type binding in the particular corner case represented in the test case I added, which I may add in a later PR as that coincidentally triggers the long-standing bug reported in #3708.