### PR TITLE
review: refactor(ArraysTest): migrate to junit 5

### DIFF
--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.arrays;
 
-import org.junit.Test;
+
+import java.lang.reflect.Array;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
@@ -30,14 +34,11 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.arrays.testclasses.VaragParam;
 import spoon.testing.utils.ModelUtils;
 
-import java.lang.reflect.Array;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class ArraysTest {


### PR DESCRIPTION
#3919 

The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testArrayReferences
Replaced junit 4 test annotation with junit 5 test annotation in testInitializeWithNewArray
Replaced junit 4 test annotation with junit 5 test annotation in testCtNewArrayInnerCtNewArray
Replaced junit 4 test annotation with junit 5 test annotation in testCtNewArrayWitComments
Replaced junit 4 test annotation with junit 5 test annotation in testParameterizedVarargReference
Replaced junit 4 test annotation with junit 5 test annotation in testParameterizedArrayReference
Replaced junit 4 test annotation with junit 5 test annotation in testParameterizedArrayVarargReference
Replaced junit 4 test annotation with junit 5 test annotation in testParameterizedTypeReference
Transformed junit4 assert to junt 5 assertion in testArrayReferences
Transformed junit4 assert to junt 5 assertion in testInitializeWithNewArray
Transformed junit4 assert to junt 5 assertion in testCtNewArrayInnerCtNewArray
Transformed junit4 assert to junt 5 assertion in testCtNewArrayWitComments
Transformed junit4 assert to junt 5 assertion in testParameterizedVarargReference
Transformed junit4 assert to junt 5 assertion in testParameterizedArrayReference
Transformed junit4 assert to junt 5 assertion in testParameterizedArrayVarargReference
Transformed junit4 assert to junt 5 assertion in testParameterizedTypeReference