### PR TITLE
fix: prevent stackoverflow when visiting of cyclic annotation/package structures

### DIFF
--- a/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
@@ -21,6 +21,10 @@ public class PackageRuntimeBuilderContext extends AbstractRuntimeBuilderContext 
 		this.ctPackage = ctPackage;
 	}
 
+	public CtPackage getPackage() {
+		return ctPackage;
+	}
+
 	@Override
 	public void addType(CtType<?> aType) {
 		ctPackage.addType(aType);

--- a/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
+++ b/src/main/java/spoon/support/visitor/java/internal/PackageRuntimeBuilderContext.java
@@ -21,6 +21,11 @@ public class PackageRuntimeBuilderContext extends AbstractRuntimeBuilderContext 
 		this.ctPackage = ctPackage;
 	}
 
+	/**
+	 * Returns the package belonging to this context.
+	 *
+	 * @return the package of this context
+	 */
 	public CtPackage getPackage() {
 		return ctPackage;
 	}

--- a/src/test/java/spoon/test/pkg/cyclic/Outside.java
+++ b/src/test/java/spoon/test/pkg/cyclic/Outside.java
@@ -1,0 +1,9 @@
+package spoon.test.pkg.cyclic;
+
+import spoon.test.pkg.cyclic.direct.Cyclic;
+import spoon.test.pkg.cyclic.indirect.Indirect;
+
+@Cyclic
+@Indirect
+public class Outside {
+}

--- a/src/test/java/spoon/test/pkg/cyclic/direct/Cyclic.java
+++ b/src/test/java/spoon/test/pkg/cyclic/direct/Cyclic.java
@@ -1,0 +1,8 @@
+package spoon.test.pkg.cyclic.direct;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Cyclic {
+}

--- a/src/test/java/spoon/test/pkg/cyclic/direct/package-info.java
+++ b/src/test/java/spoon/test/pkg/cyclic/direct/package-info.java
@@ -1,0 +1,5 @@
+@Cyclic
+@Indirect
+package spoon.test.pkg.cyclic.direct;
+
+import spoon.test.pkg.cyclic.indirect.Indirect;

--- a/src/test/java/spoon/test/pkg/cyclic/indirect/Indirect.java
+++ b/src/test/java/spoon/test/pkg/cyclic/indirect/Indirect.java
@@ -1,0 +1,8 @@
+package spoon.test.pkg.cyclic.indirect;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Indirect {
+}

--- a/src/test/java/spoon/test/pkg/cyclic/indirect/package-info.java
+++ b/src/test/java/spoon/test/pkg/cyclic/indirect/package-info.java
@@ -1,0 +1,4 @@
+@Cyclic
+package spoon.test.pkg.cyclic.indirect;
+
+import spoon.test.pkg.cyclic.direct.Cyclic;


### PR DESCRIPTION
Fixes #4351.

This is a very unfortunate situation that only happens in combination of annotations on packages. When visiting the type reference of an annotation, we're also visiting its package, and if this package is annotated, we'll do the same again.

With this fix, packages are only visited if the contexts don't not already hold a reference to the package.

The tests cover some more complex situations that would have caused similar issues.