### PR TITLE
fix: Fix square bracket printing in array field declarations

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1469,6 +1469,9 @@ public class JDTTreeBuilder extends ASTVisitor {
 		}
 		CtTypeReference typeReference = references.buildTypeReference(parameterizedTypeReference, null);
 		CtTypeAccess typeAccess = factory.Code().createTypeAccessWithoutCloningReference(typeReference);
+		if (typeAccess.getAccessedType() instanceof CtArrayTypeReference) {
+			((CtArrayTypeReferenceImpl<?>) typeAccess.getAccessedType()).setDeclarationKind(getDeclarationStyle(parameterizedTypeReference));
+		}
 		context.enter(typeAccess, parameterizedTypeReference);
 		return true;
 	}

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -884,7 +884,7 @@ public class TestSniperPrinter {
 		private Consumer<CtType<?>> markFieldForSniperPrinting() {
 			return type -> {
 				CtField<?> field = type.getField("array");
-				TestSniperPrinter.markElementForSniperPrinting(field);
+				TestSniperPrinter.markElementForSniperPrinting(field.getType());
 			};
 		}
 
@@ -936,6 +936,15 @@ public class TestSniperPrinter {
 					"sniperPrinter.arrayInitialisation.AsLocalVariable",
 					noOpModifyLocalVariable,
 					assertPrintsBracketForArrayInitialisation("int array[] = new int[]{ };"));
+		}
+
+		@GitHubIssue(issueNumber = 4421)
+		@Test
+		void test_bracketsShouldBePrintedForGenericTypeOfArray() {
+			testSniper(
+					"sniperPrinter.arrayInitialisation.GenericTypeArray",
+					markFieldForSniperPrinting(),
+					assertPrintsBracketForArrayInitialisation("Class<?> array[];"));
 		}
 	}
 

--- a/src/test/resources/sniperPrinter/arrayInitialisation/GenericTypeArray.java
+++ b/src/test/resources/sniperPrinter/arrayInitialisation/GenericTypeArray.java
@@ -1,0 +1,5 @@
+package sniperPrinter.arrayInitialisation;
+
+public class GenericTypeArray {
+    Class<?> array[];
+}


### PR DESCRIPTION
Fixes #4421

I missed attaching metadata to generic types in array type references in https://github.com/INRIA/spoon/pull/4341 which resulted in #4421. The changes in this PR fix it.

Also, I slightly changed the test case to modify the source position of type reference instead of the entire field because the former is more precise.