### PR TITLE
fix: add missing space after modifiers in sniper mode

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -278,7 +278,7 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 		CtRole role = event.getRole();
 		if (role != null) {
 			if ((event.getElement() instanceof CtModifiable && event.getElement().getPosition().isValidPosition())
-					|| role == CtRole.MODIFIER) {
+					|| role == CtRole.MODIFIER || role == CtRole.TYPE) {
 				// using only roles for handling modifiers and preexisting modifiables correctly
 				return findIndexOfNextChildTokenOfRole(childFragmentIdx + 1, role);
 			}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -797,6 +797,21 @@ public class TestSniperPrinter {
 		testSniper("superCall.SuperCallSniperTestClass", deleteForUpdate, assertContainsSuperWithUnaryOperator);
 	}
 
+	@Test
+	@GitHubIssue(issueNumber = 4220)
+	void testSniperAddsSpaceAfterFinal() {
+		Consumer<CtType<?>> modifyField = type -> {
+			Factory factory = type.getFactory();
+			CtField field = type.filterChildren(CtField.class::isInstance).first();
+			field.setType(factory.Type().integerType());
+		};
+
+		BiConsumer<CtType<?>, String> assertContainsSpaceAfterFinal = (type, result) ->
+				assertThat(result, containsString("private static final java.lang.Integer x;"));
+
+		testSniper("sniperPrint.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -811,6 +811,21 @@ public class TestSniperPrinter {
 		testSniper("ArithmeticExpression", noOpModifyFieldAssignment, assertPrintsRoundBracketsCorrectly);
 	}
 
+	@Test
+	@GitHubIssue(issueNumber = 4220)
+	void testSniperAddsSpaceAfterFinal() {
+		Consumer<CtType<?>> modifyField = type -> {
+			Factory factory = type.getFactory();
+			CtField field = type.filterChildren(CtField.class::isInstance).first();
+			field.setType(factory.Type().integerType());
+		};
+
+		BiConsumer<CtType<?>, String> assertContainsSpaceAfterFinal = (type, result) ->
+				assertThat(result, containsString("private static final java.lang.Integer x;"));
+
+		testSniper("sniperPrint.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/resources/sniperPrint/SpaceAfterFinal.java
+++ b/src/test/resources/sniperPrint/SpaceAfterFinal.java
@@ -1,0 +1,11 @@
+package sniperPrint;
+
+public class SpaceAfterFinal {
+
+    private static final java.lang.String x;
+
+    public SpaceAfterFinal()
+    {
+        x = "Test";
+    }
+}


### PR DESCRIPTION
Fixes #4220 

I haven't fixed this till now, but I have found the cause, where this bug, might emanate from.

While trying to print the modified `CtField` instance in this test, one of the functions called is [`getGroupedChildrenFragments`](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java#L490). It generates `flatChildren` of the field as follows:

```java
0 = {ElementSourceFragment@4115} "|58, 65|private|"
1 = {TokenSourceFragment@4128} "| |"
2 = {ElementSourceFragment@4129} "|66, 72|static|"
3 = {TokenSourceFragment@4130} "| |"
4 = {ElementSourceFragment@4131} "|73, 78|final|"
5 = {TokenSourceFragment@4132} "| |"
6 = {ElementSourceFragment@4133} "java.lang.String|79, 95|java.lang.String|"
7 = {TokenSourceFragment@4134} "| |"
8 = {TokenSourceFragment@4135} "|x|"
9 = {TokenSourceFragment@4136} "|;|"
```
Until now, there is a space after `final`, so we are good and can possibly expect to print the space between `final` and `java.lang.String`. However, upon reaching [this line](https://github.com/INRIA/spoon/blob/7052a94bb094ee96fb33637636255e15552b68a3/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java#L520), the value of `lastOfSameRole` is set to 4 so `childrenInSameCollection` becomes:
```java
0 = {ElementSourceFragment@4115} "|58, 65|private|"
1 = {TokenSourceFragment@4128} "| |"
2 = {ElementSourceFragment@4129} "|66, 72|static|"
3 = {TokenSourceFragment@4130} "| |"
4 = {ElementSourceFragment@4131} "|73, 78|final|"
```
Please note that space token  _after_ `final` is excluded. Now we enter the function for [writing modifiers](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java#L106-L116) where I noticed an anomaly.

While it was [at this line](https://github.com/INRIA/spoon/blob/7052a94bb094ee96fb33637636255e15552b68a3/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java#L107), I expected it to print only the items in in `firstPostion` (only `private`). However, it printed contents of `secondPosition` and `thirdPosition` too. Internally, it transformed the prettyprinted string from
```java
package sniperPrint;

public class SpaceAfterFinal {

    
```
to
```java
package sniperPrint;

public class SpaceAfterFinal {

    private static final
```
I checked why it would print all of those modifiers at once. I found out it is because of [this line here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java#L234). Note also that there is no space after `final` in the latter code snippet even though there is a writeSpace call after `writeKeyword` [here](https://github.com/INRIA/spoon/blob/7052a94bb094ee96fb33637636255e15552b68a3/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java#L107). Apparently, the `muted` attribute is changed to `true` for this space created by `writeSpace` and [it doesn't print](https://github.com/INRIA/spoon/blob/7052a94bb094ee96fb33637636255e15552b68a3/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java#L52).

Anyway, moving on to parts of code where elements of `secondPostion` and `thirdPostion` are [attempted to print](https://github.com/INRIA/spoon/blob/7052a94bb094ee96fb33637636255e15552b68a3/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java#L110-L116). The reason why `static` and `final` are not printed again is, again, because `muted` is set to `true`.

A natural way to debug this correctly is to check how the space is being printed between `public` and `class`. [There also the keyword `class` is written, and then `writeSpace` is called explicitly (which doesn't work too)](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java#L646), but when we go inside `writeIdentifier`, it writes the space and then appends the identifier.

Finally, I suspect that the space is not being printed because when `writeSpace` was called in the loop for `firstPostion`, `muted` was set to `true`. If I am right, I think I need to find out how the `muted` behaviour changes throughout the code and how exactly its value is decided. 