### PR TITLE
WIP fix: fix unexpected behavior of CtCompilationUnitImpl.setDeclaredTypes

### DIFF
--- a/src/test/java/spoon/support/reflect/declaration/CtCompilationUnitImplTest.java
+++ b/src/test/java/spoon/support/reflect/declaration/CtCompilationUnitImplTest.java
@@ -1,0 +1,51 @@
+package spoon.support.reflect.declaration;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.ClassFactory;
+import spoon.reflect.factory.CoreFactory;
+import spoon.reflect.factory.Factory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CtCompilationUnitImplTest {
+  public static final CoreFactory factory = new Launcher().getFactory().Core();
+  public static final ClassFactory classFactory = new Launcher().getFactory().Class();
+
+  @Test
+  void testSetDeclaredTypesWithNewClassUsingClassFactory() {
+    CtCompilationUnit ctCompilationUnit = factory.createCompilationUnit();
+    CtClass<?> ctClass = classFactory.create("A");
+    ctClass.addModifier(ModifierKind.PUBLIC);
+
+    ctCompilationUnit.setDeclaredTypes(Arrays.asList(ctClass));
+    assertNotNull(ctCompilationUnit.getDeclaredTypes().get(0));
+  }
+
+  @Test
+  void testSetDeclaredTypesWithNewClassUsingCoreFactory() {
+    CtCompilationUnit ctCompilationUnit = factory.createCompilationUnit();
+    CtClass<?> ctClass = factory.createClass();
+    ctClass.setSimpleName("A");
+    ctClass.addModifier(ModifierKind.PUBLIC);
+
+    ctCompilationUnit.setDeclaredTypes(Arrays.asList(ctClass));
+    assertNotNull(ctCompilationUnit.getDeclaredTypes().get(0));
+  }
+
+  @Test
+  void testSetDeclaredTypesWithParsedClassUsingCoreFactory() {
+    CtCompilationUnit ctCompilationUnit = factory.createCompilationUnit();
+    CtClass<?> ctClass = Launcher.parseClass("public class A { }");
+
+    ctCompilationUnit.setDeclaredTypes(Arrays.asList(ctClass));
+    assertNotNull(ctCompilationUnit.getDeclaredTypes().get(0));
+  }
+}


### PR DESCRIPTION
I've found an unexpected behavior of public API of `CtCompilationUnitImpl`, when using it for code transformation. Calling `setDeclaredTypes` with newly created `CtClass` does not update the corresponding internal data well. Below is detailed explanation about expected behavior which I think is desirable.

To get advices from contributors and maintainers, I'm writing this PR only with test code first. I hope discussion about where and how to fix, and more well-constructed test if any.

## Context
I'm using Spoon APIs for **Code Transformation**. I said **Code Transformation** to refer the terminology used in `spoon-user-manual.pdf` attached [here](https://spoon.gforge.inria.fr), but actually I'm using Spoon to implement **Code Synthesizer**. I mean, I'm not handling AST of pre-defined Java class, rather I'm creating code elements from scratch.

## Problem
Calling `setDeclaredTypes` with `CtClass` parsed from code works well. However, doing it with newly created `CtClass` doesn't. 

To clarify, I add two tests that I think must be passed. Currently, `testSetDeclaredTypesWithNewClass` failed in assertion at Line 26.

Before I start using `CtCompilationUnit`, I had no problem with generating codes. Newly created `CtClass` are all printed well, whereas `CtCompilationUnit` wrapping newly created `CtClass` aren't.

I attach a code snippet that discovered this issue.
```java
Environment env = new StandardEnvironment();
PrettyPrinter printer = env.createPrettyPrinterAutoImport();

CtClass<?> ctClass = factory.createClass();
// other codes updating ctClass ...
printer.printElement(ctClass)  // works well

CtCompilationUnit ctClass = factory.createCompilationUnit();
// other codes updating ctCompilationUnit...
printer.printElement(ctCompilationUnit)  // crash
```
Crash is due to `NullPointerException` in [Line 2059 of DefaultJavaPrettyPrinter.java](https://github.com/INRIA/spoon/blob/963e98dcaaa5bb2607c9fc2e9407cf122dbd1679/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java#L2059)