### PR TITLE
test: migrate TestCtBlock to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/ctBlock/TestCtBlock.java
+++ b/src/test/java/spoon/test/ctBlock/TestCtBlock.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.ctBlock;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCase;
@@ -28,11 +31,9 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.test.ctBlock.testclasses.Toto;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Created by urli on 15/03/2017.

--- a/src/test/java/spoon/test/ctBlock/TestCtBlock.java
+++ b/src/test/java/spoon/test/ctBlock/TestCtBlock.java
@@ -84,10 +84,10 @@ public class TestCtBlock {
 
 		assertEquals(5, block.getStatements().size());
 
-		assertEquals(originalBlock.getStatement(0), block.getStatement(0));
+		assertEquals((CtStatement) originalBlock.getStatement(0), block.getStatement(0));
 
 		for (int i = 1; i < 4; i++) {
-			assertEquals(originalBlock.getStatement(i), block.getStatement(i + 1));
+			assertEquals((CtStatement) originalBlock.getStatement(i), block.getStatement(i + 1));
 		}
 	}
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testRemoveStatement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddStatementInBlock`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddStatementInCase`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testRemoveStatement`
- Transformed junit4 assert to junit 5 assertion in `testAddStatementInBlock`
- Transformed junit4 assert to junit 5 assertion in `testAddStatementInCase`
