### PR TITLE
review: chore: Try to list new errors in javadoc regression check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,11 @@ name: tests
 on:
   pull_request:
     branches:
-      - master
-      - *
+      master
   push:
     branches:
-      master
+      - master
+      - "chore/*"
   schedule:
   - cron: "0 0 * * *"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,7 @@ on:
       master
   push:
     branches:
-      - master
-      - "chore/*"
+      master
   schedule:
   - cron: "0 0 * * *"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,8 @@ on:
       master
   push:
     branches:
-      master
+      - master
+      - "chore/*"
   schedule:
   - cron: "0 0 * * *"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,8 @@ name: tests
 on:
   pull_request:
     branches:
-      master
+      - master
+      - *
   push:
     branches:
       master

--- a/chore/find_javadoc_regression.py
+++ b/chore/find_javadoc_regression.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+from typing import List, Dict
+
+
+def filter_relevant_lines(lines: List[str]) -> List[str]:
+    """Tries to filter the checkstyle output to only include lines with violations."""
+    new_lines = []
+
+    for line in lines:
+        if re.search(r":\d+:", line) and "ERROR" in line:
+            new_lines.append(line)
+
+    return new_lines
+
+
+def strip_line_number(line: str) -> str:
+    return re.sub(r".java:\d+(:\d+)?:", ".java", line)
+
+
+def strip_line_numbers(lines: List[str]) -> Dict[str, int]:
+    """
+    Strips the violation line numbers to account for shifts.
+    This method returns a dictionary of "stripped line -> Count", as the same
+    error might appear multiple times.
+    """
+    output_dict: Dict[str, int] = dict()
+
+    for line in map(strip_line_number, lines):
+        if line in output_dict:
+            output_dict[line] += 1
+        else:
+            output_dict[line] = 1
+
+    return output_dict
+
+
+def try_match_lines(reference: Dict[str, int], other: Dict[str, int]) -> Dict[str, int]:
+    """Tries to find out which lines are *new* in other and which were already present in the reference."""
+    other = other.copy()
+    for line, amount in reference.items():
+        for _ in range(0, amount):
+            if line in other:
+                if other[line] > 1:
+                    other[line] -= 1
+                else:
+                    other.pop(line)
+
+    # Lines that are only in the reference aren't critical, as they were
+    # apparently fixed in "other"
+    return other
+
+
+def try_readd_line_numbers(without_numbers: Dict[str, int], with_numbers: List[str]) -> List[str]:
+    """
+    Tries to re-add the line numbers to a dict of strings.
+    This is not necessarily accurate, as it doesn't know which occurrence
+    in "with_numbers" is the real source. If the error message is unique within
+    a file it will find the exact match though.
+    """
+    output: List[str] = []
+
+    for line in with_numbers:
+        stripped = strip_line_number(line)
+        if stripped in without_numbers:
+            if without_numbers[stripped] == 1:
+                without_numbers.pop(stripped)
+            else:
+                without_numbers[stripped] -= 1
+            output.append(line)
+
+    for line in without_numbers:
+        output.append(line)
+
+    return output
+
+
+def main(file_reference: Path, file_other: Path):
+    with open(file_reference, "r") as file:
+        lines_reference = filter_relevant_lines(file.readlines())
+    with open(file_other, "r") as file:
+        lines_other = filter_relevant_lines(file.readlines())
+
+    new_errors = try_match_lines(
+        strip_line_numbers(lines_reference),
+        strip_line_numbers(lines_other)
+    )
+    with_line_numbers = try_readd_line_numbers(new_errors, lines_other)
+
+    print("You likely added the following new errors. "
+          "Line numbers might be incorrect if there are "
+          "multiple violations of the same type in the file.")
+    for error in with_line_numbers:
+        print(error.strip())
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <reference file> <own file>")
+        exit(1)
+
+    main(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/chore/find_javadoc_regression.py
+++ b/chore/find_javadoc_regression.py
@@ -24,7 +24,7 @@ def find_added_violation_lines(reference: 'Counter[str]', other: 'Counter[str]')
     """
     # Lines that are only in the reference aren't critical, as they were
     # apparently fixed in "other"
-    return other.copy() - reference
+    return other - reference
 
 
 def try_readd_line_numbers(without_numbers: 'Counter[str]', with_numbers: List[str]) -> List[str]:

--- a/chore/find_javadoc_regression.py
+++ b/chore/find_javadoc_regression.py
@@ -16,7 +16,7 @@ def strip_line_number(line: str) -> str:
     return re.sub(r".java:\d+(:\d+)?:", ".java", line)
 
 
-def find_added_violation_lines(reference: Counter[str], other: Counter[str]) -> Counter[str]:
+def find_added_violation_lines(reference: 'Counter[str]', other: 'Counter[str]') -> 'Counter[str]':
     """
     Tries to find out which violation lines are new in "other" and which
     were already present in the "reference". These lines are added violations the
@@ -27,7 +27,7 @@ def find_added_violation_lines(reference: Counter[str], other: Counter[str]) -> 
     return other.copy() - reference
 
 
-def try_readd_line_numbers(without_numbers: Counter[str], with_numbers: List[str]) -> List[str]:
+def try_readd_line_numbers(without_numbers: 'Counter[str]', with_numbers: List[str]) -> List[str]:
     """
     Tries to re-add the line numbers to a dict of strings.
     This is not necessarily accurate, as it doesn't know which occurrence

--- a/chore/find_javadoc_regression.py
+++ b/chore/find_javadoc_regression.py
@@ -16,8 +16,12 @@ def strip_line_number(line: str) -> str:
     return re.sub(r".java:\d+(:\d+)?:", ".java", line)
 
 
-def try_match_lines(reference: Counter[str], other: Counter[str]) -> Counter[str]:
-    """Tries to find out which lines are *new* in other and which were already present in the reference."""
+def find_added_violation_lines(reference: Counter[str], other: Counter[str]) -> Counter[str]:
+    """
+    Tries to find out which violation lines are new in "other" and which
+    were already present in the "reference". These lines are added violations the
+    contributor should fix.
+    """
     # Lines that are only in the reference aren't critical, as they were
     # apparently fixed in "other"
     return other.copy() - reference
@@ -53,7 +57,7 @@ def main(file_reference: Path, file_other: Path):
     with open(file_other, "r") as file:
         lines_other = filter_relevant_lines(file.readlines())
 
-    new_errors = try_match_lines(
+    new_errors = find_added_violation_lines(
         Counter(map(strip_line_number, lines_reference)),
         Counter(map(strip_line_number, lines_other))
     )

--- a/chore/find_javadoc_regression.py
+++ b/chore/find_javadoc_regression.py
@@ -9,13 +9,7 @@ from typing import List
 
 def filter_relevant_lines(lines: List[str]) -> List[str]:
     """Tries to filter the checkstyle output to only include lines with violations."""
-    new_lines = []
-
-    for line in lines:
-        if re.search(r":\d+:", line) and "ERROR" in line:
-            new_lines.append(line)
-
-    return new_lines
+    return [line for line in lines if re.search(r":\d+:", line) and "ERROR" in line]
 
 
 def strip_line_number(line: str) -> str:


### PR DESCRIPTION
## Motivation
Before this patch the CI Javadoc regression check would only look at the amount of violations and fail the build if they increased:

```
JAVADOC QUALITY SCORE (lower is better)
    Compare: 2584
    Current: 2592

Javadoc quality has deteriorated!
Run the chore/ci-checkstyle-javadoc.sh script locally to find errors
See https://github.com/inria/spoon/issues/3923 for details
```

This wasn't really helpful when actually finding the errors, as you would need to run the checkstyle command locally on both branches and diff the output yourself. 

## Changes
This patch adds a small python script that tries to (*somewhat* intelligently) perform this diff in the CI and print a more useful failure message.

The line numbers in the output will not be correct if the exact same violation message appears multiple times in a single file, but it is better than having no feedback.

## Help wanted
How do you test changes that affect your CI process? I tested them locally by:
1. Checking out this PR's branch
2. Randomly deleting some helpful javadoc
3. Committing the changes
4. Running `./chore/ci-checkstyle-javadoc.sh COMPARE_WITH_MASTER`

This, however, doesn't quite help me verify it doesn't crash in your CI environment.

## Example output
```
JAVADOC QUALITY SCORE (lower is better)
    Compare: 2584
    Current: 2592
    
Javadoc quality has deteriorated!
Run the chore/ci-checkstyle-javadoc.sh script locally to find errors
See https://github.com/inria/spoon/issues/3923 for details


You likely added the following new errors. Line numbers might be incorrect if there are multiple violations of the same type in the file.
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/visitor/CtVisitor.java:116:10: Erwartetes Tag @param für '<T>'. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/visitor/CtVisitor.java:543:54: Erwartetes Tag @param für 'pattern'. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/factory/CoreFactory.java:131: Fehlendes @return-Tag. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/factory/CoreFactory.java:136:10: Erwartetes Tag @param für '<T>'. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/code/CtTypePattern.java:40: Fehlendes @return-Tag. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/code/CtTypePattern.java:46: Fehlendes @return-Tag. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/code/CtTypePattern.java:47:10: Erwartetes Tag @param für '<C>'. [JavadocMethod]
  [ERROR] /tmp/spoon/src/main/java/spoon/reflect/code/CtTypePattern.java:47:71: Erwartetes Tag @param für 'variable'. [JavadocMethod]
```