### PR TITLE
review: test: add tests for the SpoonTreeBuilder class

### DIFF
--- a/src/test/java/spoon/support/gui/SpoonTreeBuilderTest.java
+++ b/src/test/java/spoon/support/gui/SpoonTreeBuilderTest.java
@@ -1,0 +1,53 @@
+package spoon.support.gui;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.factory.Factory;
+import spoon.support.reflect.declaration.CtClassImpl;
+
+import javax.swing.tree.DefaultMutableTreeNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpoonTreeBuilderTest {
+    Launcher spoon;
+    Factory factory;
+    SpoonTreeBuilder spoonTreeBuilder;
+
+    @BeforeEach
+    public void setUp() {
+        spoon = new Launcher();
+        spoon.buildModel();
+        factory = spoon.getFactory();
+
+        spoonTreeBuilder = new SpoonTreeBuilder();
+    }
+
+    @Test
+    public void testEnter() {
+        // contract : SpoonTreeBuilder.enter creates a node for the entered element while entering the scanner
+
+        CtClass<?> testClass = factory.Class().create("testClass");
+
+        spoonTreeBuilder.enter(testClass);
+        DefaultMutableTreeNode node = spoonTreeBuilder.nodes.peek();
+
+        assertEquals("testClass", ((CtClassImpl<?>) node.getUserObject()).getSimpleName());
+    }
+
+    @Test
+    public void testExit() {
+        // contract : SpoonTreeBuilder.exit creates removes the node for the current element while exiting the scanner
+
+        CtClass<?> testClass = factory.Class().create("testClass");
+
+        spoonTreeBuilder.enter(testClass);
+        DefaultMutableTreeNode node = spoonTreeBuilder.nodes.peek();
+        spoonTreeBuilder.exit(testClass);
+
+        assertNotEquals(node, spoonTreeBuilder.nodes.peek());
+    }
+}

--- a/src/test/java/spoon/support/gui/SpoonTreeBuilderTest.java
+++ b/src/test/java/spoon/support/gui/SpoonTreeBuilderTest.java
@@ -40,7 +40,7 @@ class SpoonTreeBuilderTest {
 
     @Test
     public void testExit() {
-        // contract : SpoonTreeBuilder.exit creates removes the node for the current element while exiting the scanner
+        // contract : SpoonTreeBuilder.exit removes the node for the current element while exiting the scanner
 
         CtClass<?> testClass = factory.Class().create("testClass");
 


### PR DESCRIPTION
#1818

Hi, I have created a new class `SpoonTreeBuilderTest` for the `SpoonTreeBuilder` class, as per Descartes's report the testing for this class was zero in all parameters hence tests were to be written from scratch.

Report before these tests : 

![Screen Shot 2021-06-26 at 23 01 07-fullpage](https://user-images.githubusercontent.com/62026125/123521137-69b6dc80-d6d2-11eb-8866-f24a27a95521.png)


These tests improve the line coverage from 0 to 60% and improve mutation coverage and strength to 60% as well.

There are testing methods `enter`, `exit`, `create` node.

Link to #3967