### PR TITLE
test: migrate DeleteTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/delete/DeleteTest.java
+++ b/src/test/java/spoon/test/delete/DeleteTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.delete;
 
-import org.junit.Test;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtIf;
@@ -33,13 +37,10 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.delete.testclasses.Adobada;
 
-import java.lang.annotation.Annotation;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class DeleteTest {


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAStatementInAnonymousExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAStatementInStaticAnonymousExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAStatementInConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAStatementInMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteReturn`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteStatementInCase`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteACaseOfASwitch`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteParameterOfMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteBodyOfAMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAnnotationOnAClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteAClassTopLevel`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteConditionInACondition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeleteChainOfAssignment`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testDeleteAStatementInAnonymousExecutable`
- Transformed junit4 assert to junit 5 assertion in `testDeleteAStatementInStaticAnonymousExecutable`
- Transformed junit4 assert to junit 5 assertion in `testDeleteAStatementInConstructor`
- Transformed junit4 assert to junit 5 assertion in `testDeleteAStatementInMethod`
- Transformed junit4 assert to junit 5 assertion in `testDeleteReturn`
- Transformed junit4 assert to junit 5 assertion in `testDeleteStatementInCase`
- Transformed junit4 assert to junit 5 assertion in `testDeleteACaseOfASwitch`
- Transformed junit4 assert to junit 5 assertion in `testDeleteMethod`
- Transformed junit4 assert to junit 5 assertion in `testDeleteParameterOfMethod`
- Transformed junit4 assert to junit 5 assertion in `testDeleteBodyOfAMethod`
- Transformed junit4 assert to junit 5 assertion in `testDeleteAnnotationOnAClass`
- Transformed junit4 assert to junit 5 assertion in `testDeleteAClassTopLevel`
- Transformed junit4 assert to junit 5 assertion in `testDeleteConditionInACondition`
- Transformed junit4 assert to junit 5 assertion in `testDeleteChainOfAssignment`
