### PR TITLE
test: migrate TargetedExpressionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -16,17 +16,10 @@
  */
 package spoon.test.targeted;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static spoon.testing.utils.ModelUtils.build;
-import static spoon.testing.utils.ModelUtils.buildClass;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -61,6 +54,14 @@ import spoon.test.targeted.testclasses.InternalSuperCall;
 import spoon.test.targeted.testclasses.Pozole;
 import spoon.test.targeted.testclasses.SuperClass;
 import spoon.test.targeted.testclasses.Tapas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.build;
+import static spoon.testing.utils.ModelUtils.buildClass;
 
 
 public class TargetedExpressionTest {
@@ -107,8 +108,8 @@ public class TargetedExpressionTest {
 		final List<CtFieldAccess<?>> elements = constructor.getElements(new TypeFilter<>(CtFieldAccess.class));
 		assertEquals(2, elements.size());
 
-		assertSame("Target is CtThisAccessImpl if there is a 'this' explicit.", CtThisAccessImpl.class, elements.get(0).getTarget().getClass());
-		assertNotNull("Target isn't null if there is a 'this' explicit.", elements.get(1).getTarget());
+		assertSame(CtThisAccessImpl.class, elements.get(0).getTarget().getClass(), "Target is CtThisAccessImpl if there is a 'this' explicit.");
+		assertNotNull(elements.get(1).getTarget(), "Target isn't null if there is a 'this' explicit.");
 		assertTrue(elements.get(1).getTarget().isImplicit());
 	}
 
@@ -493,7 +494,7 @@ public class TargetedExpressionTest {
 		CtModel model = launcher.buildModel();
 		List<CtTypeAccess<?>> typeAccesses = model.getElements(e -> e.getAccessedType().getSimpleName().equals("SomeClass"));
 
-		assertEquals("There should only be one reference to SomeClass, check the resource!", 1, typeAccesses.size());
+		assertEquals(1, typeAccesses.size(), "There should only be one reference to SomeClass, check the resource!");
 
 		CtPackageReference pkg = typeAccesses.get(0).getAccessedType().getPackage();
 


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testCtSuperAccess
Replaced junit 4 test annotation with junit 5 test annotation in testCtThisAccess
Replaced junit 4 test annotation with junit 5 test annotation in testTargetOfFieldAccess
Replaced junit 4 test annotation with junit 5 test annotation in testNotTargetedExpression
Replaced junit 4 test annotation with junit 5 test annotation in testCastWriteWithGenerics
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfFieldAccess
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfStaticFieldAccess
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfFieldAccessInInnerClass
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfFieldInAnonymousClass
Replaced junit 4 test annotation with junit 5 test annotation in testStaticTargetsOfFieldAccessNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testOnlyStaticTargetFieldReadNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testNestedClassAccessEnclosingTypeFieldNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfInv
Replaced junit 4 test annotation with junit 5 test annotation in testStaticTargetsOfInv
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfInvInInnerClass
Replaced junit 4 test annotation with junit 5 test annotation in testTargetsOfInvInAnonymousClass
Replaced junit 4 test annotation with junit 5 test annotation in testStaticTargetsOfInvNoClasspath
Replaced junit 4 test annotation with junit 5 test annotation in testInitializeFieldAccessInNoclasspathMode
Replaced junit 4 test annotation with junit 5 test annotation in testUnqualifiedStaticMethodCallNoclasspath
Replaced junit 4 test annotation with junit 5 test annotation in testClassDeclaredInALambda
Transformed junit4 assert to junit 5 assertion in testCtSuperAccess
Transformed junit4 assert to junit 5 assertion in testCtThisAccess
Transformed junit4 assert to junit 5 assertion in testTargetOfFieldAccess
Transformed junit4 assert to junit 5 assertion in testNotTargetedExpression
Transformed junit4 assert to junit 5 assertion in testCastWriteWithGenerics
Transformed junit4 assert to junit 5 assertion in testTargetsOfFieldAccess
Transformed junit4 assert to junit 5 assertion in testTargetsOfStaticFieldAccess
Transformed junit4 assert to junit 5 assertion in testTargetsOfFieldAccessInInnerClass
Transformed junit4 assert to junit 5 assertion in testTargetsOfFieldInAnonymousClass
Transformed junit4 assert to junit 5 assertion in testStaticTargetsOfFieldAccessNoClasspath
Transformed junit4 assert to junit 5 assertion in testOnlyStaticTargetFieldReadNoClasspath
Transformed junit4 assert to junit 5 assertion in testNestedClassAccessEnclosingTypeFieldNoClasspath
Transformed junit4 assert to junit 5 assertion in testTargetsOfInv
Transformed junit4 assert to junit 5 assertion in testStaticTargetsOfInv
Transformed junit4 assert to junit 5 assertion in testTargetsOfInvInInnerClass
Transformed junit4 assert to junit 5 assertion in testTargetsOfInvInAnonymousClass
Transformed junit4 assert to junit 5 assertion in testStaticTargetsOfInvNoClasspath
Transformed junit4 assert to junit 5 assertion in testInitializeFieldAccessInNoclasspathMode
Transformed junit4 assert to junit 5 assertion in testUnqualifiedStaticMethodCallNoclasspath
Transformed junit4 assert to junit 5 assertion in testClassDeclaredInALambda
Transformed junit4 assert to junit 5 assertion in assertEqualsFieldAccess
Transformed junit4 assert to junit 5 assertion in assertEqualsInvocation