### PR TITLE
test: migrate SignatureTest to Junit 5 

### DIFF
--- a/src/test/java/spoon/test/signature/SignatureTest.java
+++ b/src/test/java/spoon/test/signature/SignatureTest.java
@@ -16,19 +16,13 @@
  */
 package spoon.test.signature;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
@@ -53,6 +47,13 @@ import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
 import spoon.support.comparator.DeepRepresentationComparator;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SignatureTest {
 


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testNullSignature
Replaced junit 4 test annotation with junit 5 test annotation in testNullSignatureInUnboundVariable
Replaced junit 4 test annotation with junit 5 test annotation in testLiteralSignature
Replaced junit 4 test annotation with junit 5 test annotation in testMethodInvocationSignatureStaticFieldsVariables
Replaced junit 4 test annotation with junit 5 test annotation in testMethodInvocationSignatureWithVariableAccess
Replaced junit 4 test annotation with junit 5 test annotation in testUnboundFieldSignature
Replaced junit 4 test annotation with junit 5 test annotation in testArgumentNotNullForExecutableReference
Replaced junit 4 test annotation with junit 5 test annotation in testBugSignature
Transformed junit4 assert to junit 5 assertion in testNullSignature
Transformed junit4 assert to junit 5 assertion in testNullSignatureInUnboundVariable
Transformed junit4 assert to junit 5 assertion in testLiteralSignature
Transformed junit4 assert to junit 5 assertion in testMethodInvocationSignatureStaticFieldsVariables
Transformed junit4 assert to junit 5 assertion in testMethodInvocationSignatureWithVariableAccess
Transformed junit4 assert to junit 5 assertion in testUnboundFieldSignature
Transformed junit4 assert to junit 5 assertion in testArgumentNotNullForExecutableReference
Transformed junit4 assert to junit 5 assertion in testBugSignature