### PR TITLE
test: migrate TopLevelTypeTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/parent/TopLevelTypeTest.java
+++ b/src/test/java/spoon/test/parent/TopLevelTypeTest.java
@@ -16,10 +16,8 @@
  */
 package spoon.test.parent;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
@@ -27,11 +25,13 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class TopLevelTypeTest
 {
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		spoon.setArgs(new String[] {"--output-type", "nooutput" });


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testTopLevelType`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testTopLevelType`
