### PR TITLE
test: migrate VariableReferencesTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -16,9 +16,15 @@
  */
 package spoon.test.query_function;
 
-import org.junit.Before;
-import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtBinaryOperator;
@@ -59,18 +65,17 @@ import spoon.test.query_function.testclasses.VariableReferencesFromStaticMethod;
 import spoon.test.query_function.testclasses.VariableReferencesModelTest;
 import spoon.testing.utils.ModelUtils;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class VariableReferencesTest {
 	CtClass<?> modelClass;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {"--output-type", "nooutput","--level","info" });
@@ -111,8 +116,8 @@ public class VariableReferencesTest {
 			return false;
 		}).list();
 		assertFalse(context.unique.isEmpty());
-		assertEquals("Only these keys were found: "+context.unique.keySet(), context.maxKey, context.unique.size());
-		assertEquals("AllLocalVars#maxValue must be equal to maximum value number ", (int)getLiteralValue((CtVariable)modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class,"maxValue")).first()), context.maxKey);
+		assertEquals(context.maxKey, context.unique.size(), "Only these keys were found: " + context.unique.keySet());
+		assertEquals(((int) (getLiteralValue(((CtVariable) (modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class, "maxValue")).first()))))), context.maxKey, "AllLocalVars#maxValue must be equal to maximum value number ");
 	}
 
 	@Test
@@ -223,8 +228,8 @@ public class VariableReferencesTest {
 		modelClass.filterChildren((CtLocalVariableReference<?> varRef)->{
 			if(isTestFieldName(varRef.getSimpleName())) {
 				CtLocalVariable<?> var = varRef.getDeclaration();
-				assertNotNull("The declaration of variable "+varRef.getSimpleName()+" in "+getParentMethodName(varRef)+" on line "+var.getPosition().getLine()+" with value "+getVariableReferenceValue(varRef)+" was not found", var);
-				assertEquals("CtLocalVariableReference#getDeclaration returned wrong declaration in "+getParentMethodName(varRef), getVariableReferenceValue(varRef), (int)getLiteralValue(var));
+				assertNotNull(var, "The declaration of variable " + varRef.getSimpleName() + " in " + getParentMethodName(varRef) + " on line " + var.getPosition().getLine() + " with value " + getVariableReferenceValue(varRef) + " was not found");
+				assertEquals(getVariableReferenceValue(varRef), ((int) (getLiteralValue(var))), "CtLocalVariableReference#getDeclaration returned wrong declaration in " + getParentMethodName(varRef));
 			}
 			return false;
 		}).list();
@@ -260,7 +265,7 @@ public class VariableReferencesTest {
 				}
 			});
 			//check that both scans found same number of references
-			assertEquals("Number of references to field="+value+" does not match", context.expectedCount, context.realCount);
+			assertEquals(context.expectedCount, context.realCount, "Number of references to field=" + value + " does not match");
 			
 		} catch (Throwable e) {
 			e.printStackTrace();
@@ -368,6 +373,6 @@ public class VariableReferencesTest {
 		assertEquals("org.junit.Assert.assertTrue(field == 2)", stmt.toString());
 		CtLocalVariableReference varRef = stmt.filterChildren(new TypeFilter<>(CtLocalVariableReference.class)).first();
 		List<CtVariable> vars = varRef.map(new PotentialVariableDeclarationFunction()).list();
-		assertEquals("Found unexpected variable declaration.", 1, vars.size());
+		assertEquals(1, vars.size(), "Found unexpected variable declaration.");
 	}
 }

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -117,7 +117,7 @@ public class VariableReferencesTest {
 		}).list();
 		assertFalse(context.unique.isEmpty());
 		assertEquals(context.maxKey, context.unique.size(), "Only these keys were found: " + context.unique.keySet());
-		assertEquals(((int) (getLiteralValue(((CtVariable) (modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class, "maxValue")).first()))))), context.maxKey, "AllLocalVars#maxValue must be equal to maximum value number ");
+		assertEquals((int) getLiteralValue((CtVariable<?>) modelClass.filterChildren(new NamedElementFilter<>(CtVariable.class, "maxValue")).first()), context.maxKey, "AllLocalVars#maxValue must be equal to maximum value number ");
 	}
 
 	@Test
@@ -229,7 +229,7 @@ public class VariableReferencesTest {
 			if(isTestFieldName(varRef.getSimpleName())) {
 				CtLocalVariable<?> var = varRef.getDeclaration();
 				assertNotNull(var, "The declaration of variable " + varRef.getSimpleName() + " in " + getParentMethodName(varRef) + " on line " + var.getPosition().getLine() + " with value " + getVariableReferenceValue(varRef) + " was not found");
-				assertEquals(getVariableReferenceValue(varRef), ((int) (getLiteralValue(var))), "CtLocalVariableReference#getDeclaration returned wrong declaration in " + getParentMethodName(varRef));
+				assertEquals(getVariableReferenceValue(varRef), (int) getLiteralValue(var), "CtLocalVariableReference#getDeclaration returned wrong declaration in " + getParentMethodName(varRef));
 			}
 			return false;
 		}).list();


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCheckModelConsistency`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCatchVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLocalVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVariableReferenceFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testVariableScopeFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldScopeFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLocalVariableReferenceDeclarationFunction`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPotentialVariableAccessFromStaticMethod`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `checkKey`
- Transformed junit4 assert to junit 5 assertion in `testCheckModelConsistency`
- Transformed junit4 assert to junit 5 assertion in `testVariableScopeFunction`
- Transformed junit4 assert to junit 5 assertion in `testFieldScopeFunction`
- Transformed junit4 assert to junit 5 assertion in `testLocalVariableReferenceDeclarationFunction`
- Transformed junit4 assert to junit 5 assertion in `checkVariableAccess`
- Transformed junit4 assert to junit 5 assertion in `getLiteralValue`
- Transformed junit4 assert to junit 5 assertion in `testPotentialVariableAccessFromStaticMethod`
