### PR TITLE
test: migrate OutputTypeTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/OutputTypeTest.java
+++ b/src/test/java/spoon/test/OutputTypeTest.java
@@ -16,11 +16,11 @@
  */
 package spoon.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.OutputType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class OutputTypeTest {
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testOutputTypeLoading
Transformed junit4 assert to junit 5 assertion in testOutputTypeLoading