### PR TITLE
review: fix(test): error output for CtInheritanceScanner test prints wrong class name

### DIFF
--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -338,7 +338,6 @@ public class SpoonArchitectureEnforcerTest {
 		interfaces.addInputResource("src/main/java/spoon/support/reflect/declaration");
 		interfaces.addInputResource("src/main/java/spoon/support/reflect/code");
 		interfaces.addInputResource("src/main/java/spoon/support/reflect/reference");
-		interfaces.addInputResource("src/main/java/spoon/reflect/visitor/CtScanner.java");
 		interfaces.buildModel();
 
 		CtClass<?> ctScanner = interfaces.getFactory().Class().get(CtInheritanceScanner.class);
@@ -355,7 +354,7 @@ public class SpoonArchitectureEnforcerTest {
 			}
 		});
 
-		assertTrue("The following methods are missing in CtScanner: \n" + StringUtils.join(missingMethods, "\n"), missingMethods.isEmpty());
+		assertTrue("The following methods are missing in " + ctScanner.getSimpleName() + ": \n" + StringUtils.join(missingMethods, "\n"), missingMethods.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
When working on my other pull request, I came about this confusing output:

```cs
[ERROR] Failures: 
[ERROR]   SpoonArchitectureEnforcerTest.testInterfacesAreCtScannable:358 The following methods are missing in CtScanner: 
scanCtPattern
```
I wondered why it would expect me to add this method to the CtScanner as there are no other methods like that. Looking closer at the test revealed that the method is expected in CtInheritanceScanner instead. This PR uses the simple class name instead, so `CtInheritanceScanner` is now printed correctly.

It also seems like the CtScanner is not required as input resource. I guess that is a leftover from when this test was implemented.

**Note**: I'm not sure about this, but it the test case itself is probably named badly, indicating that it is about the CtScanner instead of the CtInheritanceScanner. If you agree on this, I can change the name of the test case too.