### PR TITLE
refactor(ContextBuilder): remove Qodana warnings

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -66,11 +66,11 @@ public class ContextBuilder {
 
 	CompilationUnit compilationUnitSpoon;
 
-	boolean isBuildLambda = false;
+	boolean isBuildLambda;
 
-	boolean isBuildTypeCast = false;
+	boolean isBuildTypeCast;
 
-	boolean ignoreComputeImports = false;
+	boolean ignoreComputeImports;
 
 	/**
 	 * Stack of all parents elements
@@ -209,7 +209,7 @@ public class ContextBuilder {
 	private static String getNormalQualifiedName(ReferenceBinding referenceBinding) {
 		String pkg = new String(referenceBinding.getPackage().readableName()).replaceAll("\\.", "\\" + CtPackage.PACKAGE_SEPARATOR);
 		String name = new String(referenceBinding.qualifiedSourceName()).replaceAll("\\.", "\\" + CtType.INNERTTYPE_SEPARATOR);
-		return pkg.equals("") ? name : pkg + "." + name;
+		return pkg.isEmpty() ? name : pkg + "." + name;
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
The following has changed in the code:
Field Initializer  false for field isBuildLambda in type spoon.support.compiler.jdt.ContextBuilder was redundant and was removed.
Field Initializer  false for field isBuildTypeCast in type spoon.support.compiler.jdt.ContextBuilder was redundant and was removed.
Field Initializer  false for field ignoreComputeImports in type spoon.support.compiler.jdt.ContextBuilder was redundant and was removed.
Empty String check was written as String.equals("") and refactored to String.isEmpty()

### Comment 

Because I'm kind of lazy, I'm currently writing a tool for auto generation of these commits. This is the first result and should fix for ContextBuilder some issues.