### PR TITLE
wip: fix: extract implicit type modifiers correctly

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -739,7 +739,13 @@ public class JDTTreeBuilderHelper {
 		}
 
 		// Setting modifiers
-		type.setExtendedModifiers(getModifiers(typeDeclaration.modifiers, false, false));
+		if (typeDeclaration.binding != null) {
+			type.setExtendedModifiers(getModifiers(typeDeclaration.binding.modifiers, true, false));
+		}
+		for (CtExtendedModifier modifier : getModifiers(typeDeclaration.modifiers, false, false)) {
+			type.addModifier(modifier.getKind()); // avoid to keep implicit AND explicit modifier of the same kind.
+		}
+
 
 		jdtTreeBuilder.getContextBuilder().enter(type, typeDeclaration);
 

--- a/src/main/java/spoon/support/reflect/CtExtendedModifier.java
+++ b/src/main/java/spoon/support/reflect/CtExtendedModifier.java
@@ -93,4 +93,9 @@ public class CtExtendedModifier implements SourcePositionHolder, Serializable {
 			return ElementSourceFragment.NO_SOURCE_FRAGMENT;
 		}
 	}
+
+	@Override
+	public String toString() {
+		return "CtExtendedModifier(" + kind + ", " + implicit + ')';
+	}
 }

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import static spoon.test.SpoonTestHelpers.contentEquals;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
@@ -417,5 +418,6 @@ public class CtClassTest {
 		MatcherAssert.assertThat(clazz.getSimpleName(), CoreMatchers.is("1MyClass"));
 		MatcherAssert.assertThat(clazz.getFields().size(), CoreMatchers.is(1));
 		MatcherAssert.assertThat(clazz.getMethods().size(), CoreMatchers.is(1));
+		MatcherAssert.assertThat(clazz.getExtendedModifiers(), contentEquals());
 	}
 }

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -24,7 +24,6 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtField;
@@ -239,6 +238,27 @@ public class EnumsTest {
 	}
 
 	@Test
+	void testEnumClassPublicFinalEnum() throws Exception {
+		// contract: enum modifiers are applied correctly (JLS 8.9)
+		// package-level enum, isn't static but implicitly final
+		CtType<?> publicFinalEnum = build("spoon.test.enums.testclasses", "Burritos");
+		assertThat(publicFinalEnum.getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.PUBLIC, false),
+				new CtExtendedModifier(ModifierKind.FINAL, true)
+		));
+	}
+
+	@Test
+	void testEnumClassModifiersPublicEnum() throws Exception {
+		// contract: enum modifiers are applied correctly (JLS 8.9)
+		// pre Java 17, enums aren't implicitly final if an enum value declares an anonymous type
+		CtType<?> publicEnum = build("spoon.test.enums.testclasses", "AnonEnum");
+		assertThat(publicEnum.getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.PUBLIC, false)
+		));
+	}
+
+	@Test
 	void testLocalEnumExists() {
 		// contract: local enums and their members are part of the model
 		String code = SpoonTestHelpers.wrapLocal(
@@ -261,5 +281,9 @@ public class EnumsTest {
 		assertThat(enumType.getSimpleName(), is("1MyEnum"));
 		assertThat(enumType.getEnumValues().size(), is(2));
 		assertThat(enumType.getMethods().size(), is(1));
+		assertThat(enumType.getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.STATIC, true),
+				new CtExtendedModifier(ModifierKind.FINAL, true)
+		));
 	}
 }

--- a/src/test/java/spoon/test/enums/testclasses/AnonEnum.java
+++ b/src/test/java/spoon/test/enums/testclasses/AnonEnum.java
@@ -1,0 +1,7 @@
+package spoon.test.enums.testclasses;
+
+public enum AnonEnum {
+	A {
+
+	}
+}

--- a/src/test/java/spoon/test/interfaces/InterfaceTest.java
+++ b/src/test/java/spoon/test/interfaces/InterfaceTest.java
@@ -18,8 +18,11 @@ package spoon.test.interfaces;
 
 import java.util.Collection;
 import java.util.stream.Collectors;
+
+import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.CtModel;
@@ -48,6 +51,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static spoon.test.SpoonTestHelpers.contentEquals;
+import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class InterfaceTest {
@@ -155,13 +160,28 @@ public class InterfaceTest {
 		assertThat("The local interface does not exist in the model", block.getStatements().size(), is(1));
 
 		CtStatement statement = block.getStatement(0);
-		assertTrue(statement instanceof CtInterface<?>);
+		Assertions.assertTrue(statement instanceof CtInterface<?>);
 		CtInterface<?> interfaceType = (CtInterface<?>) statement;
 
 		assertThat(interfaceType.isLocalType(), is(true));
 		assertThat(interfaceType.getSimpleName(), is("1MyInterface"));
 		assertThat(interfaceType.getFields().size(), is(1));
 		assertThat(interfaceType.getMethods().size(), is(1));
+		MatcherAssert.assertThat(interfaceType.getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.STATIC, true),
+				new CtExtendedModifier(ModifierKind.ABSTRACT, true)
+		));
+	}
+
+	@org.junit.jupiter.api.Test
+	void testPackageLevelInterfaceModifiers() throws Exception {
+		// contract: a simple interface has the correct modifiers applied
+		// see https://docs.oracle.com/javase/specs/jls/se17/html/jls-9.html#jls-9.1.1
+		CtType<?> emptyInterface = build("spoon.test.interfaces.testclasses", "EmptyInterface");
+		assertThat(emptyInterface.getExtendedModifiers(), contentEquals(
+				new CtExtendedModifier(ModifierKind.ABSTRACT, true),
+				new CtExtendedModifier(ModifierKind.PUBLIC, false)
+		));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/interfaces/testclasses/EmptyInterface.java
+++ b/src/test/java/spoon/test/interfaces/testclasses/EmptyInterface.java
@@ -1,0 +1,5 @@
+package spoon.test.interfaces.testclasses;
+
+public interface EmptyInterface {
+
+}


### PR DESCRIPTION
Previously, no implicit modifiers were extracted from types. I basically copied the way it is done for methods and fields.

I first thought it would only apply to enums, but it's also relevant for nested/local types and interfaces. I added assertions to the local types and test cases for enums and interfaces.

#4134 should probably also add test cases for records validating the modifiers.