### PR TITLE
test: migrate TypeTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -16,7 +16,16 @@
  */
 package spoon.test.type;
 
-import org.junit.Test;
+
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -44,20 +53,12 @@ import spoon.test.type.testclasses.Pozole;
 import spoon.test.type.testclasses.TypeMembersOrder;
 import spoon.testing.utils.ModelUtils;
 
-import java.io.Serializable;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 import static spoon.testing.utils.ModelUtils.createFactory;


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAccessForDotClass
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAccessOnPrimitive
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAccessForTypeAccessInInstanceOf
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAccessOfArrayObjectInFullyQualifiedName
Replaced junit 4 test annotation with junit 5 test annotation in testTypeAccessImplicitIsDerived
Replaced junit 4 test annotation with junit 5 test annotation in test
Replaced junit 4 test annotation with junit 5 test annotation in testIntersectionTypeReferenceInGenericsAndCasts
Replaced junit 4 test annotation with junit 5 test annotation in testTypeReferenceInGenericsAndCasts
Replaced junit 4 test annotation with junit 5 test annotation in testIntersectionTypeOnTopLevelType
Replaced junit 4 test annotation with junit 5 test annotation in testUnboxingTypeReference
Replaced junit 4 test annotation with junit 5 test annotation in testDeclarationCreatedByFactory
Replaced junit 4 test annotation with junit 5 test annotation in testPolyTypBindingInTernaryExpression
Replaced junit 4 test annotation with junit 5 test annotation in testShadowType
Replaced junit 4 test annotation with junit 5 test annotation in testTypeMemberOrder
Replaced junit 4 test annotation with junit 5 test annotation in testBinaryOpStringsType
Transformed junit4 assert to junit 5 assertion in testTypeAccessForDotClass
Transformed junit4 assert to junit 5 assertion in testTypeAccessOnPrimitive
Transformed junit4 assert to junit 5 assertion in testTypeAccessForTypeAccessInInstanceOf
Transformed junit4 assert to junit 5 assertion in testTypeAccessOfArrayObjectInFullyQualifiedName
Transformed junit4 assert to junit 5 assertion in testTypeAccessImplicitIsDerived
Transformed junit4 assert to junit 5 assertion in test
Transformed junit4 assert to junit 5 assertion in testIntersectionTypeReferenceInGenericsAndCasts
Transformed junit4 assert to junit 5 assertion in assertIntersectionTypeForPozolePrepareMethod
Transformed junit4 assert to junit 5 assertion in testTypeReferenceInGenericsAndCasts
Transformed junit4 assert to junit 5 assertion in assertIntersectionTypeForPozoleFinishMethod
Transformed junit4 assert to junit 5 assertion in testIntersectionTypeOnTopLevelType
Transformed junit4 assert to junit 5 assertion in assertIntersectionTypeForMole
Transformed junit4 assert to junit 5 assertion in testUnboxingTypeReference
Transformed junit4 assert to junit 5 assertion in testDeclarationCreatedByFactory
Transformed junit4 assert to junit 5 assertion in testPolyTypBindingInTernaryExpression
Transformed junit4 assert to junit 5 assertion in testShadowType
Transformed junit4 assert to junit 5 assertion in testTypeMemberOrder
Transformed junit4 assert to junit 5 assertion in testBinaryOpStringsType