### PR TITLE
fix: fix pretty-printing ordering for record parameters

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import spoon.JLSViolation;
@@ -42,7 +43,7 @@ public class CtRecordImpl extends CtClassImpl<Object> implements CtRecord {
 	private static final String ABSTRACT_MODIFIER_ERROR =
 			"Abstract modifier is not allowed on record";
 	@MetamodelPropertyField(role = CtRole.RECORD_COMPONENT)
-	private Set<CtRecordComponent> components = new HashSet<>();
+	private Set<CtRecordComponent> components = new LinkedHashSet<>();
 
 	@Override
 	@DerivedProperty

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +79,7 @@ public class CloneHelper {
 		if (elements == null || elements.isEmpty()) {
 			return EmptyClearableSet.instance();
 		}
-		Set<T> others = new HashSet<>(elements.size());
+		Set<T> others = new LinkedHashSet<>(elements.size());
 		for (T element : elements) {
 			addClone(others, element);
 		}

--- a/src/main/java/spoon/support/visitor/equals/CloneHelper.java
+++ b/src/main/java/spoon/support/visitor/equals/CloneHelper.java
@@ -17,7 +17,6 @@ import spoon.support.visitor.clone.CloneVisitor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -86,7 +86,10 @@ public class CtRecordTest {
 					    "    return second;\n" +
 					    "}"
 				),
-				head(records).getMethods().stream().map(String::valueOf).collect(Collectors.toList())
+				head(records).getMethods().stream()
+						.map(String::valueOf)
+						.map(s -> s.replaceAll("\\R", "\n")) // fix newlines on windows
+						.collect(Collectors.toList())
 		);
 	}
 

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -4,7 +4,9 @@ import static java.lang.System.lineSeparator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
@@ -61,8 +63,31 @@ public class CtRecordTest {
 		CtModel model = createModelFromPath(code);
 		assertEquals(1, model.getAllTypes().size());
 		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
-		assertEquals(2, head(records).getFields().size());
-		assertEquals(2, head(records).getMethods().size());
+
+		assertEquals(1, records.size());
+		assertEquals("public record MultiParameter(int first, float second) {}", head(records).toString());
+		
+		// test fields
+		assertEquals(
+				Arrays.asList(
+						"private final int first;", 
+						"private final float second;"
+				), 
+				head(records).getFields().stream().map(String::valueOf).collect(Collectors.toList())
+		);
+		
+		// test methods
+		assertEquals(
+				Arrays.asList(
+						"int first() {\n" +
+					    "    return first;\n" +
+					    "}", 
+						"float second() {\n" +
+					    "    return second;\n" +
+					    "}"
+				),
+				head(records).getMethods().stream().map(String::valueOf).collect(Collectors.toList())
+		);
 	}
 
 	@Test

--- a/src/test/resources/records/MultiParameter.java
+++ b/src/test/resources/records/MultiParameter.java
@@ -1,5 +1,5 @@
 package records;
 
-public record MultiParameter(int a, int b) {
+public record MultiParameter(int first, float second) {
   
 }


### PR DESCRIPTION
Instead of creating a new test case, I added the missing checks to the existing one. The most important one is the one with the `head(records).toString()`: changing the Set to LinkedHashSet makes all the other checks pass, but the output is still in reverse order.

The fix in CloneHelper is less than ideal, but I cannot think of a better solution. IMHO the visitor pattern is overused in spoon, i. e. I cannot see a valid reason to use it for cloning. The visitor pattern is necessary for double dispatch, but if I didn't miss anything, cloning just needs a single dispatch.

Please review and comment.