### PR TITLE
review: refactor: Remove Java 7 specific code

### DIFF
--- a/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
@@ -8,7 +8,6 @@
 package spoon.support.visitor.java.reflect;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -16,8 +15,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
-import spoon.SpoonException;
 
 public class RtMethod {
 	private final Class<?> clazz;

--- a/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtMethod.java
@@ -145,33 +145,8 @@ public class RtMethod {
 		return new RtMethod(method.getDeclaringClass(), method, method.getName(), method.getReturnType(),
 				method.getGenericReturnType(), method.getTypeParameters(), method.getParameterTypes(), method.getGenericParameterTypes(), method.getExceptionTypes(),
 				method.getModifiers(), method.getDeclaredAnnotations(), method.getParameterAnnotations(),
-				method.isVarArgs(), //spoon is compatible with Java 7, so compilation fails here
-				//method.isDefault());
-				_java8_isDefault(method));
-	}
-
-	private static Method _method_isDefault;
-	static {
-		try {
-			_method_isDefault = Method.class.getMethod("isDefault");
-		} catch (NoSuchMethodException | SecurityException e) {
-			//spoon is running with java 7 JDK
-			_method_isDefault = null;
-		}
-	}
-
-	private static boolean _java8_isDefault(Method method) {
-		if (_method_isDefault == null) {
-			//spoon is running with java 7 JDK, all methods are not default, because java 7 does not have default methods
-			return false;
-		}
-		try {
-			return (Boolean) _method_isDefault.invoke(method);
-		} catch (IllegalAccessException | IllegalArgumentException e) {
-			throw new SpoonException("Calling of Java8 Method#isDefault() failed", e);
-		} catch (InvocationTargetException e) {
-			throw new SpoonException("Calling of Java8 Method#isDefault() failed", e.getTargetException());
-		}
+				method.isVarArgs(),
+				method.isDefault());
 	}
 
 	public static <T> RtMethod[] methodsOf(Class<T> clazz) {


### PR DESCRIPTION
I found a spot where reflections where used to call Java 8 methods, for source compatibility with Java 7. This is no longer relevant and can be simplified.