### PR TITLE
review: test: add test for Substitution.insertAllConstructors

### DIFF
--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -2,6 +2,7 @@ package spoon.test.template;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -10,8 +11,10 @@ import spoon.template.StatementTemplate;
 import spoon.template.Substitution;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SubstitutionTest {
 
@@ -74,6 +77,38 @@ public class SubstitutionTest {
 
         class nestedClass {
         }
+
+        @Override
+        public void statement() {
+        }
+    }
+
+    @Test
+    public void testInsertAllConstructor() {
+        // contract: Substitution.insertAllConstructor inserts the only constructor from a single constructor template into the target class
+
+        // arrange
+        Launcher spoon = new Launcher();
+        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
+
+        spoon.buildModel();
+        Factory factory = spoon.getFactory();
+
+        CtType<?> targetType = factory.Class().create("goodClass");
+        StatementTemplate template = new SingleConstructorTemplate();
+
+        // act
+        Substitution.insertAllConstructors(targetType, template);
+        List<?> typeMembers = targetType.getTypeMembers();
+
+        // assert
+        assertEquals(1, typeMembers.size());
+        assertTrue(typeMembers.get(0) instanceof CtConstructor);
+    }
+
+    private static class SingleConstructorTemplate extends StatementTemplate {
+
+        public SingleConstructorTemplate() { }
 
         @Override
         public void statement() {


### PR DESCRIPTION
#1818

Hi, I have added a new test for `insertAllConstructor` method of the `Substitution` class, following are the features of this test:

1) This new test is killing this mutation : 

<img width="1114" alt="Screenshot 2021-06-24 at 3 42 23 PM" src="https://user-images.githubusercontent.com/62026125/123245778-c794ca00-d502-11eb-9d56-e7a96e86155f.png">

2) This method had some code coverage but, the test strength and mutation coverage was zero, now code coverage has improved and the mutation has been killed by this new test.

<img width="1411" alt="Screenshot 2021-06-24 at 3 43 44 PM" src="https://user-images.githubusercontent.com/62026125/123245990-f874ff00-d502-11eb-959c-77c0c95aa186.png">

3)  this test improves code coverage, mutation converge and test strength all from 0% to 100% for `insertConstructor` method.

<img width="1366" alt="Screenshot 2021-06-24 at 3 49 39 PM" src="https://user-images.githubusercontent.com/62026125/123246776-cadc8580-d503-11eb-9a2b-e403555190c1.png">

Link to #3967