### PR TITLE
review: Correctly parse inline tag names

### DIFF
--- a/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
+++ b/src/main/java/spoon/javadoc/internal/JavadocInlineTag.java
@@ -51,30 +51,35 @@ public class JavadocInlineTag implements JavadocDescriptionElement, Serializable
 	}
 
 	/**
-		* The type of tag: it could either correspond to a known tag (code, docRoot, etc.) or represent
-		* an unknown tag.
-		*/
+	 * The type of tag: it could either correspond to a known tag (code, docRoot, etc.) or represent
+	 * an unknown tag.
+	 *
+	 * See also:
+	 * <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html">
+	 * Tags in the Javadoc specification
+	 * </a>
+	 */
 	public enum Type {
-		CODE,
-		DOC_ROOT,
-		INHERIT_DOC,
-		LINK,
-		LINKPLAIN,
-		LITERAL,
-		VALUE,
-		UNKNOWN;
+		CODE("code"),
+		DOC_ROOT("docRoot"),
+		INHERIT_DOC("inheritDoc"),
+		LINK("link"),
+		LINKPLAIN("linkplain"),
+		LITERAL("literal"),
+		VALUE("value"),
+		UNKNOWN("unknown");
 
-		Type() {
-			this.keyword = name();
+		private final String keyword;
+
+		Type(String keyword) {
+			this.keyword = keyword;
 		}
 
-		private String keyword;
-
-		static JavadocInlineTag.Type fromName(String tagName) {
-			for (JavadocInlineTag.Type t : JavadocInlineTag.Type.values()) {
-			if (t.keyword.equals(tagName.toUpperCase())) {
-				return t;
-			}
+		static Type fromName(String tagName) {
+			for (Type type : values()) {
+				if (type.keyword.equalsIgnoreCase(tagName)) {
+					return type;
+				}
 			}
 			return UNKNOWN;
 		}

--- a/src/test/java/spoon/javadoc/internal/JavadocInlineTagTest.java
+++ b/src/test/java/spoon/javadoc/internal/JavadocInlineTagTest.java
@@ -1,0 +1,36 @@
+package spoon.javadoc.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import spoon.javadoc.internal.JavadocInlineTag.Type;
+
+class JavadocInlineTagTest {
+
+  @ParameterizedTest
+  @MethodSource("tagNameArgumentProvider")
+  void testTagNameTypeParsing(String tagName, Type expectedType) {
+
+    JavadocInlineTag element = (JavadocInlineTag) JavadocInlineTag.fromText("{@" + tagName + "}");
+    Type actualType = element.getType();
+
+    assertEquals(tagName, element.getName());
+    assertEquals(expectedType, actualType);
+  }
+
+  public static Stream<Arguments> tagNameArgumentProvider() {
+    return Stream.of(
+        Arguments.of("code", Type.CODE),
+        Arguments.of("docRoot", Type.DOC_ROOT),
+        Arguments.of("inheritDoc", Type.INHERIT_DOC),
+        Arguments.of("link", Type.LINK),
+        Arguments.of("linkplain", Type.LINKPLAIN),
+        Arguments.of("literal", Type.LITERAL),
+        Arguments.of("value", Type.VALUE),
+        Arguments.of("foobar", Type.UNKNOWN)
+    );
+  }
+}

--- a/src/test/java/spoon/javadoc/internal/JavadocInlineTagTest.java
+++ b/src/test/java/spoon/javadoc/internal/JavadocInlineTagTest.java
@@ -2,6 +2,7 @@ package spoon.javadoc.internal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -13,6 +14,19 @@ class JavadocInlineTagTest {
   @ParameterizedTest
   @MethodSource("tagNameArgumentProvider")
   void testTagNameTypeParsing(String tagName, Type expectedType) {
+    // contract: javadoc tag names should parse to their corresponding spoon type
+    JavadocInlineTag element = (JavadocInlineTag) JavadocInlineTag.fromText("{@" + tagName + "}");
+    Type actualType = element.getType();
+
+    assertEquals(tagName, element.getName());
+    assertEquals(expectedType, actualType);
+  }
+
+  @ParameterizedTest
+  @MethodSource("tagNameArgumentProvider")
+  void testTagNameCaseInsensitiveTypeParsing(String originalTagName, Type expectedType) {
+    // contract: javadoc tag names parsing should not depend on the case of the tag
+    String tagName = scrambleCase(originalTagName);
 
     JavadocInlineTag element = (JavadocInlineTag) JavadocInlineTag.fromText("{@" + tagName + "}");
     Type actualType = element.getType();
@@ -32,5 +46,18 @@ class JavadocInlineTagTest {
         Arguments.of("value", Type.VALUE),
         Arguments.of("foobar", Type.UNKNOWN)
     );
+  }
+
+  private String scrambleCase(String input) {
+    StringBuilder scrambledCaseBuilder = new StringBuilder();
+    for (char c : input.toCharArray()) {
+      if (ThreadLocalRandom.current().nextBoolean()) {
+        scrambledCaseBuilder.append(Character.toUpperCase(c));
+      } else {
+        scrambledCaseBuilder.append(c);
+      }
+    }
+
+    return scrambledCaseBuilder.toString();
   }
 }


### PR DESCRIPTION
Spoon previously expected e.g. `docRoot` to be `doc_root`, which is not correct. This PR fixes this in a backwards-compatible way by setting the keyword to its actual value.