### PR TITLE
wip: feature: Add static factory methods for CtExtendedModifier

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -92,6 +92,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -101,6 +102,10 @@ import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.searchType;
 import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.searchTypeBinding;
 
 public class ReferenceBuilder {
+	private static final Set<CtExtendedModifier> PUBLIC_PROTECTED = Set.of(
+			CtExtendedModifier.explicit(ModifierKind.PUBLIC),
+			CtExtendedModifier.explicit(ModifierKind.PROTECTED)
+	);
 
 	// Allow to detect circular references and to avoid endless recursivity
 	// when resolving parameterizedTypes (e.g. Enum<E extends Enum<E>>)
@@ -261,8 +266,7 @@ public class ReferenceBuilder {
 	 * @return a type reference.
 	 */
 	<T> CtTypeReference<T> getQualifiedTypeReference(char[][] tokens, TypeBinding receiverType, ReferenceBinding enclosingType, JDTTreeBuilder.OnAccessListener listener) {
-		final List<CtExtendedModifier> listPublicProtected = Arrays.asList(new CtExtendedModifier(ModifierKind.PUBLIC), new CtExtendedModifier(ModifierKind.PROTECTED));
-		if (enclosingType != null && Collections.disjoint(listPublicProtected, JDTTreeBuilderQuery.getModifiers(enclosingType.modifiers, false, false))) {
+		if (enclosingType != null && Collections.disjoint(PUBLIC_PROTECTED, JDTTreeBuilderQuery.getModifiers(enclosingType.modifiers, false, false))) {
 			String access = "";
 			int i = 0;
 			final CompilationUnitDeclaration[] units = ((TreeBuilderCompiler) this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.scope.environment.typeRequestor).unitsToProcess;

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -25,13 +25,46 @@ public class CtExtendedModifier implements SourcePositionHolder, Serializable {
 	private ModifierKind kind;
 	private SourcePosition position;
 
+	/**
+	 * Creates a new extended modifier of the given kind.
+	 *
+	 * @param kind the kind of this modifier.
+	 * @deprecated use {@link #explicit(ModifierKind)} to create an explicit modifier.
+	 */
+	@Deprecated
 	public CtExtendedModifier(ModifierKind kind) {
 		this.kind = kind;
 	}
 
+	/**
+	 * Creates a new extended modifier of the given kind with the given implicitness.
+	 *
+	 * @param kind the kind of this modifier.
+	 * @param implicit whether this modifier should be implicit.
+	 */
 	public CtExtendedModifier(ModifierKind kind, boolean implicit) {
 		this(kind);
 		this.implicit = implicit;
+	}
+
+	/**
+	 * Creates an extended modifier of the given kind that is explicit.
+	 *
+	 * @param kind the kind of the created modifier.
+	 * @return an explicit extended modifier.
+	 */
+	public static CtExtendedModifier explicit(ModifierKind kind) {
+		return new CtExtendedModifier(kind, false);
+	}
+
+	/**
+	 * Creates an extended modifier of the given kind that is implicit.
+	 *
+	 * @param kind the kind of the created modifier.
+	 * @return an implicit extended modifier.
+	 */
+	public static CtExtendedModifier implicit(ModifierKind kind) {
+		return new CtExtendedModifier(kind, true);
 	}
 
 	public boolean isImplicit() {

--- a/src/main/java/spoon/support/reflect/CtModifierHandler.java
+++ b/src/main/java/spoon/support/reflect/CtModifierHandler.java
@@ -82,8 +82,8 @@ public class CtModifierHandler implements Serializable {
 		}
 		getFactory().getEnvironment().getModelChangeListener().onSetAdd(element, MODIFIER, this.modifiers, modifier);
 		// we always add explicit modifiers, then we have to remove first implicit one
-		modifiers.remove(new CtExtendedModifier(modifier, true));
-		modifiers.add(new CtExtendedModifier(modifier));
+		modifiers.remove(CtExtendedModifier.implicit(modifier));
+		modifiers.add(CtExtendedModifier.explicit(modifier));
 		return this;
 	}
 
@@ -93,8 +93,8 @@ public class CtModifierHandler implements Serializable {
 		}
 		getFactory().getEnvironment().getModelChangeListener().onSetDelete(element, MODIFIER, modifiers, modifier);
 		// we want to remove implicit OR explicit modifier
-		modifiers.remove(new CtExtendedModifier(modifier));
-		modifiers.remove(new CtExtendedModifier(modifier, true));
+		modifiers.remove(CtExtendedModifier.implicit(modifier));
+		modifiers.remove(CtExtendedModifier.explicit(modifier));
 		return this;
 	}
 

--- a/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtInterfaceImpl.java
@@ -126,10 +126,10 @@ public class CtInterfaceImpl<T> extends CtTypeImpl<T> implements CtInterface<T> 
 		// modifiers if they aren't public static already.
 		Set<CtExtendedModifier> modifiers = new HashSet<>(nestedType.getExtendedModifiers());
 		if (!nestedType.isPublic()) {
-			modifiers.add(new CtExtendedModifier(ModifierKind.PUBLIC, true));
+			modifiers.add(CtExtendedModifier.implicit(ModifierKind.PUBLIC));
 		}
 		if (!nestedType.isStatic()) {
-			modifiers.add(new CtExtendedModifier(ModifierKind.STATIC, true));
+			modifiers.add(CtExtendedModifier.implicit(ModifierKind.STATIC));
 		}
 		nestedType.setExtendedModifiers(modifiers);
 


### PR DESCRIPTION
This adds two methods to `CtExtendedModifier` that allow to create instances without having to pass boolean values.

I deprecated the constructor where the implicitness defaulted to `false`, as the result is less obvious compared to the named method.

I also replaced the usages of the deprecated constructor and the usages of the other constructor where the second parameter was a boolean literal.

The usage as API might be more relevant with methods to directly add and remove extended modifiers, see #4136 for context.