### PR TITLE
review: chore: run tests with Java 17

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 16]
+        java: [11, 17]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
-            java: 16
+            java: 17
 
 
     env:
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
       - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
-          java-version: 16
+          java-version: 17
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Get date for cache # see https://github.com/actions/cache README
@@ -111,7 +111,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
-          java-version: 16
+          java-version: 17
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - uses: actions/setup-python@f38219332975fe8f9c04cca981d674bf22aea1d3 # renovate: tag=v2.3.1
         with:
@@ -155,7 +155,7 @@ jobs:
         run: cp pull_request/qodana.yml master/qodana.yml
       - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
-          java-version: 16
+          java-version: 17
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: "Create folder"
         run: "mkdir -p ${{ github.workspace }}/result/master"


### PR DESCRIPTION
In regards of #4189 and #4337, it would make sense to run tests in Java 17. Especially as the shadow model cannot be fully tested otherwise.

I just switched from Java 16 to Java 17, as Java 16 won't receive any more updates anyways.


As a side note, it might be cool for spoon to join the [Quality Outreach Program](https://wiki.openjdk.java.net/display/quality/Quality+Outreach).