### PR TITLE
review: fix: Fix return type of setParent

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
+++ b/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
@@ -208,7 +208,7 @@ public interface CtCompilationUnit extends CtElement {
 
 	@Override
 	@UnsettableProperty
-	<E extends CtElement, P extends CtElement> E setParent(P parent);
+	<E extends CtElement> E setParent(E parent);
 
 	@Override
 	@UnsettableProperty

--- a/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
+++ b/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
@@ -208,7 +208,7 @@ public interface CtCompilationUnit extends CtElement {
 
 	@Override
 	@UnsettableProperty
-	<E extends CtElement> E setParent(E parent);
+	<E extends CtElement> E setParent(CtElement parent);
 
 	@Override
 	@UnsettableProperty

--- a/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
+++ b/src/main/java/spoon/reflect/declaration/CtCompilationUnit.java
@@ -208,7 +208,7 @@ public interface CtCompilationUnit extends CtElement {
 
 	@Override
 	@UnsettableProperty
-	<E extends CtElement> E setParent(E parent);
+	<E extends CtElement, P extends CtElement> E setParent(P parent);
 
 	@Override
 	@UnsettableProperty

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -269,7 +269,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param <P> type of the parent element
 	 * @return this element
 	 */
-	<E extends CtElement, P extends CtElement> E setParent(P parent);
+	<E extends CtElement> E setParent(E parent);
 
 	/**
 	 * Tells if this parent has been initialized.

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -267,7 +267,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param parent
 	 * 		parent reference.
 	 */
-	<E extends CtElement> E setParent(E parent);
+	<E extends CtElement, P extends CtElement> E setParent(P parent);
 
 	/**
 	 * Tells if this parent has been initialized.

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -266,7 +266,6 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 *
 	 * @param parent parent reference.
 	 * @param <E> this element's type
-	 * @param <P> type of the parent element
 	 * @return this element
 	 */
 	<E extends CtElement> E setParent(E parent);

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -268,7 +268,7 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	 * @param <E> this element's type
 	 * @return this element
 	 */
-	<E extends CtElement> E setParent(E parent);
+	<E extends CtElement> E setParent(CtElement parent);
 
 	/**
 	 * Tells if this parent has been initialized.

--- a/src/main/java/spoon/reflect/declaration/CtElement.java
+++ b/src/main/java/spoon/reflect/declaration/CtElement.java
@@ -264,8 +264,10 @@ public interface CtElement extends FactoryAccessor, CtVisitable, Cloneable, CtQu
 	/**
 	 * Manually sets the parent element of the current element.
 	 *
-	 * @param parent
-	 * 		parent reference.
+	 * @param parent parent reference.
+	 * @param <E> this element's type
+	 * @param <P> type of the parent element
+	 * @return this element
 	 */
 	<E extends CtElement, P extends CtElement> E setParent(P parent);
 

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	public CtTypeReference<Void> getType() {
-		return getFactory().Type().VOID_PRIMITIVE.clone().setParent(this);
+		return (CtTypeReference<Void>) getFactory().Type().VOID_PRIMITIVE.clone().<CtTypeAccess>setParent(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	public CtTypeReference<Void> getType() {
-		return (CtTypeReference<Void>) getFactory().Type().VOID_PRIMITIVE.clone().<CtTypeAccess>setParent(this);
+		return getFactory().Type().VOID_PRIMITIVE.clone().setParent(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -419,7 +419,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 
 	@Override
 	@UnsettableProperty
-	public <E extends CtElement> E setParent(E parent) {
+	public <E extends CtElement> E setParent(CtElement parent) {
 		return (E) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -419,7 +419,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 
 	@Override
 	@UnsettableProperty
-	public <E extends CtElement> E setParent(E parent) {
+	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
 		return (E) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -419,7 +419,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 
 	@Override
 	@UnsettableProperty
-	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
+	public <E extends CtElement> E setParent(E parent) {
 		return (E) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -366,7 +366,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
+	public <E extends CtElement> E setParent(E parent) {
 		this.parent = parent;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -366,7 +366,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setParent(E parent) {
+	public <E extends CtElement> E setParent(CtElement parent) {
 		this.parent = parent;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -366,7 +366,7 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	}
 
 	@Override
-	public <E extends CtElement> E setParent(E parent) {
+	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
 		this.parent = parent;
 		return (E) this;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -425,8 +425,8 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 
 	@Override
 	@DerivedProperty
-	public <T extends CtElement> T setParent(T parent) {
-		return (T) this;
+	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
+		return (E) this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -425,7 +425,7 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 
 	@Override
 	@DerivedProperty
-	public <T extends CtElement> T setParent(T parent) {
+	public <T extends CtElement> T setParent(CtElement parent) {
 		return (T) this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtModuleImpl.java
@@ -425,8 +425,8 @@ public class CtModuleImpl extends CtNamedElementImpl implements CtModule {
 
 	@Override
 	@DerivedProperty
-	public <E extends CtElement, P extends CtElement> E setParent(P parent) {
-		return (E) this;
+	public <T extends CtElement> T setParent(T parent) {
+		return (T) this;
 	}
 
 	@Override


### PR DESCRIPTION
Fix #4098 (see issue for description of problem)

**Breaking change!**

This PR implements option 2 presented in #4098. It's a _purely statically_ breaking change, meaning that some compilation may be affected, but behavior is not. However, compilation is pretty unlikely to be affected, and it should really only be the case if the parameterization of the method is explicitly provided.