### PR TITLE
test: migrate ReplaceTest to Junit 5 

### DIFF
--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -16,8 +16,13 @@
  */
 package spoon.test.replace;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtAssignment;
@@ -49,17 +54,13 @@ import spoon.support.visitor.replace.InvalidReplaceException;
 import spoon.test.replace.testclasses.Mole;
 import spoon.test.replace.testclasses.Tacos;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 
@@ -67,7 +68,7 @@ public class ReplaceTest {
 
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4AnnotationsTransformation
- Replaced `@Before` annotation with @BeforeEach from method `setup`
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceSet`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceBlock`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceReplace`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceStmtByList`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceStmtByListStatements`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceStmtByListStatementsAndNull`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceField`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceTwoMethods`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceStatement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceIntegerReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceAllTypeRefenceWithGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceAPackageReferenceByAnotherOne`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceAParameterReferenceToFieldReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceExecutableReferenceByAnotherOne`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReplaceBlockTry`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testReplaceSet`
- Transformed junit4 assert to junit 5 assertion in `testReplaceBlock`
- Transformed junit4 assert to junit 5 assertion in `testReplaceReplace`
- Transformed junit4 assert to junit 5 assertion in `testReplaceStmtByList`
- Transformed junit4 assert to junit 5 assertion in `testReplaceStmtByListStatements`
- Transformed junit4 assert to junit 5 assertion in `testReplaceStmtByListStatementsAndNull`
- Transformed junit4 assert to junit 5 assertion in `testReplaceField`
- Transformed junit4 assert to junit 5 assertion in `testReplaceMethod`
- Transformed junit4 assert to junit 5 assertion in `testReplaceTwoMethods`
- Transformed junit4 assert to junit 5 assertion in `testReplaceExpression`
- Transformed junit4 assert to junit 5 assertion in `testReplaceStatement`
- Transformed junit4 assert to junit 5 assertion in `testReplaceIntegerReference`
- Transformed junit4 assert to junit 5 assertion in `testReplaceAllTypeRefenceWithGenerics`
- Transformed junit4 assert to junit 5 assertion in `testReplaceAPackageReferenceByAnotherOne`
- Transformed junit4 assert to junit 5 assertion in `testReplaceAParameterReferenceToFieldReference`
- Transformed junit4 assert to junit 5 assertion in `testReplaceExecutableReferenceByAnotherOne`
- Transformed junit4 assert to junit 5 assertion in `testReplaceBlockTry`
