### PR TITLE
review: test: add test for SubstituionInsertAllNestedTypes

### DIFF
--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -53,7 +53,7 @@ public class SubstitutionTest {
     }
 
     @Test
-    public void testSubstitutionInsertAllNestedTypes() {
+    public void testInsertAllNestedTypes() {
         // contract: Substitution.insertAllNestedTypes inserts the only nested class from a singly nested template into the target class
 
         // arrange

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -5,14 +5,10 @@ import spoon.Launcher;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.FileSystemFile;
-import spoon.support.reflect.declaration.CtTypeImpl;
 import spoon.template.StatementTemplate;
 import spoon.template.Substitution;
 
-import java.lang.annotation.Annotation;
 import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -71,6 +67,7 @@ public class SubstitutionTest {
 
         // assert
         assertEquals(1, targetType.getNestedTypes().size());
+        assertEquals("nestedClass", targetType.getNestedType("nestedClass").getSimpleName());
     }
 
     private static class SinglyNestedTemplate extends StatementTemplate {

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -75,16 +75,7 @@ public class SubstitutionTest {
 
     private static class SinglyNestedTemplate extends StatementTemplate {
 
-        public class nestedClass<T extends Annotation> extends CtTypeImpl<T> {
-
-            @Override
-            public boolean isSubtypeOf(CtTypeReference<?> type) {
-                return false;
-            }
-
-            @Override
-            public void accept(CtVisitor visitor) {
-            }
+        class nestedClass {
         }
 
         @Override


### PR DESCRIPTION
#1818

Hi, I have added a new test for `insertAllNestedFilelds` method of the `Substitution` class, this test improves code coverage, mutation converge and test strength all from 0% to 100%.

Here's the report before improvement.

<img width="1110" alt="Screenshot 2021-06-21 at 5 12 48 PM" src="https://user-images.githubusercontent.com/62026125/122756334-ea7d6f00-d2b3-11eb-9972-facc997dac6e.png">

The exception added in this test, is able to kill the mutation but, probably isn't the strongest assertion, I wan't able to make it stronger.