### PR TITLE
fix: force execution of `mvn -version` in CMD in case of Windows

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -525,6 +525,9 @@ public class SpoonPom implements SpoonResource {
 		try {
 			String[] cmd;
 			if (System.getProperty("os.name").contains("Windows")) {
+				// We launch a subshell in case of Windows because the subprocess below is unable to look up the PATH
+				// on Windows.
+				// See https://github.com/SpoonLabs/sorald/runs/4193699004?check_suite_focus=true#step:8:11.
 				cmd = new String[]{"cmd", "/c", "\"mvn -version\""};
 			} else if (System.getProperty("os.name").contains("Mac")) {
 				cmd = new String[]{"sh", "-c", "mvn -version"};

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -525,7 +525,7 @@ public class SpoonPom implements SpoonResource {
 		try {
 			String[] cmd;
 			if (System.getProperty("os.name").contains("Windows")) {
-				cmd = new String[]{"mvn.cmd", "-version"};
+				cmd = new String[]{"cmd", "/c", "\"mvn -version\""};
 			} else if (System.getProperty("os.name").contains("Mac")) {
 				cmd = new String[]{"sh", "-c", "mvn -version"};
 			} else {


### PR DESCRIPTION
Reference: https://github.com/SpoonLabs/sorald/issues/612

@slarse, I think the scheduled tests were failing because the "Run tests" step on windows was failing. For [other platforms](https://github.com/SpoonLabs/sorald/runs/4126994132?check_suite_focus=true#step:11:535), that step passed.

I have also tried to execute tests on Sorald on Windows after using the edited spoon build with the change in this PR and all tests passed :heavy_check_mark: .

EDIT: I saw the tests for macOS and Ubuntu pass in one of the workflows where they ran before the Windows' tests. I am not sure how to run all jobs for an individual OS in the matrix.