### PR TITLE
fix: printing of generic records (issue #4281)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -2197,8 +2197,8 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		context.pushCurrentThis(recordType);
 		visitCtType(recordType);
 		printer.writeKeyword("record").writeSpace().writeIdentifier(stripLeadingDigits(recordType.getSimpleName()));
-		elementPrinterHelper.printList(recordType.getRecordComponents(), null, false, "(", false, false, ",", true, false, ")", this::visitCtRecordComponent);
 		elementPrinterHelper.writeFormalTypeParameters(recordType);
+		elementPrinterHelper.printList(recordType.getRecordComponents(), null, false, "(", false, false, ",", true, false, ")", this::visitCtRecordComponent);
 		elementPrinterHelper.writeImplementsClause(recordType);
 
 		printer.writeSpace().writeSeparator("{").incTab();

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -148,7 +148,7 @@ public class CtRecordTest {
 
 	@Test
 	void testGenericTypeParametersArePrintedBeforeTheFunctionParameters() {
-		// a record with generic type arguments should be printed correctly 
+		// contract: a record with generic type arguments should be printed correctly 
 		String code = "src/test/resources/records/GenericRecord.java";
 		CtModel model = createModelFromPath(code);
 		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -147,7 +147,7 @@ public class CtRecordTest {
 	}
 
 	@Test
-	void printGenericRecord() {
+	void testGenericTypeParametersArePrintedBeforeTheFunctionParameters() {
 		// a record with generic type arguments should be printed correctly 
 		String code = "src/test/resources/records/GenericRecord.java";
 		CtModel model = createModelFromPath(code);

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -146,6 +146,16 @@ public class CtRecordTest {
 		return model;
 	}
 
+	@Test
+	void printGenericRecord() {
+		// a record with generic type arguments should be printed correctly 
+		String code = "src/test/resources/records/GenericRecord.java";
+		CtModel model = createModelFromPath(code);
+		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
+		CtRecord record = head(records);
+		assertEquals("public record GenericRecord<T>(T a, T b) {}", record.toString());
+	}
+
 	private <T> T head(Collection<T> collection) {
 		return collection.iterator().next();
 	}

--- a/src/test/resources/records/GenericRecord.java
+++ b/src/test/resources/records/GenericRecord.java
@@ -1,0 +1,3 @@
+package records;
+
+public record GenericRecord<T>(T a, T b) {}


### PR DESCRIPTION
Fix #4281 

This PR moves the type argument to the correct location when printing generic record declarations. A new unit test is included.