### PR TITLE
test: migrate StaticAccessTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
+++ b/src/test/java/spoon/test/staticFieldAccess/StaticAccessTest.java
@@ -16,8 +16,12 @@
  */
 package spoon.test.staticFieldAccess;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonModelBuilder;
@@ -27,10 +31,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.test.staticFieldAccess.processors.InsertBlockProcessor;
 
-import java.io.File;
-import java.util.Arrays;
-
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class StaticAccessTest {
@@ -39,7 +40,7 @@ public class StaticAccessTest {
     Factory factory;
     SpoonModelBuilder compiler;
 
-    @Before
+    @BeforeEach
     public void setUp()  throws Exception {
           spoon = new Launcher();
           factory = spoon.createFactory();


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced @Before annotation with @BeforeEach from method setUp
Replaced junit 4 test annotation with junit 5 test annotation in testReferences
Replaced junit 4 test annotation with junit 5 test annotation in testProcessAndCompile
Transformed junit4 assert to junit 5 assertion in testReferences
Transformed junit4 assert to junit 5 assertion in testProcessAndCompile