### PR TITLE
fix: correct type reference for ClassLiteralAccess

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1074,7 +1074,12 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 	@Override
 	public boolean visit(ClassLiteralAccess classLiteral, BlockScope scope) {
-		context.enter(factory.Code().createClassAccess(references.getTypeReference(classLiteral.targetType)), classLiteral);
+		if(classLiteral.targetType == null) {
+			// fix for issue #4350. 
+			context.enter(factory.Code().createClassAccess(references.getTypeReference(classLiteral.type)), classLiteral);
+		} else {
+			context.enter(factory.Code().createClassAccess(references.getTypeReference(classLiteral.targetType)), classLiteral);
+		}
 		return false;
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1074,8 +1074,8 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 	@Override
 	public boolean visit(ClassLiteralAccess classLiteral, BlockScope scope) {
-		if(classLiteral.targetType == null) {
-			// fix for issue #4350. 
+		if (classLiteral.targetType == null) {
+			// fix for issue #4350.
 			context.enter(factory.Code().createClassAccess(references.getTypeReference(classLiteral.type)), classLiteral);
 		} else {
 			context.enter(factory.Code().createClassAccess(references.getTypeReference(classLiteral.targetType)), classLiteral);

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -626,7 +626,7 @@ public class PrinterTest {
 			"        Stream.empty().map(( v) -> List.class).close();\n" +
 			"    }\n" +
 			"}";
-		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> java.util.List.class).close(); } }");
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> List.class).close(); } }");
 		assertEquals(expected, normalizeLineEnds(type.toString()));
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -603,4 +603,26 @@ public class PrinterTest {
 
 		assertTrue(FileUtils.readFileToString(new File("spooned/HelloWorld.java"), "UTF-8").contains("  class"));
 	}
+
+	
+	@Test
+	public void testTypeLostPrintingStringClassReference() {
+		// contract: when a class reference is printed, the type is not lost
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> String.class).close(); } }");
+		assertTrue("Result does not contain 'String.class', String.class should be printed instead of .class only", type.toString().contains("String.class"));
+	}
+
+	@Test
+	public void testTypeLostPrintingListClassReference() {
+		// contract: when a class reference is printed, the type is not lost
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> List.class).close(); } }");
+		assertTrue("Result does not contain 'List.class', String.class should be printed instead of .class only", type.toString().contains("List.class"));
+	}
+
+	@Test
+	public void testTypeLostPrintingFQListClassReference() {
+		// contract: when a class reference is printed, the type is not lost
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> java.util.List.class).close(); } }");
+		assertTrue("Result does not contain 'List.class', List.class should be printed instead of .class only", type.toString().contains("List.class"));
+	}
 }

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -50,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 public class PrinterTest {
 
@@ -608,21 +609,40 @@ public class PrinterTest {
 	@Test
 	public void testTypeLostPrintingStringClassReference() {
 		// contract: when a class reference is printed, the type is not lost
-		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> String.class).close(); } }");
-		assertTrue("Result does not contain 'String.class', String.class should be printed instead of .class only", type.toString().contains("String.class"));
+		String expected = "class A {\n" +
+			"    void m() {\n" +
+			"        Stream.empty().map(( v) -> String.class).close();\n" +
+			"    }\n" +
+			"}";
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> String.class).close(); } }");
+		assertEquals(expected, normalizeLineEnds(type.toString()));
 	}
 
 	@Test
 	public void testTypeLostPrintingListClassReference() {
 		// contract: when a class reference is printed, the type is not lost
-		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> List.class).close(); } }");
-		assertTrue("Result does not contain 'List.class', String.class should be printed instead of .class only", type.toString().contains("List.class"));
+		String expected = "class A {\n" +
+			"    void m() {\n" +
+			"        Stream.empty().map(( v) -> List.class).close();\n" +
+			"    }\n" +
+			"}";
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> java.util.List.class).close(); } }");
+		assertEquals(expected, normalizeLineEnds(type.toString()));
 	}
 
 	@Test
 	public void testTypeLostPrintingFQListClassReference() {
 		// contract: when a class reference is printed, the type is not lost
-		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empy().map(v-> java.util.List.class).close(); } }");
-		assertTrue("Result does not contain 'List.class', List.class should be printed instead of .class only", type.toString().contains("List.class"));
+		String expected = "class A {\n" +
+			"    void m() {\n" +
+			"        Stream.empty().map(( v) -> List.class).close();\n" +
+			"    }\n" +
+			"}";
+		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> java.util.List.class).close(); } }");
+		assertEquals(expected, normalizeLineEnds(type.toString()));
+	}
+
+	private static String normalizeLineEnds(String s) {
+		return s.lines().collect(Collectors.joining("\n"));
 	}
 }


### PR DESCRIPTION
fix #4350

This should the fix issue #4350 . I tried to create an as small class as possible for the test case. The testcase seems pretty bad, any suggestions for an assertion checking if a String equals without newline characters? Otherwise, the new testcase is again Unix only. 