### PR TITLE
test: migrate ConditionalTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/condition/ConditionalTest.java
+++ b/src/test/java/spoon/test/condition/ConditionalTest.java
@@ -16,14 +16,10 @@
  */
 package spoon.test.condition;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -37,6 +33,11 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.condition.testclasses.Foo;
 import spoon.test.condition.testclasses.Foo2;
 import spoon.testing.utils.ModelUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConditionalTest {
 	String newLine = System.getProperty("line.separator");


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testConditional`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConditionalWithAssignment`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBlockInConditionAndLoop`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoBlockInConditionAndLoop`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoThenBlock`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoThenBlockBug`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoThenBlockBug2`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testConditional`
- Transformed junit4 assert to junit 5 assertion in `testConditionalWithAssignment`
- Transformed junit4 assert to junit 5 assertion in `testBlockInConditionAndLoop`
- Transformed junit4 assert to junit 5 assertion in `testNoBlockInConditionAndLoop`
- Transformed junit4 assert to junit 5 assertion in `testNoThenBlock`
- Transformed junit4 assert to junit 5 assertion in `testNoThenBlockBug`
- Transformed junit4 assert to junit 5 assertion in `testNoThenBlockBug2`
