### PR TITLE
test: migrate EvalTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.eval;
 
-import org.junit.Test;
+
+import java.io.File;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -40,13 +44,10 @@ import spoon.support.reflect.eval.InlinePartialEvaluator;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
 import spoon.test.eval.testclasses.Foo;
 
-import java.io.File;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class EvalTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testStringConcatenation`
- Replaced junit 4 test annotation with junit 5 test annotation in `testArrayLength`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDoNotSimplify`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDoNotSimplifyCasts`
- Replaced junit 4 test annotation with junit 5 test annotation in `testScanAPartiallyEvaluatedElement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTryCatchAndStatement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDoNotSimplifyToExpressionWhenStatementIsExpected`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsKnownAtCompileTime`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVisitorPartialEvaluator_binary`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVisitorPartialEvaluator_unary`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVisitorPartialEvaluator_if`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVisitorPartialEvaluatorScanner`
- Replaced junit 4 test annotation with junit 5 test annotation in `testconvertElementToRuntimeObject`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testStringConcatenation`
- Transformed junit4 assert to junit 5 assertion in `testArrayLength`
- Transformed junit4 assert to junit 5 assertion in `testDoNotSimplify`
- Transformed junit4 assert to junit 5 assertion in `testDoNotSimplifyCasts`
- Transformed junit4 assert to junit 5 assertion in `testScanAPartiallyEvaluatedElement`
- Transformed junit4 assert to junit 5 assertion in `testTryCatchAndStatement`
- Transformed junit4 assert to junit 5 assertion in `testDoNotSimplifyToExpressionWhenStatementIsExpected`
- Transformed junit4 assert to junit 5 assertion in `testIsKnownAtCompileTime`
- Transformed junit4 assert to junit 5 assertion in `testVisitorPartialEvaluator_binary`
- Transformed junit4 assert to junit 5 assertion in `testVisitorPartialEvaluator_unary`
- Transformed junit4 assert to junit 5 assertion in `testVisitorPartialEvaluator_if`
- Transformed junit4 assert to junit 5 assertion in `testVisitorPartialEvaluatorScanner`
- Transformed junit4 assert to junit 5 assertion in `testconvertElementToRuntimeObject`
