### PR TITLE
review: fix: support type parameters on method references

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1615,6 +1615,9 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(expression.getTarget());
 		}
 		printer.writeSeparator("::");
+		if (!expression.getExecutable().getActualTypeArguments().isEmpty()) {
+			elementPrinterHelper.printList(expression.getExecutable().getActualTypeArguments(), null, false, "<", false, false, ", ", false, false, ">", this::scan);
+		}
 		if (expression.getExecutable().isConstructor()) {
 			printer.writeKeyword("new");
 		} else {

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -132,6 +132,7 @@ import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtTargetedExpression;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
@@ -1640,6 +1641,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 			return true;
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
 			context.enter(helper.createCatchVariable(singleTypeReference, scope), singleTypeReference);
+			return true;
+		} else if (context.stack.getFirst().element instanceof CtTargetedExpression) {
+			context.enter(references.getTypeParameterReference(singleTypeReference.resolvedType, singleTypeReference), singleTypeReference);
 			return true;
 		}
 		CtTypeReference<?> typeRef = references.buildTypeReference(singleTypeReference, scope);

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -125,6 +125,7 @@ import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtContinue;
+import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLambda;
@@ -132,7 +133,6 @@ import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtTargetedExpression;
 import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
@@ -1642,7 +1642,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 		} else if (context.stack.peekFirst().element instanceof CtCatch) {
 			context.enter(helper.createCatchVariable(singleTypeReference, scope), singleTypeReference);
 			return true;
-		} else if (context.stack.getFirst().element instanceof CtTargetedExpression) {
+		} else if (context.stack.getFirst().element instanceof CtExecutableReferenceExpression) {
 			context.enter(references.getTypeParameterReference(singleTypeReference.resolvedType, singleTypeReference), singleTypeReference);
 			return true;
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -851,6 +851,8 @@ public class ParentExiter extends CtInheritanceScanner {
 	public <T, E extends CtExpression<?>> void visitCtExecutableReferenceExpression(CtExecutableReferenceExpression<T, E> expression) {
 		if (child instanceof CtExpression) {
 			expression.setTarget((E) child);
+		} else if (child instanceof CtTypeParameterReference) {
+			expression.getExecutable().addActualTypeArgument((CtTypeReference<?>) child);
 		}
 		super.visitCtExecutableReferenceExpression(expression);
 	}

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -180,5 +180,16 @@ public class DefaultJavaPrettyPrinterTest {
         exeExpression.getExecutable().addActualTypeArgument(factory.Type().integerType());
         // more than one parameter type should be separated (with .* to allow imports)
         assertThat(exeExpression.toString(), containsRegexMatch("<(.*)Integer, (.*)Integer>"));
+
+        // remove type arguments again, we want to try something else
+        exeExpression.getExecutable().setActualTypeArguments(null);
+        // we want to have a bit more complex type and construct a fake Comparable<Integer, Comhyperbola<Integer>>
+        CtTypeReference<?> complexTypeReference = factory.Type().integerType().getSuperInterfaces().stream()
+                .filter(t -> t.getSimpleName().equals("Comparable"))
+                .findAny()
+                .orElseThrow();
+        complexTypeReference.addActualTypeArgument(complexTypeReference.clone().setSimpleName("Comhyperbola"));
+        exeExpression.getExecutable().addActualTypeArgument(complexTypeReference);
+        assertThat(exeExpression.toString(), containsRegexMatch("<(.*)Comparable<(.*)Integer, (.*)Comhyperbola<(.*)Integer>>>"));
     }
 }

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -7,17 +7,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.test.SpoonTestHelpers;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static spoon.test.SpoonTestHelpers.containsRegexMatch;
 
 public class DefaultJavaPrettyPrinterTest {
 
@@ -149,5 +155,30 @@ public class DefaultJavaPrettyPrinterTest {
         CtModel model = SpoonTestHelpers.createModelFromString(code, 8);
         CtType<?> first = model.getAllTypes().iterator().next();
         assertThat(first.toString(), containsString(line));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void testPrintMethodReferenceTypeParameters() {
+        // contract: type parameters of method references are printed
+        Launcher launcher = new Launcher();
+        Factory factory = launcher.getFactory();
+        CtTypeReference<?> typeReference = factory.Type().createReference("Arrays");
+        CtExecutableReferenceExpression exeExpression = factory.createExecutableReferenceExpression();
+        exeExpression.setExecutable(factory.createExecutableReference());
+        exeExpression.getExecutable().setSimpleName("binarySearch");
+        exeExpression.setTarget(factory.createTypeAccess(typeReference));
+        // if no type parameters are given, no < and no > should be printed
+        assertThat(exeExpression.toString(), not(anyOf(containsString("<"), containsString(">"))));
+
+        exeExpression.getExecutable().addActualTypeArgument(factory.Type().integerType());
+        // with type parameters, the < and > should be printed
+        assertThat(exeExpression.toString(), allOf(containsString("<"), containsString(">")));
+        // the type parameter should appear
+        assertThat(exeExpression.toString(), containsString("Integer"));
+
+        exeExpression.getExecutable().addActualTypeArgument(factory.Type().integerType());
+        // more than one parameter type should be separated (with .* to allow imports)
+        assertThat(exeExpression.toString(), containsRegexMatch("<(.*)Integer, (.*)Integer>"));
     }
 }

--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -25,6 +25,7 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewClass;
@@ -90,6 +91,9 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1560,5 +1564,18 @@ public class GenericsTest {
 		CtTypeParameter formalType = ((CtMethod) m1.getExecutable().getDeclaration()).getFormalCtTypeParameters().get(0);
 		assertEquals(formalType, ((CtTypeReference) m1.getActualTypeArguments().get(0)).getTypeParameterDeclaration());
 		assertNull(m1.getType().getTypeParameterDeclaration());
+	}
+
+	@org.junit.jupiter.api.Test
+	void testGenericMethodReference() {
+		// contract: method references keep their generic parameters
+		CtClass<?> parsed = Launcher.parseClass("class X {\n" +
+				"	BiFunction<Integer[], Integer, Integer> field = Arrays::<Integer>binarySearch;\n" +
+				"}");
+		CtField<?> field = parsed.getField("field");
+		assertThat(field.getDefaultExpression(), instanceOf(CtExecutableReferenceExpression.class));
+		CtExecutableReferenceExpression<?, ?> expression = (CtExecutableReferenceExpression<?, ?>) field.getDefaultExpression();
+		assertThat(expression.getExecutable().getActualTypeArguments().size(), equalTo(1));
+		assertThat(expression.getExecutable().getActualTypeArguments().get(0).toString(), equalTo("java.lang.Integer"));
 	}
 }


### PR DESCRIPTION
Previously, generic parameters where neither present in the model nor printed. For example,
```java
BiFunction<Integer[], Integer, Integer> field = Arrays::<Integer>binarySearch;
```
was printed as
```java
BiFunction<Integer[], Integer, Integer> field = Integer::binarySearch;
```