### PR TITLE
test: migrate CtTypeReferenceTest to Junit5

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -59,7 +59,7 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
+  <dependency>
     <!-- must come after junit5 deps, otherwise it overrides the junit version -->
     <!-- must be here in the parent POM, because the parent always comes last, see https://stackoverflow.com/questions/28999057/order-of-inherited-dependencies-in-maven-3 -->
     <groupId>com.github.stefanbirkner</groupId>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -52,8 +52,14 @@
         <version>5.7.2</version>
         <scope>test</scope>
     </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>3.10.0</version>
+            <scope>test</scope>
+        </dependency>
 
-  <dependency>
+        <dependency>
     <!-- must come after junit5 deps, otherwise it overrides the junit version -->
     <!-- must be here in the parent POM, because the parent always comes last, see https://stackoverflow.com/questions/28999057/order-of-inherited-dependencies-in-maven-3 -->
     <groupId>com.github.stefanbirkner</groupId>

--- a/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
+++ b/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
@@ -1,10 +1,10 @@
 package spoon.reflect.reference;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 import spoon.compiler.Environment;
 import spoon.reflect.factory.Factory;
@@ -17,20 +17,20 @@ import java.util.function.Supplier;
 
 import static com.google.common.primitives.Primitives.allPrimitiveTypes;
 import static com.google.common.primitives.Primitives.wrap;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.junit.MockitoJUnit.rule;
 import static spoon.testing.utils.Check.assertNotNull;
 
+@ExtendWith(MockitoExtension.class)
 public class CtTypeReferenceTest {
     private final TypeFactory typeFactory = new TypeFactory();
-    @Rule public MockitoRule mockito = rule();
+
     @Mock private Factory factory;
     @Mock private Environment environment;
     @Mock private FineModelChangeListener listener;
     @Mock private ClassLoader classLoader;
 
-    @Before public void setUp() {
+    @BeforeEach public void setUp() {
         when(factory.Type()).thenReturn(typeFactory);
         when(factory.getEnvironment()).thenReturn(environment);
         when(environment.getModelChangeListener()).thenReturn(listener);

--- a/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
+++ b/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
@@ -3,6 +3,7 @@ package spoon.reflect.reference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
@@ -34,7 +35,7 @@ public class CtTypeReferenceTest {
         when(factory.Type()).thenReturn(typeFactory);
         when(factory.getEnvironment()).thenReturn(environment);
         when(environment.getModelChangeListener()).thenReturn(listener);
-        when(environment.getInputClassLoader()).thenReturn(classLoader);
+        Mockito.lenient().when(environment.getInputClassLoader()).thenReturn(classLoader);
     }
 
     /**
@@ -77,7 +78,7 @@ public class CtTypeReferenceTest {
         reference.setFactory(factory);
         reference.setSimpleName(inputClass.getName());
         if (mockClassLoader) {
-            when(classLoader.loadClass(inputClass.getName()))
+            Mockito.lenient().when(classLoader.loadClass(inputClass.getName()))
                 .thenAnswer((Answer<Object>) invocationOnMock -> inputClass);
         }
 


### PR DESCRIPTION
#3919

This PR migrates FilterTest to Junit5.

Hi @slarse,

I tried to replace```Rule``` with ```ExtendWith```, but wasn't able to replace it successfully.

I would be glad if someone may help me perform this replacement.

I am unable to understand  [MockitoExtension](https://www.javadoc.io/doc/org.mockito/mockito-junit-jupiter/2.23.4/org/mockito/junit/jupiter/MockitoExtension.html) isn't getting resolved despite adding dependencies. (references : [baeldung](https://www.baeldung.com/mockito-junit-5-extension) & [stackoverflow](https://stackoverflow.com/questions/40961057/how-to-use-mockito-with-junit5)).