### PR TITLE
wip: fix: scan packages and extract their annotations

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -29,12 +29,15 @@ import java.util.List;
 class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public void visitPackage(Package aPackage) {
+		for (Annotation annotation : aPackage.getDeclaredAnnotations()) {
+			visitAnnotation(annotation);
+		}
 	}
 
 	@Override
 	public <T> void visitClass(Class<T> clazz) {
 		if (clazz.getPackage() != null) {
-			clazz.getPackage();
+			visitPackage(clazz.getPackage());
 		}
 		try {
 			for (TypeVariable<Class<T>> generic : clazz.getTypeParameters()) {
@@ -119,7 +122,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	public <T> void visitInterface(Class<T> clazz) {
 		assert clazz.isInterface();
 		if (clazz.getPackage() != null) {
-			clazz.getPackage();
+			visitPackage(clazz.getPackage());
 		}
 		try {
 			for (Type anInterface : clazz.getGenericInterfaces()) {
@@ -176,7 +179,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	public <T> void visitEnum(Class<T> clazz) {
 		assert clazz.isEnum();
 		if (clazz.getPackage() != null) {
-			clazz.getPackage();
+			visitPackage(clazz.getPackage());
 		}
 		try {
 			for (Type anInterface : clazz.getGenericInterfaces()) {
@@ -249,7 +252,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	public <T extends Annotation> void visitAnnotationClass(Class<T> clazz) {
 		assert clazz.isAnnotation();
 		if (clazz.getPackage() != null) {
-			clazz.getPackage();
+			visitPackage(clazz.getPackage());
 		}
 		try {
 			for (Annotation annotation : clazz.getDeclaredAnnotations()) {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -39,6 +39,7 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
+import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
@@ -64,6 +65,7 @@ import spoon.support.reflect.declaration.CtFieldImpl;
 import spoon.support.visitor.equals.EqualsChecker;
 import spoon.support.visitor.equals.EqualsVisitor;
 import spoon.test.generics.testclasses3.ComparableComparatorBug;
+import spoon.test.pkg.PackageTest;
 
 import java.io.File;
 import java.io.ObjectInputStream;
@@ -708,5 +710,15 @@ public class JavaReflectionTreeBuilderTest {
 		value = ctType.getField("VALUE");
 		// should have gotten '1'
 		assertNull(value.getDefaultExpression());
+	}
+
+
+	@Test
+	void testShadowPackage() {
+		Factory factory = createFactory();
+		CtType<?> type = new JavaReflectionTreeBuilder(factory).scan(PackageTest.class);
+		CtPackage ctPackage = type.getPackage();
+		assertEquals(1, ctPackage.getAnnotations().size());
+		assertEquals(ctPackage.getAnnotations().get(0).getAnnotationType().getQualifiedName(), "java.lang.Deprecated");
 	}
 }


### PR DESCRIPTION
Previously, packages where only visited from type references. This means the package of the type given to the `scan` method isn't necessarily visited, and its annotations aren't visited either.

This fixes it. The test case assumes that the package has the `@Deprecated` annotation declared in the `package-info.java`: https://github.com/INRIA/spoon/blob/63104c7b659c07fda43f1b3b5aa16898c3ec2e45/src/test/java/spoon/test/pkg/package-info.java#L5-L6

When debugging, I saw that packages (`java.util`, `java.lang`) are visited multiple times, as they are always visited whenever a type (new) or type reference (before) is visited. As the values of a package don't change at runtime (well, at least within a module), this doesn't seem necessary. Should we skip that by making sure that packages are only visited once here: https://github.com/INRIA/spoon/blob/9ff819461eefb1569cec29a92b6bbbb437eb47de/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java#L121-L129 ? I'm not really sure if this would cause any issues.