### PR TITLE
chore: Add MissingJavadocMethod checkstyle module to Javadoc regression test

### DIFF
--- a/chore/check-javadoc-regressions.py
+++ b/chore/check-javadoc-regressions.py
@@ -70,6 +70,9 @@ def write_checkstyle_config(path: Path) -> None:
             <module name="JavadocMethod">
                 <property name="scope" value="public"/>
             </module>
+            <module name="MissingJavadocMethod">
+                <property name="scope" value="public"/>
+            </module>
         </module>
     </module>
     """.strip()


### PR DESCRIPTION
As discussed in https://github.com/INRIA/spoon/pull/4228#discussion_r730278058, we should also check for missing Javadoc. Currently, one can get around the Javadoc regression test by simply not adding a Javadoc comment, or by misplacing it (e.g. in between method annotation and method header).