### PR TITLE
test: migrate NoClasspathTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -16,16 +16,11 @@
  */
 package spoon.test.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.code.CtFieldAccess;
@@ -43,6 +38,12 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.SpoonClassNotFoundException;
 import spoon.support.visitor.SignaturePrinter;
 import spoon.test.api.testclasses.Bar;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class NoClasspathTest {
 


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in test
Replaced junit 4 test annotation with junit 5 test annotation in testBug20141021
Replaced junit 4 test annotation with junit 5 test annotation in testGetStaticDependency
Replaced junit 4 test annotation with junit 5 test annotation in testIssue1747
Replaced junit 4 test annotation with junit 5 test annotation in testInheritanceInNoClassPathWithClasses
Transformed junit4 assert to junit 5 assertion in test
Transformed junit4 assert to junit 5 assertion in testBug20141021
Transformed junit4 assert to junit 5 assertion in testGetStaticDependency
Transformed junit4 assert to junit 5 assertion in testInheritanceInNoClassPathWithClasses