### PR TITLE
review: fix: Fix the insertion order for CtStatementListImpl.insertBegin 

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -21,6 +21,7 @@ import spoon.support.reflect.declaration.CtElementImpl;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 
 import static spoon.reflect.ModelElementContainerDefaultCapacities.BLOCK_STATEMENTS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.STATEMENT;
@@ -83,9 +84,13 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 	@Override
 	public <T extends CtStatementList> T insertBegin(CtStatementList statements) {
 		ensureModifiableStatementsList();
-		List<CtStatement> copy = new ArrayList<>(statements.getStatements());
-		statements.setStatements(null);
-		this.statements.addAll(0, copy);
+		List<CtStatement> list = statements.getStatements();
+		ListIterator listIterator = list.listIterator(list.size());
+		while (listIterator.hasPrevious()) {
+			CtStatement statement = (CtStatement) listIterator.previous();
+			statement.setParent(this);
+			this.addStatement(0, statement);
+		}
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtStatementListImpl.java
@@ -83,10 +83,9 @@ public class CtStatementListImpl<R> extends CtCodeElementImpl implements CtState
 	@Override
 	public <T extends CtStatementList> T insertBegin(CtStatementList statements) {
 		ensureModifiableStatementsList();
-		for (CtStatement statement : statements.getStatements()) {
-			statement.setParent(this);
-			this.addStatement(0, statement);
-		}
+		List<CtStatement> copy = new ArrayList<>(statements.getStatements());
+		statements.setStatements(null);
+		this.statements.addAll(0, copy);
 		if (isImplicit() && this.statements.size() > 1) {
 			setImplicit(false);
 		}

--- a/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
+++ b/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
@@ -18,21 +18,17 @@ public class CtStatementListImplTest {
         // arrange
         Factory factory = new Launcher().getFactory();
 
-        CtStatement initialStatement = factory.Code().createCodeSnippetStatement("initialStatement");
+        CtStatement initialStatement = factory.Code().createCodeSnippetStatement("int preexisting = 42;").compile();
 
-        CtStatement firstStatementToBeInserted = factory.Code().createCodeSnippetStatement("firstStatement");
-        CtStatement secondStatementToBeInserted = factory.Code().createCodeSnippetStatement("secondStatement");
+        CtStatement firstStatementToBeInserted = factory.Code().createCodeSnippetStatement("int first = 1;").compile();
+        CtStatement secondStatementToBeInserted = factory.Code().createCodeSnippetStatement("int second = 2;").compile();
 
-        CtStatementList mainStatementList =  new CtStatementListImpl<CtStatement>() {
-            { addStatement(initialStatement); }
-        };
+        CtStatementList mainStatementList =  new CtStatementListImpl<CtStatement>();
+        mainStatementList.addStatement(initialStatement);
 
-        CtStatementList statementListToBeAddedToTheMainList =  new CtStatementListImpl<CtStatement>() {
-            {
-                addStatement(firstStatementToBeInserted);
-                addStatement(secondStatementToBeInserted);
-            }
-        };
+        CtStatementList statementListToBeAddedToTheMainList =  new CtStatementListImpl<CtStatement>();
+        statementListToBeAddedToTheMainList.addStatement(firstStatementToBeInserted);
+        statementListToBeAddedToTheMainList.addStatement(secondStatementToBeInserted);
 
         // act
         mainStatementList.insertBegin(statementListToBeAddedToTheMainList);

--- a/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
+++ b/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
@@ -1,0 +1,46 @@
+package spoon.test.ctStatementList;
+
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtStatementList;
+import spoon.reflect.factory.Factory;
+import spoon.support.reflect.code.CtStatementListImpl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CtStatementListImplTest {
+
+    @Test
+    void testInsertBeginWithListOfStatements() {
+        // contract: insertBegin adds a list of statements at the beginning of the statementList
+
+        // arrange
+        Factory factory = new Launcher().getFactory();
+
+        CtStatement initialStatement = factory.Code().createCodeSnippetStatement("initialStatement");
+
+        CtStatement firstStatementToBeInserted = factory.Code().createCodeSnippetStatement("firstStatement");
+        CtStatement secondStatementToBeInserted = factory.Code().createCodeSnippetStatement("secondStatement");
+
+        CtStatementList mainStatementList =  new CtStatementListImpl<CtStatement>() {
+            { addStatement(initialStatement); }
+        };
+
+        CtStatementList statementListToBeAddedToTheMainList =  new CtStatementListImpl<CtStatement>() {
+            {
+                addStatement(firstStatementToBeInserted);
+                addStatement(secondStatementToBeInserted);
+            }
+        };
+
+        // act
+        mainStatementList.insertBegin(statementListToBeAddedToTheMainList);
+
+        // assert
+        CtStatement statementAtTheBeginningAfterInsertion = mainStatementList.getStatements().get(0);
+        CtStatement secondStatementAtTheBeginningOfTheListAfterInsertion = mainStatementList.getStatements().get(1);
+        assertEquals(firstStatementToBeInserted, statementAtTheBeginningAfterInsertion);
+        assertEquals(secondStatementToBeInserted, secondStatementAtTheBeginningOfTheListAfterInsertion);
+    }
+}

--- a/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
+++ b/src/test/java/spoon/test/ctStatementList/CtStatementListImplTest.java
@@ -6,6 +6,8 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.factory.Factory;
 import spoon.support.reflect.code.CtStatementListImpl;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -38,5 +40,7 @@ public class CtStatementListImplTest {
         CtStatement secondStatementAtTheBeginningOfTheListAfterInsertion = mainStatementList.getStatements().get(1);
         assertEquals(firstStatementToBeInserted, statementAtTheBeginningAfterInsertion);
         assertEquals(secondStatementToBeInserted, secondStatementAtTheBeginningOfTheListAfterInsertion);
+        assertThat(firstStatementToBeInserted.getParent(), is(mainStatementList));
+        assertThat(secondStatementToBeInserted.getParent(), is(mainStatementList));
     }
 }

--- a/src/test/java/spoon/test/ctStatementList/CtStatementListTest.java
+++ b/src/test/java/spoon/test/ctStatementList/CtStatementListTest.java
@@ -6,12 +6,13 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
 import spoon.reflect.factory.Factory;
 import spoon.support.reflect.code.CtStatementListImpl;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class CtStatementListImplTest {
+public class CtStatementListTest {
 
     @Test
     void testInsertBeginWithListOfStatements() {
@@ -25,10 +26,10 @@ public class CtStatementListImplTest {
         CtStatement firstStatementToBeInserted = factory.Code().createCodeSnippetStatement("int first = 1;").compile();
         CtStatement secondStatementToBeInserted = factory.Code().createCodeSnippetStatement("int second = 2;").compile();
 
-        CtStatementList mainStatementList =  new CtStatementListImpl<CtStatement>();
+        CtStatementList mainStatementList = new CtStatementListImpl<CtStatement>();
         mainStatementList.addStatement(initialStatement);
 
-        CtStatementList statementListToBeAddedToTheMainList =  new CtStatementListImpl<CtStatement>();
+        CtStatementList statementListToBeAddedToTheMainList = new CtStatementListImpl<CtStatement>();
         statementListToBeAddedToTheMainList.addStatement(firstStatementToBeInserted);
         statementListToBeAddedToTheMainList.addStatement(secondStatementToBeInserted);
 
@@ -38,8 +39,10 @@ public class CtStatementListImplTest {
         // assert
         CtStatement statementAtTheBeginningAfterInsertion = mainStatementList.getStatements().get(0);
         CtStatement secondStatementAtTheBeginningOfTheListAfterInsertion = mainStatementList.getStatements().get(1);
+
         assertEquals(firstStatementToBeInserted, statementAtTheBeginningAfterInsertion);
         assertEquals(secondStatementToBeInserted, secondStatementAtTheBeginningOfTheListAfterInsertion);
+
         assertThat(firstStatementToBeInserted.getParent(), is(mainStatementList));
         assertThat(secondStatementToBeInserted.getParent(), is(mainStatementList));
     }


### PR DESCRIPTION
fix:#4060

#4060

In #4063, I fixed `CtCaseImpl.insertBegin`, this PR aims to fix `CtStatementListImpl.insertBegin`. They have a similar bug and a similar fix, so I thought it's best to fix them simultaneously, so that we are able to close #4060 in concrete terms.

Also, this test is killing this mutation

<img width="976" alt="Screenshot 2021-07-26 at 3 13 14 PM" src="https://user-images.githubusercontent.com/62026125/126968674-4f83cfb9-f8f9-411c-b276-28d311975355.png">

link to #3967