### PR TITLE
fix: Make lambda type implicit to avoid auto-importing type targeted in lambda

### DIFF
--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -288,7 +288,9 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 
 	@Override
 	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
-		type.setImplicit(true);
+		if (type != null) {
+			type.setImplicit(true);
+		}
 		return super.setType(type);
 	}
 }

--- a/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLambdaImpl.java
@@ -23,6 +23,7 @@ import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtIntersectionTypeReference;
@@ -283,5 +284,11 @@ public class CtLambdaImpl<T> extends CtExpressionImpl<T> implements CtLambda<T> 
 	@Override
 	public CtLambda<T> clone() {
 		return (CtLambda<T>) super.clone();
+	}
+
+	@Override
+	public <C extends CtTypedElement> C setType(CtTypeReference<T> type) {
+		type.setImplicit(true);
+		return super.setType(type);
 	}
 }

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -1,12 +1,17 @@
 package spoon.reflect.visitor;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.declaration.CtCompilationUnit;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class DefaultJavaPrettyPrinterTest {
@@ -59,5 +64,22 @@ public class DefaultJavaPrettyPrinterTest {
             return printer;
         });
         return launcher;
+    }
+
+
+    @Test
+    void testAutoImportPrinterDoesNotImportFunctionalInterfaceTargetedInLambda() {
+        // contract: The auto-import printer should not import functional interfaces that are
+        // targeted in lambdas, but are not explicitly referenced anywhere
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("src/test/resources/target-functional-interface-in-lambda");
+        launcher.buildModel();
+        CtCompilationUnit cu = launcher.getFactory().Type().get("TargetsFunctionalInterface")
+                .getPosition().getCompilationUnit();
+
+        PrettyPrinter autoImportPrettyPrinter = launcher.getEnvironment().createPrettyPrinterAutoImport();
+        String output = autoImportPrettyPrinter.prettyprint(cu);
+
+        assertThat(output, not(containsString("import java.util.function.IntFunction;")));
     }
 }

--- a/src/test/resources/target-functional-interface-in-lambda/HasFunctionalInterface.java
+++ b/src/test/resources/target-functional-interface-in-lambda/HasFunctionalInterface.java
@@ -1,0 +1,7 @@
+import java.util.function.IntFunction;
+
+public class HasFunctionalInterface {
+    public static void supplyOne(IntFunction<String> intFunction) {
+        intFunction.apply(1);
+    }
+}

--- a/src/test/resources/target-functional-interface-in-lambda/TargetsFunctionalInterface.java
+++ b/src/test/resources/target-functional-interface-in-lambda/TargetsFunctionalInterface.java
@@ -1,0 +1,5 @@
+public class TargetsFunctionalInterface {
+    public static void main(String[] args) {
+        HasFunctionalInterface.supplyOne(i -> String.valueOf(i));
+    }
+}


### PR DESCRIPTION
Fix #4079 

See #4079 for a description of the problem.