### PR TITLE
test: migrate CtIteratorTest to junit 5

### DIFF
--- a/src/test/java/spoon/reflect/visitor/CtIteratorTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtIteratorTest.java
@@ -16,14 +16,15 @@
  */
 package spoon.reflect.visitor;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.declaration.CtElement;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtElement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CtIteratorTest {
 


### PR DESCRIPTION
 #3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testCtElementIteration
Transformed junit4 assert to junit 5 assertion in testCtIterator
Transformed junit4 assert to junit 5 assertion in testAsIterable
Transformed junit4 assert to junit 5 assertion in testDescendantIterator