### PR TITLE
refactor: Fix unchecked type conversions

### DIFF
--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -415,7 +415,7 @@ public class ContractVerifier {
 	public void checkParentConsistency(CtElement element) {
 		final Set<CtElement> inconsistentParents = new HashSet<>();
 		new CtScanner() {
-			private Deque<CtElement> previous = new ArrayDeque();
+			private Deque<CtElement> previous = new ArrayDeque<>();
 
 			@Override
 			protected void enter(CtElement e) {

--- a/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
+++ b/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
@@ -114,7 +114,7 @@ public class TobeMatched {
 			if (nrOfMatches == 0) {
 				return Collections.emptyList();
 			}
-			List<Object> matched = new ArrayList(nrOfMatches);
+			List<Object> matched = new ArrayList<>(nrOfMatches);
 			for (Object target : getTargets()) {
 				if (containsSame(tobeMatchedTargets.getTargets(), target)) {
 					//this origin target is still available in this to be matched targets

--- a/src/main/java/spoon/reflect/visitor/ImportCleaner.java
+++ b/src/main/java/spoon/reflect/visitor/ImportCleaner.java
@@ -311,8 +311,8 @@ public class ImportCleaner extends ImportAnalyzer<ImportCleaner.Context> {
 	 */
 	private boolean removeAllTypeImportWithPackage(Set<CtImport> imports, String packageName) {
 		boolean found = false;
-		for (Iterator iter = imports.iterator(); iter.hasNext();) {
-			CtImport newImport = (CtImport) iter.next();
+		for (Iterator<CtImport> iter = imports.iterator(); iter.hasNext();) {
+			CtImport newImport = iter.next();
 			if (newImport.getImportKind() == CtImportKind.TYPE) {
 				CtTypeReference<?> typeRef = (CtTypeReference<?>) newImport.getReference();
 				if (typeRef.getPackage() != null && packageName.equals(typeRef.getPackage().getQualifiedName())) {

--- a/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnnotationImpl.java
@@ -352,7 +352,7 @@ public class CtAnnotationImpl<A extends Annotation> extends CtExpressionImpl<A> 
 
 	@Override
 	public Map<String, CtExpression> getAllValues() {
-		Map<String, CtExpression> values = new TreeMap();
+		Map<String, CtExpression> values = new TreeMap<>();
 		// first, we put the default values
 		CtAnnotationType<?> annotationType = (CtAnnotationType) getAnnotationType().getTypeDeclaration();
 		for (CtAnnotationMethod m : annotationType.getAnnotationMethods()) {

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -506,7 +506,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	@Override
 	public Set<String> getMetadataKeys() {
 		if (metadata == null) {
-			return Collections.EMPTY_SET;
+			return Collections.emptySet();
 		}
 		return metadata.keySet();
 	}

--- a/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
+++ b/src/main/java/spoon/support/sniper/internal/ChangeResolver.java
@@ -30,7 +30,7 @@ public class ChangeResolver {
 	public ChangeResolver(ChangeCollector changeCollector, CtElement element) {
 		this.changeCollector = changeCollector;
 		this.element = element;
-		changedRoles = element != null ? changeCollector.getChanges(element) : Collections.EMPTY_SET;
+		changedRoles = element != null ? changeCollector.getChanges(element) : Collections.emptySet();
 	}
 
 	/**

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -710,7 +710,7 @@ public class ClassTypingContext extends AbstractTypingContext {
 					if (actualTA instanceof CtWildcardReference) {
 						CtWildcardReference wildcardReference = (CtWildcardReference) actualTA;
 						if (wildcardReference.isDefaultBoundingType()) {
-							thatType.setActualTypeArguments(Collections.EMPTY_LIST);
+							thatType.setActualTypeArguments(Collections.emptyList());
 						}
 					}
 				}


### PR DESCRIPTION
Resolves Sonar violations of rules S3740 and S1596 and fixes compiler warnings about unchecked conversions.

This patch was generated automatically using [Logifix](https://github.com/lyxell/logifix).