### PR TITLE
fix: fix sniper bug delated to source position of super reference

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Initializer;
 import org.eclipse.jdt.internal.compiler.ast.Javadoc;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.SuperReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
@@ -445,6 +446,11 @@ public class PositionBuilder {
 		} else if ((node instanceof AssertStatement)) {
 			AssertStatement assert_ = (AssertStatement) node;
 			sourceEnd = findNextChar(contents, contents.length, sourceEnd, ';');
+		} else if (node instanceof SuperReference) {
+			// when a super reference is followed by a unary operator (e.g. `super.method(-x)`),
+			// JDT for some reason sets the end source position to the unary operator, so we
+			// must adjust for this.
+			sourceEnd = sourceStart + "super".length() - 1;
 		}
 
 		if (e instanceof CtModifiable) {

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -776,7 +776,6 @@ public class TestSniperPrinter {
 	}
 	
 	@Test
-	@Disabled("UnresolvedBug")
 	@GitHubIssue(issueNumber = 4021)
 	void testSniperRespectsSuperWithUnaryOperator() {
 		// Combining CtSuperAccess and CtUnaryOperator leads to SpoonException with Sniper


### PR DESCRIPTION
Fix #4021 

See https://github.com/INRIA/spoon/issues/4021#issuecomment-897634177 for a description of the problem.

The tl;dr is that the end position of a super reference is incorrect from JDT when it's followed by a unary operator. This PR simply sets the end position of a super reference relative to it's start position, which is possible as `super` always has the same amount of characters.