### PR TITLE
chore: fix CI script build.sh

### DIFF
--- a/doc/jenkins/build.sh
+++ b/doc/jenkins/build.sh
@@ -12,7 +12,8 @@
 # $ curl http://spoon.gforge.inria.fr/jenkins/build.sh | bash
 
 # Allow to define some options to the maven command, such as debug or memory options
-MAVEN_COMMAND="mvn $MVN_OPTS -Dmaven.javadoc.skip=true"
+# -Drat.skip=true is for skipping license check which fails on some project incl. https://ci.inria.fr/sos/job/Commons-lang/
+MAVEN_COMMAND="mvn $MVN_OPTS -Dmaven.javadoc.skip=true -Drat.skip=true"
 
 echo " "
 echo "-------------------------------------------------------"


### PR DESCRIPTION
(same idea as https://github.com/INRIA/spoon/pull/4214)

This is required for our old project https://ci.inria.fr/sos/job/Commons-lang/

This further confirms that the script did not work as intended before and only had a weak oracle.