### PR TITLE
test: migrate SourcePositionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/serializable/SourcePositionTest.java
+++ b/src/test/java/spoon/test/serializable/SourcePositionTest.java
@@ -16,7 +16,6 @@
  */
 package spoon.test.serializable;
 
-import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -25,7 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -33,6 +32,8 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.support.SerializationModelStreamer;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SourcePositionTest {
 
@@ -84,6 +85,6 @@ public class SourcePositionTest {
 		CtField<?> field = (CtField<?>) model.getElements(
 				element -> element instanceof CtField &&
 						((CtField<?>) element).getSimpleName().equals("pleaseAttachSourcePositionToMyType")).stream().findFirst().get();
-		assertTrue("Source position unknown for type of field", field.getType().getPosition().isValidPosition());
+		assertTrue(field.getType().getPosition().isValidPosition(), "Source position unknown for type of field");
 	}
 }

--- a/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
+++ b/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
@@ -16,8 +16,10 @@
  */
 package spoon.test.sourcePosition;
 
-import org.junit.Test;
 
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtInvocation;
@@ -41,11 +43,9 @@ import spoon.support.reflect.declaration.CtClassImpl;
 import spoon.test.sourcePosition.testclasses.Brambora;
 import spoon.testing.utils.ModelUtils;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class SourcePositionTest {


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testSourcePosition
Replaced junit 4 test annotation with junit 5 test annotation in test_sourcePositionOfTypeInFieldExists
Replaced junit 4 test annotation with junit 5 test annotation in equalPositionsHaveSameHashcode
Replaced junit 4 test annotation with junit 5 test annotation in testSourcePositionOfSecondPrimitiveType
Replaced junit 4 test annotation with junit 5 test annotation in testSourcePositionStringFragment
Replaced junit 4 test annotation with junit 5 test annotation in testSourcePositionWhenCommentInAnnotation
Transformed junit4 assert to junit 5 assertion in testSourcePosition
Transformed junit4 assert to junit 5 assertion in test_sourcePositionOfTypeInFieldExists
Transformed junit4 assert to junit 5 assertion in equalPositionsHaveSameHashcode
Transformed junit4 assert to junit 5 assertion in testSourcePositionOfSecondPrimitiveType
Transformed junit4 assert to junit 5 assertion in testSourcePositionStringFragment
Transformed junit4 assert to junit 5 assertion in testSourcePositionWhenCommentInAnnotation