### PR TITLE
refactor(ReferenceBuilder): Refactor getting type refeference from TypeVariableBinding

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -894,7 +894,7 @@ public class ReferenceBuilder {
 			return getTypeReference(((CaptureBinding) binding).wildcard, resolveGeneric);
 		} else if (binding instanceof CaptureBinding) {
 			CtWildcardReference wildcard = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
-			setBoundingTypeOnWildcard(wildcard, binding, resolveGeneric);
+			setBoundingTypeOnWildcardIfExists(wildcard, binding, resolveGeneric);
 			return wildcard;
 		} else if (resolveGeneric) {
 			//it is called e.g. by ExecutableReference, which must not use CtParameterTypeReference
@@ -939,16 +939,14 @@ public class ReferenceBuilder {
 				&& exploringParameterizedBindings.containsKey(binding);
 	}
 
-	private void setBoundingTypeOnWildcard(
+	private void setBoundingTypeOnWildcardIfExists(
 			CtWildcardReference wildcard, TypeVariableBinding binding, boolean resolveGeneric) {
 		bindingCache.put(binding, wildcard);
 
 		if (binding.superclass != null && binding.firstBound == binding.superclass) {
 			CtTypeReference<?> boundingType = getTypeReference(binding.superclass, resolveGeneric);
 			wildcard.setBoundingType(boundingType);
-		}
-
-		if (binding.superInterfaces != null && binding.superInterfaces != Binding.NO_SUPERINTERFACES) {
+		} else if (binding.superInterfaces != null && binding.superInterfaces != Binding.NO_SUPERINTERFACES) {
 			setSuperInterfaceDerivedBoundingTypeOnWildcard(wildcard, binding, resolveGeneric);
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -762,7 +762,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof BinaryTypeBinding) {
 			ref = getTypeReferenceFromBinaryTypeBinding((BinaryTypeBinding) binding);
 		} else if (binding instanceof TypeVariableBinding) {
-		    ref = getTypeReferenceFromTypeVariableBinding((TypeVariableBinding) binding, resolveGeneric);
+			ref = getTypeReferenceFromTypeVariableBinding((TypeVariableBinding) binding, resolveGeneric);
 		} else if (binding instanceof BaseTypeBinding) {
 			ref = getTypeReferenceFromBaseTypeBinding((BaseTypeBinding) binding);
 		} else if (binding instanceof WildcardBinding) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -966,18 +966,22 @@ public class ReferenceBuilder {
 		}
 
 		if (binding.superInterfaces != null && binding.superInterfaces != Binding.NO_SUPERINTERFACES) {
-			List<CtTypeReference<?>> boundingTypes = new ArrayList<>();
-			CtTypeParameterReference typeParameterReference = (CtTypeParameterReference) ref;
-			if (!(typeParameterReference.isDefaultBoundingType())) { // if it's object we can ignore it
-				boundingTypes.add(typeParameterReference.getBoundingType());
-			}
-			for (ReferenceBinding superInterface : binding.superInterfaces) {
-				boundingTypes.add(getTypeReference(superInterface, resolveGeneric));
-			}
-			if (ref instanceof CtWildcardReference) {
-				((CtWildcardReference) ref).setBoundingType(this.jdtTreeBuilder.getFactory().Type()
-						.createIntersectionTypeReferenceWithBounds(boundingTypes));
-			}
+			attachSuperInterfaceTypeBounds(binding, resolveGeneric, ref);
+		}
+	}
+
+	private void attachSuperInterfaceTypeBounds(TypeVariableBinding binding, boolean resolveGeneric, CtTypeReference<?> ref) {
+		List<CtTypeReference<?>> boundingTypes = new ArrayList<>();
+		CtTypeParameterReference typeParameterReference = (CtTypeParameterReference) ref;
+		if (!(typeParameterReference.isDefaultBoundingType())) { // if it's object we can ignore it
+			boundingTypes.add(typeParameterReference.getBoundingType());
+		}
+		for (ReferenceBinding superInterface : binding.superInterfaces) {
+			boundingTypes.add(getTypeReference(superInterface, resolveGeneric));
+		}
+		if (ref instanceof CtWildcardReference) {
+			((CtWildcardReference) ref).setBoundingType(this.jdtTreeBuilder.getFactory().Type()
+					.createIntersectionTypeReferenceWithBounds(boundingTypes));
 		}
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -762,78 +762,7 @@ public class ReferenceBuilder {
 		} else if (binding instanceof BinaryTypeBinding) {
 			ref = getTypeReferenceFromBinaryTypeBinding((BinaryTypeBinding) binding);
 		} else if (binding instanceof TypeVariableBinding) {
-			boolean oldBounds = bounds;
-
-			if (binding instanceof CaptureBinding) {
-				ref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
-				bounds = true;
-			} else {
-				TypeVariableBinding typeParamBinding = (TypeVariableBinding) binding;
-				if (resolveGeneric) {
-					//it is called e.g. by ExecutableReference, which must not use CtParameterTypeReference
-					//but it needs it's bounding type instead
-					ReferenceBinding superClass = typeParamBinding.superclass;
-					ReferenceBinding[] superInterfaces = typeParamBinding.superInterfaces();
-
-					CtTypeReference refSuperClass = null;
-
-					// if the type parameter has a super class other than java.lang.Object, we get it
-					// superClass.superclass() is null if it's java.lang.Object
-					if (superClass != null && !(superClass.superclass() == null)) {
-
-						// this case could happen with Enum<E extends Enum<E>> for example:
-						// in that case we only want to have E -> Enum -> E
-						// to conserve the same behavior as JavaReflectionTreeBuilder
-						if (!(superClass instanceof ParameterizedTypeBinding) || !this.exploringParameterizedBindings.containsKey(superClass)) {
-							refSuperClass = this.getTypeReference(superClass, resolveGeneric);
-						}
-
-					// if the type parameter has a super interface, then we'll get it too, as a superclass
-					// type parameter can only extends an interface or a class, so we don't make the distinction
-					// in Spoon. Moreover we can only have one extends in a type parameter.
-					} else if (superInterfaces != null && superInterfaces.length == 1) {
-						refSuperClass = this.getTypeReference(superInterfaces[0], resolveGeneric);
-					}
-					if (refSuperClass == null) {
-						refSuperClass = this.jdtTreeBuilder.getFactory().Type().getDefaultBoundingType();
-					}
-					ref = refSuperClass.clone();
-				} else {
-					ref = this.jdtTreeBuilder.getFactory().Core().createTypeParameterReference();
-					ref.setSimpleName(new String(binding.sourceName()));
-				}
-			}
-			TypeVariableBinding b = (TypeVariableBinding) binding;
-			if (bounds) {
-				if (b instanceof CaptureBinding && ((CaptureBinding) b).wildcard != null) {
-					bounds = oldBounds;
-					return getTypeReference(((CaptureBinding) b).wildcard, resolveGeneric);
-				} else if (b.superclass != null && b.firstBound == b.superclass) {
-					bounds = false;
-					bindingCache.put(binding, ref);
-					if (ref instanceof CtWildcardReference) {
-						((CtWildcardReference) ref).setBoundingType(getTypeReference(b.superclass, resolveGeneric));
-					}
-					bounds = oldBounds;
-				}
-			}
-			if (bounds && b.superInterfaces != null && b.superInterfaces != Binding.NO_SUPERINTERFACES) {
-				bindingCache.put(binding, ref);
-				List<CtTypeReference<?>> bounds = new ArrayList<>();
-				CtTypeParameterReference typeParameterReference = (CtTypeParameterReference) ref;
-				if (!(typeParameterReference.isDefaultBoundingType())) { // if it's object we can ignore it
-					bounds.add(typeParameterReference.getBoundingType());
-				}
-				for (ReferenceBinding superInterface : b.superInterfaces) {
-					bounds.add(getTypeReference(superInterface, resolveGeneric));
-				}
-				if (ref instanceof CtWildcardReference) {
-					((CtWildcardReference) ref).setBoundingType(this.jdtTreeBuilder.getFactory().Type().createIntersectionTypeReferenceWithBounds(bounds));
-				}
-			}
-			if (binding instanceof CaptureBinding) {
-				bounds = false;
-			}
+		    ref = getTypeReferenceFromTypeVariableBinding((TypeVariableBinding) binding, resolveGeneric);
 		} else if (binding instanceof BaseTypeBinding) {
 			ref = getTypeReferenceFromBaseTypeBinding((BaseTypeBinding) binding);
 		} else if (binding instanceof WildcardBinding) {
@@ -957,6 +886,84 @@ public class ReferenceBuilder {
 			ref.setPackage(packageReference);
 		}
 		ref.setSimpleName(new String(binding.sourceName()));
+
+		return ref;
+	}
+
+	private CtTypeReference<?> getTypeReferenceFromTypeVariableBinding(TypeVariableBinding binding, boolean resolveGeneric) {
+		boolean oldBounds = bounds;
+		CtTypeReference<?> ref;
+
+		if (binding instanceof CaptureBinding) {
+			ref = this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
+			bounds = true;
+		} else {
+			TypeVariableBinding typeParamBinding = (TypeVariableBinding) binding;
+			if (resolveGeneric) {
+				//it is called e.g. by ExecutableReference, which must not use CtParameterTypeReference
+				//but it needs it's bounding type instead
+				ReferenceBinding superClass = typeParamBinding.superclass;
+				ReferenceBinding[] superInterfaces = typeParamBinding.superInterfaces();
+
+				CtTypeReference refSuperClass = null;
+
+				// if the type parameter has a super class other than java.lang.Object, we get it
+				// superClass.superclass() is null if it's java.lang.Object
+				if (superClass != null && !(superClass.superclass() == null)) {
+
+					// this case could happen with Enum<E extends Enum<E>> for example:
+					// in that case we only want to have E -> Enum -> E
+					// to conserve the same behavior as JavaReflectionTreeBuilder
+					if (!(superClass instanceof ParameterizedTypeBinding) || !this.exploringParameterizedBindings.containsKey(superClass)) {
+						refSuperClass = this.getTypeReference(superClass, resolveGeneric);
+					}
+
+					// if the type parameter has a super interface, then we'll get it too, as a superclass
+					// type parameter can only extends an interface or a class, so we don't make the distinction
+					// in Spoon. Moreover we can only have one extends in a type parameter.
+				} else if (superInterfaces != null && superInterfaces.length == 1) {
+					refSuperClass = this.getTypeReference(superInterfaces[0], resolveGeneric);
+				}
+				if (refSuperClass == null) {
+					refSuperClass = this.jdtTreeBuilder.getFactory().Type().getDefaultBoundingType();
+				}
+				ref = refSuperClass.clone();
+			} else {
+				ref = this.jdtTreeBuilder.getFactory().Core().createTypeParameterReference();
+				ref.setSimpleName(new String(binding.sourceName()));
+			}
+		}
+		TypeVariableBinding b = (TypeVariableBinding) binding;
+		if (bounds) {
+			if (b instanceof CaptureBinding && ((CaptureBinding) b).wildcard != null) {
+				bounds = oldBounds;
+				return getTypeReference(((CaptureBinding) b).wildcard, resolveGeneric);
+			} else if (b.superclass != null && b.firstBound == b.superclass) {
+				bounds = false;
+				bindingCache.put(binding, ref);
+				if (ref instanceof CtWildcardReference) {
+					((CtWildcardReference) ref).setBoundingType(getTypeReference(b.superclass, resolveGeneric));
+				}
+				bounds = oldBounds;
+			}
+		}
+		if (bounds && b.superInterfaces != null && b.superInterfaces != Binding.NO_SUPERINTERFACES) {
+			bindingCache.put(binding, ref);
+			List<CtTypeReference<?>> bounds = new ArrayList<>();
+			CtTypeParameterReference typeParameterReference = (CtTypeParameterReference) ref;
+			if (!(typeParameterReference.isDefaultBoundingType())) { // if it's object we can ignore it
+				bounds.add(typeParameterReference.getBoundingType());
+			}
+			for (ReferenceBinding superInterface : b.superInterfaces) {
+				bounds.add(getTypeReference(superInterface, resolveGeneric));
+			}
+			if (ref instanceof CtWildcardReference) {
+				((CtWildcardReference) ref).setBoundingType(this.jdtTreeBuilder.getFactory().Type().createIntersectionTypeReferenceWithBounds(bounds));
+			}
+		}
+		if (binding instanceof CaptureBinding) {
+			bounds = false;
+		}
 
 		return ref;
 	}


### PR DESCRIPTION
#3965 

Extracts getting a type reference from a TypeVariableBinding into a separate method. This is pretty incredibly complicated, so I aim to also simplify the process.

This is the final significant PR in refactoring `ReferenceBuilder.getTypeReference`, but I intend to do one final PR after this to slightly refactor the top-level method. Then I'm happy.

UPDATE: I've now finished this refactoring. It was _hard_, it took me several hours to sort out which part was doing what. In the end, I managed to significantly flatten the structure, and even remove the `bounds` field entirely (which I initially had a really hard time understanding the purpose of). Note that I didn't put it in a local variable instead, the value just isn't needed anymore.

On a side note, I'm really proud of the fact that I extracted the building of a type reference from a type variable binding into six methods, yet only increased the line count by 3 lines :)