### PR TITLE
fix(record): valid assignments in record compact constructors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Disable Git's autocrlf
         run: git config --global core.autocrlf false
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: actions/setup-java@5f00602cd1b2819185d88dc7a1b1985f598c6705 # renovate: tag=v2.4.0
+      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
           java-version: ${{ matrix.java }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -73,7 +73,7 @@ jobs:
     name: Test with coverage
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-      - uses: actions/setup-java@5f00602cd1b2819185d88dc7a1b1985f598c6705 # renovate: tag=v2.4.0
+      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
           java-version: 16
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -109,7 +109,7 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@5f00602cd1b2819185d88dc7a1b1985f598c6705 # renovate: tag=v2.4.0
+      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
           java-version: 16
           distribution: ${{ env.JAVA_DISTRIBUTION }}
@@ -153,7 +153,7 @@ jobs:
           ref: master
       - name: copy config file
         run: cp pull_request/qodana.yml master/qodana.yml
-      - uses: actions/setup-java@5f00602cd1b2819185d88dc7a1b1985f598c6705 # renovate: tag=v2.4.0
+      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
           java-version: 16
           distribution: ${{ env.JAVA_DISTRIBUTION }}

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -7,11 +7,19 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.eclipse.jdt.internal.compiler.ast.*;
+import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.Expression;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import spoon.compiler.Environment;
-import spoon.reflect.code.*;
+import spoon.reflect.code.CtAssignment;
+import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
@@ -109,7 +117,7 @@ public class ContextBuilder {
 		}
 
 		if (e instanceof CtAssignment) {
-			e.setImplicit((node.bits&ASTNode.IsImplicit) != 0);
+			e.setImplicit((node.bits & ASTNode.IsImplicit) != 0);
 		}
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -7,18 +7,11 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.eclipse.jdt.internal.compiler.ast.ASTNode;
-import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
-import org.eclipse.jdt.internal.compiler.ast.Expression;
-import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
-import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.ast.*;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import spoon.compiler.Environment;
-import spoon.reflect.code.CtCatchVariable;
-import spoon.reflect.code.CtConstructorCall;
-import spoon.reflect.code.CtExpression;
-import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.*;
 import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
@@ -115,6 +108,9 @@ public class ContextBuilder {
 			// For some element, we throw an UnsupportedOperationException when we call setType().
 		}
 
+		if (e instanceof CtAssignment) {
+			e.setImplicit((node.bits&ASTNode.IsImplicit) != 0);
+		}
 	}
 
 	void exit(ASTNode node) {

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -15,7 +15,6 @@ import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import spoon.compiler.Environment;
-import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
@@ -114,10 +113,6 @@ public class ContextBuilder {
 			}
 		} catch (UnsupportedOperationException ignore) {
 			// For some element, we throw an UnsupportedOperationException when we call setType().
-		}
-
-		if (e instanceof CtAssignment) {
-			e.setImplicit((node.bits & ASTNode.IsImplicit) != 0);
 		}
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -119,6 +119,7 @@ import org.slf4j.LoggerFactory;
 import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtArrayAccess;
+import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBreak;
@@ -1018,7 +1019,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 	@Override
 	public boolean visit(Assignment assignment, BlockScope scope) {
-		context.enter(factory.Core().createAssignment(), assignment);
+		context.enter(factory.Core().createAssignment().setImplicit((assignment.bits & ASTNode.IsImplicit) != 0), assignment);
 		return true;
 	}
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -119,7 +119,6 @@ import org.slf4j.LoggerFactory;
 import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtArrayAccess;
-import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBreak;

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -136,7 +137,7 @@ public class CtRecordTest {
 		assertEquals(correctConstructor, head(head(records).getConstructors()).toString());
 	}
 
-	@Test @Ignore
+	@Test @Disabled
 	void testCompactConstructor2() {
 		// contract: compact constructor is printed correctly for a compilable Java file (issue 4377).
 		String code = "src/test/resources/records/CompactConstructor2.java";

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -9,8 +9,6 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -137,7 +137,7 @@ public class CtRecordTest {
 		assertEquals(correctConstructor, head(head(records).getConstructors()).toString());
 	}
 
-	@Test @Disabled
+	@Test
 	void testCompactConstructor2() {
 		// contract: compact constructor is printed correctly for a compilable Java file (issue 4377).
 		String code = "src/test/resources/records/CompactConstructor2.java";

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -8,6 +8,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
+
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -126,8 +128,25 @@ public class CtRecordTest {
 		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
 		assertTrue(records.iterator().next().getConstructors().iterator().next().isCompactConstructor());
 		String correctConstructor =
-			"public CompactConstructor {" + lineSeparator()
+			"public Rational {" + lineSeparator()
 		+	"    int gcd = records.Rational.gcd(num, denom);" + lineSeparator()
+		+	"    num /= gcd;" + lineSeparator()
+		+	"    denom /= gcd;" + lineSeparator()
+		+	"}";
+		assertEquals(correctConstructor, head(head(records).getConstructors()).toString());
+	}
+
+	@Test @Ignore
+	void testCompactConstructor2() {
+		// contract: compact constructor is printed correctly for a compilable Java file (issue 4377).
+		String code = "src/test/resources/records/CompactConstructor2.java";
+		CtModel model = createModelFromPath(code);
+		assertEquals(1, model.getAllTypes().size());
+		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
+		assertTrue(records.iterator().next().getConstructors().iterator().next().isCompactConstructor());
+		String correctConstructor =
+			"public CompactConstructor2 {" + lineSeparator()
+		+	"    int gcd = records.CompactConstructor2.gcd(num, denom);" + lineSeparator()
 		+	"    num /= gcd;" + lineSeparator()
 		+	"    denom /= gcd;" + lineSeparator()
 		+	"}";

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -126,7 +126,7 @@ public class CtRecordTest {
 		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
 		assertTrue(records.iterator().next().getConstructors().iterator().next().isCompactConstructor());
 		String correctConstructor =
-			"Rational {" + lineSeparator()
+			"public CompactConstructor {" + lineSeparator()
 		+	"    int gcd = records.Rational.gcd(num, denom);" + lineSeparator()
 		+	"    num /= gcd;" + lineSeparator()
 		+	"    denom /= gcd;" + lineSeparator()

--- a/src/test/resources/records/CompactConstructor.java
+++ b/src/test/resources/records/CompactConstructor.java
@@ -1,12 +1,12 @@
 package records;
 
-public record CompactConstructor(int num, int denom) { 
+public record Rational(int num, int denom) { 
   private static int gcd(int a, int b) { 
   if (b == 0) return Math.abs(a); 
   else return gcd(b, a % b); 
   } 
   
-  public CompactConstructor { 
+  public Rational { 
     int gcd = gcd(num, denom); 
     num /= gcd; 
     denom /= gcd; 

--- a/src/test/resources/records/CompactConstructor.java
+++ b/src/test/resources/records/CompactConstructor.java
@@ -1,14 +1,14 @@
 package records;
 
-public record CompactConstructor(int num, int denom) { 
+public record Rational(int num, int denom) { 
   private static int gcd(int a, int b) { 
-  if (b == 0) return Math.abs(a); 
-  else return gcd(b, a % b); 
+    if (b == 0) return Math.abs(a); 
+    else return gcd(b, a % b); 
   } 
   
-  public CompactConstructor { 
+  public Rational { 
     int gcd = gcd(num, denom); 
     num /= gcd; 
     denom /= gcd; 
-    } 
-  }
+  } 
+}

--- a/src/test/resources/records/CompactConstructor.java
+++ b/src/test/resources/records/CompactConstructor.java
@@ -1,12 +1,12 @@
 package records;
 
-public record Rational(int num, int denom) { 
+public record CompactConstructor(int num, int denom) { 
   private static int gcd(int a, int b) { 
   if (b == 0) return Math.abs(a); 
   else return gcd(b, a % b); 
   } 
   
-  Rational { 
+  public CompactConstructor { 
     int gcd = gcd(num, denom); 
     num /= gcd; 
     denom /= gcd; 

--- a/src/test/resources/records/CompactConstructor2.java
+++ b/src/test/resources/records/CompactConstructor2.java
@@ -1,0 +1,14 @@
+package records;
+
+public record CompactConstructor2(int num, int denom) { 
+  private static int gcd(int a, int b) { 
+    if (b == 0) return Math.abs(a); 
+    else return gcd(b, a % b); 
+  } 
+  
+  public CompactConstructor2 { 
+    int gcd = gcd(num, denom); 
+    num /= gcd; 
+    denom /= gcd;
+  } 
+}


### PR DESCRIPTION
I have created a second test case for record compact constructors to demostrate the problem. I have created a PR even if I don't have a fix yet to make reproducing easier: either run CtRecordTest.testCompactConstructor2() directly from your IDE (in IntelliJ it's possible to run disabled tests from the IDE, don't know about eclipse), or remove the "@Disabled" annotation from said method.
