### PR TITLE
review: fix: Ignore Qodana action exit code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,9 +167,7 @@ jobs:
           results-dir:  "${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
-        # the action's exit codes are a bit unreliable at the moment
         continue-on-error: true
-        id: qodana # later used by the sarif annotator step
         with:
           linter: qodana-jvm-community
           project-dir: "${{ github.workspace }}/pull_request"
@@ -177,9 +175,34 @@ jobs:
           baseline-path: "/data/results/master/qodana.sarif.json"
           baseline-include-absent: true
           results-dir:  "${{ github.workspace }}/result"
-      - name: SARIF Annotator
-        uses: SirYwell/sarif-annotator@v0.2.1
-        with:
-          source: qodana
-          report-path: ${{ steps.qodana.outputs.results-json-path }}
-          baseline-state-filter: 'new'
+          fail-threshold: 1
+      - name: Print problems(full)
+        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
+      - name: Print problems(short)
+        run: |
+          jq -r '.runs
+          | .[0].results
+          | map(
+             select (.baselineState == "new") |
+             {
+                 text: .message.text,
+                 location: .locations | map({
+                       snippet: .physicalLocation.contextRegion.snippet.text,
+                       file: .physicalLocation.artifactLocation.uri,
+                       position: ((.physicalLocation.contextRegion.startLine | tostring) + ":" + (.physicalLocation.contextRegion.startColumn | tostring))
+                   })
+             }
+          )
+          | map(
+             "## " + .text + "\n" +
+             (.location
+               | map(
+                 "In file " + .file + " at " + .position + "\n```java\n" + .snippet + "\n```"
+               )
+               | join("\n")
+             )
+          )
+          | join("\n\n----\n\n")' \
+          ${{ github.workspace }}/result/qodana.sarif.json
+          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
+          if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,7 @@ jobs:
           results-dir:  "${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
+        continue-on-error: true
         with:
           linter: qodana-jvm-community
           project-dir: "${{ github.workspace }}/pull_request"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,9 @@ jobs:
           results-dir:  "${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
+        # the action's exit codes are a bit unreliable at the moment
         continue-on-error: true
+        id: qodana # later used by the sarif annotator step
         with:
           linter: qodana-jvm-community
           project-dir: "${{ github.workspace }}/pull_request"
@@ -175,34 +177,9 @@ jobs:
           baseline-path: "/data/results/master/qodana.sarif.json"
           baseline-include-absent: true
           results-dir:  "${{ github.workspace }}/result"
-          fail-threshold: 1
-      - name: Print problems(full)
-        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
-      - name: Print problems(short)
-        run: |
-          jq -r '.runs
-          | .[0].results
-          | map(
-             select (.baselineState == "new") |
-             {
-                 text: .message.text,
-                 location: .locations | map({
-                       snippet: .physicalLocation.contextRegion.snippet.text,
-                       file: .physicalLocation.artifactLocation.uri,
-                       position: ((.physicalLocation.contextRegion.startLine | tostring) + ":" + (.physicalLocation.contextRegion.startColumn | tostring))
-                   })
-             }
-          )
-          | map(
-             "## " + .text + "\n" +
-             (.location
-               | map(
-                 "In file " + .file + " at " + .position + "\n```java\n" + .snippet + "\n```"
-               )
-               | join("\n")
-             )
-          )
-          | join("\n\n----\n\n")' \
-          ${{ github.workspace }}/result/qodana.sarif.json
-          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
-          if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi
+      - name: SARIF Annotator
+        uses: SirYwell/sarif-annotator@v0.2.1
+        with:
+          source: qodana
+          report-path: ${{ steps.qodana.outputs.results-json-path }}
+          baseline-state-filter: 'new'

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -101,6 +101,10 @@ public class Launcher implements SpoonAPI {
 	 * arguments and calls {@link #run()}).
 	 */
 	public static void main(String[] args) {
+		String a = null;
+		if (a.isEmpty()) {
+			System.out.println(a.length());
+		}
 		new Launcher().run(args);
 	}
 

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -101,10 +101,6 @@ public class Launcher implements SpoonAPI {
 	 * arguments and calls {@link #run()}).
 	 */
 	public static void main(String[] args) {
-		String a = null;
-		if (a.isEmpty()) {
-			System.out.println(a.length());
-		}
 		new Launcher().run(args);
 	}
 


### PR DESCRIPTION
This PR just ignores failures in the qodana action (as its exit codes were a bit weird) and instead relies on the jq buildbreaker.