### PR TITLE
test: migrate PrinterTest JUnit 5

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -16,31 +16,6 @@
  */
 package spoon.test.prettyprinter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static spoon.testing.utils.ModelUtils.canBeBuilt;
-
-import org.apache.commons.io.FileUtils;
-import org.junit.Test;
-
-import spoon.Launcher;
-import spoon.compiler.SpoonResourceHelper;
-import spoon.reflect.code.CtBinaryOperator;
-import spoon.reflect.code.CtComment;
-import spoon.reflect.code.CtInvocation;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.factory.Factory;
-import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
-import spoon.reflect.visitor.ElementPrinterHelper;
-import spoon.reflect.visitor.PrettyPrinter;
-import spoon.reflect.visitor.PrinterHelper;
-import spoon.reflect.visitor.TokenWriter;
-import spoon.reflect.visitor.DefaultTokenWriter;
-import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.test.prettyprinter.testclasses.MissingVariableDeclaration;
-import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -51,6 +26,31 @@ import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtComment;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
+import spoon.reflect.visitor.DefaultTokenWriter;
+import spoon.reflect.visitor.ElementPrinterHelper;
+import spoon.reflect.visitor.PrettyPrinter;
+import spoon.reflect.visitor.PrinterHelper;
+import spoon.reflect.visitor.TokenWriter;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.test.prettyprinter.testclasses.MissingVariableDeclaration;
+import spoon.testing.utils.ModelUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class PrinterTest {
 
@@ -87,7 +87,7 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should not contain imports: "+result, !result.contains("import java.util.List;"));
+		assertTrue(!result.contains("import java.util.List;"), "The result should not contain imports: " + result);
 
 		// recreating an auto-immport  printer
 		spoon.getEnvironment().setAutoImports(true);
@@ -95,7 +95,7 @@ public class PrinterTest {
 
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		result = printer.getResult();
-		assertTrue("The result should now contain imports: "+result, result.contains("import java.util.List;"));
+		assertTrue(result.contains("import java.util.List;"), "The result should now contain imports: " + result);
 	}
 
 	@Test
@@ -112,8 +112,8 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain FQN for constructor: "+result, result.contains("new spoon.support.visitor.replace.ReplacementVisitor("));
-		assertTrue("The result should not contain reduced constructors: "+result, !result.contains("new ReplacementVisitor("));
+		assertTrue(result.contains("new spoon.support.visitor.replace.ReplacementVisitor("), "The result should contain FQN for constructor: " + result);
+		assertTrue(!result.contains("new ReplacementVisitor("), "The result should not contain reduced constructors: " + result);
 	}
 
 	@Test
@@ -130,11 +130,11 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should not contain import static: ", !result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"));
-		assertTrue("The result should contain import type: ", result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"));
-		assertTrue("The result should contain import static assertTrue: ", result.contains("import static org.junit.Assert.assertTrue;"));
-		assertTrue("The result should contain assertTrue(...): ", result.contains("assertTrue(\"blabla\".equals(\"toto\"));"));
-		assertTrue("The result should use System.out.println(Constants.READY): "+result, result.contains("System.out.println(Constants.READY);"));
+		assertTrue(!result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"), "The result should not contain import static: ");
+		assertTrue(result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"), "The result should contain import type: ");
+		assertTrue(result.contains("import static org.junit.Assert.assertTrue;"), "The result should contain import static assertTrue: ");
+		assertTrue(result.contains("assertTrue(\"blabla\".equals(\"toto\"));"), "The result should contain assertTrue(...): ");
+		assertTrue(result.contains("System.out.println(Constants.READY);"), "The result should use System.out.println(Constants.READY): " + result);
 	}
 
 	@Test
@@ -152,9 +152,9 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain import java.util.ArrayList: ", result.contains("import java.util.ArrayList;"));
-		assertTrue("The result should contain import java.util.List: ", result.contains("import java.util.List;"));
-		assertTrue("The result should contain import static org.Bar.m: ", result.contains("import static org.Bar.m;"));
+		assertTrue(result.contains("import java.util.ArrayList;"), "The result should contain import java.util.ArrayList: ");
+		assertTrue(result.contains("import java.util.List;"), "The result should contain import java.util.List: ");
+		assertTrue(result.contains("import static org.Bar.m;"), "The result should contain import static org.Bar.m: ");
 	}
 
 	@Test
@@ -172,9 +172,9 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain import java.util.ArrayList: ", result.contains("import java.util.ArrayList;"));
-		assertTrue("The result should contain import java.util.List: ", result.contains("import java.util.List;"));
-		assertTrue("The result should contain import static org.Bar.m: ", result.contains("import static org.Bar.*;"));
+		assertTrue(result.contains("import java.util.ArrayList;"), "The result should contain import java.util.ArrayList: ");
+		assertTrue(result.contains("import java.util.List;"), "The result should contain import java.util.List: ");
+		assertTrue(result.contains("import static org.Bar.*;"), "The result should contain import static org.Bar.m: ");
 	}
 
 	@Test
@@ -192,8 +192,8 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain import org.Bar: ", result.contains("import org.Bar;"));
-		assertTrue("The result should contain import org.foo.*: ", result.contains("import org.foo.*;"));
+		assertTrue(result.contains("import org.Bar;"), "The result should contain import org.Bar: ");
+		assertTrue(result.contains("import org.foo.*;"), "The result should contain import org.foo.*: ");
 	}
 
 	@Test
@@ -212,7 +212,7 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain direct this accessor for field: "+result, !result.contains("Rule.Phoneme.this.phonemeText"));
+		assertTrue(!result.contains("Rule.Phoneme.this.phonemeText"), "The result should contain direct this accessor for field: " + result);
 		canBeBuilt(output, 7);
 	}
 
@@ -251,7 +251,7 @@ public class PrinterTest {
 		printer.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String result = printer.getResult();
 
-		assertTrue("The result should contain direct this accessor for field: "+result, !result.contains("Rule.Phoneme.this.phonemeText"));
+		assertTrue(!result.contains("Rule.Phoneme.this.phonemeText"), "The result should contain direct this accessor for field: " + result);
 		canBeBuilt(output, 7);
 	}
 
@@ -367,7 +367,7 @@ public class PrinterTest {
 					checkRepeatingOfTokens("writeSeparator");
 					checkTokenWhitespace(separator, false);					
 					//one of the separators
-					assertTrue("Unexpected separator: "+separator, separators.contains(separator));
+					assertTrue(separators.contains(separator), "Unexpected separator: " + separator);
 					handleTabs();
 					allTokens.append(separator);
 					return this;
@@ -377,7 +377,7 @@ public class PrinterTest {
 				public TokenWriter writeOperator(String operator) {
 					checkRepeatingOfTokens("writeOperator");
 					checkTokenWhitespace(operator, false);					
-					assertTrue("Unexpected operator: "+operator, operators.contains(operator));
+					assertTrue(operators.contains(operator), "Unexpected operator: " + operator);
 					handleTabs();
 					allTokens.append(operator);
 					return this;
@@ -396,7 +396,7 @@ public class PrinterTest {
 				public TokenWriter writeKeyword(String keyword) {
 					checkRepeatingOfTokens("writeKeyword");
 					checkTokenWhitespace(keyword, false);					
-					assertTrue("Unexpected java keyword: "+keyword, javaKeywords.contains(keyword));
+					assertTrue(javaKeywords.contains(keyword), "Unexpected java keyword: " + keyword);
 					handleTabs();
 					allTokens.append(keyword);
 					return this;
@@ -417,7 +417,7 @@ public class PrinterTest {
 							assertTrue(Character.isJavaIdentifierPart(c));
 						}
 					}
-					assertEquals("Keyword found in Identifier: " + identifier, false, javaKeywords.contains(identifier));
+					assertEquals(false, javaKeywords.contains(identifier), "Keyword found in Identifier: " + identifier);
 					handleTabs();
 					allTokens.append(identifier);
 					return this;
@@ -511,7 +511,7 @@ public class PrinterTest {
 						// nothing
 					} else {
 						//check only other tokens then writeln, which is the only one which can repeat
-						assertEquals("Two tokens of same type current:" + tokenType + " " + allTokens.toString(), false, tokenType.equals(this.lastToken));
+						assertEquals(false, tokenType.equals(this.lastToken), "Two tokens of same type current:" + tokenType + " " + allTokens.toString());
 					}
 					this.lastToken = tokenType;
 				}


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testPrettyPrinter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testChangeAutoImportModeWorks`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFQNModeWriteFQNConstructorInCtVisitor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAutoimportModeDontImportUselessStatic`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAutoimportModeDontImportUselessStaticNoClassPath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnresolvedImportStaticNoClassPath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnresolvedNoClassPath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRuleCanBeBuild`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLambdaCanBeBuild`
- Replaced junit 4 test annotation with junit 5 test annotation in `testJDTBatchCompilerCanBeBuild`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPrintingOfOrphanFieldReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPrinterTokenListener`
- Replaced junit 4 test annotation with junit 5 test annotation in `testListPrinter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodParentheses`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCustomPrettyPrinter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeLostPrintingStringClassReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeLostPrintingListClassReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeLostPrintingFQListClassReference`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testPrettyPrinter`
- Transformed junit4 assert to junit 5 assertion in `testChangeAutoImportModeWorks`
- Transformed junit4 assert to junit 5 assertion in `testFQNModeWriteFQNConstructorInCtVisitor`
- Transformed junit4 assert to junit 5 assertion in `testAutoimportModeDontImportUselessStatic`
- Transformed junit4 assert to junit 5 assertion in `testAutoimportModeDontImportUselessStaticNoClassPath`
- Transformed junit4 assert to junit 5 assertion in `testUnresolvedImportStaticNoClassPath`
- Transformed junit4 assert to junit 5 assertion in `testUnresolvedNoClassPath`
- Transformed junit4 assert to junit 5 assertion in `testRuleCanBeBuild`
- Transformed junit4 assert to junit 5 assertion in `testJDTBatchCompilerCanBeBuild`
- Transformed junit4 assert to junit 5 assertion in `testPrintingOfOrphanFieldReference`
- Transformed junit4 assert to junit 5 assertion in `writeSeparator`
- Transformed junit4 assert to junit 5 assertion in `writeOperator`
- Transformed junit4 assert to junit 5 assertion in `writeLiteral`
- Transformed junit4 assert to junit 5 assertion in `writeKeyword`
- Transformed junit4 assert to junit 5 assertion in `writeIdentifier`
- Transformed junit4 assert to junit 5 assertion in `writeCodeSnippet`
- Transformed junit4 assert to junit 5 assertion in `checkRepeatingOfTokens`
- Transformed junit4 assert to junit 5 assertion in `testPrinterTokenListener`
- Transformed junit4 assert to junit 5 assertion in `checkTokenWhitespace`
- Transformed junit4 assert to junit 5 assertion in `testListPrinter`
- Transformed junit4 assert to junit 5 assertion in `testMethodParentheses`
- Transformed junit4 assert to junit 5 assertion in `testCustomPrettyPrinter`
- Transformed junit4 assert to junit 5 assertion in `testTypeLostPrintingStringClassReference`
- Transformed junit4 assert to junit 5 assertion in `testTypeLostPrintingListClassReference`
- Transformed junit4 assert to junit 5 assertion in `testTypeLostPrintingFQListClassReference`