### PR TITLE
fix: Test failure in TestModule.testModuleNames() (#4285)

### DIFF
--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
@@ -313,7 +314,7 @@ public class TestModule {
 		batchCompiler.configure(args);
 
 		CompilationUnit[] cu = batchCompiler.getCompilationUnits();
-		List list = new ArrayList<>(Arrays.asList(new String[]{String.copyValueOf(cu[0].module),String.copyValueOf(cu[1].module)}));
+		List<String> list = Arrays.stream(cu).map(CompilationUnit::getModuleName).map(String::copyValueOf).collect(Collectors.toList());
 		assertTrue(list.contains("foo"));
 		assertTrue(list.contains("bar"));
 	}

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -17,6 +17,8 @@
 package spoon.test.module;
 
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -54,12 +56,16 @@ import java.util.List;
 import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -314,9 +320,8 @@ public class TestModule {
 		batchCompiler.configure(args);
 
 		CompilationUnit[] cu = batchCompiler.getCompilationUnits();
-		List<String> list = Arrays.stream(cu).map(CompilationUnit::getModuleName).map(String::copyValueOf).collect(Collectors.toList());
-		assertTrue(list.contains("foo"));
-		assertTrue(list.contains("bar"));
+		Set<String> list = Arrays.stream(cu).map(CompilationUnit::getModuleName).map(String::copyValueOf).collect(Collectors.toSet());
+		MatcherAssert.assertThat(list, is(Set.of("foo", "bar")));
 	}
 
 	@org.junit.jupiter.api.Test

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -17,8 +17,6 @@
 package spoon.test.module;
 
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -37,9 +35,9 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtModuleDirective;
+import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtPackageExport;
-import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
@@ -52,20 +50,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Collections;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -321,7 +317,7 @@ public class TestModule {
 
 		CompilationUnit[] cu = batchCompiler.getCompilationUnits();
 		Set<String> list = Arrays.stream(cu).map(CompilationUnit::getModuleName).map(String::copyValueOf).collect(Collectors.toSet());
-		MatcherAssert.assertThat(list, is(Set.of("foo", "bar")));
+		assertThat(list, is(Set.of("foo", "bar")));
 	}
 
 	@org.junit.jupiter.api.Test


### PR DESCRIPTION
This fixes #4285. The test relied on the order of entries returned by `File#listFiles()`, which is unspecified (thank you @SirYwell ).