### PR TITLE
test: migrate ResourceTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/support/ResourceTest.java
+++ b/src/test/java/spoon/test/support/ResourceTest.java
@@ -16,14 +16,10 @@
  */
 package spoon.test.support;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
@@ -32,6 +28,11 @@ import spoon.support.compiler.FileSystemFile;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.compiler.FilteringFolder;
 import spoon.support.compiler.VirtualFolder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ResourceTest {
 


### PR DESCRIPTION
#3919 
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testEqualsFileSystemFile
Replaced junit 4 test annotation with junit 5 test annotation in testFileSystemFolder
Replaced junit 4 test annotation with junit 5 test annotation in testVirtualFolder
Replaced junit 4 test annotation with junit 5 test annotation in testFilteringFolder
Replaced Assert.assertThat with MatcherAssert.assertThat in testFileSystemFolder()
Replaced Assert.assertThat with MatcherAssert.assertThat in testFileSystemFolder()
Transformed junit4 assert to junit 5 assertion in testEqualsFileSystemFile
Transformed junit4 assert to junit 5 assertion in testFileSystemFolder
Transformed junit4 assert to junit 5 assertion in testVirtualFolder
Transformed junit4 assert to junit 5 assertion in testFilteringFolder