### PR TITLE
test: migrate QualifiedThisRefTest

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
+++ b/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
@@ -16,8 +16,13 @@
  */
 package spoon.test.prettyprinter;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtExpression;
@@ -38,20 +43,16 @@ import spoon.support.reflect.code.CtFieldAccessImpl;
 import spoon.test.delete.testclasses.Adobada;
 import spoon.test.prettyprinter.testclasses.QualifiedThisRef;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class QualifiedThisRefTest {
 
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testQualifiedThisRef`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCloneThisAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPrintCtFieldAccessWorkEvenWhenParentNotInitialized`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testQualifiedThisRef`
- Transformed junit4 assert to junit 5 assertion in `testCloneThisAccess`
- Transformed junit4 assert to junit 5 assertion in `testPrintCtFieldAccessWorkEvenWhenParentNotInitialized`
