### PR TITLE
test: migrate GetBinaryFilesTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
+++ b/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
@@ -41,9 +40,6 @@ public class GetBinaryFilesTest {
 
 	@TempDir
 	Path tmpFolder;
-
-	@BeforeEach
-
 
 	@Test
 	public void testSingleBinary() {

--- a/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
+++ b/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
@@ -16,21 +16,22 @@
  */
 package spoon.test.compilationunit;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import spoon.Launcher;
-import spoon.SpoonModelBuilder;
-import spoon.reflect.cu.CompilationUnit;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Rule;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+import spoon.Launcher;
+import spoon.SpoonModelBuilder;
+import spoon.reflect.cu.CompilationUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests {@link CompilationUnit#getBinaryFiles()}.

--- a/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
+++ b/src/test/java/spoon/test/compilationunit/GetBinaryFilesTest.java
@@ -19,12 +19,13 @@ package spoon.test.compilationunit;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.reflect.cu.CompilationUnit;
@@ -38,15 +39,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class GetBinaryFilesTest {
 
-	@Rule
-	public TemporaryFolder tmpFolder = new TemporaryFolder();
+	@TempDir
+	Path tmpFolder;
+
+	@BeforeEach
+
 
 	@Test
 	public void testSingleBinary() {
 		final String input = "./src/test/resources/compilation/compilation-tests/IBar.java";
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource(input);
-		launcher.setBinaryOutputDirectory(tmpFolder.getRoot());
+		launcher.setBinaryOutputDirectory(tmpFolder.toString());
 		launcher.buildModel();
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 
@@ -61,13 +65,13 @@ public class GetBinaryFilesTest {
 
 	@Test
 	public void testExistingButNotBuiltBinary() throws IOException {
-		tmpFolder.newFolder("compilation");
-		tmpFolder.newFile("compilation/IBar$Test.class");
+		new File(tmpFolder.toFile(), "compilation").mkdir();
+		new File(tmpFolder.toFile(), "compilation/IBar$Test.class").createNewFile();
 
 		final String input = "./src/test/resources/compilation/compilation-tests/IBar.java";
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource(input);
-		launcher.setBinaryOutputDirectory(tmpFolder.getRoot());
+		launcher.setBinaryOutputDirectory(tmpFolder.toString());
 		launcher.buildModel();
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 
@@ -90,7 +94,7 @@ public class GetBinaryFilesTest {
 		final String input = "./src/test/resources/compilation/compilation-tests/";
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource(input);
-		launcher.setBinaryOutputDirectory(tmpFolder.getRoot());
+		launcher.setBinaryOutputDirectory(tmpFolder.toString());
 		launcher.buildModel();
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 
@@ -115,7 +119,7 @@ public class GetBinaryFilesTest {
 		final String input = "./src/test/java/spoon/test/imports/testclasses/internal/PublicInterface2.java";
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource(input);
-		launcher.setBinaryOutputDirectory(tmpFolder.getRoot());
+		launcher.setBinaryOutputDirectory(tmpFolder.toString());
 		launcher.buildModel();
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 
@@ -137,7 +141,7 @@ public class GetBinaryFilesTest {
 		final String input = "./src/test/java/spoon/test/secondaryclasses/testclasses/AnonymousClass.java";
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource(input);
-		launcher.setBinaryOutputDirectory(tmpFolder.getRoot());
+		launcher.setBinaryOutputDirectory(tmpFolder.toString());
 		launcher.buildModel();
 		launcher.getModelBuilder().compile(SpoonModelBuilder.InputType.FILES);
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testSingleBinary`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExistingButNotBuiltBinary`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiClassInSingleFile`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNestedTypes`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnonymousClasses`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testSingleBinary`
- Transformed junit4 assert to junit 5 assertion in `testExistingButNotBuiltBinary`
- Transformed junit4 assert to junit 5 assertion in `testMultiClassInSingleFile`
- Transformed junit4 assert to junit 5 assertion in `testNestedTypes`
- Transformed junit4 assert to junit 5 assertion in `testAnonymousClasses`
