### PR TITLE
test: migrate AssignmentsEqualsTest to junit 5

### DIFF
--- a/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
+++ b/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
@@ -11,7 +11,6 @@ import spoon.reflect.visitor.filter.TypeFilter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class AssignmentsEqualsTest {
 
@@ -23,7 +22,7 @@ public class AssignmentsEqualsTest {
 
 		Factory factory = launcher.getFactory();
 		List<CtAssignment> assignments = Query.getElements(factory, new TypeFilter<>(CtAssignment.class));
-		assertSame(assignments.size(), 10);
+		assertEquals(assignments.size(), 10);
 		assertNotEquals(assignments.get(0), assignments.get(1));
 		assertNotEquals(assignments.get(2), assignments.get(3));
 		assertNotEquals(assignments.get(4), assignments.get(5));

--- a/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
+++ b/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
@@ -1,14 +1,17 @@
 package spoon.test.visitor;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import java.util.List;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class AssignmentsEqualsTest {
 
@@ -20,12 +23,11 @@ public class AssignmentsEqualsTest {
 
 		Factory factory = launcher.getFactory();
 		List<CtAssignment> assignments = Query.getElements(factory, new TypeFilter<>(CtAssignment.class));
-
-		assertTrue(assignments.size() == 10);
-		assertFalse(assignments.get(0).equals(assignments.get(1)));
-		assertFalse(assignments.get(2).equals(assignments.get(3)));
-		assertFalse(assignments.get(4).equals(assignments.get(5)));
-		assertFalse(assignments.get(6).equals(assignments.get(7)));
-		assertTrue(assignments.get(8).equals(assignments.get(9)));
+		assertSame(assignments.size(), 10);
+		assertNotEquals(assignments.get(0), assignments.get(1));
+		assertNotEquals(assignments.get(2), assignments.get(3));
+		assertNotEquals(assignments.get(4), assignments.get(5));
+		assertNotEquals(assignments.get(6), assignments.get(7));
+		assertEquals(assignments.get(8), assignments.get(9));
 	}
 }


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testEquals
Transformed junit4 assert to junit 5 assertion in testEquals
Replaced assertTrue checking equals with assertEquals
Replaced assertFalse checking equals with assertNotEquals
Replaced assertFalse checking equals with assertNotEquals
Replaced assertFalse checking equals with assertNotEquals
Replaced assertFalse checking equals with assertNotEquals
Replaced assertTrue checking same with assertSame