### PR TITLE
refactor(*): replace equals/hashcode implementations with proper ones

### DIFF
--- a/src/main/java/spoon/support/compiler/FileSystemFolder.java
+++ b/src/main/java/spoon/support/compiler/FileSystemFolder.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -133,17 +134,23 @@ public class FileSystemFolder implements SpoonFolder {
 		return file;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj == null) {
-			return false;
-		}
-		return toString().equals(obj.toString());
-	}
+
 
 	@Override
 	public int hashCode() {
-		return toString().hashCode();
+		return Objects.hash(file);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof FileSystemFolder)) {
+			return false;
+		}
+		FileSystemFolder other = (FileSystemFolder) obj;
+		return Objects.equals(file, other.file);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/ZipFile.java
+++ b/src/main/java/spoon/support/compiler/ZipFile.java
@@ -10,6 +10,8 @@ package spoon.support.compiler;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Objects;
 
 import spoon.compiler.SpoonFile;
 import spoon.compiler.SpoonFolder;
@@ -84,13 +86,27 @@ public class ZipFile implements SpoonFile {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		return toString().equals(obj.toString());
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + Arrays.hashCode(buffer);
+		result = prime * result + Objects.hash(name, parent);
+		return result;
 	}
 
 	@Override
-	public int hashCode() {
-		return toString().hashCode();
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ZipFile)) {
+			return false;
+		}
+		ZipFile other = (ZipFile) obj;
+		return Arrays.equals(buffer, other.buffer) && Objects.equals(name, other.name)
+				&& Objects.equals(parent, other.parent);
 	}
+
+
 
 }

--- a/src/main/java/spoon/support/compiler/ZipFolder.java
+++ b/src/main/java/spoon/support/compiler/ZipFolder.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -141,14 +142,23 @@ public class ZipFolder implements SpoonFolder {
 		return file;
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		return toString().equals(obj.toString());
-	}
+
 
 	@Override
 	public int hashCode() {
-		return toString().hashCode();
+		return Objects.hash(file, files);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof ZipFolder)) {
+			return false;
+		}
+		ZipFolder other = (ZipFolder) obj;
+		return Objects.equals(file, other.file) && Objects.equals(files, other.files);
 	}
 
 	@Override


### PR DESCRIPTION
This fixes three LGTM issues, `equals without type check`. I replaced the old equals/hashcode directly because they only compared `toString()` which seems kinda strange and not correct.