### PR TITLE
review: fix: add usage of String#lines

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -78,7 +78,7 @@ public class CommentHelper {
 	static void printCommentContent(PrinterHelper printer, CtComment comment, Function<String, String> transfo) {
 		CtComment.CommentType commentType = comment.getCommentType();
 		String content = comment.getContent();
-		
+
 		String[] lines = content.lines().toArray(String[]::new);
 		for (String com : lines) {
 			if (commentType == CtComment.CommentType.BLOCK) {

--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -14,7 +14,6 @@ import spoon.support.Internal;
 
 import java.util.Collection;
 import java.util.function.Function;
-import java.util.regex.Pattern;
 
 /**
  * Computes source code representation of the Comment literal
@@ -22,10 +21,6 @@ import java.util.regex.Pattern;
 @Internal
 public class CommentHelper {
 
-	/**
-	 * RegExp which matches all possible line separators
-	 */
-	private static final Pattern LINE_SEPARATORS_RE = Pattern.compile("\\n\\r|\\n|\\r");
 
 	private CommentHelper() {
 	}
@@ -83,7 +78,8 @@ public class CommentHelper {
 	static void printCommentContent(PrinterHelper printer, CtComment comment, Function<String, String> transfo) {
 		CtComment.CommentType commentType = comment.getCommentType();
 		String content = comment.getContent();
-		String[] lines = LINE_SEPARATORS_RE.split(content);
+		
+		String[] lines = content.lines().toArray(String[]::new);
 		for (String com : lines) {
 			if (commentType == CtComment.CommentType.BLOCK) {
 				printer.write(com);
@@ -113,7 +109,7 @@ public class CommentHelper {
 			printer.write(docTag.getParam()).writeln();
 		}
 
-		String[] tagLines = LINE_SEPARATORS_RE.split(docTag.getContent());
+		String[] tagLines = docTag.getContent().lines().toArray(String[]::new);
 		for (int i = 0; i < tagLines.length; i++) {
 			String com = tagLines[i];
 			if (docTag.getType().hasParam()) {

--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -7,13 +7,13 @@
  */
 package spoon.reflect.visitor;
 
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
 import spoon.support.Internal;
-
-import java.util.Collection;
-import java.util.function.Function;
 
 /**
  * Computes source code representation of the Comment literal
@@ -82,7 +82,7 @@ public class CommentHelper {
 		content.lines().forEach(line -> {
 			if (commentType == CtComment.CommentType.BLOCK) {
 				printer.write(line);
-				if (content.lines().count() > 1) {
+				if (hasMoreThanOneElement(content.lines())) {
 					printer.write(CtComment.LINE_SEPARATOR);
 				}
 			} else {
@@ -98,6 +98,15 @@ public class CommentHelper {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Checks if the given stream has more than one element.
+	 * @param stream  the stream to check
+	 * @return  true if the stream has more than one element, false otherwise.
+	 */
+	private static boolean hasMoreThanOneElement(Stream<?> stream) {
+		return stream.skip(1).findAny().isPresent();
 	}
 
 	static void printJavaDocTag(PrinterHelper printer, CtJavaDocTag docTag, Function<String, String> transfo) {

--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -79,17 +79,16 @@ public class CommentHelper {
 		CtComment.CommentType commentType = comment.getCommentType();
 		String content = comment.getContent();
 
-		String[] lines = content.lines().toArray(String[]::new);
-		for (String com : lines) {
+		content.lines().forEach(line -> {
 			if (commentType == CtComment.CommentType.BLOCK) {
-				printer.write(com);
-				if (lines.length > 1) {
+				printer.write(line);
+				if (content.lines().count() > 1) {
 					printer.write(CtComment.LINE_SEPARATOR);
 				}
 			} else {
-				printer.write(transfo.apply(com)).writeln(); // removing spaces at the end of the space
+				printer.write(transfo.apply(line)).writeln(); // removing spaces at the end of the space
 			}
-		}
+		});
 		if (comment instanceof CtJavaDoc) {
 			Collection<CtJavaDocTag> javaDocTags = ((CtJavaDoc) comment).getTags();
 			if (javaDocTags != null && javaDocTags.isEmpty() == false) {
@@ -109,13 +108,11 @@ public class CommentHelper {
 			printer.write(docTag.getParam()).writeln();
 		}
 
-		String[] tagLines = docTag.getContent().lines().toArray(String[]::new);
-		for (int i = 0; i < tagLines.length; i++) {
-			String com = tagLines[i];
+		docTag.getContent().lines().forEach(com -> {
 			if (docTag.getType().hasParam()) {
 				printer.write(transfo.apply("\t\t"));
 			}
 			printer.write(com.trim()).writeln();
-		}
+		});
 	}
 }


### PR DESCRIPTION
As @I-Al-Istannen already pointed out, Java 11 has the nice `String#lines` method. Removes the regex and replaces it with this.
fixes #4105 