### PR TITLE
test: migrate ModelStreamerTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/serializable/ModelStreamerTest.java
+++ b/src/test/java/spoon/test/serializable/ModelStreamerTest.java
@@ -16,7 +16,6 @@
  */
 package spoon.test.serializable;
 
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,9 +25,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.After;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.declaration.CtElement;
@@ -37,6 +36,8 @@ import spoon.reflect.visitor.Filter;
 import spoon.support.CompressionType;
 import spoon.support.SerializationModelStreamer;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class ModelStreamerTest {
 
 	private static final String SOURCE_DIRECTORY = "./src/main/java/spoon/reflect/declaration";
@@ -44,7 +45,7 @@ public class ModelStreamerTest {
 	private static File outputFile;
 	private static Factory factory;
 
-	@BeforeClass
+	@BeforeAll
     public static void setUp() {
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(SOURCE_DIRECTORY);
@@ -53,7 +54,7 @@ public class ModelStreamerTest {
 		outputFile = new File(OUTPUT_FILENAME);
     }
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		outputFile.delete();
 	}
@@ -112,8 +113,7 @@ public class ModelStreamerTest {
 		List<CtElement> elementsFactory = factory.getModel().getRootPackage().filterChildren(filter).list();
 		List<CtElement> elementsFactoryFromFile = factoryFromFile.getModel().getRootPackage().filterChildren(filter).list();
 
-		assertTrue("Model before & after serialization must have the same number of elements", 
-				elementsFactory.size() == elementsFactoryFromFile.size());
+		assertTrue(elementsFactory.size() == elementsFactoryFromFile.size(), "Model before & after serialization must have the same number of elements");
 
 		List<String> st1 = elementsFactory.stream().map(CtElement::toString).collect(Collectors.toList());
 		List<String> st2 = elementsFactoryFromFile.stream().map(CtElement::toString).collect(Collectors.toList());
@@ -121,8 +121,7 @@ public class ModelStreamerTest {
 		Collections.sort(st2);
 
 		for (int i = 0; i < st1.size(); i++) {
-			assertTrue("All CtElement of the model should be striclty identical before & after serialization",
-					st1.get(i).equals(st2.get(i)));
+			assertTrue(st1.get(i).equals(st2.get(i)), "All CtElement of the model should be striclty identical before & after serialization");
 		}
 	}
 }


### PR DESCRIPTION
#3919
The following has changed in the code:
Replaced @BeforeClass annotation with @BeforeAll from method setUp
Replaced @After annotation with @AfterEach from method tearDown
Replaced junit 4 test annotation with junit 5 test annotation in testDefaultCompressionType
Replaced junit 4 test annotation with junit 5 test annotation in testGZipCompressionType
Replaced junit 4 test annotation with junit 5 test annotation in testBZip2CompressionType
Replaced junit 4 test annotation with junit 5 test annotation in testNoneCompressionType
Replaced junit 4 test annotation with junit 5 test annotation in testLZMACompressionType
Transformed junit4 assert to junit 5 assertion in compareFactoryModels