### PR TITLE
testCastTest): migrate to junit 5

### DIFF
--- a/src/test/java/spoon/test/casts/CastTest.java
+++ b/src/test/java/spoon/test/casts/CastTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.casts;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtVariableRead;
@@ -31,7 +31,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.casts.testclasses.Castings;
 import spoon.testing.utils.ModelUtils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 


### PR DESCRIPTION
#3919 

The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testCast1
Replaced junit 4 test annotation with junit 5 test annotation in testCast2
Replaced junit 4 test annotation with junit 5 test annotation in testCast3
Replaced junit 4 test annotation with junit 5 test annotation in testCase4
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAnnotationOnCast
Transformed junit4 assert to junt 5 assertion in testCast1
Transformed junit4 assert to junt 5 assertion in testCast2
Transformed junit4 assert to junt 5 assertion in testCast3
Transformed junit4 assert to junt 5 assertion in testCase4
Transformed junit4 assert to junt 5 assertion in testTypeAnnotationOnCast