### PR TITLE
fix: print each resource in `CtTryWithResource` exactly once and retain separator

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -52,11 +52,10 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 				return false;
 			} else if (tpe.getType() == TokenType.IDENTIFIER) {
 				return findIndexOfNextChildTokenByType(TokenType.IDENTIFIER) >= 0;
-			}
-			// We check for ; printed using printList in DJPP#visitCtTryWithResource because if we do not, the context
-			// gets popped from the stack and printer messes up printing of the latter elements.
-			// See: https://github.com/INRIA/spoon/pull/4309.
-			else if (tpe.getToken().equals(";") && anyChildFragmentHasRole(CtRole.TRY_RESOURCE)) {
+			} else if (tpe.getToken().equals(";") && anyChildFragmentHasRole(CtRole.TRY_RESOURCE)) {
+				// We check for ; printed using printList in DJPP#visitCtTryWithResource because if we do not, the context
+				// gets popped from the stack and printer messes up printing of the latter elements.
+				// See: https://github.com/INRIA/spoon/pull/4309.
 				return true;
 			}
 			return findIndexOfNextChildTokenByValue(tpe.getToken()) >= 0;

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -8,7 +8,7 @@
 package spoon.support.sniper.internal;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtCompilationUnit;
@@ -53,10 +53,8 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 				return false;
 			} else if (tpe.getType() == TokenType.IDENTIFIER) {
 				return findIndexOfNextChildTokenByType(TokenType.IDENTIFIER) >= 0;
-			} else if (tpe.getToken().equals(";")) {
-				if (checkIfPartOfRole(CtRole.TRY_RESOURCE)) {
-					return true;
-				}
+			} else if (tpe.getToken().equals(";") && doesChildFragmentHasRoleInParent(CtRole.TRY_RESOURCE)) {
+				return true;
 			}
 			return findIndexOfNextChildTokenByValue(tpe.getToken()) >= 0;
 		}
@@ -73,13 +71,13 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 		throw new SpoonException("Unexpected PrintEvent: " + event.getClass());
 	}
 
-	private boolean checkIfPartOfRole(CtRole role) {
-		List<SourceFragment> elementSourceFragments = childFragments.stream()
+	private boolean doesChildFragmentHasRoleInParent(CtRole roleInParent) {
+		Optional<SourceFragment> optionSourceFragment = childFragments.stream()
 				.filter(fragment -> fragment instanceof ElementSourceFragment)
-				.collect(Collectors.toList());
-		for (SourceFragment sourceFragment: elementSourceFragments) {
-			ElementSourceFragment elementSourceFragment = ((ElementSourceFragment) sourceFragment);
-			return elementSourceFragment.getRoleInParent() == role;
+				.findFirst();
+		if (optionSourceFragment.isPresent()) {
+			ElementSourceFragment elementSourceFragment = (ElementSourceFragment) optionSourceFragment.get();
+			return  elementSourceFragment.getRoleInParent() == roleInParent;
 		}
 		return false;
 	}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -55,6 +55,7 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 			}
 			// We check for ; printed using printList in DJPP#visitCtTryWithResource because if we do not, the context
 			// gets popped from the stack and printer messes up printing of the latter elements.
+			// See: https://github.com/INRIA/spoon/pull/4309.
 			else if (tpe.getToken().equals(";") && anyChildFragmentHasRole(CtRole.TRY_RESOURCE)) {
 				return true;
 			}

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -53,7 +53,7 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 				return false;
 			} else if (tpe.getType() == TokenType.IDENTIFIER) {
 				return findIndexOfNextChildTokenByType(TokenType.IDENTIFIER) >= 0;
-			} else if (tpe.getToken().equals(";") && doesChildFragmentHasRoleInParent(CtRole.TRY_RESOURCE)) {
+			} else if (tpe.getToken().equals(";") && childFragmentHasSpecifiedRoleInParent(CtRole.TRY_RESOURCE)) {
 				return true;
 			}
 			return findIndexOfNextChildTokenByValue(tpe.getToken()) >= 0;
@@ -71,7 +71,7 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 		throw new SpoonException("Unexpected PrintEvent: " + event.getClass());
 	}
 
-	private boolean doesChildFragmentHasRoleInParent(CtRole roleInParent) {
+	private boolean childFragmentHasSpecifiedRoleInParent(CtRole roleInParent) {
 		Optional<SourceFragment> optionSourceFragment = childFragments.stream()
 				.filter(fragment -> fragment instanceof ElementSourceFragment)
 				.findFirst();

--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentContextCollection.java
@@ -8,6 +8,7 @@
 package spoon.support.sniper.internal;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtCompilationUnit;
@@ -52,6 +53,10 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 				return false;
 			} else if (tpe.getType() == TokenType.IDENTIFIER) {
 				return findIndexOfNextChildTokenByType(TokenType.IDENTIFIER) >= 0;
+			} else if (tpe.getToken().equals(";")) {
+				if (checkIfPartOfRole(CtRole.TRY_RESOURCE)) {
+					return true;
+				}
 			}
 			return findIndexOfNextChildTokenByValue(tpe.getToken()) >= 0;
 		}
@@ -66,6 +71,17 @@ abstract class AbstractSourceFragmentContextCollection extends AbstractSourceFra
 			return findIndexOfNextChildTokenOfElement(event.getElement()) >= 0;
 		}
 		throw new SpoonException("Unexpected PrintEvent: " + event.getClass());
+	}
+
+	private boolean checkIfPartOfRole(CtRole role) {
+		List<SourceFragment> elementSourceFragments = childFragments.stream()
+				.filter(fragment -> fragment instanceof ElementSourceFragment)
+				.collect(Collectors.toList());
+		for (SourceFragment sourceFragment: elementSourceFragments) {
+			ElementSourceFragment elementSourceFragment = ((ElementSourceFragment) sourceFragment);
+			return elementSourceFragment.getRoleInParent() == role;
+		}
+		return false;
 	}
 
 	@Override

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -71,7 +71,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.allOf;

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -845,33 +845,34 @@ public class TestSniperPrinter {
 
 	@Nested
 	class ResourcePrintingInTryWithResourceStatement{
-		private CtTryWithResource getTryWithResource(CtType<?> type, int statementIdx) {
-			return type.getMethodsByName("resourcePrinting").get(0).getBody().getStatement(statementIdx);
+		private CtTryWithResource getTryWithResource(CtType<?> type) {
+			return type.getMethodsByName("resourcePrinting").get(0).getBody().getStatement(0);
 		}
 
 		@Test
 		void test_printSecondResourceExactlyOnce() {
 			// contract: sniper should print the second resource exactly once
 			Consumer<CtType<?>> noOpModifyTryWithResource = type ->
-					TestSniperPrinter.markElementForSniperPrinting(getTryWithResource(type, 0));
+					TestSniperPrinter.markElementForSniperPrinting(getTryWithResource(type));
 
 			BiConsumer<CtType<?>, String> assertPrintsResourcesCorrectly = (type, result) ->
 					assertThat(result, containsString(" try (ZipFile zf = new ZipFile(zipFileName);\n" +
 							"             BufferedWriter writer = newBufferedWriter(outputFilePath, charset))"));
 
-			testSniper("sniperPrinter.TryWithResource", noOpModifyTryWithResource, assertPrintsResourcesCorrectly);
+			testSniper("sniperPrinter.tryWithResource.PrintOnce", noOpModifyTryWithResource, assertPrintsResourcesCorrectly);
 		}
 
 		@Test
 		void test_retainSemiColonAfterTheLastResource() {
+			// contract: sniper should retain the semi-colon after second resource
 			Consumer<CtType<?>> noOpModifyTryWithResource = type ->
-					TestSniperPrinter.markElementForSniperPrinting(getTryWithResource(type, 1));
+					TestSniperPrinter.markElementForSniperPrinting(getTryWithResource(type));
 
 			BiConsumer<CtType<?>, String> assertPrintsResourcesCorrectly = (type, result) ->
 					assertThat(result, containsString(" try (ZipFile zf = new ZipFile(zipFileName);\n" +
 							"             BufferedWriter writer = newBufferedWriter(outputFilePath, charset);)"));
 
-			testSniper("sniperPrinter.TryWithResource", noOpModifyTryWithResource, assertPrintsResourcesCorrectly);
+			testSniper("sniperPrinter.tryWithResource.RetainSemiColon", noOpModifyTryWithResource, assertPrintsResourcesCorrectly);
 		}
 	}
 

--- a/src/test/resources/sniperPrinter/TryWithResource.java
+++ b/src/test/resources/sniperPrinter/TryWithResource.java
@@ -8,5 +8,7 @@ public class TryWithResource {
     public void resourcePrinting() {
         try (ZipFile zf = new ZipFile(zipFileName);
              BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
+        try (ZipFile zf = new ZipFile(zipFileName);
+             BufferedWriter writer = newBufferedWriter(outputFilePath, charset);) { }
     }
 }

--- a/src/test/resources/sniperPrinter/TryWithResource.java
+++ b/src/test/resources/sniperPrinter/TryWithResource.java
@@ -1,0 +1,12 @@
+package sniperPrinter;
+
+import java.util.zip.ZipFile;
+import java.io.BufferedWriter;
+import java.nio.file.Files.newBufferedWriter;
+
+public class TryWithResource {
+    public void resourcePrinting() {
+        try (ZipFile zf = new ZipFile(zipFileName);
+             BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
+    }
+}

--- a/src/test/resources/sniperPrinter/tryWithResource/PrintOnce.java
+++ b/src/test/resources/sniperPrinter/tryWithResource/PrintOnce.java
@@ -1,0 +1,12 @@
+package sniperPrinter.tryWithResource;
+
+import java.util.zip.ZipFile;
+import java.io.BufferedWriter;
+import java.nio.file.Files.newBufferedWriter;
+
+public class PrintOnce {
+    public void resourcePrinting() {
+        try (ZipFile zf = new ZipFile(zipFileName);
+             BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
+    }
+}

--- a/src/test/resources/sniperPrinter/tryWithResource/RetainSemiColon.java
+++ b/src/test/resources/sniperPrinter/tryWithResource/RetainSemiColon.java
@@ -1,13 +1,11 @@
-package sniperPrinter;
+package sniperPrinter.tryWithResource;
 
 import java.util.zip.ZipFile;
 import java.io.BufferedWriter;
 import java.nio.file.Files.newBufferedWriter;
 
-public class TryWithResource {
+public class RetainSemiColon {
     public void resourcePrinting() {
-        try (ZipFile zf = new ZipFile(zipFileName);
-             BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
         try (ZipFile zf = new ZipFile(zipFileName);
              BufferedWriter writer = newBufferedWriter(outputFilePath, charset);) { }
     }


### PR DESCRIPTION
Reference: https://github.com/SpoonLabs/sorald/issues/600

The second resource in the catch block, `BufferedWriter writer = newBufferedWriter(outputFilePath, charset)`, is printed twice. For example,

```java
        try (ZipFile zf = new ZipFile(zipFileName);
             BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
```
is changed to
```java
        try (ZipFile zf = new ZipFile(zipFileName);
             BufferedWriter writer = newBufferedWriter(outputFilePath, charset);BufferedWriter writer = newBufferedWriter(outputFilePath, charset)) { }
```
when printed using the sniper printer.

I think it is happening because we add a separator, `;`, after first `BufferedWriter writer = newBufferedWriter(outputFilePath, charset)` which changes `muted` from `true` to `false`. Although the separator is not needed here, it is still printed. This may be similar to #4306 .

Please note that `muted` should remain true till we print the second resource because all resources are [printed at once](https://github.com/INRIA/spoon/blob/f898632bbdaf5c671b74a652c04d10dfc65328c3/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java#L327) because of this line [here](https://github.com/INRIA/spoon/blob/f898632bbdaf5c671b74a652c04d10dfc65328c3/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java#L327). Basically, if a collection fragment is not modified, we print it at once and set `muted` to `true` for upcoming elements in the collection.

