### PR TITLE
test: migrate CtInheritanceScannerMethodsTest to junit 5

### DIFF
--- a/src/test/java/spoon/reflect/visitor/CtInheritanceScannerMethodsTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtInheritanceScannerMethodsTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.reflect.visitor;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.visitor.processors.CheckVisitorTestProcessor;
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testMethodsInInheritanceScanner