### PR TITLE
wip: chore(deps): update jdt to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.26.0</version>
+      <version>3.27.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -473,7 +473,7 @@ public class ParentExiter extends CtInheritanceScanner {
 		if (node instanceof CaseStatement) {
 			caseStatement.setCaseKind(((CaseStatement) node).isExpr ? CaseKind.ARROW : CaseKind.COLON);
 		}
-		if (node instanceof CaseStatement && ((CaseStatement) node).constantExpression != null && child instanceof CtExpression
+		if (node instanceof CaseStatement && ((CaseStatement) node).constantExpressions != null && child instanceof CtExpression
 				&& caseStatement.getCaseExpressions().size() < ((CaseStatement) node).constantExpressions.length) {
 			caseStatement.addCaseExpression((CtExpression<E>) child);
 			return;


### PR DESCRIPTION
Supersedes #4161.

This JDT release adds support for Java 17. There was one breaking change with spoon that was simple to fix as the representation was just unified.

**Edit**: Oh well, that worked locally because I'm running it with Java 16. Seems like JDT now requires Java 11 as minimum version. How do we want to deal with that? @monperrus 

Blocked by ~~#4169~~ #4173 