### PR TITLE
fix: remove annotation from the pretty-printed string if it is deleted from the model

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -201,9 +201,9 @@ public abstract class CtElementImpl implements CtElement, Serializable {
 	public <E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotations) {
 		if (annotations == null || annotations.isEmpty()) {
 			this.annotations = emptyList();
+			getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
 			return (E) this;
 		}
-		getFactory().getEnvironment().getModelChangeListener().onListDeleteAll(this, CtRole.ANNOTATION, this.annotations, new ArrayList<>(this.annotations));
 		this.annotations.clear();
 		for (CtAnnotation<? extends Annotation> annot : annotations) {
 			addAnnotation(annot);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -28,6 +28,7 @@ import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtThrow;
 import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtElement;
@@ -39,7 +40,6 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -74,7 +74,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -795,6 +795,19 @@ public class TestSniperPrinter {
 				assertThat(result, containsString("super.a(-x);"));
 
 		testSniper("superCall.SuperCallSniperTestClass", deleteForUpdate, assertContainsSuperWithUnaryOperator);
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 4218)
+	void testSniperDoesNotPrintTheDeletedAnnotation() {
+		Consumer<CtType<?>> deleteAnnotation = type -> {
+			type.getAnnotations().forEach(CtAnnotation::delete);
+		};
+
+		BiConsumer<CtType<?>, String> assertDoesNotContainAnnotation = (type, result) ->
+				assertThat(result, not(containsString("@abc.def.xyz")));
+
+		testSniper("sniperPrinter.DeleteAnnotation", deleteAnnotation, assertDoesNotContainAnnotation);
 	}
 
 	/**

--- a/src/test/resources/sniperPrinter/DeleteAnnotation.java
+++ b/src/test/resources/sniperPrinter/DeleteAnnotation.java
@@ -1,0 +1,4 @@
+package sniperPrinter;
+
+@abc.def.xyz
+class DeleteAnnotation { }


### PR DESCRIPTION
Fixes #4218 

I am still looking for a fix for this, but I think the problem could be with the [`changeCollector`](https://github.com/INRIA/spoon/blame/master/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java#L94). The size of the map `elementToChangeRole` is `0`, which is unusual as we have altered the type by deleting the annotation attached to it. Thus, I am concluding that it fails to listen for deletion of annotation in the model build for the resource file in this PR. 

EDIT:

`onChange` is not being called when I delete an annotation, however, it is called when I delete an instance of `CtField` inside a `CtType`. This should confirm that what I am saying above is right.