### PR TITLE
refactor: Fix wonky indentation in CtModifierHandler.setModifiers

### DIFF
--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -68,11 +68,11 @@ public class CtModifierHandler implements Serializable {
 		if (modifiers == null) {
 			modifiers = Collections.emptySet();
 		}
-			getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(element, MODIFIER, this.modifiers, new HashSet<>(this.modifiers));
-			this.modifiers.clear();
-			for (ModifierKind modifier : modifiers) {
-				addModifier(modifier);
-			}
+		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(element, MODIFIER, this.modifiers, new HashSet<>(this.modifiers));
+		this.modifiers.clear();
+		for (ModifierKind modifier : modifiers) {
+			addModifier(modifier);
+		}
 		return this;
 	}
 


### PR DESCRIPTION
Found some wonky indentation in `CtModifierHandler.setModifiers`, this PR just fixes that.