### PR TITLE
test: improve the test for SpoonTagger class

### DIFF
--- a/src/test/java/spoon/processing/ProcessingTest.java
+++ b/src/test/java/spoon/processing/ProcessingTest.java
@@ -87,8 +87,13 @@ public class ProcessingTest {
 
 	@Test
 	public void testSpoonTagger() {
+		// contract: this tests the process method of the SpoonTagger class.
 		final Launcher launcher = new Launcher();
 		launcher.addProcessor("spoon.processing.SpoonTagger");
+		// we need to make sure that the spoon/Spoon.java file doesn't already exist in the system, as it will cause the assertion to be irrelevant
+		File file = new File (launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/Spoon.java");
+		// deleting the Spoon.java if it exists
+		file.delete();
 		launcher.run();
 		assertTrue(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/Spoon.java").exists());
 	}

--- a/src/test/java/spoon/processing/ProcessingTest.java
+++ b/src/test/java/spoon/processing/ProcessingTest.java
@@ -17,6 +17,7 @@
 package spoon.processing;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.code.CtAssert;
@@ -86,14 +87,11 @@ public class ProcessingTest {
 	}
 
 	@Test
-	public void testSpoonTagger() {
-		// contract: this tests the process method of the SpoonTagger class.
+	public void testSpoonTagger(@TempDir File tempDir) {
+		// contract: after running SpoonTagger, the file spoon/Spoon.java should exist in the output directory
 		final Launcher launcher = new Launcher();
+		launcher.setSourceOutputDirectory(tempDir.getAbsolutePath());
 		launcher.addProcessor("spoon.processing.SpoonTagger");
-		// we need to make sure that the spoon/Spoon.java file doesn't already exist in the system, as it will cause the assertion to be irrelevant
-		File file = new File (launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/Spoon.java");
-		// deleting the Spoon.java if it exists
-		file.delete();
 		launcher.run();
 		assertTrue(new File(launcher.getModelBuilder().getSourceOutputDirectory() + "/spoon/Spoon.java").exists());
 	}


### PR DESCRIPTION
Hi, I have improved the mutation strength from 0% to 100% for the SpoonTagger class.

Here's the report before improvement.

![Screen Shot 2021-06-08 at 22 20 25-fullpage](https://user-images.githubusercontent.com/62026125/121226095-ce3b0480-c8a7-11eb-9c1d-d8b97c574deb.png)


Actually, the test was poorly written, it had overlooked the scenario when the Spoon.java file already exists. I have taken care of that scenario and have manually tested the mutation "Removed all instructions in the method", and it is getting killed now.

I feel the PR is ready for merging.