### PR TITLE
test: migrate FileSystemFolderTest to junit 5

### DIFF
--- a/src/test/java/spoon/test/api/FileSystemFolderTest.java
+++ b/src/test/java/spoon/test/api/FileSystemFolderTest.java
@@ -16,18 +16,19 @@
  */
 package spoon.test.api;
 
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.compiler.SpoonFolder;
 import spoon.support.compiler.FileSystemFolder;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileSystemFolderTest {
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in jarFileIsNotSubfolder
Replaced junit 4 test annotation with junit 5 test annotation in testLauncherWithWrongPathAsInput
Transformed junit4 assert to junit 5 assertion in jarFileIsNotSubfolder
Transformed junit4 assert to junit 5 assertion in testLauncherWithWrongPathAsInput