### PR TITLE
test: migrate NullParentTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/parent/NullParentTest.java
+++ b/src/test/java/spoon/test/parent/NullParentTest.java
@@ -16,8 +16,8 @@
  */
 package spoon.test.parent;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtAssert;
@@ -33,13 +33,13 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NullParentTest {
 
 	Factory factory;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testTargetedAccessNullTarget`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTargetedExpressionNullTarget`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAssertNullExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testForLoopNullChildren`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIfNullBranches`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLocalVariableNullDefaultExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldNullDefaultExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReturnNullExpression`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testTargetedAccessNullTarget`
- Transformed junit4 assert to junit 5 assertion in `testTargetedExpressionNullTarget`
- Transformed junit4 assert to junit 5 assertion in `testAssertNullExpression`
- Transformed junit4 assert to junit 5 assertion in `testForLoopNullChildren`
- Transformed junit4 assert to junit 5 assertion in `testIfNullBranches`
- Transformed junit4 assert to junit 5 assertion in `testLocalVariableNullDefaultExpression`
- Transformed junit4 assert to junit 5 assertion in `testFieldNullDefaultExpression`
- Transformed junit4 assert to junit 5 assertion in `testReturnNullExpression`