### PR TITLE
chore: Pin setup-java action to tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # renovate: tag=v2.3.4
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c
+      - uses: actions/setup-java@3bc31aaf88e8fc94dc1e632d48af61be5ca8721c # renovate: tag=v2.3.0
         with:
           java-version: 15
           distribution: ${{ env.JAVA_DISTRIBUTION }}


### PR DESCRIPTION
#4156 showed that I'd missed pinning one of the setup-java actions to a tag. This PR fixes that, which makes renovate only suggest updates when a new version is available (as opposed to on every new push to the main branch of the action).