### PR TITLE
test: migrate AnnotationFieldReferenceTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/reference/AnnotationFieldReferenceTest.java
+++ b/src/test/java/spoon/test/reference/AnnotationFieldReferenceTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.reference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
@@ -26,8 +26,8 @@ import spoon.test.reference.testclasses.Mole;
 import spoon.test.reference.testclasses.Parameter;
 import spoon.testing.utils.ModelUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class AnnotationFieldReferenceTest {
 	@Test


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotationFieldReference`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `testAnnotationFieldReference`
