### PR TITLE
test: migrate TryCatchTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -16,8 +16,17 @@
  */
 package spoon.test.trycatch;
 
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.CtModel;
@@ -38,23 +47,16 @@ import spoon.support.reflect.CtExtendedModifier;
 import spoon.test.trycatch.testclasses.Foo;
 import spoon.test.trycatch.testclasses.Main;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -334,7 +336,7 @@ public class TryCatchTest {
 
 		List<CtCatch> catchers = model.getElements(e -> true);
 
-		assertEquals("There should only be one catch statement, check the resource", 1, catchers.size());
+		assertEquals(1, catchers.size(), "There should only be one catch statement, check the resource");
 		CtTypeReference<?> caughtType = catchers.get(0).getParameter().getType();
 
 		assertEquals("CustomException", caughtType.getSimpleName());
@@ -367,8 +369,8 @@ public class TryCatchTest {
 		CtCatch targetCatch = catches.get(0);
 		List<CtTypeReference<?>> paramTypes = targetCatch.getParameter().getMultiTypes();
 		assertThat(paramTypes.size(), equalTo(2));
-		assertTrue("first type reference is fully qualified", paramTypes.get(0).isSimplyQualified());
-		assertTrue("second type reference is fully qualified", paramTypes.get(1).isSimplyQualified());
+		assertTrue(paramTypes.get(0).isSimplyQualified(), "first type reference is fully qualified");
+		assertTrue(paramTypes.get(1).isSimplyQualified(), "second type reference is fully qualified");
 	}
 
 	@Test
@@ -384,8 +386,8 @@ public class TryCatchTest {
 		CtCatch targetCatch = catches.get(0);
 		List<CtTypeReference<?>> paramTypes = targetCatch.getParameter().getMultiTypes();
 		assertThat(paramTypes.size(), equalTo(2));
-		assertTrue("first type reference should be unqualified", paramTypes.get(0).isSimplyQualified());
-		assertFalse("second type reference should be qualified", paramTypes.get(1).isSimplyQualified());
+		assertTrue(paramTypes.get(0).isSimplyQualified(), "first type reference should be unqualified");
+		assertFalse(paramTypes.get(1).isSimplyQualified(), "second type reference should be qualified");
 	}
 
 	@Test


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testModelBuildingInitializer
Replaced junit 4 test annotation with junit 5 test annotation in testFullyQualifiedException
Replaced junit 4 test annotation with junit 5 test annotation in testCatchOrder
Replaced junit 4 test annotation with junit 5 test annotation in testExceptionJava7
Replaced junit 4 test annotation with junit 5 test annotation in testRethrowingExceptionsJava7
Replaced junit 4 test annotation with junit 5 test annotation in testTryWithOneResource
Replaced junit 4 test annotation with junit 5 test annotation in testTryWithResources
Replaced junit 4 test annotation with junit 5 test annotation in testMultiTryCatchWithCustomExceptions
Replaced junit 4 test annotation with junit 5 test annotation in testCompileMultiTryCatchWithCustomExceptions
Replaced junit 4 test annotation with junit 5 test annotation in testTryCatchVariableGetType
Replaced junit 4 test annotation with junit 5 test annotation in testCatchWithExplicitFinalVariable
Replaced junit 4 test annotation with junit 5 test annotation in testCatchWithUnknownExceptions
Replaced junit 4 test annotation with junit 5 test annotation in testCatchQualifiedReferenceNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testCatchUnqualifiedReferenceIsMarkedSimplyQualified
Replaced junit 4 test annotation with junit 5 test annotation in testCatchUnqualifiedReferenceMarkedSimplyQualifiedWhenMultipleTypesAreSpecified
Replaced junit 4 test annotation with junit 5 test annotation in testCatchWithQualifiedAndUnqualifiedTypeReferencesInSameCatcher
Replaced junit 4 test annotation with junit 5 test annotation in testNonCloseableGenericTypeInTryWithResources
Transformed junit4 assert to junit 5 assertion in testModelBuildingInitializer
Transformed junit4 assert to junit 5 assertion in testFullyQualifiedException
Transformed junit4 assert to junit 5 assertion in testCatchOrder
Transformed junit4 assert to junit 5 assertion in testExceptionJava7
Transformed junit4 assert to junit 5 assertion in testRethrowingExceptionsJava7
Transformed junit4 assert to junit 5 assertion in testTryWithOneResource
Transformed junit4 assert to junit 5 assertion in testTryWithResources
Transformed junit4 assert to junit 5 assertion in testMultiTryCatchWithCustomExceptions
Transformed junit4 assert to junit 5 assertion in testCompileMultiTryCatchWithCustomExceptions
Transformed junit4 assert to junit 5 assertion in testTryCatchVariableGetType
Transformed junit4 assert to junit 5 assertion in testCatchWithExplicitFinalVariable
Transformed junit4 assert to junit 5 assertion in testCatchWithUnknownExceptions
Transformed junit4 assert to junit 5 assertion in testCatchQualifiedReferenceNoClasspath
Transformed junit4 assert to junit 5 assertion in testCatchUnqualifiedReferenceIsMarkedSimplyQualified
Transformed junit4 assert to junit 5 assertion in testCatchUnqualifiedReferenceMarkedSimplyQualifiedWhenMultipleTypesAreSpecified
Transformed junit4 assert to junit 5 assertion in testCatchWithQualifiedAndUnqualifiedTypeReferencesInSameCatcher