### PR TITLE
test: migrate PathTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -16,8 +16,15 @@
  */
 package spoon.test.path;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtIf;
@@ -36,24 +43,18 @@ import spoon.reflect.path.CtElementPathBuilder;
 import spoon.reflect.path.CtPath;
 import spoon.reflect.path.CtPathBuilder;
 import spoon.reflect.path.CtPathException;
+import spoon.reflect.path.CtPathStringBuilder;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.reflect.path.CtPathStringBuilder;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Created by nicolas on 10/06/2015.
@@ -62,7 +63,7 @@ public class PathTest {
 
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();
@@ -304,7 +305,7 @@ public class PathTest {
 		for (CtTypeMember typeMember : type.getTypeMembers()) {
 			CtPath path = typeMember.getPath();
 			List<CtElement> elements = path.evaluateOn(factory.getModel().getRootPackage());
-			assertEquals("ambiguous path " + path + " on element " + typeMember.toString(), 1, elements.size());
+			assertEquals(1, elements.size(), "ambiguous path " + path + " on element " + typeMember.toString());
 			assertSame(typeMember, elements.get(0));
 		}
 	}


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testBuilderMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBuilder`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPathFromString`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiPathFromString`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIncorrectPathFromString`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetPathFromNonParent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWildcards`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFastPathWithIndex`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRoles`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAmbiguousTypeMembers`
- Replaced junit 4 test annotation with junit 5 test annotation in `toStringTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `exceptionTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericTypeReferenceInSuperType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSignatureOfVarargMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAmbiguousName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldOfArrayType`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### AssertionsTransformation
- Transformed junit4 assert to junit 5 assertion in `equals`
- Transformed junit4 assert to junit 5 assertion in `equalsSet`
- Transformed junit4 assert to junit 5 assertion in `testMultiPathFromString`
- Transformed junit4 assert to junit 5 assertion in `testIncorrectPathFromString`
- Transformed junit4 assert to junit 5 assertion in `testGetPathFromNonParent`
- Transformed junit4 assert to junit 5 assertion in `testFastPathWithIndex`
- Transformed junit4 assert to junit 5 assertion in `testRoles`
- Transformed junit4 assert to junit 5 assertion in `testAmbiguousTypeMembers`
- Transformed junit4 assert to junit 5 assertion in `comparePath`
- Transformed junit4 assert to junit 5 assertion in `exceptionTest`
- Transformed junit4 assert to junit 5 assertion in `testGenericTypeReferenceInSuperType`
- Transformed junit4 assert to junit 5 assertion in `testSignatureOfVarargMethod`
- Transformed junit4 assert to junit 5 assertion in `testAmbiguousName`
- Transformed junit4 assert to junit 5 assertion in `testFieldOfArrayType`