### PR TITLE
test: migrate LauncherTest to Junit 5

### DIFF
--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -16,13 +16,6 @@
  */
 package spoon;
 
-import org.junit.Test;
-
-import spoon.compiler.Environment;
-import spoon.reflect.CtModel;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
-import spoon.support.JavaOutputProcessor;
-import spoon.support.compiler.VirtualFile;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -34,11 +27,18 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import spoon.compiler.Environment;
+import spoon.reflect.CtModel;
+import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
+import spoon.support.JavaOutputProcessor;
+import spoon.support.compiler.VirtualFile;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LauncherTest {
 
@@ -158,6 +158,6 @@ public class LauncherTest {
 		launcher.addInputResource(Paths.get("./src/test/resources/path with spaces/Foo.java").toAbsolutePath().toString());
 		CtModel model = launcher.buildModel();
 
-		assertTrue("CtTxpe 'Foo' not present in model", model.getAllTypes().stream().anyMatch(ct -> ct.getQualifiedName().equals("Foo")));
+		assertTrue(model.getAllTypes().stream().anyMatch(ct -> ct.getQualifiedName().equals("Foo")), "CtTxpe 'Foo' not present in model");
 	}
 }


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testInitEnvironmentDefault
Replaced junit 4 test annotation with junit 5 test annotation in testInitEnvironment
Replaced junit 4 test annotation with junit 5 test annotation in testLauncherInEmptyWorkingDir
Replaced junit 4 test annotation with junit 5 test annotation in testLLauncherBuildModelReturnAModel
Replaced junit 4 test annotation with junit 5 test annotation in testPrettyPrintWithVirtualFileInput
Replaced junit 4 test annotation with junit 5 test annotation in testClasspathURLWithSpaces
Transformed junit4 assert to junit 5 assertion in testInitEnvironmentDefault
Transformed junit4 assert to junit 5 assertion in testInitEnvironment
Transformed junit4 assert to junit 5 assertion in testLLauncherBuildModelReturnAModel
Transformed junit4 assert to junit 5 assertion in testClasspathURLWithSpaces