### PR TITLE
review: chore(git): add gradle enterprise ID to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ gradle-app.setting
 
 ### Gradle Patch ###
 **/build/
+
+## Gradle Enterprise ID File ##
+.mvn/.gradle-enterprise/gradle-enterprise-workspace-id


### PR DESCRIPTION
This file doesn't look like it should be in the repo, let's add it to the gitignore.