### PR TITLE
refactor(ReferenceBuilder): Extract parameterized type reference creation into helpers

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -749,7 +749,6 @@ public class ReferenceBuilder {
 	<T> CtTypeReference<T> getTypeReference(TypeBinding binding) {
 		return getTypeReference(binding, false);
 	}
-
 	/**
 	 * @param resolveGeneric if true then it never returns CtTypeParameterReference, but it's superClass instead
 	 */

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -747,6 +747,55 @@ public class ReferenceBuilder {
 	<T> CtTypeReference<T> getTypeReference(TypeBinding binding) {
 		return getTypeReference(binding, false);
 	}
+
+	private <T> CtTypeReference<T> getParameterizedTypeReference(TypeBinding binding) {
+		CtTypeReference<T> ref;
+		if (binding.actualType() != null && binding.actualType() instanceof LocalTypeBinding) {
+			// When we define a nested class in a method and when the enclosing class of this method
+			// is a parameterized type binding, JDT give a ParameterizedTypeBinding for the nested class
+			// and hide the real class in actualType().
+			ref = getTypeReference(binding.actualType());
+		} else {
+			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+			this.exploringParameterizedBindings.put(binding, ref);
+			if (binding.isAnonymousType()) {
+				ref.setSimpleName("");
+			} else {
+				ref.setSimpleName(String.valueOf(binding.sourceName()));
+				if (binding.enclosingType() != null) {
+					ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+				} else {
+					ref.setPackage(getPackageReference(binding.getPackage()));
+				}
+			}
+		}
+		if (binding.actualType() instanceof MissingTypeBinding) {
+			ref = getTypeReference(binding.actualType());
+		}
+
+		if (((ParameterizedTypeBinding) binding).arguments != null) {
+			for (TypeBinding b : ((ParameterizedTypeBinding) binding).arguments) {
+				if (bindingCache.containsKey(b)) {
+					ref.addActualTypeArgument(getCtCircularTypeReference(b));
+				} else {
+					if (!this.exploringParameterizedBindings.containsKey(b)) {
+						this.exploringParameterizedBindings.put(b, null);
+						CtTypeReference<T> typeRefB = getTypeReference(b);
+						this.exploringParameterizedBindings.put(b, typeRefB);
+						ref.addActualTypeArgument(typeRefB);
+					} else {
+						@SuppressWarnings("unchecked")
+						CtTypeReference<T> typeRefB = this.exploringParameterizedBindings.get(b);
+						if (typeRefB != null) {
+							ref.addActualTypeArgument(typeRefB.clone());
+						}
+					}
+				}
+			}
+		}
+		return ref;
+	}
+
 	/**
 	 * @param resolveGeneric if true then it never returns CtTypeParameterReference, but it's superClass instead
 	 */
@@ -760,48 +809,7 @@ public class ReferenceBuilder {
 		if (binding instanceof RawTypeBinding) {
 			ref = getTypeReference(((ParameterizedTypeBinding) binding).genericType());
 		} else if (binding instanceof ParameterizedTypeBinding) {
-			if (binding.actualType() != null && binding.actualType() instanceof LocalTypeBinding) {
-				// When we define a nested class in a method and when the enclosing class of this method
-				// is a parameterized type binding, JDT give a ParameterizedTypeBinding for the nested class
-				// and hide the real class in actualType().
-				ref = getTypeReference(binding.actualType());
-			} else {
-				ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-				this.exploringParameterizedBindings.put(binding, ref);
-				if (binding.isAnonymousType()) {
-					ref.setSimpleName("");
-				} else {
-					ref.setSimpleName(String.valueOf(binding.sourceName()));
-					if (binding.enclosingType() != null) {
-						ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-					} else {
-						ref.setPackage(getPackageReference(binding.getPackage()));
-					}
-				}
-			}
-			if (binding.actualType() instanceof MissingTypeBinding) {
-				ref = getTypeReference(binding.actualType());
-			}
-
-			if (((ParameterizedTypeBinding) binding).arguments != null) {
-				for (TypeBinding b : ((ParameterizedTypeBinding) binding).arguments) {
-					if (bindingCache.containsKey(b)) {
-						ref.addActualTypeArgument(getCtCircularTypeReference(b));
-					} else {
-						if (!this.exploringParameterizedBindings.containsKey(b)) {
-							this.exploringParameterizedBindings.put(b, null);
-							CtTypeReference typeRefB = getTypeReference(b);
-							this.exploringParameterizedBindings.put(b, typeRefB);
-							ref.addActualTypeArgument(typeRefB);
-						} else {
-							CtTypeReference typeRefB = this.exploringParameterizedBindings.get(b);
-							if (typeRefB != null) {
-								ref.addActualTypeArgument(typeRefB.clone());
-							}
-						}
-					}
-				}
-			}
+			ref = getParameterizedTypeReference(binding);
 		} else if (binding instanceof MissingTypeBinding) {
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			ref.setSimpleName(new String(binding.sourceName()));

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -762,7 +762,7 @@ public class ReferenceBuilder {
 		if (binding instanceof RawTypeBinding) {
 			ref = getTypeReference(((ParameterizedTypeBinding) binding).genericType());
 		} else if (binding instanceof ParameterizedTypeBinding) {
-			ref = getParameterizedTypeReference(binding);
+			ref = getParameterizedTypeReference((ParameterizedTypeBinding) binding);
 		} else if (binding instanceof MissingTypeBinding) {
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			ref.setSimpleName(new String(binding.sourceName()));
@@ -952,7 +952,7 @@ public class ReferenceBuilder {
 	/**
 	 * Create a parameterized type reference based on the provided binding.
 	 */
-	private CtTypeReference<?> getParameterizedTypeReference(TypeBinding binding) {
+	private CtTypeReference<?> getParameterizedTypeReference(ParameterizedTypeBinding binding) {
 		CtTypeReference<?> ref;
 		if (binding.actualType() instanceof LocalTypeBinding) {
 			// When we define a nested class in a method and when the enclosing class of this method
@@ -984,16 +984,13 @@ public class ReferenceBuilder {
 	/**
 	 * Get the type arguments from the binding, or an empty list if no type arguments can be found.
 	 */
-	private List<CtTypeReference<?>> getTypeArguments(TypeBinding binding) {
-		if (!(binding instanceof ParameterizedTypeBinding)
-				|| ((ParameterizedTypeBinding) binding).arguments == null) {
-			return Collections.emptyList();
-		}
-
-		return Arrays.stream(((ParameterizedTypeBinding) binding).arguments)
-				.map(this::getTypeReferenceFromTypeArgument)
-				.filter(Objects::nonNull)
-				.collect(Collectors.toList());
+	private List<CtTypeReference<?>> getTypeArguments(ParameterizedTypeBinding binding) {
+		return binding.arguments == null
+				? Collections.emptyList()
+				: Arrays.stream((binding.arguments))
+					.map(this::getTypeReferenceFromTypeArgument)
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -948,9 +948,12 @@ public class ReferenceBuilder {
 		return (CtTypeReference<T>) ref;
 	}
 
+	/**
+	 * Create a parameterized type reference based on the provided binding.
+	 */
 	private CtTypeReference<?> getParameterizedTypeReference(TypeBinding binding) {
 		CtTypeReference<?> ref;
-		if (binding.actualType() != null && binding.actualType() instanceof LocalTypeBinding) {
+		if (binding.actualType() instanceof LocalTypeBinding) {
 			// When we define a nested class in a method and when the enclosing class of this method
 			// is a parameterized type binding, JDT give a ParameterizedTypeBinding for the nested class
 			// and hide the real class in actualType().
@@ -977,6 +980,9 @@ public class ReferenceBuilder {
 		return ref;
 	}
 
+	/**
+	 * Get the type arguments from the binding, or an empty list if no type arguments can be found.
+	 */
 	private List<CtTypeReference<?>> getTypeArguments(TypeBinding binding) {
 	    if (!(binding instanceof ParameterizedTypeBinding)
 				|| ((ParameterizedTypeBinding) binding).arguments == null) {
@@ -984,17 +990,17 @@ public class ReferenceBuilder {
 		}
 
 	    List<CtTypeReference<?>> typeArguments = new ArrayList<>();
-		for (TypeBinding b : ((ParameterizedTypeBinding) binding).arguments) {
-			if (bindingCache.containsKey(b)) {
-				typeArguments.add(getCtCircularTypeReference(b));
+		for (TypeBinding typeArgBinding : ((ParameterizedTypeBinding) binding).arguments) {
+			if (bindingCache.containsKey(typeArgBinding)) {
+				typeArguments.add(getCtCircularTypeReference(typeArgBinding));
 			} else {
-				if (!this.exploringParameterizedBindings.containsKey(b)) {
-					this.exploringParameterizedBindings.put(b, null);
-					CtTypeReference<?> typeRefB = getTypeReference(b);
-					this.exploringParameterizedBindings.put(b, typeRefB);
+				if (!this.exploringParameterizedBindings.containsKey(typeArgBinding)) {
+					this.exploringParameterizedBindings.put(typeArgBinding, null);
+					CtTypeReference<?> typeRefB = getTypeReference(typeArgBinding);
+					this.exploringParameterizedBindings.put(typeArgBinding, typeRefB);
 					typeArguments.add(typeRefB);
 				} else {
-					CtTypeReference<?> typeRefB = this.exploringParameterizedBindings.get(b);
+					CtTypeReference<?> typeRefB = this.exploringParameterizedBindings.get(typeArgBinding);
 					if (typeRefB != null) {
 						typeArguments.add(typeRefB.clone());
 					}


### PR DESCRIPTION
#3965 

First PR in refactoring `ReferenceBuilder.getTypeReference()`.

This PR extracts the creation of parameterized type references into a set of three smaller helper methods. This will make it easier for me to later handle #3964 