### PR TITLE
test: migrate CtBodyHolderTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/ctBodyHolder/CtBodyHolderTest.java
+++ b/src/test/java/spoon/test/ctBodyHolder/CtBodyHolderTest.java
@@ -16,13 +16,7 @@
  */
 package spoon.test.ctBodyHolder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static spoon.testing.utils.ModelUtils.build;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBlock;
@@ -41,6 +35,12 @@ import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.test.ctBodyHolder.testclasses.CWBStatementTemplate;
 import spoon.test.ctBodyHolder.testclasses.ClassWithBodies;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static spoon.testing.utils.ModelUtils.build;
 
 public class CtBodyHolderTest {
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTryCatch`
- Replaced junit 4 test annotation with junit 5 test annotation in `testForWithStatement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testForWithBlock`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWhileWithBlock`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testConstructor`
- Transformed junit4 assert to junit 5 assertion in `testMethod`
- Transformed junit4 assert to junit 5 assertion in `testTryCatch`
- Transformed junit4 assert to junit 5 assertion in `testForWithStatement`
- Transformed junit4 assert to junit 5 assertion in `testForWithBlock`
- Transformed junit4 assert to junit 5 assertion in `testWhileWithBlock`
- Transformed junit4 assert to junit 5 assertion in `checkCtBody`
