### PR TITLE
fix: prevent appending semicolon after enum constant if it is not there initially

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -841,6 +841,17 @@ public class TestSniperPrinter {
 		testSniper("sniperPrint.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
 	}
 
+	@Test
+	void testSniperShouldNotAddSemicolonAfterEnumIfItIsNotPresent() {
+		Consumer<CtType<?>> noOpModifyFieldAssignment = type ->
+				type.descendantIterator().forEachRemaining(TestSniperPrinter::markElementForSniperPrinting);
+
+		BiConsumer<CtType<?>, String> assertPrintsRoundBracketsCorrectly = (type, result) ->
+				assertThat(result, not(containsString("SATURDAY;")));
+
+		testSniper("sniperPrinter.Days", noOpModifyFieldAssignment, assertPrintsRoundBracketsCorrectly);
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/resources/sniperPrinter/Days.java
+++ b/src/test/resources/sniperPrinter/Days.java
@@ -1,0 +1,6 @@
+package sniperPrinter;
+
+public enum Days {
+    SUNDAY, MONDAY, TUESDAY, WEDNESDAY,
+    THURSDAY, FRIDAY, SATURDAY
+}


### PR DESCRIPTION
Printing enum constants with sniper printer enforces `;` at the end even though it is not present before. For example,
```java
public enum Days {
    SUNDAY, MONDAY, TUESDAY, WEDNESDAY,
    THURSDAY, FRIDAY, SATURDAY
}
```
is changed to
```java
public enum Days {
    SUNDAY, MONDAY, TUESDAY, WEDNESDAY,
    THURSDAY, FRIDAY, SATURDAY;
}
```

`enum` is compilable with or without the `;` if there are no method declarations afterwards. Source: https://docs.oracle.com/javase/tutorial/java/javaOO/enum.html.
> when there are fields and methods, the list of enum constants must end with a semicolon.

I think we should configure the sniper printer to check for `;` and print it only if required. The current behaviour is not causing a compilation error, but it helps minimise the diff so we should consider it.