### PR TITLE
fix: clone metadata for elements created via template

### DIFF
--- a/src/main/java/spoon/pattern/internal/node/ElementNode.java
+++ b/src/main/java/spoon/pattern/internal/node/ElementNode.java
@@ -264,6 +264,7 @@ public class ElementNode extends AbstractPrimitiveMatcher {
 		@SuppressWarnings("rawtypes")
 		CtElement clone = generator.getFactory().Core().create((Class) elementType.getMetamodelInterface().getActualClass());
 		generateSingleNodeAttributes(generator, clone, parameters);
+		clone.setAllMetadata(templateElement.getAllMetadata());
 		generator.applyGeneratedBy(clone, generator.getGeneratedByComment(templateElement));
 		result.addResult((U) clone);
 	}

--- a/src/test/java/spoon/test/template/PatternTest.java
+++ b/src/test/java/spoon/test/template/PatternTest.java
@@ -1647,4 +1647,22 @@ public class PatternTest {
 		assertNotNull(v);
 		return ((ImmutableMap) v).asMap();
 	}
+
+	@Test
+	void testGeneratorCopiesMetadataOfTemplateElement() {
+		// contract: metadata should be cloned for all elements generated via template
+
+		String c1 = "public class A { int getOne() { return 1; } }";
+		CtType <?> type = Launcher.parseClass(c1);
+		String key = "foo";
+		String val = "bar";
+
+		// attach metadata
+		type.descendantIterator().forEachRemaining(ctElement -> ctElement.putMetadata(key, val));
+
+		// create clone using the above type as template
+		CtType <?> cloneType = PatternBuilder.create(type).build().generator().generate("B", new HashMap<>());
+
+		cloneType.descendantIterator().forEachRemaining(ctElement -> assertEquals(val, ctElement.getMetadata(key), "Metadata does not match for: " + ctElement));
+	}
 }


### PR DESCRIPTION
The metadata of the template element was ignored when its clone was generated. This was creating an issue for preserving the declaration style of arrays. See [this comment](https://github.com/INRIA/spoon/pull/4341#discussion_r776262782).

