### PR TITLE
review: test: improve tests for abstractTemplate

### DIFF
--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -443,15 +443,14 @@ public class TemplateTest {
 	public void testAbstractTemplateIsWellFormed() {
 		// contract: IsWellFormed method of AbstractTemplate class returns false if there are zero template parameter
 
-		// arrange
-		AbstractTemplate<CtElement> abstractTemplate = new AbstractTemplate<CtElement>() {
+		AbstractTemplate<CtElement> zeroParameterTemplate = new AbstractTemplate<CtElement>() {
 			@Override
 			public CtElement apply(CtType<?> targetType) {
 				return null;
 			}
 		};
 
-		assertFalse(abstractTemplate.isWellFormed());
+		assertFalse(zeroParameterTemplate.isWellFormed());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -451,11 +451,7 @@ public class TemplateTest {
 			}
 		};
 
-		// act
-		boolean zeroTemplateParameters = abstractTemplate.isWellFormed();
-
-		// assert
-		assertFalse(zeroTemplateParameters);
+		assertFalse(abstractTemplate.isWellFormed());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -444,9 +444,9 @@ public class TemplateTest {
 		// contract: IsWellFormed method of AbstractTemplate class returns false if there are zero template parameter
 
 		// arrange
-		AbstractTemplate abstractTemplate = new AbstractTemplate() {
+		AbstractTemplate<CtElement> abstractTemplate = new AbstractTemplate<CtElement>() {
 			@Override
-			public CtElement apply(CtType targetType) {
+			public CtElement apply(CtType<?> targetType) {
 				return null;
 			}
 		};

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -44,10 +44,7 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.template.Parameters;
-import spoon.template.ExpressionTemplate;
-import spoon.template.Substitution;
-import spoon.template.TemplateMatcher;
-import spoon.template.TemplateParameter;
+import spoon.template.*;
 import spoon.test.template.testclasses.AnExpressionTemplate;
 import spoon.test.template.testclasses.AnotherFieldAccessTemplate;
 import spoon.test.template.testclasses.ArrayAccessTemplate;
@@ -440,6 +437,25 @@ public class TemplateTest {
 		// adds the bound check at the beginning of a method
 		method.getBody().insertBegin(injectedCode);
 		assertEquals(injectedCode, method.getBody().getStatement(0));
+	}
+
+	@Test
+	public void testAbstractTemplateIsWellFormed() {
+		// contract: IsWellFormed method of AbstractTemplate class returns false if there are zero template parameter
+
+		// arrange
+		AbstractTemplate abstractTemplate = new AbstractTemplate() {
+			@Override
+			public CtElement apply(CtType targetType) {
+				return null;
+			}
+		};
+
+		// act
+		boolean zeroTemplateParameters = abstractTemplate.isWellFormed();
+
+		// assert
+		assertFalse(zeroTemplateParameters);
 	}
 
 	@Test


### PR DESCRIPTION
#1818

Hi, I have improved both the test strength and mutation coverage from 75% to 100%  class.

Here's the report before improvement.

![Screen Shot 2021-06-14 at 14 57 08-fullpage](https://user-images.githubusercontent.com/62026125/121870564-d02a1b00-cd20-11eb-8a1b-3c721934d41b.png)

This PR was actually supposed to be raised in week 1, but I had to wait for tests to get converted in Junit5.

What I believe is, unhappy path test was missing for `isWellFormed` function which led to poor test strength in Descartes report, so I wrote a test for an unhappy path to fix that.

Next, for this week I will be working on the `Substitution.java` which is 660 lines of codes with many methods, so I believe I will raise another PR for that after a couple of days.

Link to #3967