### PR TITLE
chore(qodana): bump Qodana version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-      QODANA_LINTER: jetbrains/qodana-jvm-community:2021.2
+      QODANA_LINTER: jetbrains/qodana-jvm-community:2021.3
     name: code-quality qodana
     steps:
       - name: Checkout


### PR DESCRIPTION
We had some problems with stuck qodana runs, but it seems that jetbrains rolled some updates out. Let's see if this works. 