### PR TITLE
chore: Manually set the renovate GHA tags

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
     name: Run Sorald Buildbreaker
     steps:
       - name: Checkout
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
         with:
           fetch-depth: 0
       - name: Run Sorald Buildbreaker

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,8 @@ jobs:
     steps:
       - name: Disable Git's autocrlf
         run: git config --global core.autocrlf false
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
+      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c # renovate: tag=v2.3.0
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -50,7 +50,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
       - name: Use Maven dependency cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # renovate: tag=v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
@@ -74,8 +74,8 @@ jobs:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     name: Test with coverage
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
+      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c # renovate: tag=v2.3.0
         with:
           java-version: 15
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -85,7 +85,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
       - name: Use Maven dependency cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # renovate: tag=v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
@@ -108,14 +108,14 @@ jobs:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     name: Extra checks
     steps:
-      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
         with:
           fetch-depth: 0
       - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c
         with:
           java-version: 15
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-      - uses: actions/setup-python@41b7212b1668f5de9d65e9c82aa777e6bbedb3a8 # v2.1.4
+      - uses: actions/setup-python@41b7212b1668f5de9d65e9c82aa777e6bbedb3a8 # renovate: tag=v2.1.4
         with:
           python-version: 3.6
 
@@ -124,7 +124,7 @@ jobs:
         run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
         shell: bash
       - name: Use Maven dependency cache
-        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # v2.1.4
+        uses: actions/cache@26968a09c0ea4f3e233fdddbafd1166051a095f6 # renovate: tag=v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
@@ -142,7 +142,7 @@ jobs:
     name: Run Sorald Buildbreaker
     steps:
       - name: Checkout
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
         with:
           fetch-depth: 0
       - name: Run Sorald Buildbreaker


### PR DESCRIPTION
As all but one of the PRs opened by renovate on GHA versions have _not_ pinned to a tag, I'm now manually pinning to tags [as suggested by the docs here](https://docs.renovatebot.com/modules/manager/github-actions/). The auto-pinning simply does not work, at least not reliably.