### PR TITLE
test: migrate ConstructorTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -16,8 +16,15 @@
  */
 package spoon.test.constructor;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonAPI;
 import spoon.reflect.code.CtConstructorCall;
@@ -35,26 +42,21 @@ import spoon.test.constructor.testclasses.ImplicitConstructor;
 import spoon.test.constructor.testclasses.Tacos;
 import spoon.testing.utils.ModelUtils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class ConstructorTest {
 	private Factory factory;
 	private CtClass<?> aClass;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		SpoonAPI launcher = new Launcher();
 		launcher.run(new String[] {


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced @Before annotation with @BeforeEach from method setUp
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitConstructor
Replaced junit 4 test annotation with junit 5 test annotation in testTransformationOnConstructorWithInsertBegin
Replaced junit 4 test annotation with junit 5 test annotation in testTransformationOnConstructorWithInsertBefore
Replaced junit 4 test annotation with junit 5 test annotation in callParamConstructor
Replaced junit 4 test annotation with junit 5 test annotation in testConstructorCallFactory
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAnnotationOnExceptionDeclaredInConstructors
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAnnotationWithConstructorsOnFormalType
Replaced junit 4 test annotation with junit 5 test annotation in test_addParameterAt_addsParameterToSpecifiedPosition
Replaced junit 4 test annotation with junit 5 test annotation in test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds
Replaced junit 4 test annotation with junit 5 test annotation in test_addFormalCtTypeParameterAt_addsTypeParameterToSpecifiedPosition
Replaced junit 4 test annotation with junit 5 test annotation in test_addFormalCtTypeParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds
Transformed junit4 assert to junit 5 assertion in testImplicitConstructor
Transformed junit4 assert to junit 5 assertion in testTransformationOnConstructorWithInsertBegin
Transformed junit4 assert to junit 5 assertion in testTransformationOnConstructorWithInsertBefore
Transformed junit4 assert to junit 5 assertion in callParamConstructor
Transformed junit4 assert to junit 5 assertion in testConstructorCallFactory
Transformed junit4 assert to junit 5 assertion in testTypeAnnotationOnExceptionDeclaredInConstructors
Transformed junit4 assert to junit 5 assertion in testTypeAnnotationWithConstructorsOnFormalType
Transformed junit4 assert to junit 5 assertion in assertIntersectionTypeInConstructor
Transformed junit4 assert to junit 5 assertion in test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds
Transformed junit4 assert to junit 5 assertion in test_addFormalCtTypeParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds