### PR TITLE
fix(MavenLauncher): maximum recovery from missing libraries

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -465,6 +465,7 @@ public class SpoonPom implements SpoonResource {
 			}
 			properties.setProperty("mdep.outputFile", getSpoonClasspathTmpFileName(sourceType));
 			request.setProperties(properties);
+			request.setReactorFailureBehavior(InvocationRequest.ReactorFailureBehavior.FailNever);
 
 			if (LOGGER != null) {
 				request.getOutputHandler(s -> LOGGER.debug(s));


### PR DESCRIPTION
The way Spoon build the class path for a Maven project in `MavenLauncher` is to launch `mvn dependencies:build-classpath` to generate a text file containing class path. However, for multi-module projects, when there is a module whose dependencies can not be resolved, Maven will skip the remaining modules and report an error.

In this PR, I added the `-fn` flag to the Maven invocation request such that Maven can continue to resolve dependencies for the remaining modules even though there is an error occurred. This can help resolve as many libraries as possible.