### PR TITLE
test: migrate ExecutableReferenceGenericTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceGenericTest.java
@@ -16,8 +16,12 @@
  */
 package spoon.test.reference;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.SpoonResourceHelper;
@@ -34,12 +38,9 @@ import spoon.reflect.visitor.filter.AbstractReferenceFilter;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by gerard on 21/11/2014.
@@ -49,7 +50,7 @@ public class ExecutableReferenceGenericTest {
 	private Factory factory;
 	public static final String NAME_MY_CLASS_1 = "MyClass";
 
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4AnnotationsTransformation
- Replaced `@Before` annotation with @BeforeEach from method `setUp`
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferencesBetweenConstructors`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferencesBetweenConstructorsInOtherClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testOneReferenceBetweenMethodsInSameClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiReferenceBetweenMethodsWithGenericInSameClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiReferencesBetweenMethodsWithoutGenericInSameClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodWithoutReferences`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodGenericWithoutReferences`
- Replaced junit 4 test annotation with junit 5 test annotation in `testOneReferenceWithGenericMethodOutOfTheClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testOneReferenceWithMethodNotGenericOutOfTheClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiReferenceWithGenericMethodOutOfTheClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferencesBetweenMethods`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExecutableReferences`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testReferencesBetweenConstructors`
- Transformed junit4 assert to junit 5 assertion in `testReferencesBetweenConstructorsInOtherClass`
- Transformed junit4 assert to junit 5 assertion in `testOneReferenceBetweenMethodsInSameClass`
- Transformed junit4 assert to junit 5 assertion in `testMultiReferenceBetweenMethodsWithGenericInSameClass`
- Transformed junit4 assert to junit 5 assertion in `testMultiReferencesBetweenMethodsWithoutGenericInSameClass`
- Transformed junit4 assert to junit 5 assertion in `testMethodWithoutReferences`
- Transformed junit4 assert to junit 5 assertion in `testMethodGenericWithoutReferences`
- Transformed junit4 assert to junit 5 assertion in `testOneReferenceWithGenericMethodOutOfTheClass`
- Transformed junit4 assert to junit 5 assertion in `testOneReferenceWithMethodNotGenericOutOfTheClass`
- Transformed junit4 assert to junit 5 assertion in `testMultiReferenceWithGenericMethodOutOfTheClass`
- Transformed junit4 assert to junit 5 assertion in `testReferencesBetweenMethods`
- Transformed junit4 assert to junit 5 assertion in `testExecutableReferences`
