### PR TITLE
test: migrate ImplicitStaticFieldReferenceTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/staticFieldAccess2/ImplicitStaticFieldReferenceTest.java
+++ b/src/test/java/spoon/test/staticFieldAccess2/ImplicitStaticFieldReferenceTest.java
@@ -16,10 +16,7 @@
  */
 package spoon.test.staticFieldAccess2;
 
-import static spoon.testing.utils.ModelUtils.canBeBuilt;
-
-import static org.junit.Assert.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.declaration.CtClass;
@@ -27,6 +24,10 @@ import spoon.test.staticFieldAccess2.testclasses.AmbiguousImplicitFieldReference
 import spoon.test.staticFieldAccess2.testclasses.ChildOfGenericsWithAmbiguousStaticField;
 import spoon.test.staticFieldAccess2.testclasses.ImplicitFieldReference;
 import spoon.test.staticFieldAccess2.testclasses.ImplicitStaticFieldReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class ImplicitStaticFieldReferenceTest
 {


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitStaticFieldReference
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitStaticFieldReferenceAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitFieldReference
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitFieldReferenceAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testAmbiguousImplicitFieldReference
Replaced junit 4 test annotation with junit 5 test annotation in testAmbiguousImplicitFieldReferenceAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitStaticClassAccess
Replaced junit 4 test annotation with junit 5 test annotation in testImplicitStaticClassAccessAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testGenericsWithAmbiguousStaticField
Replaced junit 4 test annotation with junit 5 test annotation in testGenericsWithAmbiguousStaticFieldAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testChildOfGenericsWithAmbiguousStaticField
Replaced junit 4 test annotation with junit 5 test annotation in testChildOfGenericsWithAmbiguousStaticFieldAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testGenericsWithAmbiguousMemberField
Replaced junit 4 test annotation with junit 5 test annotation in testGenericsWithAmbiguousMemberFieldAutoImport
Replaced junit 4 test annotation with junit 5 test annotation in testAnnotationInChildWithConstants
Replaced junit 4 test annotation with junit 5 test annotation in testAnnotationInChildWithConstantsAutoImport
Transformed junit4 assert to junit 5 assertion in testImplicitStaticFieldReference
Transformed junit4 assert to junit 5 assertion in testImplicitStaticFieldReferenceAutoImport
Transformed junit4 assert to junit 5 assertion in testImplicitFieldReference
Transformed junit4 assert to junit 5 assertion in testImplicitFieldReferenceAutoImport
Transformed junit4 assert to junit 5 assertion in testAmbiguousImplicitFieldReference
Transformed junit4 assert to junit 5 assertion in testAmbiguousImplicitFieldReferenceAutoImport
Transformed junit4 assert to junit 5 assertion in testChildOfGenericsWithAmbiguousStaticFieldAutoImport