### PR TITLE
test: migrate ClassesTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
+++ b/src/test/java/spoon/test/secondaryclasses/ClassesTest.java
@@ -16,21 +16,13 @@
  */
 package spoon.test.secondaryclasses;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static spoon.testing.utils.ModelUtils.build;
-import static spoon.testing.utils.ModelUtils.buildClass;
 
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeSet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtNewClass;
@@ -50,6 +42,15 @@ import spoon.test.secondaryclasses.testclasses.AnonymousClass.I;
 import spoon.test.secondaryclasses.testclasses.ClassWithInternalPublicClassOrInterf;
 import spoon.test.secondaryclasses.testclasses.Pozole;
 import spoon.test.secondaryclasses.testclasses.PrivateInnerClasses;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.build;
+import static spoon.testing.utils.ModelUtils.buildClass;
 
 public class ClassesTest {
 


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 TestAnnotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testClassWithInternalPublicClassOrInterf`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnonymousClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsAnonymousMethodInCtClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTopLevel`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInnerClassContruction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnonymousClassInStaticField`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testClassWithInternalPublicClassOrInterf`
- Transformed junit4 assert to junit 5 assertion in `testAnonymousClass`
- Transformed junit4 assert to junit 5 assertion in `testIsAnonymousMethodInCtClass`
- Transformed junit4 assert to junit 5 assertion in `testTopLevel`
- Transformed junit4 assert to junit 5 assertion in `testInnerClassContruction`
- Transformed junit4 assert to junit 5 assertion in `testAnonymousClassInStaticField`