### PR TITLE
refactor: fix potential resource leaks

### DIFF
--- a/src/main/java/spoon/IncrementalLauncher.java
+++ b/src/main/java/spoon/IncrementalLauncher.java
@@ -94,8 +94,8 @@ public class IncrementalLauncher extends Launcher {
 	}
 
 	private static void saveFactory(Factory factory, File file) {
-		try {
-			new SerializationModelStreamer().save(factory, new FileOutputStream(file));
+		try (FileOutputStream fileStream = new FileOutputStream(file)) {
+			new SerializationModelStreamer().save(factory, fileStream);
 		} catch (IOException e) {
 			throw new SpoonException("unable to save factory");
 		}

--- a/src/main/java/spoon/support/gui/SpoonModelTree.java
+++ b/src/main/java/spoon/support/gui/SpoonModelTree.java
@@ -137,9 +137,8 @@ public class SpoonModelTree extends JFrame implements KeyListener,
 					boolean cont = chooser.showSaveDialog(SpoonModelTree.this) == JFileChooser.APPROVE_OPTION;
 					if (cont) {
 						SerializationModelStreamer ser = new SerializationModelStreamer();
-						try {
-							ser.save(factory, new FileOutputStream(chooser
-									.getSelectedFile()));
+						try (FileOutputStream out = new FileOutputStream(chooser.getSelectedFile())) {
+							ser.save(factory, out);
 						} catch (IOException e1) {
 							Launcher.LOGGER.error(e1.getMessage(), e1);
 						}


### PR DESCRIPTION
This PR fixes an issue with potential resource leaks. In both cases a try-with-resources fixed the problem. See

[LGTM-Link](https://lgtm.com/projects/g/INRIA/spoon?mode=tree&id=java%2Fcontradictory-type-checks%2Cjava%2Fdereferenced-value-may-be-null%2Cjava%2Finconsistent-equals-and-hashcode%2Cjava%2Findex-out-of-bounds%2Cjava%2Foutput-resource-leak%2Cjava%2Funchecked-cast-in-equals%2Cjava%2Funknown-javadoc-parameter%2Cjava%2Funused-container%2Cjava%2Fuseless-type-test%2Cjava%2Fzipslip&tag=external%2Fcwe%2Fcwe-022%2Cexternal%2Fcwe%2Fcwe-193%2Cexternal%2Fcwe%2Fcwe-404%2Cexternal%2Fcwe%2Fcwe-476%2Cexternal%2Fcwe%2Fcwe-561%2Cexternal%2Fcwe%2Fcwe-581%2Cexternal%2Fcwe%2Fcwe-772&ruleFocus=2980072)