### PR TITLE
test: migrate ElasticsearchStackoverflowTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
+++ b/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.reference;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtType;
@@ -26,12 +29,10 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ElasticsearchStackoverflowTest {
 


### PR DESCRIPTION
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testStackOverflow`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testStackOverflow`
