### PR TITLE
review: refactor: reference comparison between List and Set

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -40,9 +40,6 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 			this.bounds = CtElementImpl.emptyList();
 			return (C) this;
 		}
-		if (this.bounds == CtElementImpl.<CtTypeReference<?>>emptySet()) {
-			this.bounds = new ArrayList<>();
-		}
 		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, BOUND, this.bounds, new ArrayList<>(this.bounds));
 		this.bounds.clear();
 		for (CtTypeReference<?> bound : bounds) {


### PR DESCRIPTION
When the underlying data structure in CtIntersectionTypeReferenceImpl was changed (#659), one reference check wasn't changed. From what I've seen that didn't introduce any behavioral changes other than the parameters passed to `onListDeleteAll`. 

I didn't find any contracts for that method, that's why I consider it to be a refactoring instead of a bug fix. If that's wrong, please let me know.