### PR TITLE
test: migrate ParameterTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.parameters;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
@@ -26,11 +29,9 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ParameterTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testParameterInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParameterReferenceInLambdaNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiParameterLambdaTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParentAfterGetParameterReference`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testParameterInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testGetParameterReferenceInLambdaNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testMultiParameterLambdaTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testGetParentAfterGetParameterReference`
