### PR TITLE
test: migrate TestCompilationUnit to Junit 5

### DIFF
--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -16,8 +16,18 @@
  */
 package spoon.test.compilationunit;
 
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.compiler.SpoonFile;
@@ -36,24 +46,16 @@ import spoon.reflect.visitor.CtScanner;
 import spoon.support.reflect.cu.position.PartialSourcePositionImpl;
 import spoon.test.api.testclasses.Bar;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testIsoEncodingIsSupported
Replaced junit 4 test annotation with junit 5 test annotation in testGetUnitTypeWorksWithDeclaredType
Replaced junit 4 test annotation with junit 5 test annotation in testGetUnitTypeWorksWithDeclaredPackage
Replaced junit 4 test annotation with junit 5 test annotation in testGetUnitTypeWorksWithCreatedObjects
Replaced junit 4 test annotation with junit 5 test annotation in testCompilationUnitDeclaredTypes
Replaced junit 4 test annotation with junit 5 test annotation in testCompilationUnitInNamedModuleHasDeclaredTypes
Replaced junit 4 test annotation with junit 5 test annotation in testCompilationUnitSourcePosition
Replaced junit 4 test annotation with junit 5 test annotation in testAddDeclaredTypeInCU
Replaced junit 4 test annotation with junit 5 test annotation in testNewlyCreatedCUWouldGetAPartialPosition
Replaced junit 4 test annotation with junit 5 test annotation in testCompilationUnitModelContracts
Replaced junit 4 test annotation with junit 5 test annotation in testDifferentEncodings
Replaced junit 4 test annotation with junit 5 test annotation in testPrintImport
Transformed junit4 assert to junit 5 assertion in testIsoEncodingIsSupported
Transformed junit4 assert to junit 5 assertion in testGetUnitTypeWorksWithDeclaredType
Transformed junit4 assert to junit 5 assertion in testGetUnitTypeWorksWithDeclaredPackage
Transformed junit4 assert to junit 5 assertion in testGetUnitTypeWorksWithCreatedObjects
Transformed junit4 assert to junit 5 assertion in testCompilationUnitDeclaredTypes
Transformed junit4 assert to junit 5 assertion in testCompilationUnitSourcePosition
Transformed junit4 assert to junit 5 assertion in testAddDeclaredTypeInCU
Transformed junit4 assert to junit 5 assertion in testNewlyCreatedCUWouldGetAPartialPosition
Transformed junit4 assert to junit 5 assertion in testCompilationUnitModelContracts
Transformed junit4 assert to junit 5 assertion in testDifferentEncodings
Transformed junit4 assert to junit 5 assertion in testPrintImport