### PR TITLE
test: migrate TreeBuilderCompilerTest to junit 5

### DIFF
--- a/src/test/java/spoon/support/compiler/jdt/TreeBuilderCompilerTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/TreeBuilderCompilerTest.java
@@ -1,13 +1,13 @@
 package spoon.support.compiler.jdt;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import uk.org.lidalia.slf4jtest.TestLogger;
 import uk.org.lidalia.slf4jtest.TestLoggerFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TreeBuilderCompilerTest {
 


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testIgnoreSyntaxErrorsCompilation
Replaced junit 4 test annotation with junit 5 test annotation in testIgnoreSyntaxErrorsLogging
Replaced junit 4 test annotation with junit 5 test annotation in testEveryInputHasSyntaxError
Replaced junit 4 test annotation with junit 5 test annotation in testIgnoreSyntaxErrorsCommandLine
Transformed junit4 assert to junit 5 assertion in testIgnoreSyntaxErrorsCompilation
Transformed junit4 assert to junit 5 assertion in testIgnoreSyntaxErrorsLogging
Transformed junit4 assert to junit 5 assertion in testEveryInputHasSyntaxError
Transformed junit4 assert to junit 5 assertion in testIgnoreSyntaxErrorsCommandLine