### PR TITLE
test: migrate SerializableTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/serializable/SerializableTest.java
+++ b/src/test/java/spoon/test/serializable/SerializableTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.serializable;
 
-import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
@@ -26,13 +30,10 @@ import spoon.support.SerializationModelStreamer;
 import spoon.support.StandardEnvironment;
 import spoon.support.util.ByteSerialization;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class SerializableTest {


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced junit 4 test annotation with junit 5 test annotation in testSerialCtStatement
Replaced junit 4 test annotation with junit 5 test annotation in testSerialFile
Replaced junit 4 test annotation with junit 5 test annotation in testSerializationModelStreamer
Transformed junit4 assert to junit 5 assertion in testSerialCtStatement
Transformed junit4 assert to junit 5 assertion in testSerializationModelStreamer