### PR TITLE
refactor(ReferenceBuilder): Extract small reference-building subroutines into helpers

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -765,17 +765,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof ParameterizedTypeBinding) {
 			ref = getParameterizedTypeReference((ParameterizedTypeBinding) binding);
 		} else if (binding instanceof MissingTypeBinding) {
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			ref.setSimpleName(new String(binding.sourceName()));
-			ref.setPackage(getPackageReference(binding.getPackage()));
-			if (!this.jdtTreeBuilder.getContextBuilder().ignoreComputeImports) {
-				final CtReference declaring = this.getDeclaringReferenceFromImports(binding.sourceName());
-				if (declaring instanceof CtPackageReference) {
-					ref.setPackage((CtPackageReference) declaring);
-				} else if (declaring instanceof CtTypeReference) {
-					ref.setDeclaringType((CtTypeReference) declaring);
-				}
-			}
+		    ref = getTypeReferenceFromMissingTypeBinding((MissingTypeBinding) binding);
 		} else if (binding instanceof BinaryTypeBinding) {
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			if (binding.enclosingType() != null) {
@@ -1022,6 +1012,23 @@ public class ReferenceBuilder {
 			this.exploringParameterizedBindings.put(typeArgBinding, typeRefB);
 			return typeRefB;
 		}
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromMissingTypeBinding(MissingTypeBinding binding) {
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		ref.setSimpleName(new String(binding.sourceName()));
+		ref.setPackage(getPackageReference(binding.getPackage()));
+
+		if (!this.jdtTreeBuilder.getContextBuilder().ignoreComputeImports) {
+			final CtReference declaring = this.getDeclaringReferenceFromImports(binding.sourceName());
+			if (declaring instanceof CtPackageReference) {
+				ref.setPackage((CtPackageReference) declaring);
+			} else if (declaring instanceof CtTypeReference) {
+				ref.setDeclaringType((CtTypeReference) declaring);
+			}
+		}
+
+		return ref;
 	}
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -844,21 +844,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof BaseTypeBinding) {
 			ref = getTypeReferenceFromBaseTypeBinding((BaseTypeBinding) binding);
 		} else if (binding instanceof WildcardBinding) {
-			WildcardBinding wildcardBinding = (WildcardBinding) binding;
-			CtWildcardReference wref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
-			ref = wref;
-
-			if (wildcardBinding.boundKind == Wildcard.SUPER) {
-				wref.setUpper(false);
-			}
-
-			if (wildcardBinding.bound != null) {
-				if (bindingCache.containsKey(wildcardBinding.bound)) {
-					wref.setBoundingType(getCtCircularTypeReference(wildcardBinding.bound));
-				} else {
-					wref.setBoundingType(getTypeReference(((WildcardBinding) binding).bound));
-				}
-			}
+		    ref = getTypeReferenceFromWildcardBinding((WildcardBinding) binding);
 		} else if (binding instanceof LocalTypeBinding) {
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			if (binding.isAnonymousType()) {
@@ -1040,6 +1026,24 @@ public class ReferenceBuilder {
 		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 		ref.setSimpleName(name);
 		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromWildcardBinding(WildcardBinding binding) {
+		CtWildcardReference wref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
+
+		if (binding.boundKind == Wildcard.SUPER) {
+			wref.setUpper(false);
+		}
+
+		if (binding.bound != null) {
+			if (bindingCache.containsKey(binding.bound)) {
+				wref.setBoundingType(getCtCircularTypeReference(binding.bound));
+			} else {
+				wref.setBoundingType(getTypeReference(binding.bound));
+			}
+		}
+
+		return wref;
 	}
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -858,11 +858,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof ProblemReferenceBinding) {
 		    ref = getTypeReferenceFromProblemReferenceBinding((ProblemReferenceBinding) binding);
 		} else if (binding instanceof IntersectionTypeBinding18) {
-			List<CtTypeReference<?>> bounds = new ArrayList<>();
-			for (ReferenceBinding superInterface : binding.getIntersectingTypes()) {
-				bounds.add(getTypeReference(superInterface));
-			}
-			ref = this.jdtTreeBuilder.getFactory().Type().createIntersectionTypeReferenceWithBounds(bounds);
+		    ref = getTypeReferenceFromIntersectionTypeBinding((IntersectionTypeBinding18) binding);
 		} else {
 			throw new RuntimeException("Unknown TypeBinding: " + binding.getClass() + " " + binding);
 		}
@@ -1067,6 +1063,14 @@ public class ReferenceBuilder {
 		setPackageOrDeclaringType(ref, declaring);
 
 		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromIntersectionTypeBinding(IntersectionTypeBinding18 binding) {
+		List<CtTypeReference<?>> boundingTypes = new ArrayList<>();
+		for (ReferenceBinding superInterface : binding.getIntersectingTypes()) {
+			boundingTypes.add(getTypeReference(superInterface));
+		}
+		return this.jdtTreeBuilder.getFactory().Type().createIntersectionTypeReferenceWithBounds(boundingTypes);
 	}
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -842,10 +842,7 @@ public class ReferenceBuilder {
 				bounds = false;
 			}
 		} else if (binding instanceof BaseTypeBinding) {
-			String name = new String(binding.sourceName());
-			//always create new TypeReference, because clonning from a cache clones invalid SourcePosition
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			ref.setSimpleName(name);
+			ref = getTypeReferenceFromBaseTypeBinding((BaseTypeBinding) binding);
 		} else if (binding instanceof WildcardBinding) {
 			WildcardBinding wildcardBinding = (WildcardBinding) binding;
 			CtWildcardReference wref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
@@ -1037,6 +1034,13 @@ public class ReferenceBuilder {
 		return ref;
 	}
 
+	private CtTypeReference<?> getTypeReferenceFromBaseTypeBinding(BaseTypeBinding binding) {
+		String name = new String(binding.sourceName());
+		//always create new TypeReference, because clonning from a cache clones invalid SourcePosition
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		ref.setSimpleName(name);
+		return ref;
+	}
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {
 		return bindingCache.get(b).clone();

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -767,14 +767,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof MissingTypeBinding) {
 		    ref = getTypeReferenceFromMissingTypeBinding((MissingTypeBinding) binding);
 		} else if (binding instanceof BinaryTypeBinding) {
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			if (binding.enclosingType() != null) {
-				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-			} else {
-				CtPackageReference packageReference = getPackageReference(binding.getPackage());
-				ref.setPackage(packageReference);
-			}
-			ref.setSimpleName(new String(binding.sourceName()));
+		    ref = getTypeReferenceFromBinaryTypeBinding((BinaryTypeBinding) binding);
 		} else if (binding instanceof TypeVariableBinding) {
 			boolean oldBounds = bounds;
 
@@ -1030,6 +1023,20 @@ public class ReferenceBuilder {
 
 		return ref;
 	}
+
+	private CtTypeReference<?> getTypeReferenceFromBinaryTypeBinding(BinaryTypeBinding binding) {
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		if (binding.enclosingType() != null) {
+			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+		} else {
+			CtPackageReference packageReference = getPackageReference(binding.getPackage());
+			ref.setPackage(packageReference);
+		}
+		ref.setSimpleName(new String(binding.sourceName()));
+
+		return ref;
+	}
+
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {
 		return bindingCache.get(b).clone();

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -846,19 +846,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof WildcardBinding) {
 		    ref = getTypeReferenceFromWildcardBinding((WildcardBinding) binding);
 		} else if (binding instanceof LocalTypeBinding) {
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			if (binding.isAnonymousType()) {
-				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(((SourceTypeBinding) binding).constantPoolName()));
-				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-			} else {
-				ref.setSimpleName(new String(binding.sourceName()));
-				if (((LocalTypeBinding) binding).enclosingMethod == null && binding.enclosingType() != null && binding.enclosingType() instanceof LocalTypeBinding) {
-					ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-				} else if (binding.enclosingMethod() != null) {
-					ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(((SourceTypeBinding) binding).constantPoolName()));
-					ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-				}
-			}
+		    ref = getTypeReferenceFromLocalTypeBinding((LocalTypeBinding) binding);
 		} else if (binding instanceof SourceTypeBinding) {
 			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 			if (binding.isAnonymousType()) {
@@ -1044,6 +1032,24 @@ public class ReferenceBuilder {
 		}
 
 		return wref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromLocalTypeBinding(LocalTypeBinding binding) {
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		if (binding.isAnonymousType()) {
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+		} else {
+			ref.setSimpleName(new String(binding.sourceName()));
+			if (binding.enclosingMethod == null && binding.enclosingType() != null && binding.enclosingType() instanceof LocalTypeBinding) {
+				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+			} else if (binding.enclosingMethod() != null) {
+				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+			}
+		}
+
+		return ref;
 	}
 
 	private CtTypeReference<?> getCtCircularTypeReference(TypeBinding b) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -765,9 +765,9 @@ public class ReferenceBuilder {
 		} else if (binding instanceof ParameterizedTypeBinding) {
 			ref = getParameterizedTypeReference((ParameterizedTypeBinding) binding);
 		} else if (binding instanceof MissingTypeBinding) {
-		    ref = getTypeReferenceFromMissingTypeBinding((MissingTypeBinding) binding);
+			ref = getTypeReferenceFromMissingTypeBinding((MissingTypeBinding) binding);
 		} else if (binding instanceof BinaryTypeBinding) {
-		    ref = getTypeReferenceFromBinaryTypeBinding((BinaryTypeBinding) binding);
+			ref = getTypeReferenceFromBinaryTypeBinding((BinaryTypeBinding) binding);
 		} else if (binding instanceof TypeVariableBinding) {
 			boolean oldBounds = bounds;
 
@@ -844,21 +844,21 @@ public class ReferenceBuilder {
 		} else if (binding instanceof BaseTypeBinding) {
 			ref = getTypeReferenceFromBaseTypeBinding((BaseTypeBinding) binding);
 		} else if (binding instanceof WildcardBinding) {
-		    ref = getTypeReferenceFromWildcardBinding((WildcardBinding) binding);
+			ref = getTypeReferenceFromWildcardBinding((WildcardBinding) binding);
 		} else if (binding instanceof LocalTypeBinding) {
-		    ref = getTypeReferenceFromLocalTypeBinding((LocalTypeBinding) binding);
+			ref = getTypeReferenceFromLocalTypeBinding((LocalTypeBinding) binding);
 		} else if (binding instanceof SourceTypeBinding) {
 			ref = getTypeReferenceFromSourceTypeBinding((SourceTypeBinding) binding);
 		} else if (binding instanceof ArrayBinding) {
-		    ref = getTypeReferenceFromArrayBinding((ArrayBinding) binding, resolveGeneric);
+			ref = getTypeReferenceFromArrayBinding((ArrayBinding) binding, resolveGeneric);
 		} else if (binding instanceof PolyTypeBinding) {
 			// JDT can't resolve the type of this binding and we only have a string.
 			// In this case, we return a type Object because we can't know more about it.
 			ref = this.jdtTreeBuilder.getFactory().Type().objectType();
 		} else if (binding instanceof ProblemReferenceBinding) {
-		    ref = getTypeReferenceFromProblemReferenceBinding((ProblemReferenceBinding) binding);
+			ref = getTypeReferenceFromProblemReferenceBinding((ProblemReferenceBinding) binding);
 		} else if (binding instanceof IntersectionTypeBinding18) {
-		    ref = getTypeReferenceFromIntersectionTypeBinding((IntersectionTypeBinding18) binding);
+			ref = getTypeReferenceFromIntersectionTypeBinding((IntersectionTypeBinding18) binding);
 		} else {
 			throw new RuntimeException("Unknown TypeBinding: " + binding.getClass() + " " + binding);
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -848,18 +848,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof LocalTypeBinding) {
 		    ref = getTypeReferenceFromLocalTypeBinding((LocalTypeBinding) binding);
 		} else if (binding instanceof SourceTypeBinding) {
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			if (binding.isAnonymousType()) {
-				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(((SourceTypeBinding) binding).constantPoolName()));
-				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-			} else {
-				ref.setSimpleName(new String(binding.sourceName()));
-				if (binding.enclosingType() != null) {
-					ref.setDeclaringType(getTypeReference(binding.enclosingType()));
-				} else {
-					ref.setPackage(getPackageReference(binding.getPackage()));
-				}
-			}
+			ref = getTypeReferenceFromSourceTypeBinding((SourceTypeBinding) binding);
 		} else if (binding instanceof ArrayBinding) {
 			CtArrayTypeReference<Object> arrayref;
 			arrayref = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
@@ -1046,6 +1035,23 @@ public class ReferenceBuilder {
 			} else if (binding.enclosingMethod() != null) {
 				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+			}
+		}
+
+		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromSourceTypeBinding(SourceTypeBinding binding) {
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		if (binding.isAnonymousType()) {
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+		} else {
+			ref.setSimpleName(new String(binding.sourceName()));
+			if (binding.enclosingType() != null) {
+				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
+			} else {
+				ref.setPackage(getPackageReference(binding.getPackage()));
 			}
 		}
 

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1030,8 +1030,8 @@ public class ReferenceBuilder {
 	}
 
 	private CtTypeReference<?> getTypeReferenceFromArrayBinding(ArrayBinding binding, boolean resolveGeneric) {
-		CtArrayTypeReference<Object> ref;
-		ref = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
+		CtArrayTypeReference<Object> ref = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
+		CtTypeReference<?> outermostRef = ref;
 		for (int i = 1; i < binding.dimensions(); i++) {
 			CtArrayTypeReference<Object> tmp = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
 			ref.setComponentType(tmp);
@@ -1039,7 +1039,7 @@ public class ReferenceBuilder {
 		}
 		ref.setComponentType(getTypeReference(binding.leafComponentType(), resolveGeneric));
 
-		return ref;
+		return outermostRef;
 	}
 
 	private CtTypeReference<?> getTypeReferenceFromProblemReferenceBinding(ProblemReferenceBinding binding) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -856,24 +856,7 @@ public class ReferenceBuilder {
 			// In this case, we return a type Object because we can't know more about it.
 			ref = this.jdtTreeBuilder.getFactory().Type().objectType();
 		} else if (binding instanceof ProblemReferenceBinding) {
-			// Spoon is able to analyze also without the classpath
-			String readableName = String.valueOf(binding.readableName());
-			if (isParameterizedProblemReferenceBinding(binding)) {
-				// on some rare occasions, such as the one explained in #3951, the name of the problem
-				// binding contains type arguments. We currently ignore the type arguments themselves
-				// as parsing them is a massive pain, but we must strip them from the name.
-				readableName = readableName.substring(0, readableName.indexOf('<'));
-				jdtTreeBuilder.getFactory().getEnvironment().report(
-						null,
-						Level.WARN,
-						"Ignoring type parameters for problem binding: " + binding);
-			}
-
-			String simpleName = readableName.substring(Math.max(0, readableName.lastIndexOf('.') + 1));
-			ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
-			ref.setSimpleName(simpleName);
-			final CtReference declaring = this.getDeclaringReferenceFromImports(binding.sourceName());
-			setPackageOrDeclaringType(ref, declaring);
+		    ref = getTypeReferenceFromProblemReferenceBinding((ProblemReferenceBinding) binding);
 		} else if (binding instanceof IntersectionTypeBinding18) {
 			List<CtTypeReference<?>> bounds = new ArrayList<>();
 			for (ReferenceBinding superInterface : binding.getIntersectingTypes()) {
@@ -1059,6 +1042,29 @@ public class ReferenceBuilder {
 			ref = tmp;
 		}
 		ref.setComponentType(getTypeReference(binding.leafComponentType(), resolveGeneric));
+
+		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromProblemReferenceBinding(ProblemReferenceBinding binding) {
+		// Spoon is able to analyze also without the classpath
+		String readableName = String.valueOf(binding.readableName());
+		if (isParameterizedProblemReferenceBinding(binding)) {
+			// on some rare occasions, such as the one explained in #3951, the name of the problem
+			// binding contains type arguments. We currently ignore the type arguments themselves
+			// as parsing them is a massive pain, but we must strip them from the name.
+			readableName = readableName.substring(0, readableName.indexOf('<'));
+			jdtTreeBuilder.getFactory().getEnvironment().report(
+					null,
+					Level.WARN,
+					"Ignoring type parameters for problem binding: " + binding);
+		}
+
+		String simpleName = readableName.substring(Math.max(0, readableName.lastIndexOf('.') + 1));
+		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
+		ref.setSimpleName(simpleName);
+		final CtReference declaring = this.getDeclaringReferenceFromImports(binding.sourceName());
+		setPackageOrDeclaringType(ref, declaring);
 
 		return ref;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -850,15 +850,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof SourceTypeBinding) {
 			ref = getTypeReferenceFromSourceTypeBinding((SourceTypeBinding) binding);
 		} else if (binding instanceof ArrayBinding) {
-			CtArrayTypeReference<Object> arrayref;
-			arrayref = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
-			ref = arrayref;
-			for (int i = 1; i < binding.dimensions(); i++) {
-				CtArrayTypeReference<Object> tmp = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
-				arrayref.setComponentType(tmp);
-				arrayref = tmp;
-			}
-			arrayref.setComponentType(getTypeReference(binding.leafComponentType(), resolveGeneric));
+		    ref = getTypeReferenceFromArrayBinding((ArrayBinding) binding, resolveGeneric);
 		} else if (binding instanceof PolyTypeBinding) {
 			// JDT can't resolve the type of this binding and we only have a string.
 			// In this case, we return a type Object because we can't know more about it.
@@ -1054,6 +1046,19 @@ public class ReferenceBuilder {
 				ref.setPackage(getPackageReference(binding.getPackage()));
 			}
 		}
+
+		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromArrayBinding(ArrayBinding binding, boolean resolveGeneric) {
+		CtArrayTypeReference<Object> ref;
+		ref = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
+		for (int i = 1; i < binding.dimensions(); i++) {
+			CtArrayTypeReference<Object> tmp = this.jdtTreeBuilder.getFactory().Core().createArrayTypeReference();
+			ref.setComponentType(tmp);
+			ref = tmp;
+		}
+		ref.setComponentType(getTypeReference(binding.leafComponentType(), resolveGeneric));
 
 		return ref;
 	}


### PR DESCRIPTION
#3965 

This PR extracts all of the "sufficiently small subroutines" in `getTypeReference` into methods of their own.

I can create one PR for each little helper, but as they edit code very close to each other I'd need to do them sequentially (wait for one to get merged before opening the next), so I figured I'd submit like this to begin with.

@monperrus  Let me know if you want me to break it up into smaller PRs (perhaps split into 3 PRs with 3 extractions each?), or if this size is OK.