### PR TITLE
test: migrate CompilationTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -16,13 +16,6 @@
  */
 package spoon.test.compilation;
 
-import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -34,10 +27,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -68,6 +62,14 @@ import spoon.test.compilation.testclasses.IBar;
 import spoon.test.compilation.testclasses.Ifoo;
 import spoon.testing.utils.ModelUtils;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 public class CompilationTest {
 
 	@Test
@@ -90,14 +92,7 @@ public class CompilationTest {
 		SpoonModelBuilder compiler = launcher.createCompiler();
 		boolean compile = compiler.compile(SpoonModelBuilder.InputType.CTTYPES);
 		final String nl = System.getProperty("line.separator");
-		assertTrue(
-				nl + "the compilation should succeed: " + nl +
-						((JDTBasedSpoonCompiler) compiler).getProblems()
-								.stream()
-								.filter(IProblem::isError)
-								.map(CategorizedProblem::toString)
-								.collect(Collectors.joining(nl)),
-				compile
+		assertTrue(compile, nl + "the compilation should succeed: " + nl + ((JDTBasedSpoonCompiler) (compiler)).getProblems().stream().filter(IProblem::isError).map(CategorizedProblem::toString).collect(Collectors.joining(nl))
 		);
 	}
 
@@ -385,7 +380,7 @@ public class CompilationTest {
 
 		CtTypeReference<?> mIFoo = launcher.getFactory().Type().createReference("spoontest.IFoo");
 		CtTypeReference<?> mFoo = launcher.getFactory().Type().createReference("spoontest.Foo");
-		assertTrue("Foo subtype of IFoo", mFoo.isSubtypeOf(mIFoo));
+		assertTrue(mFoo.isSubtypeOf(mIFoo), "Foo subtype of IFoo");
 
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 
@@ -412,7 +407,7 @@ public class CompilationTest {
 		mIFoo = launcher.getFactory().Type().createReference("spoontest.IFoo");
 		mFoo = launcher.getFactory().Type().createReference("spoontest.Foo");
 		//if it fails then it is because each class is loaded by different class loader
-		assertTrue("Foo subtype of IFoo", mFoo.isSubtypeOf(mIFoo));
+		assertTrue(mFoo.isSubtypeOf(mIFoo), "Foo subtype of IFoo");
 
 		// not in the spoon classpath before setting it
 		Class<?> ifoo = launcher.getEnvironment().getInputClassLoader().loadClass("spoontest.IFoo");


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in compileTestWithImportStaticWildcard
Replaced junit 4 test annotation with junit 5 test annotation in compileCommandLineTest
Replaced junit 4 test annotation with junit 5 test annotation in compileTest
Replaced junit 4 test annotation with junit 5 test annotation in testNewInstanceFromExistingClass
Replaced junit 4 test annotation with junit 5 test annotation in testNewInstance
Replaced junit 4 test annotation with junit 5 test annotation in testFilterResourcesFile
Replaced junit 4 test annotation with junit 5 test annotation in testModuleResolution
Replaced junit 4 test annotation with junit 5 test annotation in testFilterResourcesDir
Replaced junit 4 test annotation with junit 5 test annotation in testPrecompile
Replaced junit 4 test annotation with junit 5 test annotation in testClassLoader
Replaced junit 4 test annotation with junit 5 test annotation in testSingleClassLoader
Replaced junit 4 test annotation with junit 5 test annotation in testExoticClassLoader
Replaced junit 4 test annotation with junit 5 test annotation in testURLClassLoader
Replaced junit 4 test annotation with junit 5 test annotation in testPathRetrievalFromURLClassLoader
Replaced junit 4 test annotation with junit 5 test annotation in testURLClassLoaderWithOtherResourcesThanOnlyFiles
Replaced junit 4 test annotation with junit 5 test annotation in testCompilationInEmptyDir
Replaced junit 4 test annotation with junit 5 test annotation in testCompileUnresolvedFullyQualifiedName
Replaced junit 4 test annotation with junit 5 test annotation in testBuildAstWithSyntheticMethods
Replaced junit 4 test annotation with junit 5 test annotation in testBuildAstWithSyntheticMethodsSwapOrder
Replaced junit 4 test annotation with junit 5 test annotation in buildAstWithDuplicateClass
Replaced Assert.assertThat with MatcherAssert.assertThat in testCompilationInEmptyDir()
Transformed junit4 assert to junit 5 assertion in compileTestWithImportStaticWildcard
Transformed junit4 assert to junit 5 assertion in compileCommandLineTest
Transformed junit4 assert to junit 5 assertion in compileTest
Transformed junit4 assert to junit 5 assertion in testNewInstanceFromExistingClass
Transformed junit4 assert to junit 5 assertion in testNewInstance
Transformed junit4 assert to junit 5 assertion in testFilterResourcesFile
Transformed junit4 assert to junit 5 assertion in testModuleResolution
Transformed junit4 assert to junit 5 assertion in testFilterResourcesDir
Transformed junit4 assert to junit 5 assertion in testPrecompile
Transformed junit4 assert to junit 5 assertion in testClassLoader
Transformed junit4 assert to junit 5 assertion in testSingleClassLoader
Transformed junit4 assert to junit 5 assertion in testExoticClassLoader
Transformed junit4 assert to junit 5 assertion in testURLClassLoader
Transformed junit4 assert to junit 5 assertion in testPathRetrievalFromURLClassLoader
Transformed junit4 assert to junit 5 assertion in testURLClassLoaderWithOtherResourcesThanOnlyFiles
Transformed junit4 assert to junit 5 assertion in testBuildAstWithSyntheticMethods
Transformed junit4 assert to junit 5 assertion in testBuildAstWithSyntheticMethodsSwapOrder
Transformed junit4 assert to junit 5 assertion in buildAstWithDuplicateClass