### PR TITLE
test: refactor StringLiteralTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/strings/StringLiteralTest.java
+++ b/src/test/java/spoon/test/strings/StringLiteralTest.java
@@ -16,12 +16,12 @@
  */
 package spoon.test.strings;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.factory.Factory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class StringLiteralTest {
@@ -71,6 +71,7 @@ public class StringLiteralTest {
 		assertEquals("char c5 = '	';", c5.toString());
 
 		// spoon cannot handle unicode and unicode in the same literal
+
 		// assertEquals("java.lang.String f6 = \"€\\u20ac\";", f6.toString());
 	}
 


### PR DESCRIPTION
I split the PR in 2 as the guidelines say.

The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testSnippetFullClass
Transformed junit4 assert to junt 5 assertion in testSnippetFullClass