### PR TITLE
review: chore: update qodana action to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      QODANA_LINTER: jetbrains/qodana-jvm-community:latest
     name: code-quality qodana
     steps:
       - name: Checkout
@@ -161,7 +162,7 @@ jobs:
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@f1c286a991696626e79b750fd8701477fee6fcd2 # renovate: tag=v4.1.0
         with:
-          linter: qodana-jvm-community
+          linter: ${{ env.QODANA_LINTER }}
           project-dir: "${{ github.workspace }}/master"
           inspected-dir: ./src/main/java # only main spoon project at first
           results-dir:  "${{ github.workspace }}/result/master"
@@ -169,7 +170,7 @@ jobs:
         uses: JetBrains/qodana-action@f1c286a991696626e79b750fd8701477fee6fcd2 # renovate: tag=v4.1.0
         continue-on-error: true
         with:
-          linter: qodana-jvm-community
+          linter: ${{ env.QODANA_LINTER }}
           project-dir: "${{ github.workspace }}/pull_request"
           inspected-dir: ./src/main/java # only main spoon project at first
           baseline-path: "/data/results/master/qodana.sarif.json"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,14 +159,14 @@ jobs:
       - name: "Create folder"
         run: "mkdir -p ${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
+        uses: JetBrains/qodana-action@f1c286a991696626e79b750fd8701477fee6fcd2 # renovate: tag=v4.1.0
         with:
           linter: qodana-jvm-community
           project-dir: "${{ github.workspace }}/master"
           inspected-dir: ./src/main/java # only main spoon project at first
           results-dir:  "${{ github.workspace }}/result/master"
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@cd7dc31b49427ce740ebf6255319b267801d08cf # renovate: tag=v3.2.1
+        uses: JetBrains/qodana-action@f1c286a991696626e79b750fd8701477fee6fcd2 # renovate: tag=v4.1.0
         continue-on-error: true
         with:
           linter: qodana-jvm-community


### PR DESCRIPTION
With v4, the way how the linter is defined was changed. I adapted this manually.

Supersedes #4361.