### PR TITLE
doc: fix Javadoc search feature

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -303,6 +303,7 @@
                     <detectJavaApiLink>false</detectJavaApiLink>
                     <!-- ref: https://github.com/INRIA/spoon/pull/4253 -->
                     <additionalJOption>-notimestamp</additionalJOption>
+                    <additionalJOption>--no-module-directories</additionalJOption>
                 </configuration>
                 <reportSets>
                     <reportSet>


### PR DESCRIPTION
Since Spoon is now using Java 11, the Javadoc has a search field. However, using it results in a "Page Not Found" like this:
https://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/undefined/spoon/reflect/declaration/CtMethod.html
Removing the `undefined` part from this URL loads the correct page. The problem is a known bug in JDK and seems to be fixed in Java 12:
https://bugs.openjdk.java.net/browse/JDK-8215291

For Java 11, adding the `--no-module-directories` option to `maven-javadoc-plugin` fixes the issue.
see: https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url