### PR TITLE
fix: no parentheses for single lambda parameters

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1642,10 +1642,15 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	@Override
 	public <T> void visitCtLambda(CtLambda<T> lambda) {
 		enterCtExpression(lambda);
+		// single parameter lambdas with implicit type can be printed without parantheses
+		if (isSingleParameterWithoutExplicitType(lambda) && !ignoreImplicit) {
+			elementPrinterHelper.printList(lambda.getParameters(), null, false, "", false, false, ",",
+					false, false, "", this::scan);
+		} else {
+			elementPrinterHelper.printList(lambda.getParameters(), null, false, "(", false, false, ",",
+					false, false, ")", this::scan);
+		}
 
-		elementPrinterHelper.printList(lambda.getParameters(),
-			null, false, "(", false, false, ",", false, false, ")",
-			parameter -> scan(parameter));
 		printer.writeSpace();
 		printer.writeSeparator("->");
 		printer.writeSpace();
@@ -1656,6 +1661,11 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(lambda.getExpression());
 		}
 		exitCtExpression(lambda);
+	}
+
+	private <T> boolean isSingleParameterWithoutExplicitType(CtLambda<T> lambda) {
+		return lambda.getParameters().size() == 1 && (lambda.getParameters().get(0).getType() == null
+				|| lambda.getParameters().get(0).getType().isImplicit());
 	}
 
 	@Override
@@ -1724,7 +1734,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		} else {
 			scan(parameter.getType());
 		}
-		printer.writeSpace();
+		// after an implicit type, there is no space because we dont print anything
+		if ((parameter.getType() != null && !parameter.getType().isImplicit()) || ignoreImplicit) {
+			printer.writeSpace();
+		}
 		printer.writeIdentifier(parameter.getSimpleName());
 	}
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1735,10 +1735,20 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			scan(parameter.getType());
 		}
 		// after an implicit type, there is no space because we dont print anything
-		if ((parameter.getType() != null && !parameter.getType().isImplicit()) || ignoreImplicit) {
+		if (isParameterWithImplicitType(parameter) || isNotFirstParameter(parameter)
+				|| ignoreImplicit) {
 			printer.writeSpace();
 		}
 		printer.writeIdentifier(parameter.getSimpleName());
+	}
+
+	private <T> boolean isParameterWithImplicitType(CtParameter<T> parameter) {
+		return parameter.getType() != null && !parameter.getType().isImplicit();
+	}
+
+	private <T> boolean isNotFirstParameter(CtParameter<T> parameter) {
+		return parameter.getParent() != null
+				&& parameter.getParent().getParameters().indexOf(parameter) != 0;
 	}
 
 	@Override

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -181,7 +181,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((Predicate<Person>) (( p) -> p.age > 10))",
+				"((Predicate<Person>) (p -> p.age > 10))",
 				lambda);
 	}
 
@@ -200,7 +200,7 @@ public class LambdaTest {
 		assertHasExpressionBody(lambda);
 
 		assertIsWellPrinted(
-				"((CheckPersons) (( p1, p2) -> (p1.age - p2.age) > 0))",
+				"((CheckPersons) ((p1, p2) -> (p1.age - p2.age) > 0))",
 				lambda);
 	}
 
@@ -265,7 +265,7 @@ public class LambdaTest {
 		assertStatementBody(lambda);
 
 		assertIsWellPrinted(
-				"((Predicate<Person>) (( p) -> {"
+				"((Predicate<Person>) (p -> {"
 						+ System.lineSeparator()
 						+ "    p.doSomething();" + System.lineSeparator()
 						+ "    return p.age > 10;" + System.lineSeparator()
@@ -291,7 +291,7 @@ public class LambdaTest {
 			}
 		}).get(0);
 		final String expected =
-				"if (((Predicate<Person>) (( p) -> p.age > 18)).test(new Person(10))) {"
+				"if (((Predicate<Person>) (p -> p.age > 18)).test(new Person(10))) {"
 						+ System.lineSeparator()
 						+ "    System.err.println(\"Enjoy, you have more than 18.\");" + System
 						.lineSeparator()
@@ -459,7 +459,7 @@ public class LambdaTest {
 		assertParameterIsNamedBy("elt", parameter);
 		assertTrue(typeReference.getBounds().size() == 2);
 		assertHasExpressionBody(lambda);
-		assertIsWellPrinted("( elt) -> elt.test()", lambda);
+		assertIsWellPrinted("elt -> elt.test()", lambda);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/lambda/LambdaTest.java
+++ b/src/test/java/spoon/test/lambda/LambdaTest.java
@@ -581,4 +581,19 @@ public class LambdaTest {
 		assertThrows(IndexOutOfBoundsException.class,
 				() -> lamda.addParameterAt(2, paramater));
 	}
+
+	@Test
+	public void singleParameterLambdaWithoutParentheses() {
+		// contract: single parameter lambdas without parentheses should be well printed
+		Factory factory = new Launcher().getFactory();
+		CtLambda<?> lambda = factory.createLambda();
+		CtParameter<String> parameter = factory.createParameter();
+		parameter.setSimpleName("x");
+		CtTypeReference<String> stringType = factory.Type().stringType();
+		stringType.setImplicit(true);
+		parameter.setType(stringType);
+		lambda.addParameter(parameter);
+		lambda.setExpression(factory.createCodeSnippetExpression("x"));
+		assertThat(lambda.toString(), equalTo("x -> x"));
+	}
 }

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -611,7 +611,7 @@ public class PrinterTest {
 		// contract: when a class reference is printed, the type is not lost
 		String expected = "class A {\n" +
 			"    void m() {\n" +
-			"        Stream.empty().map(( v) -> String.class).close();\n" +
+			"        Stream.empty().map(v -> String.class).close();\n" +
 			"    }\n" +
 			"}";
 		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> String.class).close(); } }");
@@ -623,7 +623,7 @@ public class PrinterTest {
 		// contract: when a class reference is printed, the type is not lost
 		String expected = "class A {\n" +
 			"    void m() {\n" +
-			"        Stream.empty().map(( v) -> List.class).close();\n" +
+			"        Stream.empty().map(v -> List.class).close();\n" +
 			"    }\n" +
 			"}";
 		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> List.class).close(); } }");
@@ -635,7 +635,7 @@ public class PrinterTest {
 		// contract: when a class reference is printed, the type is not lost
 		String expected = "class A {\n" +
 			"    void m() {\n" +
-			"        Stream.empty().map(( v) -> List.class).close();\n" +
+				"        Stream.empty().map(v -> List.class).close();\n" +
 			"    }\n" +
 			"}";
 		CtType<?> type = Launcher.parseClass("class A { void m() { Stream.empty().map(v-> java.util.List.class).close(); } }");


### PR DESCRIPTION
Before the fix DJPP printed  `((Predicate<Person>) (( p) -> p.age > 10))` and now `((Predicate<Person>) (p -> p.age > 10))`
The removed whitespace and parentheses for single parameter lambdas without type is much closer to normal style.