### PR TITLE
test: migrate EqualTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.comparison;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.code.CtComment;
@@ -32,11 +32,11 @@ import spoon.reflect.path.CtRole;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.support.visitor.equals.EqualsVisitor;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class EqualTest {
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualsEmptyException`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualsComment`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualsMultitype`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualsActualTypeRef`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualsDetails`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testEqualsEmptyException`
- Transformed junit4 assert to junit 5 assertion in `testEqualsComment`
- Transformed junit4 assert to junit 5 assertion in `testEqualsMultitype`
- Transformed junit4 assert to junit 5 assertion in `testEqualsActualTypeRef`
- Transformed junit4 assert to junit 5 assertion in `testEqualsDetails`
