### PR TITLE
test(AstCheckerTest): Refactor isSurcharged

### DIFF
--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -220,31 +220,22 @@ public class AstCheckerTest {
 		}
 
 		private Optional<CtInvocation<?>> extractPotentialSurchargeDelegate(CtMethod<?> candidate) {
-			CtBlock<?> body = candidate.getBody();
+			final CtBlock<?> body = candidate.getBody();
 			if (body.getStatements().isEmpty()) {
 				return Optional.empty();
 			}
 
-			CtStatement firstStatement = body.getStatement(0);
-			CtStatement lastStatement = body.getLastStatement();
-			if (hasOnlySingleInvocation(body) ||
-					startsWithInvocationAndEndsWithReturnWithoutInvocation(body)) {
+			final CtStatement firstStatement = body.getStatement(0);
+			final CtStatement lastStatement = body.getLastStatement();
+			if (firstStatement instanceof CtInvocation &&
+					(body.getStatements().size() == 1 || isReturnWithoutInvocation(lastStatement))) {
 				return Optional.of((CtInvocation<?>) firstStatement);
 			} else if (isReturnWithInvocation(lastStatement)) {
-				return Optional.of((CtInvocation<?>) ((CtReturn<?>) lastStatement).getReturnedExpression());
+				CtReturn<?> lastStatementReturn = (CtReturn<?>) lastStatement;
+				return Optional.of((CtInvocation<?>) lastStatementReturn.getReturnedExpression());
 			} else {
 				return Optional.empty();
 			}
-		}
-
-		private boolean startsWithInvocationAndEndsWithReturnWithoutInvocation(CtBlock<?> block) {
-			return block.getStatement(0) instanceof CtInvocation
-					&& isReturnWithoutInvocation(block.getLastStatement());
-		}
-
-		private boolean hasOnlySingleInvocation(CtBlock<?> block) {
-			return block.getStatements().size() == 1
-					&& block.getLastStatement() instanceof CtInvocation;
 		}
 
 		private boolean isReturnWithoutInvocation(CtStatement statement) {

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -18,6 +18,7 @@ package spoon.reflect.ast;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.support.modelobs.FineModelChangeListener;
@@ -207,22 +208,31 @@ public class AstCheckerTest {
 			if (block.getStatements().isEmpty()) {
 				return false;
 			}
+			// invariant 1: block is non-empty
 			CtInvocation potentialDelegate;
 			if (block.getLastStatement() instanceof CtReturn) {
+				// 1, invariant 2: last statement is a return
 				if (!(((CtReturn) block.getLastStatement()).getReturnedExpression() instanceof CtInvocation)) {
+					// 1, 2, invariant 3: last statement is not a return with an invocation
 					if (block.getStatement(0) instanceof CtInvocation) {
+						// 1, 2, 3, invariant 4: first statement is an invocation
 						potentialDelegate = block.getStatement(0);
 					} else {
+						// 1, 2, 3, ~4
 						return false;
 					}
 				} else {
+					// 1, 2, ~3
 					potentialDelegate = (CtInvocation) ((CtReturn) block.getLastStatement()).getReturnedExpression();
 				}
 			} else if (block.getStatement(0) instanceof CtInvocation && block.getStatements().size() == 1) {
+				// 1, ~2, invariant 7: there's only one statement, and it's an invocation
 				potentialDelegate = block.getStatement(0);
 			} else {
+				// 1, ~2, ~7 ==> either a single statement that is neither return nor invocation, or multiple statements
 				return false;
 			}
+
 			CtExecutable declaration = potentialDelegate.getExecutable().getDeclaration();
 			if (!(declaration instanceof CtMethod)) {
 				return false;


### PR DESCRIPTION
#4100

This is a refactor of `AstCheckerTest#isSurcharged()`. It should be noted that I don't understand what "surcharged" means in the context, and I also don't understand the intent of the function. The mechanics are however clear to me, see the invariants in 32de37d.

An invocation `v` is a potential surcharge delegate if it:

* Is an invocation that is the only statement in the body.
* Is an invocation that is the first statement in the body, and the last statement is a return _without_ an invocation.
* Is an invocation in a return occurring as the last statement in the body.

`v` is determined to be a surcharge delegate if it fulfills any of the 3 above points, and returns false for `isToBeProcessed(v)`.