### PR TITLE
test: migrate SnippetTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -16,19 +16,19 @@
  */
 package spoon.test.snippets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResource;
 import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeSnippetExpression;
 import spoon.reflect.code.CtCodeSnippetStatement;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtComment;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
@@ -38,13 +38,14 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.SnippetCompilationHelper;
 import spoon.support.compiler.VirtualFile;
 
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class SnippetTest {


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testSnippetFullClass
Replaced junit 4 test annotation with junit 5 test annotation in testSnippetWihErrors
Replaced junit 4 test annotation with junit 5 test annotation in testCompileSnippetSeveralTimes
Replaced junit 4 test annotation with junit 5 test annotation in testCompileSnippetWithContext
Replaced junit 4 test annotation with junit 5 test annotation in testCompileStatementWithReturn
Replaced junit 4 test annotation with junit 5 test annotation in testIssue981
Replaced junit 4 test annotation with junit 5 test annotation in testCompileAndReplaceSnippetsIn
Replaced junit 4 test annotation with junit 5 test annotation in testCompileSnippetsWithCtComment
Replaced junit 4 test annotation with junit 5 test annotation in testCommentSnippetCompilation
Replaced junit 4 test annotation with junit 5 test annotation in testSnippetCompilationInUnnamedPackage
Replaced junit 4 test annotation with junit 5 test annotation in testCodeSnippetExpressionsWithNonEqualValuesAreNotEqual
Replaced junit 4 test annotation with junit 5 test annotation in testCodeSnippetExpressionsWithEqualValuesAreEqual
Replaced junit 4 test annotation with junit 5 test annotation in testCodeSnippetStatementsWithNonEqualValuesAreNotEqual
Replaced junit 4 test annotation with junit 5 test annotation in testCodeSnippetStatementsWithEqualValuesAreEqual
Transformed junit4 assert to junit 5 assertion in testSnippetFullClass
Transformed junit4 assert to junit 5 assertion in testSnippetWihErrors
Transformed junit4 assert to junit 5 assertion in testCompileSnippetSeveralTimes
Transformed junit4 assert to junit 5 assertion in testCompileSnippetWithContext
Transformed junit4 assert to junit 5 assertion in testCompileStatementWithReturn
Transformed junit4 assert to junit 5 assertion in testIssue981
Transformed junit4 assert to junit 5 assertion in testCompileAndReplaceSnippetsIn
Transformed junit4 assert to junit 5 assertion in testCompileSnippetsWithCtComment
Transformed junit4 assert to junit 5 assertion in testCommentSnippetCompilation
Transformed junit4 assert to junit 5 assertion in testSnippetCompilationInUnnamedPackage