### PR TITLE
test: migrate TypeReferenceTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -16,7 +16,14 @@
  */
 package spoon.test.reference;
 
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import spoon.Launcher;
@@ -61,23 +68,18 @@ import spoon.test.reference.testclasses.ParamRefs;
 import spoon.test.reference.testclasses.SuperAccess;
 import spoon.testing.utils.ModelUtils;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -351,10 +353,10 @@ public class TypeReferenceTest {
 				containsJoinerReference = true;
 			}
 		}
-		assertTrue("Reference to Demo is missing", containsDemoReference);
-		assertTrue("Reference to void is missing", containsVoidReference);
-		assertTrue("Reference to String is missing", containsStringReference);
-		assertTrue("Reference to Joiner is missing", containsJoinerReference);
+		assertTrue(containsDemoReference, "Reference to Demo is missing");
+		assertTrue(containsVoidReference, "Reference to void is missing");
+		assertTrue(containsStringReference, "Reference to String is missing");
+		assertTrue(containsJoinerReference, "Reference to Joiner is missing");
 	}
 
 	@Test
@@ -729,7 +731,7 @@ public class TypeReferenceTest {
 			loopIterations++;
 		}
 
-		assertTrue("Test loop did not execute", loopIterations > 0);
+		assertTrue(loopIterations > 0, "Test loop did not execute");
 	}
 
 	private static CtTypeReference<?> getDeepestComponentType(CtArrayTypeReference<?> arrayTypeRef) {
@@ -751,7 +753,7 @@ public class TypeReferenceTest {
 		CtModel model = launcher.buildModel();
 		List<CtTypeReference<?>> typeReferences = model.getElements(e -> e.getSimpleName().equals("SOMETHING"));
 
-		assertEquals("There should only be one reference to SOMETHING, check the resource!", 1, typeReferences.size());
+		assertEquals(1, typeReferences.size(), "There should only be one reference to SOMETHING, check the resource!");
 
 		CtTypeReference<?> typeRef = typeReferences.get(0);
 		CtTypeReference<?> declType = typeRef.getDeclaringType();


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetAllExecutablesForInterfaces`
- Replaced junit 4 test annotation with junit 5 test annotation in `loadReferencedClassFromClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `doNotCloseLoader`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNullReferenceSubtype`
- Replaced junit 4 test annotation with junit 5 test annotation in `unboxTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `testToStringEqualityBetweenTwoGenericTypeDifferent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRecursiveTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRecursiveTypeReferenceInGenericType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnknownSuperClassWithSameNameInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeReferenceSpecifiedInClassDeclarationInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeReferenceSpecifiedInClassDeclarationInNoClasspathWithGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testArgumentOfAInvocationIsNotATypeAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInvocationWithFieldAccessInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotationOnMethodWithPrimitiveReturnTypeInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnonymousClassesHaveAnEmptyStringForItsNameInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testShortTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClearBoundsForWildcardReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIgnoreEnclosingClassInActualTypes`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCorrectEnumParent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testImproveAPIActualTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsSubTypeSuperClassNull`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSubTypeAnonymous`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetTypeDeclaration`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeDeclarationWildcard`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualityTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeReferenceWithGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeReferenceImplicitParent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsInTheSamePackageNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testQualifiedArrayTypeReferenceNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnqualifiedExternalTypeMemberAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeReferenceToChildClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testProblemTypeReferenceToChildClass`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testGetAllExecutablesForInterfaces`
- Transformed junit4 assert to junit 5 assertion in `loadReferencedClassFromClasspath`
- Transformed junit4 assert to junit 5 assertion in `doNotCloseLoader`
- Transformed junit4 assert to junit 5 assertion in `testNullReferenceSubtype`
- Transformed junit4 assert to junit 5 assertion in `unboxTest`
- Transformed junit4 assert to junit 5 assertion in `testToStringEqualityBetweenTwoGenericTypeDifferent`
- Transformed junit4 assert to junit 5 assertion in `testRecursiveTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testRecursiveTypeReferenceInGenericType`
- Transformed junit4 assert to junit 5 assertion in `testUnknownSuperClassWithSameNameInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testPackageInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testTypeReferenceSpecifiedInClassDeclarationInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testTypeReferenceSpecifiedInClassDeclarationInNoClasspathWithGenerics`
- Transformed junit4 assert to junit 5 assertion in `testArgumentOfAInvocationIsNotATypeAccess`
- Transformed junit4 assert to junit 5 assertion in `testInvocationWithFieldAccessInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testAnnotationOnMethodWithPrimitiveReturnTypeInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testAnonymousClassesHaveAnEmptyStringForItsNameInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testConstructorCallInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testShortTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testClearBoundsForWildcardReference`
- Transformed junit4 assert to junit 5 assertion in `testIgnoreEnclosingClassInActualTypes`
- Transformed junit4 assert to junit 5 assertion in `testCorrectEnumParent`
- Transformed junit4 assert to junit 5 assertion in `testImproveAPIActualTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testIsSubTypeSuperClassNull`
- Transformed junit4 assert to junit 5 assertion in `testSubTypeAnonymous`
- Transformed junit4 assert to junit 5 assertion in `testGetTypeDeclaration`
- Transformed junit4 assert to junit 5 assertion in `testTypeDeclarationWildcard`
- Transformed junit4 assert to junit 5 assertion in `testEqualityTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testTypeReferenceWithGenerics`
- Transformed junit4 assert to junit 5 assertion in `testTypeReferenceImplicitParent`
- Transformed junit4 assert to junit 5 assertion in `testIsInTheSamePackageNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testQualifiedArrayTypeReferenceNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testUnqualifiedExternalTypeMemberAccess`
- Transformed junit4 assert to junit 5 assertion in `testTypeReferenceToChildClass`
- Transformed junit4 assert to junit 5 assertion in `testProblemTypeReferenceToChildClass`
