### PR TITLE
test: migrate PackageTest JUnit 5

### DIFF
--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -16,9 +16,18 @@
  */
 package spoon.test.pkg;
 
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonModelBuilder;
@@ -46,22 +55,15 @@ import spoon.test.pkg.processors.ElementProcessor;
 import spoon.test.pkg.testclasses.Foo;
 import spoon.testing.utils.ModelUtils;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 import static spoon.testing.utils.ModelUtils.createFactory;
@@ -326,7 +328,7 @@ public class PackageTest {
 		CtModel model = launcher.buildModel();
 
 		List<CtTypeAccess<?>> typeAccesses = model.getElements(e -> e.getAccessedType().getSimpleName().equals("SomeClass"));
-		assertEquals("There should only be a single type access in the test source code", 1, typeAccesses.size());
+		assertEquals(1, typeAccesses.size(), "There should only be a single type access in the test source code");
 		CtPackageReference pkgRef = typeAccesses.get(0).getAccessedType().getPackage();
 
 		assertTrue(pkgRef.getSimpleName().isEmpty());


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotationOnPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPrintPackageInfoWhenNothingInPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testHandlesDuplicatePackageInfo`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotationInPackageInfoWhenTemplatesCompiled`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRenamePackageAndPrettyPrint`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRenamePackageAndPrettyPrintNoclasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRenamePackageAndPrettyPrintWithProcessor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRenameRootPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRenameRootPackageWithNullOrEmpty`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddAnnotationToPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoPackageAssumptionWithStarImportNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetFQNSimple`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetFQNInNoClassPath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddTypeOverwritingSameName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeRename`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageRename`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeRenameReplaceExisting`
- Replaced junit 4 test annotation with junit 5 test annotation in `testPackageRenameReplaceExisting`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testPackage`
- Transformed junit4 assert to junit 5 assertion in `testAnnotationOnPackage`
- Transformed junit4 assert to junit 5 assertion in `testPrintPackageInfoWhenNothingInPackage`
- Transformed junit4 assert to junit 5 assertion in `testRenamePackageAndPrettyPrint`
- Transformed junit4 assert to junit 5 assertion in `testRenamePackageAndPrettyPrintNoclasspath`
- Transformed junit4 assert to junit 5 assertion in `testRenamePackageAndPrettyPrintWithProcessor`
- Transformed junit4 assert to junit 5 assertion in `testRenameRootPackage`
- Transformed junit4 assert to junit 5 assertion in `testRenameRootPackageWithNullOrEmpty`
- Transformed junit4 assert to junit 5 assertion in `testAddAnnotationToPackage`
- Transformed junit4 assert to junit 5 assertion in `testNoPackageAssumptionWithStarImportNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testGetFQNSimple`
- Transformed junit4 assert to junit 5 assertion in `testGetFQNInNoClassPath`
- Transformed junit4 assert to junit 5 assertion in `testAddTypeOverwritingSameName`
- Transformed junit4 assert to junit 5 assertion in `testTypeRename`
- Transformed junit4 assert to junit 5 assertion in `testPackageRename`
- Transformed junit4 assert to junit 5 assertion in `testTypeRenameReplaceExisting`
- Transformed junit4 assert to junit 5 assertion in `testPackageRenameReplaceExisting`
