### PR TITLE
test: migrate ControlTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/control/ControlTest.java
+++ b/src/test/java/spoon/test/control/ControlTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.control;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtDo;
 import spoon.reflect.code.CtFor;
@@ -26,11 +29,9 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class ControlTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingFor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingDoWhile`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingFor`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingDoWhile`
