### PR TITLE
wip: refactor: use java 11 immutable lists where appropriate

### DIFF
--- a/src/main/java/spoon/pattern/PatternBuilder.java
+++ b/src/main/java/spoon/pattern/PatternBuilder.java
@@ -107,7 +107,7 @@ public class PatternBuilder {
 			throw new SpoonException("Cannot create a Pattern from an null model");
 		}
 		this.templateTypeRef = getDeclaringTypeRef(template);
-		this.patternModel = Collections.unmodifiableList(new ArrayList<>(template));
+		this.patternModel = List.copyOf(template);
 		this.valueConvertor = new ValueConvertorImpl();
 		patternNodes = ElementNode.create(this.patternModel, patternElementToSubstRequests);
 		patternQuery = new PatternBuilder.PatternQuery(getFactory().Query(), patternModel);

--- a/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
+++ b/src/main/java/spoon/pattern/internal/matcher/TobeMatched.java
@@ -68,14 +68,14 @@ public class TobeMatched {
 	private TobeMatched(ImmutableMap parameters, Collection<?> targets, boolean ordered) {
 		this.parameters = parameters;
 		//make a copy of origin collection, because it might be modified during matching process (by a refactoring algorithm)
-		this.targets = targets == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(targets));
+		this.targets = targets == null ? Collections.emptyList() : List.copyOf(targets);
 		this.ordered = ordered;
 	}
 
 	private TobeMatched(ImmutableMap parameters, Map<String, ?> targets) {
 		this.parameters = parameters;
 		//make a copy of origin collection, because it might be modified during matching process (by a refactoring algorithm)
-		this.targets = targets == null ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(targets.entrySet()));
+		this.targets = targets == null ? Collections.emptyList() : List.copyOf(targets.entrySet());
 		this.ordered = false;
 	}
 

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -59,10 +59,10 @@ import java.util.function.Function;
  */
 public class TypeFactory extends SubFactory {
 
-	private static final Set<String> NULL_PACKAGE_CLASSES = Collections.unmodifiableSet(new HashSet<>(
-			Arrays.asList("void", "boolean", "byte", "short", "char", "int", "float", "long", "double",
-					// TODO (leventov) it is questionable to me that nulltype should also be here
-					CtTypeReference.NULL_TYPE_NAME)));
+	private static final Set<String> NULL_PACKAGE_CLASSES = Set.of(
+			"void", "boolean", "byte", "short", "char", "int", "float", "long", "double",
+			// TODO (leventov) it is questionable to me that nulltype should also be here
+			CtTypeReference.NULL_TYPE_NAME);
 
 	public final CtTypeReference<?> NULL_TYPE = createReference(CtTypeReference.NULL_TYPE_NAME);
 	public final CtTypeReference<Void> VOID = createReference(Void.class);

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -673,7 +673,8 @@ private transient  ClassLoader inputClassloader;
 				//solve conflicts, the current imports are relevant too
 				new ImportConflictDetector(),
 				//compute final imports
-				new ImportCleaner().setImportComparator(new DefaultImportComparator()));
+				new ImportCleaner().setImportComparator(new DefaultImportComparator())
+		);
 		printer.setIgnoreImplicit(false);
 		printer.setPreprocessors(preprocessors);
 		return printer;
@@ -700,7 +701,8 @@ private transient  ClassLoader inputClassloader;
 						//solve conflicts, the current imports are relevant too
 						new ImportConflictDetector(),
 						//compute final imports
-						new ImportCleaner().setImportComparator(new DefaultImportComparator()));
+						new ImportCleaner().setImportComparator(new DefaultImportComparator())
+				);
 				printer.setIgnoreImplicit(false);
 				printer.setPreprocessors(preprocessors);
 				return printer;

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -665,7 +665,7 @@ private transient  ClassLoader inputClassloader;
 	@Override
 	public PrettyPrinter createPrettyPrinterAutoImport() {
 		DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-		List<Processor<CtElement>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtElement>>asList(
+		List<Processor<CtElement>> preprocessors = List.of(
 				//try to import as much types as possible
 				new ForceImportProcessor(),
 				//remove unused imports first. Do not add new imports at time when conflicts are not resolved
@@ -673,8 +673,7 @@ private transient  ClassLoader inputClassloader;
 				//solve conflicts, the current imports are relevant too
 				new ImportConflictDetector(),
 				//compute final imports
-				new ImportCleaner().setImportComparator(new DefaultImportComparator())
-		));
+				new ImportCleaner().setImportComparator(new DefaultImportComparator()));
 		printer.setIgnoreImplicit(false);
 		printer.setPreprocessors(preprocessors);
 		return printer;
@@ -695,14 +694,13 @@ private transient  ClassLoader inputClassloader;
 
 			if (PRETTY_PRINTING_MODE.FULLYQUALIFIED.equals(prettyPrintingMode)) {
 				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-				List<Processor<CtElement>> preprocessors = Collections.unmodifiableList(Arrays.<Processor<CtElement>>asList(
+				List<Processor<CtElement>> preprocessors = List.of(
 						//force fully qualified
 						new ForceFullyQualifiedProcessor(),
 						//solve conflicts, the current imports are relevant too
 						new ImportConflictDetector(),
 						//compute final imports
-						new ImportCleaner().setImportComparator(new DefaultImportComparator())
-				));
+						new ImportCleaner().setImportComparator(new DefaultImportComparator()));
 				printer.setIgnoreImplicit(false);
 				printer.setPreprocessors(preprocessors);
 				return printer;

--- a/src/main/java/spoon/support/compiler/VirtualFolder.java
+++ b/src/main/java/spoon/support/compiler/VirtualFolder.java
@@ -56,7 +56,7 @@ public class VirtualFolder implements SpoonFolder {
 
 	@Override
 	public List<SpoonFile> getFiles() {
-		return Collections.unmodifiableList(new ArrayList<>(files));
+		return List.copyOf(files);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -494,7 +494,7 @@ public class ParentExiter extends CtInheritanceScanner {
 			// Catch annotations are processed before actual CtCatchVariable is created and because of that they attach to CtCatch.
 			// Since annotations cannot be attached to CtCatch itself, we can simply transfer them to CtCatchVariable.
 			catchBlock.getAnnotations().forEach(a -> { a.setParent(child); child.addAnnotation(a); });
-			catchBlock.setAnnotations(Collections.unmodifiableList(Collections.emptyList()));
+			catchBlock.setAnnotations(List.of());
 			return;
 		}
 		super.visitCtCatch(catchBlock);


### PR DESCRIPTION
This replaces usages of `Collections.unmodifiableX()` when it was used to create an *immutable* collection (in most cases by wrapping a newly creating collection). 

This does not touch places where `Collections.unmodifiableX()` is used to expose an unmodifiable view for a collection that might be changed internally.