### PR TITLE
fix: escape sequences in text-blocks are kept

### DIFF
--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -62,7 +62,7 @@ abstract class LiteralHelper {
 	 */
 	public static String getTextBlockToken(CtTextBlock literal) {
 		String token = "\"\"\"\n"
-				+ literal.getValue().replaceAll("\\\\", "\\\\\\\\")
+				+ literal.getValue().replace("\\", "\\\\")
 				+ "\"\"\"";
 		return token;
 	}

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -58,12 +58,11 @@ abstract class LiteralHelper {
 
 	/**
 	 * @param literal CtTextBlock to be converted
-	 * @param numTabs
 	 * @return source code representation of the literal
 	 */
 	public static String getTextBlockToken(CtTextBlock literal) {
 		String token = "\"\"\"\n"
-				+ literal.getValue()
+				+ literal.getValue().replaceAll("\\\\", "\\\\\\\\")
 				+ "\"\"\"";
 		return token;
 	}

--- a/src/test/java/spoon/test/textBlocks/TextBlockTest.java
+++ b/src/test/java/spoon/test/textBlocks/TextBlockTest.java
@@ -121,6 +121,7 @@ public class TextBlockTest{
 	}
 
 	@Test
+	@ExtendWith(LineSeperatorExtension.class)
 	public void testTextBlockEscapes(){
 		//contract: text-blocks should retain escape sequences in code
 		Launcher launcher = setUpTest();

--- a/src/test/java/spoon/test/textBlocks/TextBlockTest.java
+++ b/src/test/java/spoon/test/textBlocks/TextBlockTest.java
@@ -3,7 +3,6 @@ package spoon.test.textBlocks;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import spoon.Launcher;
@@ -121,33 +120,35 @@ public class TextBlockTest{
 		);
 	}
 
-	@Test @Disabled
+	@Test
 	public void testTextBlockEscapes(){
-		//contract: Test Text Block usage introduced in Java 15
+		//contract: text-blocks should retain escape sequences in code
 		Launcher launcher = setUpTest();
 		launcher.getEnvironment().setAutoImports(true);
 		
 		CtClass<?> allstmt = (CtClass<?>) launcher.getFactory().Type().get("textBlock.TextBlockTestClass");
 		CtMethod<?> m5 =  allstmt.getMethod("m5");
 
+		CtStatement stmt5 = m5.getBody().getStatement(0);
+		assertTrue(stmt5.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
+
+		// test text block value
+		CtTextBlock l1 = (CtTextBlock) stmt5.getValueByRole(CtRole.ASSIGNMENT);
+		assertEquals("no-break space: \\00a0\n" +
+						"newline:        \\n\n" +
+						"tab:            \\t ('\t')\n",
+				l1.getValue());
+
+		// escape sequences should be retained in code
 		String m5Text = m5.toString();
 		assertEquals("void m5() {\n" +
 						"    String escape = \"\"\"\n" +
 						"    no-break space: \\\\00a0\n" +
 						"    newline:        \\\\n\n" +
-						"    tab:            \\\\t ('\\t')\n" +
+						"    tab:            \\\\t ('\t')\n" +
 						"    \"\"\";\n" +
 						"}",
 				m5Text);
-
-		CtStatement stmt5 = m5.getBody().getStatement(0);
-		assertTrue(stmt5.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
-
-		CtTextBlock l1 = (CtTextBlock) stmt5.getValueByRole(CtRole.ASSIGNMENT);
-		assertEquals("no-break space: \\\\00a0\n" +
-				"newline:        \\\\n\n" +
-				"tab:            \\\\t ('\t')\n",
-				l1.getValue());
 	}
 
 }

--- a/src/test/java/spoon/test/textBlocks/TextBlockTest.java
+++ b/src/test/java/spoon/test/textBlocks/TextBlockTest.java
@@ -44,7 +44,7 @@ public class TextBlockTest{
 		CtStatement stmt1 = m1.getBody().getStatement(0);
 		assertTrue(stmt1.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
 		CtTextBlock l1 = (CtTextBlock) stmt1.getValueByRole(CtRole.ASSIGNMENT);
-		assertEquals(l1.getValue(), "<html>\n    <body>\n        <p>Hello, कसौटी 🥲</p>\n    </body>\n</html>\n");
+		assertEquals("<html>\n    <body>\n        <p>Hello, कसौटी 🥲</p>\n    </body>\n</html>\n", l1.getValue());
 	}
 
 	@Test
@@ -57,9 +57,10 @@ public class TextBlockTest{
 		CtStatement stmt2 = m2.getBody().getStatement(0);
 		assertTrue(stmt2.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
 		CtTextBlock l2 = (CtTextBlock) stmt2.getValueByRole(CtRole.ASSIGNMENT);
-		assertEquals(l2.getValue(), "SELECT \"EMP_ID\", \"LAST_NAME\" FROM \"EMPLOYEE_TB\"\n"
+		assertEquals("SELECT \"EMP_ID\", \"LAST_NAME\" FROM \"EMPLOYEE_TB\"\n"
 				+ "WHERE \"CITY\" = 'INDIANAPOLIS'\n"
-				+ "ORDER BY \"EMP_ID\", \"LAST_NAME\";\n");
+				+ "ORDER BY \"EMP_ID\", \"LAST_NAME\";\n",
+				l2.getValue());
 	}
 
 	@Test
@@ -74,12 +75,13 @@ public class TextBlockTest{
 		CtInvocation inv = (CtInvocation) stmt5.getDirectChildren().get(1);
 		assertTrue(inv.getArguments().get(0) instanceof CtTextBlock);
 		CtTextBlock l3 = (CtTextBlock) inv.getArguments().get(0);
-		assertEquals(l3.getValue(), "function hello() {\n"
+		assertEquals("function hello() {\n"
 				+ "    print('\"Hello, world\"');\n"
 				+ "}\n"
 				+ "\n"
 				+ "hello();\n"
-				+ "");
+				+ "",
+				l3.getValue());
 	}
 
 	@Test
@@ -92,7 +94,7 @@ public class TextBlockTest{
 		CtStatement stmt1 = m4.getBody().getStatement(0);
 		assertTrue(stmt1.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
 		CtTextBlock l1 = (CtTextBlock) stmt1.getValueByRole(CtRole.ASSIGNMENT);
-		assertEquals(l1.getValue(), "");
+		assertEquals("", l1.getValue());
 	}
 
 	@Test
@@ -118,4 +120,21 @@ public class TextBlockTest{
 				c.toString()
 		);
 	}
+
+	@Test
+	public void testTextBlockEscapes(){
+		//contract: Test Text Block usage introduced in Java 15
+		Launcher launcher = setUpTest();
+		CtClass<?> allstmt = (CtClass<?>) launcher.getFactory().Type().get("textBlock.TextBlockTestClass");
+		CtMethod<?> m1 =  allstmt.getMethod("m5");
+
+		CtStatement stmt1 = m1.getBody().getStatement(0);
+		assertTrue(stmt1.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
+		CtTextBlock l1 = (CtTextBlock) stmt1.getValueByRole(CtRole.ASSIGNMENT);
+		assertEquals("no-break space: \\00a0\n" +
+				"newline:        \\n\n" +
+				"tab:            \\t ('\t')\n",
+				l1.getValue());
+	}
+
 }

--- a/src/test/java/spoon/test/textBlocks/TextBlockTest.java
+++ b/src/test/java/spoon/test/textBlocks/TextBlockTest.java
@@ -1,14 +1,14 @@
 package spoon.test.textBlocks;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import spoon.Launcher;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTextBlock;
@@ -121,19 +121,32 @@ public class TextBlockTest{
 		);
 	}
 
-	@Test
+	@Test @Disabled
 	public void testTextBlockEscapes(){
 		//contract: Test Text Block usage introduced in Java 15
 		Launcher launcher = setUpTest();
+		launcher.getEnvironment().setAutoImports(true);
+		
 		CtClass<?> allstmt = (CtClass<?>) launcher.getFactory().Type().get("textBlock.TextBlockTestClass");
-		CtMethod<?> m1 =  allstmt.getMethod("m5");
+		CtMethod<?> m5 =  allstmt.getMethod("m5");
 
-		CtStatement stmt1 = m1.getBody().getStatement(0);
-		assertTrue(stmt1.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
-		CtTextBlock l1 = (CtTextBlock) stmt1.getValueByRole(CtRole.ASSIGNMENT);
-		assertEquals("no-break space: \\00a0\n" +
-				"newline:        \\n\n" +
-				"tab:            \\t ('\t')\n",
+		String m5Text = m5.toString();
+		assertEquals("void m5() {\n" +
+						"    String escape = \"\"\"\n" +
+						"    no-break space: \\\\00a0\n" +
+						"    newline:        \\\\n\n" +
+						"    tab:            \\\\t ('\\t')\n" +
+						"    \"\"\";\n" +
+						"}",
+				m5Text);
+
+		CtStatement stmt5 = m5.getBody().getStatement(0);
+		assertTrue(stmt5.getValueByRole(CtRole.ASSIGNMENT) instanceof CtTextBlock);
+
+		CtTextBlock l1 = (CtTextBlock) stmt5.getValueByRole(CtRole.ASSIGNMENT);
+		assertEquals("no-break space: \\\\00a0\n" +
+				"newline:        \\\\n\n" +
+				"tab:            \\\\t ('\t')\n",
 				l1.getValue());
 	}
 

--- a/src/test/resources/textBlock/TextBlockTestClass.java
+++ b/src/test/resources/textBlock/TextBlockTestClass.java
@@ -40,4 +40,12 @@ public class TextBlockTestClass{
 		String empty = """
 		""";
 	}
+
+	void m5() {
+		String escape = """
+        no-break space: \\00a0
+        newline:        \\n
+        tab:            \\t ('\t')
+        """;
+	}
 }


### PR DESCRIPTION
Fixes #4408
Besides adding the (currently disabled) test case, I changed the Junit imports and fixed the parameter order of the assertEquals calls.