### PR TITLE
chore: Add tag pinning to GHA digest update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Related to https://github.com/INRIA/spoon/pull/4046#issuecomment-881218494

Currently, Renovate is updating the SHA digests of GitHub Actions to the latest one on the primary branch, but we only want stable releases. Based on [the docs over here](https://docs.renovatebot.com/modules/manager/github-actions/), I think that this PR should fix that problem.

I'm not _entirely_ sure, as the docs are a little bit ambiguous, and there's a possibility that they mean that they'll just stick to that specific tag and update the digest if the tag is updated, but not update to later tags. If that's the case, then we should specify `tag=vX` (only the major version) for each action, as that tag is by GHA conventions moved to the latest iteration of that major version each time there's a new release.