### PR TITLE
community: update the integrator list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,9 @@ How to become integrator? The integrators are the developers who have made signi
 
 Current integrators:
 
+- Simon Larsen [@slarse](https://github.com/slarse/)
 - Nicolas Harrand [@nharrand](https://github.com/nharrand/)
-- Benjamin Danglot @danglotb
-- Thomas Durieux @tdurieux
-- Martin Monperrus @monperrus
-- Simon Urli @surli
-- Pavel Vojtechovsky @pvojtechovsky
+- Martin Monperrus [@monperrus](https://github.com/monperrus/)
 
 Guidelines for pull requests
 ----------------------------


### PR DESCRIPTION
It's been a long time we haven't updated the integrator list.
 
Per our governance guidelines, the integrators are those of us who have significantly contributed and/or merged over the past year.
 
Per the past year's contributions, we would thus have the following new list of integrators:
- Simon Larsen @slarse (welcome Simon and thanks for your great [recent contributions](https://github.com/INRIA/spoon/commits?author=slarse))
- Nicolas Harrand @nharrand 
- Martin Monperrus @monperrus 

And this is the opportunity to thank again @pvojtechovsky @tdurieux @danglotb @surli for the outstanding effort and care put in Spoon!