### PR TITLE
test: migrate ExecutableReferenceTest to Junit 5

### DIFF
--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -7,7 +7,12 @@
  */
 package spoon.test.reference;
 
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.reflect.code.CtInvocation;
@@ -27,17 +32,13 @@ import spoon.test.reference.testclasses.Kuu;
 import spoon.test.reference.testclasses.Stream;
 import spoon.test.reference.testclasses.SuperFoo;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ExecutableReferenceTest {
 	@Test


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testCallMethodOfClassNotPresent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSuperClassInGetAllExecutables`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetAllExecutablesMethodForInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetAllExecutablesMethodForClasses`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreateReferenceForAnonymousExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInvokeEnumMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLambdaNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testHashcodeWorksWithReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPbWithStream`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testCallMethodOfClassNotPresent`
- Transformed junit4 assert to junit 5 assertion in `testSuperClassInGetAllExecutables`
- Transformed junit4 assert to junit 5 assertion in `testGetAllExecutablesMethodForInterface`
- Transformed junit4 assert to junit 5 assertion in `testGetAllExecutablesMethodForClasses`
- Transformed junit4 assert to junit 5 assertion in `matches`
- Transformed junit4 assert to junit 5 assertion in `testInvokeEnumMethod`
- Transformed junit4 assert to junit 5 assertion in `testHashcodeWorksWithReference`
- Transformed junit4 assert to junit 5 assertion in `testPbWithStream`
