### PR TITLE
test: migrate TestSourceFragment to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/position/TestSourceFragment.java
+++ b/src/test/java/spoon/test/position/TestSourceFragment.java
@@ -16,17 +16,13 @@
  */
 package spoon.test.position;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
@@ -46,17 +42,22 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.support.sniper.internal.SourceFragment;
-import spoon.support.sniper.internal.CollectionSourceFragment;
-import spoon.support.sniper.internal.ElementSourceFragment;
 import spoon.support.reflect.cu.CompilationUnitImpl;
 import spoon.support.reflect.cu.position.SourcePositionImpl;
+import spoon.support.sniper.internal.CollectionSourceFragment;
+import spoon.support.sniper.internal.ElementSourceFragment;
+import spoon.support.sniper.internal.SourceFragment;
 import spoon.test.position.testclasses.AnnonymousClassNewIface;
 import spoon.test.position.testclasses.FooField;
 import spoon.test.position.testclasses.FooSourceFragments;
 import spoon.test.position.testclasses.NewArrayList;
 import spoon.test.prettyprinter.testclasses.OneLineMultipleVariableDeclaration;
 import spoon.testing.utils.ModelUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSourceFragment {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentField`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourcePositionFragment`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentAddChild`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentAddChildBeforeOrAfter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentWrapChild`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentWrapChildrenAndSiblings`
- Replaced junit 4 test annotation with junit 5 test annotation in `testElementSourceFragment_getSourceFragmentOf`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExactSourceFragments`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentsOfCompilationUnit`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentsOfFieldAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentsOfNewArrayList`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourceFragmentsOfNewAnnonymousClass`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentField`
- Transformed junit4 assert to junit 5 assertion in `testSourcePositionFragment`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentAddChild`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentAddChildBeforeOrAfter`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentWrapChild`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentWrapChildrenAndSiblings`
- Transformed junit4 assert to junit 5 assertion in `testElementSourceFragment_getSourceFragmentOf`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentsOfCompilationUnit`
- Transformed junit4 assert to junit 5 assertion in `assertStartsWith`
- Transformed junit4 assert to junit 5 assertion in `assertEndsWith`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentsOfFieldAccess`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentsOfNewArrayList`
- Transformed junit4 assert to junit 5 assertion in `testSourceFragmentsOfNewAnnonymousClass`
- Transformed junit4 assert to junit 5 assertion in `checkElementFragments`
- Transformed junit4 assert to junit 5 assertion in `assertGroupsEqual`
