### PR TITLE
test: migrate PositionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -16,13 +16,18 @@
  */
 package spoon.test.position;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
 import org.apache.commons.io.FileUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtAssignment;
@@ -72,6 +77,7 @@ import spoon.support.reflect.CtExtendedModifier;
 import spoon.test.comment.testclasses.BlockComment;
 import spoon.test.comment.testclasses.Comment1;
 import spoon.test.position.testclasses.AnnonymousClassNewIface;
+import spoon.test.position.testclasses.AnnotationWithAngleBracket;
 import spoon.test.position.testclasses.ArrayArgParameter;
 import spoon.test.position.testclasses.CatchPosition;
 import spoon.test.position.testclasses.CompilationUnitComments;
@@ -91,25 +97,24 @@ import spoon.test.position.testclasses.FooLabel;
 import spoon.test.position.testclasses.FooLambda;
 import spoon.test.position.testclasses.FooMethod;
 import spoon.test.position.testclasses.FooStatement;
-import spoon.test.position.testclasses.AnnotationWithAngleBracket;
 import spoon.test.position.testclasses.FooSwitch;
 import spoon.test.position.testclasses.Kokos;
+import spoon.test.position.testclasses.MoreLambda;
 import spoon.test.position.testclasses.NoMethodModifiers;
 import spoon.test.position.testclasses.PositionParameterTypeWithReference;
 import spoon.test.position.testclasses.PositionTry;
 import spoon.test.position.testclasses.SomeEnum;
 import spoon.test.position.testclasses.TypeParameter;
-import spoon.test.position.testclasses.MoreLambda;
 import spoon.test.query_function.testclasses.VariableReferencesModelTest;
 import spoon.testing.utils.ModelUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 
@@ -427,7 +432,8 @@ public class PositionTest {
 		assertEquals("protected static", contentAtPosition(classContent, position3.getModifierSourceStart(), position3.getModifierSourceEnd()));
 	}
 
-	@Test(timeout=10000)
+	@Test
+	@Timeout(unit = TimeUnit.MILLISECONDS, value = 10000L)
 	public void testPositionTerminates() {
 		assertDoesNotThrow(() -> {
 			final Factory build = build(AnnotationWithAngleBracket.class);
@@ -1420,8 +1426,7 @@ public class PositionTest {
 			.filter(elt -> elt.getPosition().isValidPosition())
 			.collect(Collectors.toList());
 
-		assertTrue("Some Spoon elements have an invalid line position",
-			listOfBadPositionElements.stream().allMatch(elt -> elt.getPosition().getLine() == 1));
+		assertTrue(listOfBadPositionElements.stream().allMatch(elt -> elt.getPosition().getLine() == 1), "Some Spoon elements have an invalid line position");
 	}
 
 	@Test


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionClassWithComments`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionParameterTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionAnnotation`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionField`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionGeneric`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionTerminates`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionAbstractMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionStatement`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourcePosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `defaultConstructorPositionTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `getPositionOfImplicitBlock`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionMethodTypeParameter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionOfAnnonymousType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionOfAnnonymousTypeByNewInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionOfCtImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEmptyModifiersOfMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeModifiersPositionAfterComment`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionTryCatch`
- Replaced junit 4 test annotation with junit 5 test annotation in `testArrayArgParameter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExpressions`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCatchPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEnumConstructorCallComment`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSwitchCase`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFooForEach`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEndColumn`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFirstLineColumn`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSingleLineClassColumn`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLabel`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNestedLabels`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageDeclaration`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageDeclarationPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testImportPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageDeclarationWithCommentPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCommentedOutClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSourcePositionOfFieldReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPositionBuilderFailureIsCaugth`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathVariableAccessInInnerClass1`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathVariableAccessInInnerClass2`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathVariableAccessInInnerInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLinePositionOkWithOneLineClassCode`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLambdaParameterPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLambdaParameterPosition1`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testPositionClass`
- Transformed junit4 assert to junit 5 assertion in `testPositionClassWithComments`
- Transformed junit4 assert to junit 5 assertion in `testPositionParameterTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testPositionInterface`
- Transformed junit4 assert to junit 5 assertion in `testPositionAnnotation`
- Transformed junit4 assert to junit 5 assertion in `testPositionField`
- Transformed junit4 assert to junit 5 assertion in `testPositionGeneric`
- Transformed junit4 assert to junit 5 assertion in `testPositionMethod`
- Transformed junit4 assert to junit 5 assertion in `testPositionAbstractMethod`
- Transformed junit4 assert to junit 5 assertion in `testPositionStatement`
- Transformed junit4 assert to junit 5 assertion in `testSourcePosition`
- Transformed junit4 assert to junit 5 assertion in `assertFails`
- Transformed junit4 assert to junit 5 assertion in `defaultConstructorPositionTest`
- Transformed junit4 assert to junit 5 assertion in `getPositionOfImplicitBlock`
- Transformed junit4 assert to junit 5 assertion in `testPositionMethodTypeParameter`
- Transformed junit4 assert to junit 5 assertion in `testPositionOfAnnonymousType`
- Transformed junit4 assert to junit 5 assertion in `testPositionOfAnnonymousTypeByNewInterface`
- Transformed junit4 assert to junit 5 assertion in `testPositionOfCtImport`
- Transformed junit4 assert to junit 5 assertion in `testEmptyModifiersOfMethod`
- Transformed junit4 assert to junit 5 assertion in `testTypeModifiersPositionAfterComment`
- Transformed junit4 assert to junit 5 assertion in `testPositionTryCatch`
- Transformed junit4 assert to junit 5 assertion in `testArrayArgParameter`
- Transformed junit4 assert to junit 5 assertion in `testExpressions`
- Transformed junit4 assert to junit 5 assertion in `testCatchPosition`
- Transformed junit4 assert to junit 5 assertion in `testEnumConstructorCallComment`
- Transformed junit4 assert to junit 5 assertion in `testSwitchCase`
- Transformed junit4 assert to junit 5 assertion in `testFooForEach`
- Transformed junit4 assert to junit 5 assertion in `testEndColumn`
- Transformed junit4 assert to junit 5 assertion in `testFirstLineColumn`
- Transformed junit4 assert to junit 5 assertion in `testSingleLineClassColumn`
- Transformed junit4 assert to junit 5 assertion in `testLabel`
- Transformed junit4 assert to junit 5 assertion in `testNestedLabels`
- Transformed junit4 assert to junit 5 assertion in `testPackageDeclaration`
- Transformed junit4 assert to junit 5 assertion in `testPackageDeclarationPosition`
- Transformed junit4 assert to junit 5 assertion in `testImportPosition`
- Transformed junit4 assert to junit 5 assertion in `testPackageDeclarationWithCommentPosition`
- Transformed junit4 assert to junit 5 assertion in `testCommentedOutClass`
- Transformed junit4 assert to junit 5 assertion in `testSourcePositionOfFieldReference`
- Transformed junit4 assert to junit 5 assertion in `testPositionBuilderFailureIsCaugth`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathVariableAccessInInnerClass1`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathVariableAccessInInnerClass2`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathVariableAccessInInnerInterface`
- Transformed junit4 assert to junit 5 assertion in `testLinePositionOkWithOneLineClassCode`
- Transformed junit4 assert to junit 5 assertion in `testLambdaParameterPosition`
- Transformed junit4 assert to junit 5 assertion in `testLambdaParameterPosition1`
