### PR TITLE
review: test: extract NameFilterTest from FilterTest

### DIFF
--- a/src/test/java/spoon/legacy/NameFilterTest.java
+++ b/src/test/java/spoon/legacy/NameFilterTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2006-2021 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.legacy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.factory.Factory;
+import spoon.test.filters.testclasses.Foo;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static spoon.testing.utils.ModelUtils.build;
+
+class NameFilterTest {
+
+    private Factory factory;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        factory = build(Foo.class);
+    }
+
+    @Test
+    public void testNameFilter() throws Exception {
+        // contract: legacy NameFilter is tested and works
+        CtClass<?> foo = factory.Package().get("spoon.test.filters.testclasses").getType("Foo");
+        assertEquals("Foo", foo.getSimpleName());
+        List<CtNamedElement> elements = foo.getElements(new NameFilter<>("i"));
+        assertEquals(1, elements.size());
+    }
+}

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -19,7 +19,6 @@ package spoon.test.filters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
-import spoon.legacy.NameFilter;
 import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -107,15 +106,6 @@ public class FilterTest {
 	@BeforeEach
 	public void setup() throws Exception {
 		factory = build(Foo.class);
-	}
-
-	@Test
-	public void testNameFilter() throws Exception {
-		// contract: legacy NameFilter is tested and works
-		CtClass<?> foo = factory.Package().get("spoon.test.filters.testclasses").getType("Foo");
-		assertEquals("Foo", foo.getSimpleName());
-		List<CtNamedElement> elements = foo.getElements(new NameFilter<>("i"));
-		assertEquals(1, elements.size());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -108,6 +108,7 @@ public class FilterTest {
 		factory = build(Foo.class);
 	}
 
+
 	@Test
 	public void testFilters() {
 		CtClass<?> foo = factory.Package().get("spoon.test.filters.testclasses").getType("Foo");


### PR DESCRIPTION
This PR aims to extract the NameFilterTest from FilterTest, and placing it in its correct location.

This PR involves pure refactoring, no new test added or removed.

Extraction has been done safely as the code coverage for NameFilter remains the same before and after extracting the test.

Link to #3967

(I thought it will be nicer to first extract the NameFilterTest before adding new tests).