### PR TITLE
fix: Fix equality for CtCodeSnippet

### DIFF
--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -16,6 +16,7 @@ import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTextBlock;
 import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
@@ -107,6 +108,15 @@ public class EqualsChecker extends CtInheritanceScanner {
 			setNotEqual(CtRole.MODIFIER);
 		}
 		super.scanCtModifiable(m);
+	}
+
+	@Override
+	public void scanCtCodeSnippet(CtCodeSnippet snippet) {
+		final CtCodeSnippet peek = (CtCodeSnippet) this.other;
+		if (!snippet.getValue().equals(peek.getValue())) {
+			setNotEqual(CtRole.SNIPPET);
+		}
+		super.scanCtCodeSnippet(snippet);
 	}
 
 	@Override

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -30,7 +30,6 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -243,13 +243,24 @@ public class SnippetTest {
 	}
 
 	@Test
-	public void testSnippetsWithDifferingValuesAreNotEqual() {
-		// contract: Two snippets with different values should be considered not equal
+	public void testCodeSnippetExpressionsWithNonEqualValuesAreNotEqual() {
+		// contract: Two code snippet expressions with non-equal values are not equal
 		Factory factory = new Launcher().getFactory();
 
 		CtExpression<Integer> one = factory.createCodeSnippetExpression("1");
 		CtExpression<Integer> two = factory.createCodeSnippetExpression("2");
 
 		assertThat(one.equals(two), is(false));
+	}
+
+	@Test
+	public void testCodeSnippetStatementsWithNonEqualValuesAreNotEqual() {
+		// contract: Two code snippet statements with non-equal values are not equal
+		Factory factory = new Launcher().getFactory();
+
+		CtStatement intDeclaration = factory.createCodeSnippetStatement("int a;");
+		CtStatement doubleDeclaration = factory.createCodeSnippetStatement("double a;");
+
+		assertThat(intDeclaration.equals(doubleDeclaration), is(false));
 	}
 }

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -38,6 +38,9 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.SnippetCompilationHelper;
 import spoon.support.compiler.VirtualFile;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
@@ -238,5 +241,16 @@ public class SnippetTest {
 		snippetClass.compileAndReplaceSnippets();
 		assertTrue(body.getStatements().get(0) instanceof CtLocalVariable);
 		assertEquals(1,body.getStatements().size()); 
+	}
+
+	@Test
+	public void testSnippetsWithDifferingValuesAreNotEqual() {
+		// contract: Two snippets with different values should be considered not equal
+		Factory factory = new Launcher().getFactory();
+
+		CtExpression<Integer> one = factory.createCodeSnippetExpression("1");
+		CtExpression<Integer> two = factory.createCodeSnippetExpression("2");
+
+		assertThat(one, not(equalTo(two)));
 	}
 }

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -30,6 +30,7 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
@@ -247,8 +248,8 @@ public class SnippetTest {
 		// contract: Two code snippet expressions with non-equal values are not equal
 		Factory factory = new Launcher().getFactory();
 
-		CtExpression<Integer> one = factory.createCodeSnippetExpression("1");
-		CtExpression<Integer> two = factory.createCodeSnippetExpression("2");
+		CtCodeSnippetExpression<Integer> one = factory.createCodeSnippetExpression("1");
+		CtCodeSnippetExpression<Integer> two = factory.createCodeSnippetExpression("2");
 
 		assertThat(one.equals(two), is(false));
 	}
@@ -258,8 +259,8 @@ public class SnippetTest {
 		// contract: Two code snippet statements with non-equal values are not equal
 		Factory factory = new Launcher().getFactory();
 
-		CtStatement intDeclaration = factory.createCodeSnippetStatement("int a;");
-		CtStatement doubleDeclaration = factory.createCodeSnippetStatement("double a;");
+		CtCodeSnippetStatement intDeclaration = factory.createCodeSnippetStatement("int a;");
+		CtCodeSnippetStatement doubleDeclaration = factory.createCodeSnippetStatement("double a;");
 
 		assertThat(intDeclaration.equals(doubleDeclaration), is(false));
 	}

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -254,6 +254,18 @@ public class SnippetTest {
 	}
 
 	@Test
+	public void testCodeSnippetExpressionsWithEqualValuesAreEqual() {
+		// contract: Two code snippet expressions with equal values, that are also otherwise equal,
+		// are equal
+		Factory factory = new Launcher().getFactory();
+
+		CtCodeSnippetExpression<Integer> one = factory.createCodeSnippetExpression("1");
+		CtCodeSnippetExpression<Integer> alsoOne = factory.createCodeSnippetExpression("1");
+
+		assertThat(one.equals(alsoOne), is(true));
+	}
+
+	@Test
 	public void testCodeSnippetStatementsWithNonEqualValuesAreNotEqual() {
 		// contract: Two code snippet statements with non-equal values are not equal
 		Factory factory = new Launcher().getFactory();
@@ -262,5 +274,17 @@ public class SnippetTest {
 		CtCodeSnippetStatement doubleDeclaration = factory.createCodeSnippetStatement("double a;");
 
 		assertThat(intDeclaration.equals(doubleDeclaration), is(false));
+	}
+
+	@Test
+	public void testCodeSnippetStatementsWithEqualValuesAreEqual() {
+		// contract: Two code snippet statements with equal values, that are also otherwise equal,
+		// are equal
+		Factory factory = new Launcher().getFactory();
+
+		CtCodeSnippetStatement intDeclaration = factory.createCodeSnippetStatement("int a;");
+		CtCodeSnippetStatement alsoIntDeclaration = factory.createCodeSnippetStatement("int a;");
+
+		assertThat(intDeclaration.equals(alsoIntDeclaration), is(true));
 	}
 }

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -38,8 +38,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.SnippetCompilationHelper;
 import spoon.support.compiler.VirtualFile;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -251,6 +250,6 @@ public class SnippetTest {
 		CtExpression<Integer> one = factory.createCodeSnippetExpression("1");
 		CtExpression<Integer> two = factory.createCodeSnippetExpression("2");
 
-		assertThat(one, not(equalTo(two)));
+		assertThat(one.equals(two), is(false));
 	}
 }


### PR DESCRIPTION
Fix #4022

This PR fixes equality between `CtCodeSnippet` instances. Previously, two code snippets would be considered equal regardless of their contained snippet (i.e. the raw string). With this PR, the raw snippet is now also considered part of the equality of code snippets (both statements and expressions).