### PR TITLE
test: migrate ConstructorCallTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/ConstructorCallTest.java
@@ -16,8 +16,15 @@
  */
 package spoon.test.constructorcallnewclass;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
@@ -33,23 +40,18 @@ import spoon.support.comparator.DeepRepresentationComparator;
 import spoon.test.constructorcallnewclass.testclasses.Foo;
 import spoon.test.constructorcallnewclass.testclasses.Panini;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.TreeSet;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConstructorCallTest {
 	private List<CtConstructorCall<?>> constructorCalls;
 	private List<CtConstructorCall<?>> constructorCallsPanini;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/" + Foo.class.getCanonicalName().replace(".", "/") + ".java");
@@ -119,18 +121,18 @@ public class ConstructorCallTest {
 
 	private void assertHasParameters(int sizeExpected, CtConstructorCall<?> constructorCall) {
 		if (sizeExpected == 0) {
-			assertEquals("Constructor call without parameter", sizeExpected, constructorCall.getArguments().size());
+			assertEquals(sizeExpected, constructorCall.getArguments().size(), "Constructor call without parameter");
 		} else {
-			assertEquals("Constructor call with parameters", sizeExpected, constructorCall.getArguments().size());
+			assertEquals(sizeExpected, constructorCall.getArguments().size(), "Constructor call with parameters");
 		}
 	}
 
 	private void assertIsConstructor(CtConstructorCall<?> constructorCall) {
-		assertTrue("Method must be a constructor", constructorCall.getExecutable().isConstructor());
+		assertTrue(constructorCall.getExecutable().isConstructor(), "Method must be a constructor");
 	}
 
 	private void assertConstructorCallWithType(Class<?> typeExpected, CtConstructorCall<?> constructorCall) {
-		assertSame("Constructor call is typed by the class of the constructor", typeExpected, constructorCall.getType().getActualClass());
+		assertSame(typeExpected, constructorCall.getType().getActualClass(), "Constructor call is typed by the class of the constructor");
 	}
 
 	@Test


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallStringWithoutParameters`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallStringWithParameters`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallObjectWithoutParameters`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallObjectWithParameters`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallWithGenericArray`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCoreConstructorCall`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterizedConstructorCallOmittedTypeArgsNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterizedConstructorCallOmittedTypeArgsUnknownExpectedTypeNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterizedConstructorCallOmittedTypeArgsResolvedTypeNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addArgumentAt_addsArgumentToSpecifiedPosition`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setUp`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testConstructorCallWithGenericArray`
- Transformed junit4 assert to junit 5 assertion in `assertHasParameters`
- Transformed junit4 assert to junit 5 assertion in `assertIsConstructor`
- Transformed junit4 assert to junit 5 assertion in `assertConstructorCallWithType`
- Transformed junit4 assert to junit 5 assertion in `testCoreConstructorCall`
- Transformed junit4 assert to junit 5 assertion in `testParameterizedConstructorCallOmittedTypeArgsNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testParameterizedConstructorCallOmittedTypeArgsUnknownExpectedTypeNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testParameterizedConstructorCallOmittedTypeArgsResolvedTypeNoClasspath`
