### PR TITLE
test: migrate CtBFSIteratorTest to junit 5

### DIFF
--- a/src/test/java/spoon/reflect/visitor/CtBFSIteratorTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtBFSIteratorTest.java
@@ -1,15 +1,17 @@
 package spoon.reflect.visitor;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.declaration.CtElement;
 
 import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtElement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CtBFSIteratorTest {
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testCtElementIteration
Transformed junit4 assert to junit 5 assertion in testCtIterator