### PR TITLE
test: migrate AccessTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/variable/AccessTest.java
+++ b/src/test/java/spoon/test/variable/AccessTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.variable;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.ContractVerifier;
 import spoon.Launcher;
 import spoon.reflect.code.CtArrayAccess;
@@ -44,10 +47,8 @@ import spoon.test.variable.testclasses.RHSSample;
 import spoon.test.variable.testclasses.StackedAssignmentSample;
 import spoon.test.variable.testclasses.VariableAccessSample;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testCanVisitVariableAccessAndSubClasses
Replaced junit 4 test annotation with junit 5 test annotation in testCanVisitFieldAccessAndSubClasses
Replaced junit 4 test annotation with junit 5 test annotation in testCanVisitArrayAccessAndSubClasses
Replaced junit 4 test annotation with junit 5 test annotation in testStackedAssignments
Replaced junit 4 test annotation with junit 5 test annotation in testRHS
Replaced junit 4 test annotation with junit 5 test annotation in testFieldWriteDeclaredInTheSuperclass
Replaced junit 4 test annotation with junit 5 test annotation in testVariableAccessInNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testAccessToStringOnPostIncrement
Transformed junit4 assert to junit 5 assertion in testCanVisitVariableAccessAndSubClasses
Transformed junit4 assert to junit 5 assertion in testCanVisitFieldAccessAndSubClasses
Transformed junit4 assert to junit 5 assertion in testCanVisitArrayAccessAndSubClasses
Transformed junit4 assert to junit 5 assertion in testStackedAssignments
Transformed junit4 assert to junit 5 assertion in testRHS
Transformed junit4 assert to junit 5 assertion in testVariableAccessInNoClasspath
Transformed junit4 assert to junit 5 assertion in testAccessToStringOnPostIncrement