### PR TITLE
review: test: Migrate support and testing tests to Junit5

### DIFF
--- a/src/test/java/spoon/support/compiler/SpoonPomTest.java
+++ b/src/test/java/spoon/support/compiler/SpoonPomTest.java
@@ -1,7 +1,7 @@
 package spoon.support.compiler;
 
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.MavenLauncher;
 import spoon.support.StandardEnvironment;
 
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.nio.file.Paths;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SpoonPomTest {
 

--- a/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
+++ b/src/test/java/spoon/support/compiler/classpath/ComputeClasspathTest.java
@@ -16,8 +16,8 @@
  */
 package spoon.support.compiler.classpath;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.builder.ClasspathOptions;
@@ -26,7 +26,7 @@ import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ComputeClasspathTest {
 
@@ -45,7 +45,7 @@ public class ComputeClasspathTest {
 
 	private String[] systemClasspath;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		Launcher launcher = new Launcher() {
 

--- a/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/ExtendedStringLiteralTest.java
@@ -16,12 +16,12 @@
  */
 package spoon.support.compiler.jdt;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;

--- a/src/test/java/spoon/support/compiler/jdt/JDTBasedSpoonCompilerTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBasedSpoonCompilerTest.java
@@ -17,12 +17,12 @@
 package spoon.support.compiler.jdt;
 
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JDTBasedSpoonCompilerTest {
 
@@ -44,7 +44,7 @@ public class JDTBasedSpoonCompilerTest {
 				String filenameCu0 = new String(cu0.getFileName());
 				String filenameCu1 = new String(cu1.getFileName());
 
-				assertTrue("There is a sort error: " + filenameCu0 + " should be before " + filenameCu1, filenameCu0.compareTo(filenameCu1) < 0);
+				assertTrue(filenameCu0.compareTo(filenameCu1) < 0, "There is a sort error: " + filenameCu0 + " should be before " + filenameCu1);
 			}
 		}
 	}

--- a/src/test/java/spoon/support/compiler/jdt/JDTBatchCompilerTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBatchCompilerTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import java.io.File;

--- a/src/test/java/spoon/support/compiler/jdt/JDTBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBuilderTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.compiler.builder.AdvancedOptions;
 import spoon.compiler.builder.AnnotationProcessingOptions;
 import spoon.compiler.builder.ClasspathOptions;
@@ -26,7 +26,7 @@ import spoon.compiler.builder.SourceOptions;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JDTBuilderTest {
 	private static final String TEST_CLASSPATH = "./src/test/java/spoon/test/";

--- a/src/test/java/spoon/support/compiler/jdt/JDTImportBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTImportBuilderTest.java
@@ -1,7 +1,7 @@
 package spoon.support.compiler.jdt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -17,8 +17,8 @@ import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -55,7 +55,7 @@ public class JDTImportBuilderTest {
 
 	private List<ImportReference> imports = new ArrayList<>();
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 

--- a/src/test/java/spoon/support/util/QualifiedNameBasedSortedSetTest.java
+++ b/src/test/java/spoon/support/util/QualifiedNameBasedSortedSetTest.java
@@ -1,6 +1,6 @@
 package spoon.support.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtType;
@@ -14,9 +14,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QualifiedNameBasedSortedSetTest {
     @Test

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -17,7 +17,7 @@
 package spoon.support.visitor.java;
 
 import com.mysema.query.support.ProjectableQuery;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.metamodel.MetamodelConcept;
@@ -83,12 +83,12 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class JavaReflectionTreeBuilderTest {
@@ -208,7 +208,7 @@ public class JavaReflectionTreeBuilderTest {
 			allProblems.addAll(checkShadowTypeIsEqual(concept.getImplementationClass()));
 			allProblems.addAll(checkShadowTypeIsEqual(concept.getMetamodelInterface()));
 		}
-		assertTrue("Found " + allProblems.size() + " problems:\n" + String.join("\n", allProblems), allProblems.isEmpty());
+		assertTrue(allProblems.isEmpty(), "Found " + allProblems.size() + " problems:\n" + String.join("\n", allProblems));
 	}
 
 	private List<String> checkShadowTypeIsEqual(CtType<?> type) {
@@ -501,11 +501,11 @@ public class JavaReflectionTreeBuilderTest {
 		CtTypeReference<?> aTypeRef = typeFactory.createReference(CtExpression.class);
 		CtType aType = aTypeRef.getTypeDeclaration();
 		for (CtTypeReference<?> ifaceRef : aType.getSuperInterfaces()) {
-			assertNotNull(ifaceRef.getQualifiedName() + " doesn't exist?", ifaceRef.getActualClass());
+			assertNotNull(ifaceRef.getActualClass(), ifaceRef.getQualifiedName() + " doesn't exist?");
 			assertSame(aType, ifaceRef.getParent());
 		}
 		for (CtTypeReference<?> ifaceRef : aTypeRef.getSuperInterfaces()) {
-			assertNotNull(ifaceRef.getQualifiedName() + " doesn't exist?", ifaceRef.getActualClass());
+			assertNotNull(ifaceRef.getActualClass(), ifaceRef.getQualifiedName() + " doesn't exist?");
 			assertSame(aType, ifaceRef.getParent());
 		}
 	}

--- a/src/test/java/spoon/testing/AbstractAssertTest.java
+++ b/src/test/java/spoon/testing/AbstractAssertTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.testing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;

--- a/src/test/java/spoon/testing/CtElementAssertTest.java
+++ b/src/test/java/spoon/testing/CtElementAssertTest.java
@@ -16,13 +16,14 @@
  */
 package spoon.testing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.buildNoClasspath;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -48,23 +49,23 @@ public class CtElementAssertTest {
 		assertThat(type.getField("i")).isEqualTo("public int i;");
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualityBetweenTwoCtElementWithTypeDifferent() {
-		assertThat(createFactory().Core().createAnnotation()).isEqualTo(createFactory().Core().createBlock());
+		assertThrows(AssertionError.class, ()-> assertThat(createFactory().Core().createAnnotation()).isEqualTo(createFactory().Core().createBlock()));
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualityBetweenTwoCtElementWithTheSameSignatureButNotTheSameContent() throws Exception {
-		assertThat(buildNoClasspath(CtElementAssertTest.class).Type().get(CtElementAssertTest.class)).isEqualTo(createFactory().Class().create(CtElementAssertTest.class.getName()));
+		assertThrows(AssertionError.class, ()-> assertThat(buildNoClasspath(CtElementAssertTest.class).Type().get(CtElementAssertTest.class)).isEqualTo(createFactory().Class().create(CtElementAssertTest.class.getName())));
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualityBetweenTwoDifferentCtElement() throws Exception {
 		class String {
 		}
 		final Factory build = buildNoClasspath(CtElementAssertTest.class);
 		final CtFieldAccess<Class<String>> actual = build.Code().createClassAccess(build.Type().<String>get(String.class).getReference());
 		final CtFieldAccess<Class<java.lang.String>> expected = createFactory().Code().createClassAccess(createFactory().Type().STRING);
-		assertThat(actual).isEqualTo(expected);
+		assertThrows(AssertionError.class, ()-> assertThat(actual).isEqualTo(expected));
 	}
 }

--- a/src/test/java/spoon/testing/CtPackageAssertTest.java
+++ b/src/test/java/spoon/testing/CtPackageAssertTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.testing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtClass;
@@ -29,10 +29,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import java.io.File;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.*;
 import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -55,17 +52,17 @@ public class CtPackageAssertTest {
 		assertThat(aRootPackage2).isEqualTo(aRootPackage);
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualityBetweenTwoDifferentCtPackage() {
-		assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(createFactory().Package().getOrCreate("another.package"));
+		assertThrows(AssertionError.class, ()-> assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(createFactory().Package().getOrCreate("another.package")));
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualityBetweenTwoCtPackageWithDifferentTypes() {
 		final Factory factory = createFactory();
 		final CtPackage aRootPackage = factory.Package().getOrCreate("");
 		factory.Class().create("spoon.testing.testclasses.Foo").addModifier(ModifierKind.PUBLIC);
-		assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(aRootPackage);
+		assertThrows(AssertionError.class, ()->assertThat(build(new File("./src/test/java/spoon/testing/testclasses/")).Package().getRootPackage()).isEqualTo(aRootPackage));
 	}
 
 	@Test

--- a/src/test/java/spoon/testing/FileAssertTest.java
+++ b/src/test/java/spoon/testing/FileAssertTest.java
@@ -16,8 +16,9 @@
  */
 package spoon.testing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static spoon.testing.Assert.assertThat;
 
 public class FileAssertTest {
@@ -29,8 +30,8 @@ public class FileAssertTest {
 		assertThat(actual).isEqualTo(actual);
 	}
 
-	@Test(expected = AssertionError.class)
+	@Test
 	public void testEqualsBetweenTwoDifferentFile() {
-		assertThat(PATH + "Foo.java").isEqualTo(PATH + "Bar.java");
+		assertThrows(AssertionError.class, ()-> assertThat(PATH + "Foo.java").isEqualTo(PATH + "Bar.java"));
 	}
 }


### PR DESCRIPTION
#3919

While waiting for review on #4005 and #4006, I thought it will be nice to finish up the migration of the spoon.support.

Migration of testing tests is important because I will later work on it in the latter weeks plus, tests in the testing package can't be migrated automatically or by some tool, somebody needs to migrate them manually.

This PR just involves these two types of changes:

 1)   changing imports

  2)  In Junit5, assertThrows have been introduced so `@Test(expected = IndexOutOfBoundsException.class)` isn't supported anymore.
