### PR TITLE
review: chore(gitignore): improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,22 @@ doc/_jekyll/_site/
 
 # Nodejs
 node_modules/
+
+### Gradle ###
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+### Gradle Patch ###
+**/build/


### PR DESCRIPTION
The old git ignore was missing some Gradle build artifacts, I added them to the git ignore. The input was created by [https://www.toptal.com/developers/gitignore/api/gradle](https://www.toptal.com/developers/gitignore/api/gradle)