### PR TITLE
review: test: add tests for substitution class

### DIFF
--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -8,10 +8,9 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.CtVisitor;
 import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
-import spoon.support.reflect.code.CtExpressionImpl;
+import spoon.support.reflect.code.CtLiteralImpl;
 import spoon.template.*;
 import spoon.test.template.testclasses.types.AClassModel;
 import spoon.test.template.testclasses.types.AnEnumModel;
@@ -220,15 +219,15 @@ public class SubstitutionTest {
         CtClass<?> targetClass = factory.Class().create("TargetClass");
 
         String templateExecutableName = "executable";
-        String templateVariableName = "x";
-        int initializerToSubstitute = 20;
+        String templateVariableName = "s";
+        String initializerToSubstitute = "My chosen initializer";
         CtStatement expectedStatement = factory.createLocalVariable(
-                factory.Type().integerType(), templateVariableName, factory.createLiteral(initializerToSubstitute)
+                factory.Type().stringType(), templateVariableName, factory.createLiteral(initializerToSubstitute)
         );
         final CtBlock<?> expectedMethodBody = factory.Code().createCtBlock(expectedStatement);
 
-        BodyWithTemplatedInitializer template = new BodyWithTemplatedInitializer();
-        template._initializer_ = initializerToSubstitute;
+        StatementWithTemplatedInitializer template = new StatementWithTemplatedInitializer();
+        template._initializer_ = factory.createLiteral(initializerToSubstitute);
 
         // act
         CtBlock<?> substitutedMethodBody = Substitution.substituteMethodBody(
@@ -237,15 +236,6 @@ public class SubstitutionTest {
 
         // assert
         assertEquals(expectedMethodBody, substitutedMethodBody);
-    }
-
-    private static class BodyWithTemplatedInitializer extends ExtensionTemplate {
-        @Parameter
-        Integer _initializer_;
-
-        public void executable() {
-            Integer x = _initializer_;
-        }
     }
 
     @Test
@@ -299,7 +289,7 @@ public class SubstitutionTest {
         String templateFieldName = "s";
         CtExpression<String> expectedExpression =  factory.createLiteral(initializerToSubstitute);
 
-        ExpressionWithTemplatedInitializer template = new ExpressionWithTemplatedInitializer();
+        FieldWithTemplatedInitializer template = new FieldWithTemplatedInitializer();
         template._initializer_ = factory.createLiteral(initializerToSubstitute);
 
         // act

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -311,7 +311,7 @@ public class SubstitutionTest {
         assertEquals(expectedExpression, substitutedExpression);
     }
 
-    private static class ExpressionWithTemplatedInitializer extends ExtensionTemplate {
+    private static class FieldWithTemplatedInitializer extends ExtensionTemplate {
         TemplateParameter<String> _initializer_ = new CtLiteralImpl<>();
         String s = _initializer_.S();
     }

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -297,10 +297,10 @@ public class SubstitutionTest {
 
         String initializerToSubstitute = "My chosen initializer";
         String templateFieldName = "s";
-        CtExpression expectedExpression =  factory.createCodeSnippetExpression(initializerToSubstitute);
+        CtExpression<String> expectedExpression =  factory.createLiteral(initializerToSubstitute);
 
         ExpressionWithTemplatedInitializer template = new ExpressionWithTemplatedInitializer();
-        template._initializer_ = factory.createCodeSnippetExpression(initializerToSubstitute);
+        template._initializer_ = factory.createLiteral(initializerToSubstitute);
 
         // act
         CtExpression<?> substitutedExpression = Substitution.substituteFieldDefaultExpression(

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -312,12 +312,8 @@ public class SubstitutionTest {
     }
 
     private static class ExpressionWithTemplatedInitializer extends ExtensionTemplate {
-        @Parameter
-        CtExpression _initializer_ = new CtExpressionImpl() {
-            @Override
-            public void accept(CtVisitor visitor) { }
-        };
-        String s = (String) _initializer_.S();
+        TemplateParameter<String> _initializer_ = new CtLiteralImpl<>();
+        String s = _initializer_.S();
     }
 
     private static Factory createFactoryWithTemplates() {

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -2,6 +2,9 @@ package spoon.test.template;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
@@ -204,6 +207,61 @@ public class SubstitutionTest {
 
         @Override
         public void statement()  { }
+    }
+
+    @Test
+    public void testSubstituteMethodBody() {
+        // contract: Substitution.SubstituteMethodBody gets a body from a template consisting of an executable with single statement
+
+        // arrange
+        Factory factory = createFactoryWithTemplates();
+        CtClass<?> targetClass = factory.Class().create("testClass");
+        StatementTemplate template = new executableWithSingleStatementTemplate();
+
+        // act
+        CtBlock<?> ctBlock = Substitution.substituteMethodBody(targetClass, template, "executable");
+        List<CtStatement> statements = ctBlock.getStatements();
+        CtNamedElement statement = (CtNamedElement) statements.get(0);
+
+        // assert
+        assertEquals(1, statements.size());
+        assertEquals("testString", statement.getSimpleName());
+    }
+
+    @Test
+    public void testSubstituteStatement() {
+        // contract: Substitution.SubstituteStatement gets a statement from a template consisting of an executable with single statement, having testString at it's 0 index
+
+        Factory factory = createFactoryWithTemplates();
+        CtClass<?> targetClass = factory.Class().create("testClass");
+        StatementTemplate template = new executableWithSingleStatementTemplate();
+
+        CtStatement ctStatement = Substitution.substituteStatement(targetClass, template, 0, "executable");
+
+        assertEquals("testString", ((CtNamedElement) ctStatement).getSimpleName());
+    }
+
+    private static class executableWithSingleStatementTemplate extends StatementTemplate {
+
+        public void executable() {
+            String testString;
+        }
+
+        @Override
+        public void statement() { }
+    }
+
+    @Test
+    public void testSubstituteFieldDefaultExpression() {
+        // contract: Substitution.SubstituteFieldDefaultExpression gets a default expression from a single-field template
+
+        Factory factory = createFactoryWithTemplates();
+        CtType<?> targetType = factory.Class().create("testClass");
+        StatementTemplate template = new SingleFieldTemplate();
+
+        CtExpression<?> ctExpression = Substitution.substituteFieldDefaultExpression(targetType, template, "testString");
+
+        assertEquals("\"goodName\"", ctExpression.toString());
     }
 
     private static Factory createFactoryWithTemplates() {


### PR DESCRIPTION
#1818

Hi, I have added 3 new tests for  methods of the `Substitution` class : 

1) `testSubstituteMethodBody` should kill this mutation : 
<img width="1428" alt="Screenshot 2021-06-30 at 4 01 07 PM" src="https://user-images.githubusercontent.com/62026125/123946030-636b7d80-d9bc-11eb-9765-01c8ee4b3323.png">

2) `testSubstituteStatement` should kill this mutation :

<img width="1098" alt="Screenshot 2021-06-30 at 4 02 09 PM" src="https://user-images.githubusercontent.com/62026125/123946161-885ff080-d9bc-11eb-8e16-a93c7c9ef95e.png">

3) `testSubstituteFieldDefaultExpression`should kill this mutation :
<img width="1183" alt="Screenshot 2021-06-30 at 4 03 34 PM" src="https://user-images.githubusercontent.com/62026125/123946353-bcd3ac80-d9bc-11eb-9b32-892c8dceca13.png">

Link to #3967
