### PR TITLE
review: chore: Add lgtm.yml to set java version

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: 11


### PR DESCRIPTION
This PR adds a `lgtm.yml` file to force LGTM to use java 11 to analyze spoon. The current default seems to be 8 (or it didn't properly recognize the version in our pom files).