### PR TITLE
test: migrate VisibilityTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.visibility;
 
-import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonAPI;
@@ -36,13 +40,10 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.visibility.testclasses.A;
 import spoon.test.visibility.testclasses.A2;
 
-import java.io.File;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testMethodeWithNonAccessibleTypeArgument
Replaced junit 4 test annotation with junit 5 test annotation in testVisibilityOfClassesNamedByClassesInJavaLangPackage
Replaced junit 4 test annotation with junit 5 test annotation in testFullyQualifiedNameOfTypeReferenceWithGeneric
Replaced junit 4 test annotation with junit 5 test annotation in testName
Replaced junit 4 test annotation with junit 5 test annotation in testInvocationVisibilityInFieldDeclaration
Transformed junit4 assert to junit 5 assertion in testMethodeWithNonAccessibleTypeArgument
Transformed junit4 assert to junit 5 assertion in testVisibilityOfClassesNamedByClassesInJavaLangPackage
Transformed junit4 assert to junit 5 assertion in testFullyQualifiedNameOfTypeReferenceWithGeneric
Transformed junit4 assert to junit 5 assertion in testName
Transformed junit4 assert to junit 5 assertion in testInvocationVisibilityInFieldDeclaration