### PR TITLE
test: use GitHub issue annotation for types

### DIFF
--- a/src/test/java/spoon/test/GitHubIssue.java
+++ b/src/test/java/spoon/test/GitHubIssue.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface GitHubIssue {
 	int issueNumber();
 }


### PR DESCRIPTION
This annotation should also be valid for applying to types because there are cases when developers write `@Nested` classes for writing tests for a particular issue—for example, #4341 .