### PR TITLE
test: migrate TestCtRole to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/role/TestCtRole.java
+++ b/src/test/java/spoon/test/role/TestCtRole.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.role;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.SpoonException;
 import spoon.reflect.path.CtRole;
@@ -26,12 +26,12 @@ import spoon.support.reflect.declaration.CtConstructorImpl;
 import spoon.support.reflect.declaration.CtFieldImpl;
 import spoon.support.reflect.declaration.CtMethodImpl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestCtRole {
     @Test


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetCtRoleByName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRolesNotNull`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleSubRoleMatchesWithSuperRole`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRole`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRoleFailsOnOthers`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtRoleGetSubRoleFailsOnNull`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testGetCtRoleByName`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRolesNotNull`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleSubRoleMatchesWithSuperRole`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRole`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRoleFailsOnOthers`
- Transformed junit4 assert to junit 5 assertion in `testCtRoleGetSubRoleFailsOnNull`