### PR TITLE
test: migrate VariableReferencesModelTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/query_function/testclasses/VariableReferencesModelTest.java
+++ b/src/test/java/spoon/test/query_function/testclasses/VariableReferencesModelTest.java
@@ -1,13 +1,14 @@
 package spoon.test.query_function.testclasses;
 
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The main purpose of this test is to be transfomed by Spoon into Spoon model, 
@@ -26,7 +27,11 @@ public class VariableReferencesModelTest {
 				int field = 1;
 				assertTrue(field == 1);
 			}
-			int f1,f2,f3,field = 2,f4;
+			int f1;
+			int f2;
+			int f3;
+			int field = 2;
+			int f4;
 			assertTrue(field == 2);
 		}
 		int field = 3;
@@ -118,7 +123,7 @@ public class VariableReferencesModelTest {
 	
 	@Test
 	public void parameterInLambdaWithBody() {
-		Consumer<Integer> fnc = (field)->{
+		Consumer<Integer> fnc = field->{
 			assertTrue(field == 17);
 		};
 		fnc.accept(17);
@@ -126,7 +131,7 @@ public class VariableReferencesModelTest {
 	
 	@Test
 	public void parameterInLambdaWithExpression() {
-		Consumer<Integer> fnc = (field)->assertTrue(field == 18);
+		Consumer<Integer> fnc = field->assertTrue(field == 18);
 		fnc.accept(18);
 	}
 	


### PR DESCRIPTION
#3919
## The following has changed in the code:
### Junit4AnnotationsTransformation
- Replaced `@Before` annotation with @BeforeEach from method `setup`
### Junit4 @Test Annotation
- Replaced junit 4 test annotation with junit 5 test annotation in `testCheckModelConsistency`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCatchVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLocalVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVariableScopeFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldScopeFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLocalVariableReferenceDeclarationFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPotentialVariableAccessFromStaticMethod`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `checkKey`
- Transformed junit4 assert to junit 5 assertion in `testCheckModelConsistency`
- Transformed junit4 assert to junit 5 assertion in `testVariableScopeFunction`
- Transformed junit4 assert to junit 5 assertion in `testFieldScopeFunction`
- Transformed junit4 assert to junit 5 assertion in `testLocalVariableReferenceDeclarationFunction`
- Transformed junit4 assert to junit 5 assertion in `checkVariableAccess`
- Transformed junit4 assert to junit 5 assertion in `getLiteralValue`
- Transformed junit4 assert to junit 5 assertion in `testPotentialVariableAccessFromStaticMethod`
