### PR TITLE
test: migrate UnknownDeclarationTest to junit 5

### DIFF
--- a/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
+++ b/src/test/java/spoon/reflect/declaration/UnknownDeclarationTest.java
@@ -16,13 +16,13 @@
  */
 package spoon.reflect.declaration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.CtScanner;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * @author Marcel Steinbeck


### PR DESCRIPTION
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testUnknownCalls
Transformed junit4 assert to junt 5 assertion in testUnknownCalls