### PR TITLE
refactor: Remove unnecessary unchecked cast in getParent(Class)

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -381,13 +381,12 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <P extends CtElement> P getParent(Class<P> parentType) {
 		CtElement current = this;
 		while (current.isParentInitialized()) {
 			current = current.getParent();
 			if (parentType.isAssignableFrom(current.getClass())) {
-				return (P) current;
+				return parentType.cast(current);
 			}
 		}
 


### PR DESCRIPTION
Related to the discussion in #1846 

I found a completely redundant unchecked cast in a method (`getParent(Class)`) where we actually have the runtime type to cast to! Using `Class.cast()` is _safe_, as it actually performs a cast at runtime.

It should be noted that in this method it doesn't actually matter, because the unchecked cast is preceded by a call to `Class.isAssignableFrom()`, which makes it "safe". But still, I think it's a nicer design to just avoid unchecked casts altogether when possible, because the not every Java developer is intimately familiar with what's safe and not when it comes to casting and type parameters.