### PR TITLE
test: migrate ParentTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -16,15 +16,18 @@
  */
 package spoon.test.parent;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonResourceHelper;
-import spoon.reflect.declaration.ParentNotInitializedException;
-import spoon.support.sniper.SniperJavaPrettyPrinter;
-import spoon.test.intercession.IntercessionScanner;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
@@ -45,6 +48,7 @@ import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.ParentNotInitializedException;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -55,21 +59,18 @@ import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.ReferenceTypeFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.UnsettableProperty;
+import spoon.support.sniper.SniperJavaPrettyPrinter;
+import spoon.test.intercession.IntercessionScanner;
 import spoon.test.replace.testclasses.Tacos;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -77,7 +78,7 @@ public class ParentTest {
 
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		spoon.setArgs(new String[] {"--output-type", "nooutput" });
@@ -313,7 +314,7 @@ public class ParentTest {
 	}
 
 	@Test
-	@Ignore // too fragile because of conventions
+	@Disabled // too fragile because of conventions
 	public void testParentSetInSetter() {
 		// contract: Check that all setters protect their parameter.
 		final Launcher launcher = new Launcher();


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## Junit4-@Ignore
The JUnit 4 `@Ignore` annotation should be replaced with JUnit 5 `@Disabled` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testParent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentSet`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfCtPackageReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfCtVariableReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfCtExecutableReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfGenericInTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentOfPrimitiveReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParentWithFilter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testHasParent`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentSetInSetter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testParentNotInitializedException`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParentOverloadsInNoParentElements`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParentOverloadsWithNoMatchingElements`
### Junit4-@Ignore
- Replaced `@Ignore` annotation with `@Disabled` at method `testParentSetInSetter`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testParent`
- Transformed junit4 assert to junit 5 assertion in `testParentSet`
- Transformed junit4 assert to junit 5 assertion in `testAddType`
- Transformed junit4 assert to junit 5 assertion in `testParentOfCtPackageReference`
- Transformed junit4 assert to junit 5 assertion in `testParentOfCtVariableReference`
- Transformed junit4 assert to junit 5 assertion in `testParentOfCtExecutableReference`
- Transformed junit4 assert to junit 5 assertion in `testParentOfGenericInTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testParentOfPrimitiveReference`
- Transformed junit4 assert to junit 5 assertion in `testGetParentWithFilter`
- Transformed junit4 assert to junit 5 assertion in `testHasParent`
- Transformed junit4 assert to junit 5 assertion in `checkAddStrategy`
- Transformed junit4 assert to junit 5 assertion in `checkSetStrategy`
- Transformed junit4 assert to junit 5 assertion in `testGetParentOverloadsInNoParentElements`
- Transformed junit4 assert to junit 5 assertion in `testGetParentOverloadsWithNoMatchingElements`