### PR TITLE
refactor(ClassTypingContext): remove unneeded type check, fix LGTM warning

### DIFF
--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -298,7 +298,7 @@ public class ClassTypingContext extends AbstractTypingContext {
 	 * @return true if this method and thatMethod has same signature
 	 */
 	public boolean isSameSignature(CtExecutable<?> thisExecutable, CtMethod<?> thatExecutable) {
-		if (!(thatExecutable instanceof CtConstructor)) {
+		if (thatExecutable instanceof CtConstructor) {
 			//only method or constructor can have same signature
 			return false;
 		}

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -298,7 +298,7 @@ public class ClassTypingContext extends AbstractTypingContext {
 	 * @return true if this method and thatMethod has same signature
 	 */
 	public boolean isSameSignature(CtExecutable<?> thisExecutable, CtMethod<?> thatExecutable) {
-		if ((thatExecutable instanceof CtMethod || thatExecutable instanceof CtConstructor) == false) {
+		if (!(thatExecutable instanceof CtConstructor)) {
 			//only method or constructor can have same signature
 			return false;
 		}


### PR DESCRIPTION
This PR fixes an issue with an unneeded `instanceof` check. A `CtMethod` is always `instanceof` `CtMethod`. See https://lgtm.com/projects/g/INRIA/spoon/snapshot/af0caa74d58ecec12adf3cb64df0da3681c13544/files/src/main/java/spoon/support/visitor/ClassTypingContext.java?sort=name&dir=ASC&mode=heatmap#x6d177e115261d850:1