### PR TITLE
refactor: make a single test resource package for testing sniper printer

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -838,7 +838,7 @@ public class TestSniperPrinter {
 		BiConsumer<CtType<?>, String> assertContainsSpaceAfterFinal = (type, result) ->
 				assertThat(result, containsString("private static final java.lang.Integer x;"));
 
-		testSniper("sniperPrint.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
+		testSniper("sniperPrinter.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
 	}
 
 	/**

--- a/src/test/resources/sniperPrinter/SpaceAfterFinal.java
+++ b/src/test/resources/sniperPrinter/SpaceAfterFinal.java
@@ -1,4 +1,4 @@
-package sniperPrint;
+package sniperPrinter;
 
 public class SpaceAfterFinal {
 


### PR DESCRIPTION
`sniperPrinter` directory is already there for test resources related to testing sniper printer. 