### PR TITLE
test: migrate GenerateParentlessPackageTest to junit 5

### DIFF
--- a/src/test/java/spoon/reflect/factory/GenerateParentlessPackageTest.java
+++ b/src/test/java/spoon/reflect/factory/GenerateParentlessPackageTest.java
@@ -1,15 +1,16 @@
 package spoon.reflect.factory;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.declaration.CtPackage;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtPackage;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This test generates a parent-less package.


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in generateParentlessPackage
Transformed junit4 assert to junit 5 assertion in generateParentlessPackage