### PR TITLE
test: migrate ToStringBugTest to Junit 5

### DIFF
--- a/src/test/java/spoon/toStringBugTest/ToStringBugTest.java
+++ b/src/test/java/spoon/toStringBugTest/ToStringBugTest.java
@@ -1,14 +1,14 @@
 package spoon.toStringBugTest;
 
 
-import org.junit.Test;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtType;
 
-import java.util.List;
-
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ToStringBugTest {
     


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testIssue3382
Transformed junit4 assert to junit 5 assertion in testIssue3382