### PR TITLE
review: fix: Handle nested `}` in inline tag

### DIFF
--- a/src/main/java/spoon/javadoc/internal/Javadoc.java
+++ b/src/main/java/spoon/javadoc/internal/Javadoc.java
@@ -146,8 +146,32 @@ public class Javadoc implements Serializable {
 		if (index == -1) {
 			return null;
 		}
-		// we are interested only in complete inline tags
-		int closeIndex = text.indexOf("}", index);
+
+		// Find the corresponding end curly brace:
+		//
+		//                 Tag doesn't end here
+		//                            |
+		//                            v
+		//   {@code public class Foo {}}
+		//   ^                         ^
+		//   |                         |
+		// index                 Tag ends here
+
+		int closeIndex = -1;
+		int nesting = 1;
+		for (int i = index + 2; i < text.length(); i++) {
+			char read = text.charAt(i);
+			if (read == '{') {
+				nesting++;
+			} else if (read == '}') {
+				nesting--;
+			}
+			if (nesting == 0) {
+				closeIndex = i;
+				break;
+			}
+		}
+
 		if (closeIndex == -1) {
 			return null;
 		}

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -16,10 +16,12 @@
  */
 package spoon.test.javadoc;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonAPI;
+import spoon.javadoc.internal.Javadoc;
+import spoon.javadoc.internal.JavadocDescriptionElement;
 import spoon.javadoc.internal.JavadocInlineTag;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtComment;
@@ -39,8 +41,8 @@ import spoon.test.javadoc.testclasses.Bar;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.Check.assertCtElementEquals;
 
 public class JavaDocTest {
@@ -180,6 +182,29 @@ public class JavaDocTest {
 		assertEquals(TagType.SINCE, type.getMethodsByName("m10").get(0).getElements(new TypeFilter<>(CtJavaDoc.class)).get(0).getTags().get(0).getType());
 		assertEquals(TagType.THROWS, type.getMethodsByName("m11").get(0).getElements(new TypeFilter<>(CtJavaDoc.class)).get(0).getTags().get(0).getType());
 		assertEquals(TagType.UNKNOWN, type.getMethodsByName("m12").get(0).getElements(new TypeFilter<>(CtJavaDoc.class)).get(0).getTags().get(0).getType());
+	}
+
+	@Test
+	public void testNestedBracesInJavadocTag() {
+		CtClass<?> ctClass = Launcher.parseClass("/**\n"
+				+ " * This is code: {@code public void foo() { Hello }} and something after it.\n"
+				+ " */\n"
+				+ "public class Foo {}");
+
+		Javadoc javadoc = Javadoc.parse(ctClass.getComments().get(0).asJavaDoc().getContent());
+		JavadocDescriptionElement firstTextElement = javadoc.getDescription()
+				.getElements()
+				.get(0);
+		JavadocInlineTag codeElement = (JavadocInlineTag) javadoc.getDescription()
+				.getElements()
+				.get(1);
+		JavadocDescriptionElement finalTextElement = javadoc.getDescription()
+				.getElements()
+				.get(2);
+
+		assertEquals("This is code: ", firstTextElement.toText());
+		assertEquals("public void foo() { Hello }", codeElement.getContent());
+		assertEquals(" and something after it.", finalTextElement.toText());
 	}
 
 }


### PR DESCRIPTION
An inline tag does *not* end at the next `}` bracket but at the next
*matching* `}` bracket. This can be especially noticeable in code tags:

```
                  Tag doesn't end here
                         |
                         v
{@code public class Foo {}}
                          ^
                    Tag ends here
```

Closes #4154.