### PR TITLE
test: migrate CtClassTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -16,32 +16,18 @@
  */
 package spoon.test.ctClass;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-
-import static org.hamcrest.core.Is.is;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
-import static spoon.test.SpoonTestHelpers.contentEquals;
-import static spoon.testing.utils.ModelUtils.build;
-import static spoon.testing.utils.ModelUtils.buildClass;
-import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 import java.io.File;
 import java.util.Set;
 
+import java.util.concurrent.TimeUnit;
+
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Test;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
@@ -52,13 +38,13 @@ import spoon.reflect.code.CtNewClass;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.cu.position.NoSourcePosition;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
@@ -68,6 +54,21 @@ import spoon.test.SpoonTestHelpers;
 import spoon.test.ctClass.testclasses.AnonymousClass;
 import spoon.test.ctClass.testclasses.Foo;
 import spoon.test.ctClass.testclasses.Pozole;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.test.SpoonTestHelpers.contentEquals;
+import static spoon.testing.utils.ModelUtils.build;
+import static spoon.testing.utils.ModelUtils.buildClass;
+import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class CtClassTest {
 
@@ -359,7 +360,8 @@ public class CtClassTest {
 		assertEquals(newClassInvocation.toString(), newClassInvocationCloned.toString());
 	}
 
-	@Test(timeout = 5000L)
+	@Test
+	@Timeout(unit = TimeUnit.MILLISECONDS, value = 5000L)
 	public void test_buildParameterizedClass_withTypeParameterUsedInQualifiedName() {
 		// contract: It should be possible to build a generic class when one of the type parameters
 		// is used in the qualified name of another type.


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4-AssertThat
`AssertThat` in Junit 4 is deprecated. Use `AssertThat` in Hamcrest instead.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `getConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfTheEnclosingClassOfStaticClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathWithSuperClassOfAClassInAnInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAllTypeReferencesToALocalTypeShouldNotStartWithNumber`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSpoonShouldInferImplicitPackageInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `toStringWithImports`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDefaultConstructorAreOk`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCloneAnonymousClassInvocation`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCloneAnonymousClassInvocationWithAutoimports`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_buildParameterizedClass_withTypeParameterUsedInQualifiedName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRemoveAnnotation`
### JUnit4-AssertThat
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testSpoonShouldInferImplicitPackageInNoClasspath`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testSpoonShouldInferImplicitPackageInNoClasspath`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testDefaultConstructorAreOk`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `test_buildParameterizedClass_withTypeParameterUsedInQualifiedName`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `test_buildParameterizedClass_withTypeParameterUsedInQualifiedName`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `getConstructor`
- Transformed junit4 assert to junit 5 assertion in `testParentOfTheEnclosingClassOfStaticClass`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathWithSuperClassOfAClassInAnInterface`
- Transformed junit4 assert to junit 5 assertion in `testAllTypeReferencesToALocalTypeShouldNotStartWithNumber`
- Transformed junit4 assert to junit 5 assertion in `toStringWithImports`
- Transformed junit4 assert to junit 5 assertion in `testCloneAnonymousClassInvocation`
- Transformed junit4 assert to junit 5 assertion in `testCloneAnonymousClassInvocationWithAutoimports`
- Transformed junit4 assert to junit 5 assertion in `testRemoveAnnotation`
