### PR TITLE
test: migrate ChangeCollectorTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/change/ChangeCollectorTest.java
+++ b/src/test/java/spoon/test/change/ChangeCollectorTest.java
@@ -16,23 +16,23 @@
  */
 package spoon.test.change;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.junit.Test;
-
-import spoon.support.modelobs.ChangeCollector;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.path.CtRole;
+import spoon.support.modelobs.ChangeCollector;
 import spoon.test.change.testclasses.SubjectOfChange;
 import spoon.testing.utils.ModelUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class ChangeCollectorTest {
 


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testChangeCollector
Transformed junit4 assert to junit 5 assertion in testChangeCollector