### PR TITLE
review: refactor(*): Remove redundant supertypes

### DIFF
--- a/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
+++ b/src/main/java/spoon/reflect/cu/position/NoSourcePosition.java
@@ -12,12 +12,11 @@ import spoon.reflect.cu.SourcePosition;
 import spoon.support.reflect.cu.CompilationUnitImpl;
 
 import java.io.File;
-import java.io.Serializable;
 
 /**
  * This class represents the position of a program element in a source file.
  */
-public class NoSourcePosition implements SourcePosition, Serializable {
+public class NoSourcePosition implements SourcePosition {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/spoon/reflect/declaration/CtConstructor.java
+++ b/src/main/java/spoon/reflect/declaration/CtConstructor.java
@@ -17,7 +17,7 @@ import spoon.support.UnsettableProperty;
 /**
  * This element defines a constructor declaration.
  */
-public interface CtConstructor<T> extends CtExecutable<T>, CtTypeMember, CtFormalTypeDeclarer, CtShadowable {
+public interface CtConstructor<T> extends CtExecutable<T>, CtFormalTypeDeclarer, CtShadowable {
 
 	/**
 	 * Always returns "&lt;init&gt;".

--- a/src/main/java/spoon/reflect/declaration/CtMethod.java
+++ b/src/main/java/spoon/reflect/declaration/CtMethod.java
@@ -19,7 +19,7 @@ import static spoon.reflect.path.CtRole.IS_DEFAULT;
 /**
  * This element defines a method declaration.
  */
-public interface CtMethod<T> extends CtExecutable<T>, CtTypeMember, CtFormalTypeDeclarer, CtShadowable {
+public interface CtMethod<T> extends CtExecutable<T>, CtFormalTypeDeclarer, CtShadowable {
 	/**
 	 * @param superMethod to be checked method
 	 * @return true if this method overrides `superMethod`.<br>

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -343,7 +343,6 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 */
 	@PropertySetter(role = TYPE_MEMBER)
 	<C extends CtType<T>> C setTypeMembers(List<CtTypeMember> members);
-
 	@Override
 	CtType<T> clone();
 

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -343,6 +343,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 */
 	@PropertySetter(role = TYPE_MEMBER)
 	<C extends CtType<T>> C setTypeMembers(List<CtTypeMember> members);
+
 	@Override
 	CtType<T> clone();
 

--- a/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
+++ b/src/main/java/spoon/reflect/visitor/filter/AbstractReferenceFilter.java
@@ -8,7 +8,6 @@
 package spoon.reflect.visitor.filter;
 
 import spoon.reflect.reference.CtReference;
-import spoon.reflect.visitor.Filter;
 
 /**
  * This class defines an abstract reference filter that needs to be subclassed
@@ -17,7 +16,7 @@ import spoon.reflect.visitor.Filter;
  * @param <T>
  * 		the type of the reference to be matched
  */
-public abstract class AbstractReferenceFilter<T extends CtReference> extends AbstractFilter<T> implements Filter<T> {
+public abstract class AbstractReferenceFilter<T extends CtReference> extends AbstractFilter<T> {
 
 	/**
 	 * Creates a reference filter with the type of the potentially matching

--- a/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/BodyHolderSourcePositionImpl.java
@@ -10,14 +10,12 @@ package spoon.support.reflect.cu.position;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.position.BodyHolderSourcePosition;
 
-import java.io.Serializable;
-
 /**
  * This class represents the position of a Java program element in a source
  * file.
  */
 public class BodyHolderSourcePositionImpl extends DeclarationSourcePositionImpl
-		implements BodyHolderSourcePosition, Serializable {
+		implements BodyHolderSourcePosition {
 
 	private static final long serialVersionUID = 1L;
 	private int bodyStart;

--- a/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/CompoundSourcePositionImpl.java
@@ -10,14 +10,12 @@ package spoon.support.reflect.cu.position;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.position.CompoundSourcePosition;
 
-import java.io.Serializable;
-
 /**
  * This class represents the position of a named Java program element in a source
  * file.
  */
 public class CompoundSourcePositionImpl extends SourcePositionImpl
-		implements CompoundSourcePosition, Serializable {
+		implements CompoundSourcePosition {
 
 	private static final long serialVersionUID = 1L;
 	private int declarationSourceStart;

--- a/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/DeclarationSourcePositionImpl.java
@@ -11,14 +11,12 @@ import spoon.SpoonException;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.position.DeclarationSourcePosition;
 
-import java.io.Serializable;
-
 /**
  * This class represents the position of a Java program element in a source
  * file.
  */
 public class DeclarationSourcePositionImpl extends CompoundSourcePositionImpl
-		implements DeclarationSourcePosition, Serializable, Cloneable {
+		implements DeclarationSourcePosition, Cloneable {
 
 	private static final long serialVersionUID = 1L;
 	private int modifierSourceEnd;

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -15,14 +15,13 @@ import spoon.reflect.cu.position.DeclarationSourcePosition;
 import spoon.reflect.cu.position.NoSourcePosition;
 
 import java.io.File;
-import java.io.Serializable;
 import java.util.Arrays;
 
 /**
  * This immutable class represents the position of a Java program element in a source
  * file.
  */
-public class SourcePositionImpl implements SourcePosition, Serializable {
+public class SourcePositionImpl implements SourcePosition {
 
 	private static final long serialVersionUID = 1L;
 

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -53,8 +53,6 @@ import spoon.support.visitor.TypeReferenceScanner;
 import spoon.support.visitor.equals.CloneHelper;
 import spoon.support.visitor.equals.EqualsVisitor;
 import spoon.support.visitor.replace.ReplacementVisitor;
-
-import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -72,7 +70,7 @@ import static spoon.reflect.visitor.CommentHelper.printComment;
  * Contains the default implementation of most CtElement methods.
  *
  */
-public abstract class CtElementImpl implements CtElement, Serializable {
+public abstract class CtElementImpl implements CtElement {
 	private static final long serialVersionUID = 1L;
 	protected static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	public static final String ERROR_MESSAGE_TO_STRING = "Error in printing the node. One parent isn't initialized!";


### PR DESCRIPTION
Removed a lot of not needed supertypes in the code, where other supertypes already have the interface as supertype.
 
The following has changed in the code:
Removed interface java.io.Serializable from type spoon.reflect.cu.position.NoSourcePosition, because it's redundant
Removed interface spoon.reflect.declaration.CtTypeMember from type spoon.reflect.declaration.CtConstructor, because it's redundant
Removed interface spoon.reflect.declaration.CtTypeMember from type spoon.reflect.declaration.CtMethod, because it's redundant
Removed interface java.io.Serializable from type spoon.support.reflect.cu.position.BodyHolderSourcePositionImpl, because it's redundant
Removed interface java.io.Serializable from type spoon.support.reflect.cu.position.CompoundSourcePositionImpl, because it's redundant
Removed interface java.io.Serializable from type spoon.support.reflect.cu.position.DeclarationSourcePositionImpl, because it's redundant
Removed interface java.io.Serializable from type spoon.support.reflect.cu.position.SourcePositionImpl, because it's redundant
Removed interface java.io.Serializable from type spoon.support.reflect.declaration.CtElementImpl, because it's redundant
Removed interface spoon.reflect.visitor.Filter from type spoon.reflect.visitor.filter.AbstractReferenceFilter, because it's redundant