### PR TITLE
doc: fix wrong variable in example snippet

### DIFF
--- a/doc/factories.md
+++ b/doc/factories.md
@@ -58,7 +58,7 @@ Example:
             .getMethodsByName("sayHello")
             .get(0)
             .accept(v);
-    System.out.println(b.getResult());
+    System.out.println(v.getResult());
 ```
 
 will print:


### PR DESCRIPTION
Changed `b` to `v`.