### PR TITLE
test(TestSniperPrinter): make the method testSniper able to handle non class types

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -811,16 +811,16 @@ public class TestSniperPrinter {
 		launcher.buildModel();
 		Factory f = launcher.getFactory();
 
-		final CtClass<?> ctClass = f.Class().get(testClass);
+		final CtType<?> ctType = f.Type().get(testClass);
 
 		//change the model
-		transformation.accept(ctClass);
+		transformation.accept(ctType);
 
 		//print the changed model
 		launcher.prettyprint();
 
 		//check the printed file
-		resultChecker.accept(ctClass, getContentOfPrettyPrintedClassFromDisk(ctClass));
+		resultChecker.accept(ctType, getContentOfPrettyPrintedClassFromDisk(ctType));
 	}
 
 	private static Launcher createLauncherWithSniperPrinter() {


### PR DESCRIPTION
This fix allows testing the SniperPrettyPrinter with types that are not classes (Interfaces, AnnotationTypes, etc). (As for example #4219)