### PR TITLE
test: migrate LoopSniperJavaPrettyPrinterTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/LoopSniperJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/LoopSniperJavaPrettyPrinterTest.java
@@ -1,16 +1,16 @@
 package spoon.test.prettyprinter;
 
-import static org.junit.Assert.assertThat;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.processing.AbstractProcessor;
@@ -18,12 +18,14 @@ import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtLoop;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class LoopSniperJavaPrettyPrinterTest {
 
 	private static final Path INPUT_PATH = Paths.get("src/test/java/");
 	private static final Path OUTPUT_PATH = Paths.get("target/test-output");
 
-	@BeforeClass
+	@BeforeAll
 	public static void setup() throws IOException {
 		FileUtils.deleteDirectory(OUTPUT_PATH.toFile());
 	}
@@ -43,8 +45,9 @@ public class LoopSniperJavaPrettyPrinterTest {
 		runSniperJavaPrettyPrinter("spoon/test/prettyprinter/testclasses/loop/WhileNoBraces.java");
 	}
 
-	@Ignore
+	
 	@Test
+	@Disabled
 	public void whileWithBraces() throws IOException {
 		runSniperJavaPrettyPrinter("spoon/test/prettyprinter/testclasses/loop/WhileWithBraces.java");
 	}


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@BeforeClass
The JUnit 4 `@BeforeClass` annotation should be replaced with JUnit 5 `@BeforeAll` annotation.
## Junit4-@Ignore
The JUnit 4 `@Ignore` annotation should be replaced with JUnit 5 `@Disabled` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4-AssertThat
`AssertThat` in Junit 4 is deprecated. Use `AssertThat` in Hamcrest instead.

## The following has changed in the code:
### Junit4-@BeforeClass
- Replaced `@BeforeClass` annotation with `@BeforeAll` at method `setup`
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `forNoBraces`
- Replaced junit 4 test annotation with junit 5 test annotation in `forEachBraces`
- Replaced junit 4 test annotation with junit 5 test annotation in `whileNoBraces`
- Replaced junit 4 test annotation with junit 5 test annotation in `whileWithBraces`
### JUnit4-AssertThat
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `runSniperJavaPrettyPrinter`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `runSniperJavaPrettyPrinter`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `runSniperJavaPrettyPrinter`
### Junit4-@Ignore
- Replaced `@Ignore` annotation with `@Disabled` at method `whileWithBraces`
