### PR TITLE
fix(noclasspath): Handle type resolution of anonymous class with unresolved constructor

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -659,7 +659,7 @@ public class ReferenceBuilder {
 			CtPackageReference packageReference = index >= 0 ? packageFactory.getOrCreate(concatSubArray(namesParameterized, index)).getReference() : packageFactory.topLevel();
 			inner.setPackage(packageReference);
 		}
-		if (!res.toStringDebug().replace(", ?", ",?").endsWith(nameParameterized)) {
+		if (!res.toStringDebug().replace(", ", ",").endsWith(nameParameterized)) {
 			// verify that we did not match a class that have the same name in a different package
 			return this.jdtTreeBuilder.getFactory().Type().createReference(typeName);
 		}

--- a/src/test/resources/noclasspath/BadAnonymousClassOfNestedType.java
+++ b/src/test/resources/noclasspath/BadAnonymousClassOfNestedType.java
@@ -1,0 +1,12 @@
+/*
+Test source file to reproduce the behavior reported in https://github.com/INRIA/spoon/issues/3913
+ */
+public final class BadAnonymousClassOfNestedType<K, V> {
+    public void test() {
+        new BadAnonymousClassOfNestedType.GenericType<K, V>(this) {
+        };
+    }
+
+    static class GenericType<K, V> {
+    }
+}


### PR DESCRIPTION
Fix #3913 

This PR fixes a problem in resolving generic types in noclasspath mode. The symptoms are specifically evident when creating an anonymous subclass of a generic type while using a constructor that does not exist. It can probably occur elsewhere as well, but this is where it was found to be easily reproducible.

See #3913 for further details.