### PR TITLE
fix: Fix violation of Sonar rule 2097

### DIFF
--- a/src/main/java/spoon/support/compiler/FileSystemFile.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFile.java
@@ -110,6 +110,9 @@ public class FileSystemFile implements SpoonFile {
 
 	@Override
 	public boolean equals(Object obj) {
+		if (obj == null || getClass() != obj.getClass()) {
+			return false;
+		}
 		return toFile().equals(((SpoonResource) obj).toFile());
 	}
 


### PR DESCRIPTION
PULL REQUEST TITLE: 
Hi,

This PR fixes 1 violation of [Sonar Rule 2097: '"equals(Object obj)" should test argument type'](https://rules.sonarsource.com/java/RSPEC-2097).

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2097](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#equalsobject-obj-should-test-argument-type-sonar-rule-2097).

The violation can be seen in [Spoon's SonarQube dashboard](https://sonarqube.ow2.org/project/issues?id=fr.inria.gforge.spoon%3Aspoon-core&issues=AWhzp_HYOQZh-5uoMgNg&open=AWhzp_HYOQZh-5uoMgNg).