### PR TITLE
test: migrate ReferenceQueryTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTest.java
+++ b/src/test/java/spoon/test/reflect/visitor/ReferenceQueryTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.reflect.visitor;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
@@ -24,9 +27,7 @@ import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.test.reflect.visitor.testclasses.ReferenceQueryTestEnum;
 
-import java.util.List;
-
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class ReferenceQueryTest {
@@ -36,7 +37,7 @@ public class ReferenceQueryTest {
 		List< CtTypeReference<?> > enumTypeRefs = Query.getElements(testEnum, new ReferenceTypeFilter<>(CtTypeReference.class));
 		TypeFactory typeFactory = testEnum.getFactory().Type();
 		for (Class<?> c : new Class<?>[]{Integer.class, Long.class, Boolean.class, Number.class, String.class, Void.class}) {
-			assertTrue("the reference query on the enum should return all the types defined in the enum declaration", enumTypeRefs.contains(typeFactory.createReference(c)));
+			assertTrue(enumTypeRefs.contains(typeFactory.createReference(c)), "the reference query on the enum should return all the types defined in the enum declaration");
 		}
 	}
 }


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `getAllTypeReferencesInEnum`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `getAllTypeReferencesInEnum`
