### PR TITLE
review: fix: Nested enums modifiers

### DIFF
--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -659,7 +659,7 @@ public class AnnotationTest {
 		final Set<CtTypeReference<?>> superInterfacesOfEnum = enumActual.getSuperInterfaces();
 		final CtTypeReference<?> firstSuperInterfaceOfEnum = superInterfacesOfEnum.toArray(new CtTypeReference<?>[0])[0];
 		final List<CtAnnotation<? extends Annotation>> enumTypeAnnotations = firstSuperInterfaceOfEnum.getAnnotations();
-		final String enumExpected = "public enum DummyEnum implements spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "BasicAnnotation {" + System.lineSeparator() + "    ;" + System.lineSeparator() + "}";
+		final String enumExpected = "public static enum DummyEnum implements spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "BasicAnnotation {" + System.lineSeparator() + "    ;" + System.lineSeparator() + "}";
 		assertEquals("Implements in a enum with a type annotation must have it in its model", 1, enumTypeAnnotations.size());
 		assertSame("Type annotation on a implements in a enum must be typed by TypeAnnotation", TypeAnnotation.class, enumTypeAnnotations.get(0).getAnnotationType().getActualClass());
 		assertEquals(CtAnnotatedElementType.TYPE_USE, enumTypeAnnotations.get(0).getAnnotatedElementType());

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -659,7 +659,7 @@ public class AnnotationTest {
 		final Set<CtTypeReference<?>> superInterfacesOfEnum = enumActual.getSuperInterfaces();
 		final CtTypeReference<?> firstSuperInterfaceOfEnum = superInterfacesOfEnum.toArray(new CtTypeReference<?>[0])[0];
 		final List<CtAnnotation<? extends Annotation>> enumTypeAnnotations = firstSuperInterfaceOfEnum.getAnnotations();
-		final String enumExpected = "public static enum DummyEnum implements spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "BasicAnnotation {" + System.lineSeparator() + "    ;" + System.lineSeparator() + "}";
+		final String enumExpected = "public enum DummyEnum implements spoon.test.annotation.testclasses.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "BasicAnnotation {" + System.lineSeparator() + "    ;" + System.lineSeparator() + "}";
 		assertEquals("Implements in a enum with a type annotation must have it in its model", 1, enumTypeAnnotations.size());
 		assertSame("Type annotation on a implements in a enum must be typed by TypeAnnotation", TypeAnnotation.class, enumTypeAnnotations.get(0).getAnnotationType().getActualClass());
 		assertEquals(CtAnnotatedElementType.TYPE_USE, enumTypeAnnotations.get(0).getAnnotatedElementType());

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -119,22 +119,22 @@ public class EnumsTest {
 		CtType<?> ctClass = ModelUtils.buildClass(NestedEnums.class);
 		{
 			CtEnum<?> ctEnum = ctClass.getNestedType("PrivateENUM");
-			assertEquals(asSet(ModifierKind.PRIVATE), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PRIVATE, ModifierKind.STATIC), ctEnum.getModifiers());
 			assertEquals(asSet(ModifierKind.PRIVATE, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
 		}
 		{
 			CtEnum<?> ctEnum = ctClass.getNestedType("PublicENUM");
-			assertEquals(asSet(ModifierKind.PUBLIC), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PUBLIC, ModifierKind.STATIC), ctEnum.getModifiers());
 			assertEquals(asSet(ModifierKind.PUBLIC, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
 		}
 		{
 			CtEnum<?> ctEnum = ctClass.getNestedType("ProtectedENUM");
-			assertEquals(asSet(ModifierKind.PROTECTED), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.PROTECTED, ModifierKind.STATIC), ctEnum.getModifiers());
 			assertEquals(asSet(ModifierKind.PROTECTED, ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
 		}
 		{
 			CtEnum<?> ctEnum = ctClass.getNestedType("PackageProtectedENUM");
-			assertEquals(asSet(), ctEnum.getModifiers());
+			assertEquals(asSet(ModifierKind.STATIC), ctEnum.getModifiers());
 			assertEquals(asSet(ModifierKind.STATIC, ModifierKind.FINAL), ctEnum.getField("VALUE").getModifiers());
 		}
 	}

--- a/src/test/resources/nestedEnum/NestedEnumsAreImplicitlyStatic.java
+++ b/src/test/resources/nestedEnum/NestedEnumsAreImplicitlyStatic.java
@@ -1,0 +1,21 @@
+class NestedInClass {
+  enum NestedEnum {
+    A;
+  }
+}
+interface NestedInInterface {
+  enum NestedEnum {
+    A;
+  }
+}
+enum NestedInEnum {
+  A;
+  enum NestedEnum {
+    A;
+  }
+}
+@interface NestedInAnnotation {
+  enum NestedEnum {
+    A;
+  }
+}


### PR DESCRIPTION
## About
This PR tries to improve implicit modifier support in Spoon. For more details see #4036.

## Questions
Why does `CtModifierHandler#setExtendedModifiers` reject empty sets? I don't see any other way to remove the modifiers I added, so I removed the check for now. This looks a bit dangerous, but maybe I will find out why that's there while fixing tests.

*EDIT: I didn't, I don't see any reason why you'd want that in the if condition currently*

## Closes
Closes #4036