### PR TITLE
Wip: refactor: replace old stream api with new

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -13,7 +13,6 @@ import java.io.FileInputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -160,7 +159,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 
 	@Override
 	public List<CtType<?>> getDeclaredTypes() {
-		return Collections.unmodifiableList(declaredTypeReferences.stream().map(ref -> ref.getTypeDeclaration()).collect(Collectors.toList()));
+		return declaredTypeReferences.stream().map(CtTypeReference::getTypeDeclaration).collect(Collectors.toUnmodifiableList());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -122,6 +122,8 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 			if (getDeclaredTypes().isEmpty()) {
 				if (getDeclaredModuleReference() != null) {
 					return UNIT_TYPE.MODULE_DECLARATION;
+				} else if (getDeclaredPackage() != null && getDeclaredTypeReferences().size() == 1) {
+					return UNIT_TYPE.TYPE_DECLARATION;
 				} else if (packageDeclaration != null) {
 					return UNIT_TYPE.PACKAGE_DECLARATION;
 				} else {

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -14,9 +14,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
-
 import spoon.SpoonException;
+import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
@@ -40,7 +41,6 @@ import spoon.support.UnsettableProperty;
 import spoon.support.reflect.cu.position.PartialSourcePositionImpl;
 import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.util.ModelList;
-import spoon.reflect.ModelElementContainerDefaultCapacities;
 
 /**
  * Implements a compilation unit. In Java, a compilation unit can contain only one
@@ -159,7 +159,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 
 	@Override
 	public List<CtType<?>> getDeclaredTypes() {
-		return declaredTypeReferences.stream().map(CtTypeReference::getTypeDeclaration).collect(Collectors.toUnmodifiableList());
+		return declaredTypeReferences.stream().map(CtTypeReference::getTypeDeclaration).filter(Objects::nonNull).collect(Collectors.toUnmodifiableList());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -122,7 +122,7 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 			if (getDeclaredTypes().isEmpty()) {
 				if (getDeclaredModuleReference() != null) {
 					return UNIT_TYPE.MODULE_DECLARATION;
-				} else if (getDeclaredPackage() != null && getDeclaredTypeReferences().size() == 1) {
+				} else if (getDeclaredPackage() != null && !getDeclaredTypeReferences().isEmpty()) {
 					return UNIT_TYPE.TYPE_DECLARATION;
 				} else if (packageDeclaration != null) {
 					return UNIT_TYPE.PACKAGE_DECLARATION;


### PR DESCRIPTION
Fix qodana issue. As always, we had the neat case of nulls in Collections(why?). I removed them because this is never the wanted behaviour. 