### PR TITLE
refactor: fix LGTM warning by removing unaccessed fields

### DIFF
--- a/src/main/java/spoon/metamodel/MetamodelConcept.java
+++ b/src/main/java/spoon/metamodel/MetamodelConcept.java
@@ -45,10 +45,6 @@ public class MetamodelConcept {
 	 * List of super concepts of this concept
 	 */
 	private final List<MetamodelConcept> superConcepts = new ArrayList<>();
-	/**
-	 * List of sub concepts of this concept
-	 */
-	private final List<MetamodelConcept> subConcepts = new ArrayList<>();
 
 	/**
 	 * The {@link CtClass} linked to this {@link MetamodelConcept}. Is null in case of class without interface
@@ -145,7 +141,6 @@ public class MetamodelConcept {
 			throw new SpoonException("Cannot add supertype to itself");
 		}
 		if (addUniqueObject(superConcepts, superType)) {
-			superType.subConcepts.add(this);
 			superType.role2Property.forEach((role, superMMField) -> {
 				MetamodelProperty mmField = getOrCreateMMField(role);
 				mmField.addSuperField(superMMField);

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -93,8 +93,6 @@ public class MetamodelProperty {
 	 */
 	private final List<MetamodelProperty> superProperties = new ArrayList<>();
 
-	private List<MMMethodKind> ambiguousMethodKinds = new ArrayList<>();
-
 	MetamodelProperty(String name, CtRole role, MetamodelConcept ownerConcept) {
 		this.name = name;
 		this.role = role;
@@ -299,14 +297,9 @@ public class MetamodelProperty {
 		List<MMMethod> methods = methodsByKind.get(key);
 		if (methods != null && methods.size() > 1) {
 			int idx = getIdxOfBestMatch(methods, key);
-			if (idx >= 0) {
 				if (idx > 0) {
 					//move the matching to the beginning
 					methods.add(0, methods.remove(idx));
-				}
-			} else {
-				//add all methods as ambiguous
-				ambiguousMethodKinds.add(key);
 			}
 		}
 	}


### PR DESCRIPTION
This PR removes 2 never accessed containers and fixes a LGTM alert. @monperrus are these field import to keep or needed for a future feature?
 See [LGTM-link](https://lgtm.com/projects/g/INRIA/spoon?mode=tree&id=java%2Fcontradictory-type-checks%2Cjava%2Fdereferenced-value-may-be-null%2Cjava%2Finconsistent-equals-and-hashcode%2Cjava%2Findex-out-of-bounds%2Cjava%2Foutput-resource-leak%2Cjava%2Funchecked-cast-in-equals%2Cjava%2Funknown-javadoc-parameter%2Cjava%2Funused-container%2Cjava%2Fuseless-type-test%2Cjava%2Fzipslip&tag=external%2Fcwe%2Fcwe-022%2Cexternal%2Fcwe%2Fcwe-193%2Cexternal%2Fcwe%2Fcwe-404%2Cexternal%2Fcwe%2Fcwe-476%2Cexternal%2Fcwe%2Fcwe-561%2Cexternal%2Fcwe%2Fcwe-581%2Cexternal%2Fcwe%2Fcwe-772&ruleFocus=890083)