### PR TITLE
Review: bug: NPE while querying sneaky throws

### DIFF
--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -171,6 +171,9 @@ public class MethodTypingContext extends AbstractTypingContext {
 	 */
 	@Override
 	protected CtTypeReference<?> adaptTypeParameter(CtTypeParameter typeParam) {
+		if (typeParam == null) {
+			return null;
+		}
 		CtFormalTypeDeclarer typeParamDeclarer = typeParam.getTypeParameterDeclarer();
 		if (typeParamDeclarer instanceof CtType<?>) {
 			return getEnclosingGenericTypeAdapter().adaptType(typeParam);

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -266,5 +267,14 @@ public class CtTypeTest {
 		CtType<?> reFetchedTypeDecl = typeRef.getTypeDeclaration();
 
 		assertSame(reFetchedTypeDecl, typeDecl);
+	}
+	@Test
+	public void testSneakyThrowsInSubClasses() {
+		// contract: Sneaky throws doesn't crash spoons method return type resolution.
+		// see e.g https://projectlombok.org/features/SneakyThrows for explanation
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/npe");
+		CtModel model = launcher.buildModel();
+		assertDoesNotThrow(() -> model.getAllTypes().stream().forEach(CtType::getAllExecutables));
 	}
 }

--- a/src/test/resources/npe/Hm.java
+++ b/src/test/resources/npe/Hm.java
@@ -1,0 +1,8 @@
+package npe;
+
+public class Hm extends SneakyCrashy {
+
+  public void foo() {
+
+  }
+}

--- a/src/test/resources/npe/Hm.java
+++ b/src/test/resources/npe/Hm.java
@@ -1,8 +1,0 @@
-package npe;
-
-public class Hm extends SneakyCrashy {
-
-  public void foo() {
-
-  }
-}

--- a/src/test/resources/npe/SneakyCrashy.java
+++ b/src/test/resources/npe/SneakyCrashy.java
@@ -1,0 +1,13 @@
+package npe;
+
+public class SneakyCrashy {
+
+  @SuppressWarnings("unchecked")
+  public static <T extends Throwable> void uncheckedThrow(Throwable t) throws T {
+    if (t != null)
+      throw (T)t; // rely on vacuous cast
+    else
+      throw new Error("Unknown Exception");
+  }
+
+}

--- a/src/test/resources/npe/SneakyCrashy.java
+++ b/src/test/resources/npe/SneakyCrashy.java
@@ -1,13 +1,5 @@
 package npe;
 
-public class SneakyCrashy {
-
-  @SuppressWarnings("unchecked")
-  public static <T extends Throwable> void uncheckedThrow(Throwable t) throws T {
-    if (t != null)
-      throw (T)t; // rely on vacuous cast
-    else
-      throw new Error("Unknown Exception");
-  }
-
+public interface SneakyCrashy {
+  <T extends Throwable> void sneakyThrows() throws T;
 }

--- a/src/test/resources/npe/SneakySubclass.java
+++ b/src/test/resources/npe/SneakySubclass.java
@@ -1,0 +1,5 @@
+package npe;
+
+public interface SneakySubclass extends SneakyCrashy {
+  void iForceTypeAdaption();
+}


### PR DESCRIPTION
This PR fixes the `CtType#getAllExecutable` method for so called sneaky throws constructs.