### PR TITLE
chore: add support for Gradle build dashboard

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <version>1.11.1</version>
+  </extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,9 @@
+<gradleEnterprise>
+  <buildScan>
+    <publish>ALWAYS</publish>
+    <termsOfService>
+      <url>https://gradle.com/terms-of-service</url>
+      <accept>true</accept>
+    </termsOfService>
+  </buildScan>
+</gradleEnterprise>


### PR DESCRIPTION
Adds the following lines at the end of the Spoon build:

```
[INFO] Publishing build scan...
[INFO] https://gradle.com/s/XXXXXXXXX
```

Where `XXXXXXXXX` is a randomly generated string for the URL, where one can see a lot of information about the Spoon build.

See https://github.com/INRIA/spoon/issues/4269