### PR TITLE
doc: Add note in CONTRIBUTING.md about force-pushing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,9 @@ Guidelines for all pull-requests:
   * The pull-request title starts with a prefix stating its kind: "fix:", "feature:", "refactor:", "perf:", "checkstyle:"
   * Pull-requests that are in progress are prefixed by "WIP".
   * Pull-requests that are ready for review are prefixed by "review", or labeled as "[review](https://github.com/INRIA/spoon/labels/review)".
+* **Avoid force-pushing** after you have marked your PR as ready for review or have received any form of feedback on your PR.
+  * While a clean and clear commit history can help in reviewing a PR, it's confusing for reviewers to have previously reviewed commits disappear.
+  * It's OK to force-push to WIP PRs as long as you are not collaborating with anyone.
 * **Your contribution is highly welcome**! If you have anything interesting, then we welcome your PR even if it is not perfect at the beginning. The Spoon community will help you to fix the remaining problems, if any.;-)
   
 Guidelines for bug-fix pull-requests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Guidelines for all pull-requests:
   * Pull-requests that are ready for review are prefixed by "review", or labeled as "[review](https://github.com/INRIA/spoon/labels/review)".
 * **Avoid force-pushing** after you have marked your PR as ready for review or have received any form of feedback on your PR.
   * While a clean and clear commit history can help in reviewing a PR, it's confusing for reviewers to have previously reviewed commits disappear.
+  * Note that PRs are squashed. Don't worry if the commit history becomes a bit convoluted as you iterate on the PR after receiving feedback.
   * It's OK to force-push to WIP PRs as long as you are not collaborating with anyone.
 * **Your contribution is highly welcome**! If you have anything interesting, then we welcome your PR even if it is not perfect at the beginning. The Spoon community will help you to fix the remaining problems, if any.;-)
   


### PR DESCRIPTION
IMO it's pretty confusing to leave feedback on a PR, and then have the author of that PR force-push changes to it such that the parts that were reviewed are no longer even part of the PRs commit history.

This PR adds a note to the CONTRIBUTING.md about avoiding force-pushing when collaborating on a PR (e.g. after receiving a review).

@monperrus @nharrand Thoughts on the general idea and potentially the phrasing in the docs?