### PR TITLE
wip: fix: change how modifiers are handled to use an ordered LinkedHashSet

### DIFF
--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -58,7 +58,7 @@ public class CtModifierHandler implements Serializable {
 	}
 
 	public Set<ModifierKind> getModifiers() {
-		return modifiers.stream().map(CtExtendedModifier::getKind).collect(linkedHashSetCollector());
+		return modifiers.stream().map(CtExtendedModifier::getKind).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 	public boolean hasModifier(ModifierKind modifier) {

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -16,8 +16,9 @@ import spoon.support.reflect.declaration.CtElementImpl;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Collector;
 
 import static spoon.reflect.path.CtRole.MODIFIER;
 
@@ -44,7 +45,7 @@ public class CtModifierHandler implements Serializable {
 		if (extendedModifiers != null && !extendedModifiers.isEmpty()) {
 			getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(element, MODIFIER, this.modifiers, new HashSet<>(this.modifiers));
 			if (this.modifiers == CtElementImpl.<CtExtendedModifier>emptySet()) {
-				this.modifiers = new HashSet<>();
+				this.modifiers = new LinkedHashSet<>();
 			} else {
 				this.modifiers.clear();
 			}
@@ -57,7 +58,7 @@ public class CtModifierHandler implements Serializable {
 	}
 
 	public Set<ModifierKind> getModifiers() {
-		return modifiers.stream().map(CtExtendedModifier::getKind).collect(Collectors.toSet());
+		return modifiers.stream().map(CtExtendedModifier::getKind).collect(linkedHashSetCollector());
 	}
 
 	public boolean hasModifier(ModifierKind modifier) {
@@ -199,5 +200,20 @@ public class CtModifierHandler implements Serializable {
 			return false;
 		}
 		return getModifiers().containsAll(other.getModifiers());
+	}
+
+	private <T> Collector<T, LinkedHashSet<T>, LinkedHashSet<T>> linkedHashSetCollector() {
+		return Collector.of(
+				LinkedHashSet::new,
+				LinkedHashSet::add,
+				(left, right) -> {
+					if (left.size() < right.size()) {
+						right.addAll(left);
+						return right;
+					} else {
+						left.addAll(right);
+						return left;
+					}
+				});
 	}
 }

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import static spoon.reflect.path.CtRole.MODIFIER;
 
@@ -67,7 +68,7 @@ public class CtModifierHandler implements Serializable {
 
 	public CtModifierHandler setModifiers(Set<ModifierKind> modifiers) {
 		if (modifiers == null) {
-			modifiers = Collections.emptySet();
+			modifiers = new LinkedHashSet<>();
 		}
 		getFactory().getEnvironment().getModelChangeListener().onSetDeleteAll(element, MODIFIER, this.modifiers, new HashSet<>(this.modifiers));
 		this.modifiers.clear();
@@ -79,7 +80,7 @@ public class CtModifierHandler implements Serializable {
 
 	public CtModifierHandler addModifier(ModifierKind modifier) {
 		if (this.modifiers == CtElementImpl.<CtExtendedModifier>emptySet()) {
-			this.modifiers = new HashSet<>();
+			this.modifiers = new LinkedHashSet<>();
 		}
 		getFactory().getEnvironment().getModelChangeListener().onSetAdd(element, MODIFIER, this.modifiers, modifier);
 		// we always add explicit modifiers, then we have to remove first implicit one

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -201,19 +201,4 @@ public class CtModifierHandler implements Serializable {
 		}
 		return getModifiers().containsAll(other.getModifiers());
 	}
-
-	private <T> Collector<T, LinkedHashSet<T>, LinkedHashSet<T>> linkedHashSetCollector() {
-		return Collector.of(
-				LinkedHashSet::new,
-				LinkedHashSet::add,
-				(left, right) -> {
-					if (left.size() < right.size()) {
-						right.addAll(left);
-						return right;
-					} else {
-						left.addAll(right);
-						return left;
-					}
-				});
-	}
 }

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static spoon.reflect.path.CtRole.MODIFIER;

--- a/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
+++ b/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
@@ -1,67 +1,85 @@
 package spoon.support.reflect;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 
-import java.util.Arrays;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class CtModifierHandlerTest {
 
-    LinkedHashSet<ModifierKind> inputModifierKinds = new LinkedHashSet<>(Arrays.asList(
+    private final List<ModifierKind> inputModifierKinds = Arrays.asList(
             ModifierKind.STATIC,
             ModifierKind.PUBLIC,
             ModifierKind.ABSTRACT,
             ModifierKind.NATIVE
-    ));
-    LinkedHashSet<CtExtendedModifier> inputExtendedModifiers = inputModifierKinds.stream().map(CtExtendedModifier::new).collect(Collectors.toCollection(LinkedHashSet::new));
+    );
+    private final List<CtExtendedModifier> inputExtendedModifiers = inputModifierKinds
+            .stream()
+            .map(CtExtendedModifier::new)
+            .collect(Collectors.toList());
 
-    // these will be overwritten in each test.
-    Set<ModifierKind> modifiers;
-    Set<CtExtendedModifier> modifiersExt;
-    CtModifierHandler handler;
+    private void assertPass(CtModifierHandler handler) {
+        Set<ModifierKind> outputModifierKinds = handler.getModifiers();
+        Set<CtExtendedModifier> outputExtendedModifiers = handler.getExtendedModifiers();
 
-    @Before
-    public void setUp() {
-        Launcher l = new Launcher();
-        Factory f = l.createFactory();
-        handler = new CtModifierHandler(f.createClass("org.test.Test"));
+        // We iterate over these collections
+        Iterator<ModifierKind> inputIterator = inputModifierKinds.iterator();
+        Iterator<CtExtendedModifier> inputIteratorExt = inputExtendedModifiers.iterator();
+        Iterator<ModifierKind> outputIterator = outputModifierKinds.iterator();
+        Iterator<CtExtendedModifier> outputIteratorExt = outputExtendedModifiers.iterator();
+
+        Supplier<Boolean> hasNext = () -> inputIterator.hasNext()
+                && inputIteratorExt.hasNext()
+                && outputIterator.hasNext()
+                && outputIteratorExt.hasNext();
+
+        while (hasNext.get()) {
+            assertEquals(inputIterator.next(), outputIterator.next());
+            assertEquals(inputIteratorExt.next(), outputIteratorExt.next());
+        }
+
+        // None of these iterators should have any elements left.
+        assertFalse(inputIterator.hasNext()
+                || inputIteratorExt.hasNext()
+                || outputIterator.hasNext()
+                || outputIteratorExt.hasNext()
+        );
     }
 
     @Test
     public void testAddModifier() {
-        inputModifierKinds.forEach(handler::addModifier);
-        modifiersExt = handler.getExtendedModifiers();
-        modifiers = handler.getModifiers();
+        Launcher launcher = new Launcher();
+        Factory factory = launcher.createFactory();
+        CtModifierHandler handler = new CtModifierHandler(factory.createClass("org.test.Test"));
 
-        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
-        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+        inputModifierKinds.forEach(handler::addModifier);
+        assertPass(handler);
     }
 
     @Test
     public void testSetModifiers() {
-        handler.setModifiers(inputModifierKinds);
-        modifiersExt = handler.getExtendedModifiers();
-        modifiers = handler.getModifiers();
+        Launcher launcher = new Launcher();
+        Factory factory = launcher.createFactory();
+        CtModifierHandler handler = new CtModifierHandler(factory.createClass("org.test.Test"));
 
-        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
-        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+        handler.setModifiers(new LinkedHashSet<>(inputModifierKinds));
+        assertPass(handler);
     }
 
     @Test
     public void testSetExtendedModifiers() {
-        handler.setExtendedModifiers(inputExtendedModifiers);
-        modifiersExt = handler.getExtendedModifiers();
-        modifiers = handler.getModifiers();
+        Launcher launcher = new Launcher();
+        Factory factory = launcher.createFactory();
+        CtModifierHandler handler = new CtModifierHandler(factory.createClass("org.test.Test"));
 
-        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
-        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+        handler.setExtendedModifiers(new LinkedHashSet<>(inputExtendedModifiers));
+        assertPass(handler);
     }
 }

--- a/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
+++ b/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
@@ -29,7 +29,8 @@ public class CtModifierHandlerTest {
         Set<ModifierKind> outputModifierKinds = handler.getModifiers();
         Set<CtExtendedModifier> outputExtendedModifiers = handler.getExtendedModifiers();
 
-        // We iterate over these collections
+        // We iterate over these collections in step with each other
+        // to ensure we access elements in order.
         Iterator<ModifierKind> inputIterator = inputModifierKinds.iterator();
         Iterator<CtExtendedModifier> inputIteratorExt = inputExtendedModifiers.iterator();
         Iterator<ModifierKind> outputIterator = outputModifierKinds.iterator();

--- a/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
+++ b/src/test/java/spoon/support/reflect/CtModifierHandlerTest.java
@@ -1,0 +1,67 @@
+package spoon.support.reflect;
+
+import org.junit.Before;
+import org.junit.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.Factory;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class CtModifierHandlerTest {
+
+    LinkedHashSet<ModifierKind> inputModifierKinds = new LinkedHashSet<>(Arrays.asList(
+            ModifierKind.STATIC,
+            ModifierKind.PUBLIC,
+            ModifierKind.ABSTRACT,
+            ModifierKind.NATIVE
+    ));
+    LinkedHashSet<CtExtendedModifier> inputExtendedModifiers = inputModifierKinds.stream().map(CtExtendedModifier::new).collect(Collectors.toCollection(LinkedHashSet::new));
+
+    // these will be overwritten in each test.
+    Set<ModifierKind> modifiers;
+    Set<CtExtendedModifier> modifiersExt;
+    CtModifierHandler handler;
+
+    @Before
+    public void setUp() {
+        Launcher l = new Launcher();
+        Factory f = l.createFactory();
+        handler = new CtModifierHandler(f.createClass("org.test.Test"));
+    }
+
+    @Test
+    public void testAddModifier() {
+        inputModifierKinds.forEach(handler::addModifier);
+        modifiersExt = handler.getExtendedModifiers();
+        modifiers = handler.getModifiers();
+
+        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
+        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+    }
+
+    @Test
+    public void testSetModifiers() {
+        handler.setModifiers(inputModifierKinds);
+        modifiersExt = handler.getExtendedModifiers();
+        modifiers = handler.getModifiers();
+
+        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
+        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+    }
+
+    @Test
+    public void testSetExtendedModifiers() {
+        handler.setExtendedModifiers(inputExtendedModifiers);
+        modifiersExt = handler.getExtendedModifiers();
+        modifiers = handler.getModifiers();
+
+        assertEquals("Order of modifiers was not preserved.", inputModifierKinds, modifiers);
+        assertEquals("Order of extended modifiers was not preserved.", inputExtendedModifiers, modifiersExt);
+    }
+}


### PR DESCRIPTION
I should probably move the linkedHashSetCollector method elsewhere (a utility class for example). 

this PR addresses #4033 