### PR TITLE
review: fix: extract enum constant modifiers from the right place

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1208,15 +1208,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		field.setSimpleName(CharOperation.charToString(fieldDeclaration.name));
 		if (fieldDeclaration.binding != null) {
-			if (fieldDeclaration.binding.declaringClass != null
-				&& fieldDeclaration.binding.declaringClass.isEnum()
-				&& field instanceof CtEnumValue) {
-				//enum values take over visibility from enum type
-				//JDT compiler has a bug that enum values are always public static final, even for private enum
-				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.declaringClass.modifiers, true, false));
-			} else {
-				field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true, false));
-			}
+			field.setExtendedModifiers(getModifiers(fieldDeclaration.binding.modifiers, true, false));
 		}
 		for (CtExtendedModifier extendedModifier : getModifiers(fieldDeclaration.modifiers, false, false)) {
 			field.addModifier(extendedModifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -310,7 +310,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 	public void visitEnumValue(Field field) {
 		final CtEnumValue<Object> ctEnumValue = factory.Core().createEnumValue();
 		ctEnumValue.setSimpleName(field.getName());
-		setModifier(ctEnumValue, field.getDeclaringClass().getModifiers(), field.getDeclaringClass().getDeclaringClass());
+		setModifier(ctEnumValue, field.getModifiers(), field.getDeclaringClass());
 
 		enter(new VariableRuntimeBuilderContext(ctEnumValue));
 		super.visitEnumValue(field);
@@ -497,7 +497,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 	private void setModifier(CtModifiable ctModifiable, int modifiers, Class<?> declaringClass) {
 		// an interface is implicitly abstract
 		if (Modifier.isAbstract(modifiers) && !(ctModifiable instanceof CtInterface)) {
-			if (ctModifiable instanceof CtEnum) {
+			if (ctModifiable instanceof CtEnum || ctModifiable instanceof CtEnumValue) {
 				//enum must not be declared abstract (even if it can be made abstract see CtStatementImpl.InsertType)
 				//as stated in java lang spec https://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.9
 			} else if (isInterface(declaringClass)) {

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -19,12 +19,16 @@ package spoon.test.enums;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtField;
@@ -49,6 +53,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -114,58 +119,15 @@ public class EnumsTest {
 		assertTrue(burritos.getAllMethods().contains(name));
 	}
 
-	@Test
-	void testNestedPrivateEnumValues() throws Exception {
-		// contract: enum values have correct modifiers
-		CtType<?> ctClass = ModelUtils.buildClass(NestedEnums.class);
-		{
-			CtEnum<?> ctEnum = ctClass.getNestedType("PrivateENUM");
-			// TODO this is technically not correct, the enum should be implicitly final
-			assertThat(ctEnum.getExtendedModifiers(), contentEquals(
-					new CtExtendedModifier(ModifierKind.PRIVATE))
-			);
-			assertThat(ctEnum.getField("VALUE").getExtendedModifiers(), contentEquals(
-					// TODO PRIVATE is wrong here, should be PUBLIC
-					new CtExtendedModifier(ModifierKind.PRIVATE, true),
-					new CtExtendedModifier(ModifierKind.STATIC, true),
-					new CtExtendedModifier(ModifierKind.FINAL, true)
-			));
-		}
-		{
-			CtEnum<?> ctEnum = ctClass.getNestedType("PublicENUM");
-			// TODO this is technically not correct, the enum should be implicitly final
-			assertThat(ctEnum.getExtendedModifiers(), contentEquals(
-					new CtExtendedModifier(ModifierKind.PUBLIC)
-			));
-			assertThat(ctEnum.getField("VALUE").getExtendedModifiers(), contentEquals(
-					new CtExtendedModifier(ModifierKind.PUBLIC, true),
-					new CtExtendedModifier(ModifierKind.STATIC, true),
-					new CtExtendedModifier(ModifierKind.FINAL, true)
-			));
-		}
-		{
-			CtEnum<?> ctEnum = ctClass.getNestedType("ProtectedENUM");
-			// TODO this is technically not correct, the enum should be implicitly final
-			assertThat(ctEnum.getExtendedModifiers(), contentEquals(
-					new CtExtendedModifier(ModifierKind.PROTECTED)
-			));
-			assertThat(ctEnum.getField("VALUE").getExtendedModifiers(), contentEquals(
-					// TODO PROTECTED is wrong here, should be PUBLIC
-					new CtExtendedModifier(ModifierKind.PROTECTED, true),
-					new CtExtendedModifier(ModifierKind.STATIC, true),
-					new CtExtendedModifier(ModifierKind.FINAL, true)
-			));
-		}
-		{
-			CtEnum<?> ctEnum = ctClass.getNestedType("PackageProtectedENUM");
-			// TODO this is technically not correct, the enum should be implicitly final
-			assertThat(ctEnum.getExtendedModifiers(), contentEquals());
-			assertThat(ctEnum.getField("VALUE").getExtendedModifiers(), contentEquals(
-					// TODO package-private is wrong here, should be PUBLIC
-					new CtExtendedModifier(ModifierKind.STATIC, true),
-					new CtExtendedModifier(ModifierKind.FINAL, true)
-			));
-		}
+	@ParameterizedTest
+	@ArgumentsSource(NestedEnumTypeProvider.class)
+	void testNestedPrivateEnumValues(CtEnum<?> type) {
+		// contract: enum values have correct modifiers matching the produced bytecode
+		assertThat(type.getField("VALUE").getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.PUBLIC, true),
+				new CtExtendedModifier(ModifierKind.STATIC, true),
+				new CtExtendedModifier(ModifierKind.FINAL, true)
+		));
 	}
 
 	@Test
@@ -261,5 +223,22 @@ public class EnumsTest {
 		assertThat(enumType.getSimpleName(), is("1MyEnum"));
 		assertThat(enumType.getEnumValues().size(), is(2));
 		assertThat(enumType.getMethods().size(), is(1));
+	}
+
+
+	static class NestedEnumTypeProvider implements ArgumentsProvider {
+		private final CtType<?> ctClass;
+
+		NestedEnumTypeProvider() throws Exception {
+			this.ctClass = ModelUtils.buildClass(NestedEnums.class);
+		}
+
+		@Override
+		public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+			return Stream.of("Private", "PackageProtected", "Protected", "Public")
+					.map(s -> s + "ENUM")
+					.map(ctClass::getNestedType)
+					.map(Arguments::of);
+		}
 	}
 }


### PR DESCRIPTION
Previously, the enum values' modifiers were read from the declaring class by both the JDTTreeBuilder and the JavaReflectionTreeBuilder. This does not match the produced bytecode. For more context, see #4138.