### PR TITLE
reveiw: test: add test for Substituion.insertAllSuperInterfaces

### DIFF
--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -25,11 +25,7 @@ public class SubstitutionTest {
         // contract: Substitution.insertAllFields inserts the only field from a single-field template into the target class
 
         // arrange
-        Launcher spoon = new Launcher();
-        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
-
-        spoon.buildModel();
-        Factory factory = spoon.getFactory();
+        Factory factory = createFactoryWithTemplates();
 
         CtField<String> expectedField = factory.createField();
         expectedField.setSimpleName("testString");
@@ -58,12 +54,7 @@ public class SubstitutionTest {
         // contract: Substitution.insertAllNestedTypes inserts the only nested class from a singly nested template into the target class
 
         // arrange
-        Launcher spoon = new Launcher();
-        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
-
-        spoon.buildModel();
-        Factory factory = spoon.getFactory();
-
+        Factory factory = createFactoryWithTemplates();
         CtType<?> targetType = factory.Class().create("goodClass");
         StatementTemplate template = new SinglyNestedTemplate();
 
@@ -90,12 +81,7 @@ public class SubstitutionTest {
         // contract: Substitution.insertAllConstructor inserts the only constructor from a single constructor template into the target class
 
         // arrange
-        Launcher spoon = new Launcher();
-        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
-
-        spoon.buildModel();
-        Factory factory = spoon.getFactory();
-
+        Factory factory = createFactoryWithTemplates();
         CtType<?> targetType = factory.Class().create("goodClass");
         StatementTemplate template = new SingleConstructorTemplate();
 
@@ -122,12 +108,7 @@ public class SubstitutionTest {
         // contract: Substitution.insertAllSuperInterfaces inserts the only superInterface from a single interface implementing template into the target class
 
         // arrange
-        Launcher spoon = new Launcher();
-        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
-
-        spoon.buildModel();
-        Factory factory = spoon.getFactory();
-
+        Factory factory = createFactoryWithTemplates();
         CtType<?> targetType = factory.Class().create("goodClass");
         StatementTemplate template = new SingleInterfaceImplementingTemplate();
 
@@ -148,4 +129,11 @@ public class SubstitutionTest {
     }
 
     private interface A { }
+
+    private static Factory createFactoryWithTemplates() {
+        Launcher spoon = new Launcher();
+        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
+        spoon.buildModel();
+        return spoon.getFactory();
+    }
 }

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -6,10 +6,12 @@ import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.support.compiler.FileSystemFile;
 import spoon.template.StatementTemplate;
 import spoon.template.Substitution;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -114,4 +116,36 @@ public class SubstitutionTest {
         public void statement() {
         }
     }
+
+    @Test
+    public void testInsertAllSuperInterfaces() {
+        // contract: Substitution.insertAllSuperInterfaces inserts the only superInterface from a single interface implementing template into the target class
+
+        // arrange
+        Launcher spoon = new Launcher();
+        spoon.addTemplateResource(new FileSystemFile("./src/test/java/spoon/test/template/SubstitutionTest.java"));
+
+        spoon.buildModel();
+        Factory factory = spoon.getFactory();
+
+        CtType<?> targetType = factory.Class().create("goodClass");
+        StatementTemplate template = new SingleInterfaceImplementingTemplate();
+
+        // act
+        Substitution.insertAllSuperInterfaces(targetType, template);
+        List<CtTypeReference> superInterfaces = new ArrayList<>(targetType.getSuperInterfaces());
+
+        // assert
+        assertEquals(1, superInterfaces.size());
+        assertTrue(superInterfaces.get(0).isInterface());
+        assertEquals("A", superInterfaces.get(0).getSimpleName());
+    }
+
+    private static class SingleInterfaceImplementingTemplate extends StatementTemplate implements A {
+
+        @Override
+        public void statement() { }
+    }
+
+    private interface A { }
 }


### PR DESCRIPTION
#1818

Hi, I have added a new test for `insertAllSuperInterfaces` method of the `Substitution` class, following are the features of this test:

1) The test kills this mutation

![Screenshot 2021-06-28 at 2 20 29 PM](https://user-images.githubusercontent.com/62026125/123607989-ffaa4e80-d81b-11eb-9ce5-37b172ef1025.png)

2) It is killing this mutation as well

![Screenshot 2021-06-28 at 2 21 23 PM](https://user-images.githubusercontent.com/62026125/123608132-1f417700-d81c-11eb-9958-5ac08d645aa0.png)

Link to #3967