### PR TITLE
review: refactor(*): Convert StringTests to junit5

### DIFF
--- a/src/test/java/spoon/test/strings/StringTest.java
+++ b/src/test/java/spoon/test/strings/StringTest.java
@@ -23,9 +23,9 @@ import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import static spoon.testing.utils.ModelUtils.build;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.build;
 
 public class StringTest {
 

--- a/src/test/java/spoon/test/strings/StringTest.java
+++ b/src/test/java/spoon/test/strings/StringTest.java
@@ -16,16 +16,16 @@
  */
 package spoon.test.strings;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringTest {
 


### PR DESCRIPTION
#3919 

The following has changed in the code:
In type spoon.test.strings.StringLiteralTest:
- Replaced junit 4 test annotation with junit 5 test annotation in testSnippetFullClass

In type spoon.test.strings.StringTest:
- Replaced junit 4 test annotation with junit 5 test annotation in testModelBuildingInitializer