### PR TITLE
fix: fix printing of joint declaration of fields and local variable

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtVariable.java
+++ b/src/main/java/spoon/reflect/declaration/CtVariable.java
@@ -49,4 +49,16 @@ public interface CtVariable<T> extends CtNamedElement, CtTypedElement<T>, CtModi
 	 */
 	@DerivedProperty
 	boolean isPartOfJointDeclaration();
+
+	/**
+	 * Returns true if field or a local variable are part of the same joint declaration.
+	 * Eg:
+	 * ```
+	 * int a,b;
+	 * int c;
+	 * ```
+	 * a and b are part of the same joint declaration.
+	 * a and c are not part of the same joint declaration.
+	 */
+	boolean isInSameJointDeclarationAs(CtVariable<?> variable);
 }

--- a/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtCatchVariableImpl.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.reflect.code;
 
+import spoon.SpoonException;
 import spoon.reflect.ModelElementContainerDefaultCapacities;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtCatchVariable;
@@ -110,6 +111,11 @@ public class CtCatchVariableImpl<T> extends CtCodeElementImpl implements CtCatch
 	@Override
 	public boolean isPartOfJointDeclaration() {
 		return false;
+	}
+
+	@Override
+	public boolean isInSameJointDeclarationAs(CtVariable<?> variable) {
+		throw new SpoonException("Joint declaration does not exist for " + variable.getClass());
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLocalVariableImpl.java
@@ -11,6 +11,7 @@ import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtRHSReceiver;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
@@ -101,6 +102,18 @@ public class CtLocalVariableImpl<T> extends CtStatementImpl implements CtLocalVa
 					&& f.getPosition().getSourceEnd() == this.getPosition().getSourceEnd()) {
 				return true;
 			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isInSameJointDeclarationAs(CtVariable<?> variable) {
+		if (isPartOfJointDeclaration() && variable.isPartOfJointDeclaration()) {
+			SourcePosition thisPosition = getPosition();
+			SourcePosition otherPosition = variable.getPosition();
+
+			return thisPosition.getSourceStart() == otherPosition.getSourceStart()
+					&& thisPosition.getSourceEnd() == otherPosition.getSourceEnd();
 		}
 		return false;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtFieldImpl.java
@@ -10,6 +10,7 @@ package spoon.support.reflect.declaration;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtRHSReceiver;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtModifiable;
@@ -252,6 +253,17 @@ public class CtFieldImpl<T> extends CtNamedElementImpl implements CtField<T> {
 			if (f.getPosition().getSourceStart() == this.getPosition().getSourceStart()) {
 				return true;
 			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isInSameJointDeclarationAs(CtVariable<?> variable) {
+		if (isPartOfJointDeclaration() && variable.isPartOfJointDeclaration()) {
+			SourcePosition thisPosition = getPosition();
+			SourcePosition otherPosition = variable.getPosition();
+
+			return thisPosition.getSourceStart() == otherPosition.getSourceStart();
 		}
 		return false;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtParameterImpl.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.reflect.declaration;
 
+import spoon.SpoonException;
 import spoon.reflect.annotations.MetamodelPropertyField;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtExecutable;
@@ -82,6 +83,11 @@ public class CtParameterImpl<T> extends CtNamedElementImpl implements CtParamete
 	public boolean isPartOfJointDeclaration() {
 		// a parameter can never be part of a joint declaration
 		return false;
+	}
+
+	@Override
+	public boolean isInSameJointDeclarationAs(CtVariable<?> variable) {
+		throw new SpoonException("Joint declaration does not exist for " + variable.getClass());
 	}
 
 	@Override

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.field;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -222,5 +222,28 @@ public class FieldTest {
 
 	}
 
+	@Test
+	void testFieldIsInSameJointDeclarationAsProvidedField() {
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/isPartOfJointDeclaration/Field.java");
+		CtModel model = launcher.buildModel();
 
+		List<CtField<?>> fields = model.getElements(new TypeFilter<>(CtField.class));
+		Boolean[][] jointlyDeclared = {
+				{true,  true,  false, false, false, false},
+				{true,  true,  false, false, false, false},
+				{false, false, true,  true,  true,  false},
+				{false, false, true,  true,  true,  false},
+				{false, false, true,  true,  true,  false},
+				{false, false, false, false, false, false},
+		};
+		for (int i=0; i < fields.size(); ++i) {
+			CtField<?> first = fields.get(i);
+			for (int j=0; j < fields.size(); ++j) {
+				CtField<?> second = fields.get(j);
+				assertEquals(jointlyDeclared[i][j], first.isInSameJointDeclarationAs(second), first + " " + second);
+				assertEquals(jointlyDeclared[i][j], second.isInSameJointDeclarationAs(first), second + " " + first);
+			}
+		}
+	}
 }

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -948,6 +948,34 @@ public class TestSniperPrinter {
 		}
 	}
 
+	@GitHubIssue(issueNumber = 3386)
+	@Nested
+	class JointDeclarationPrinting {
+		private BiConsumer<CtType<?>, String> assertPrintsJointDeclaration(String jointDeclaration) {
+			return (type, result) ->
+					assertThat(result, containsString(jointDeclaration));
+		}
+
+		@Test
+		void test_localVariablePrinting() {
+			testSniper(
+					"sniperPrinter.jointDeclaration.LocalVariable",
+					(type) -> type.getMethod("doNothing").getBody().getStatements().forEach(TestSniperPrinter::markElementForSniperPrinting),
+					assertPrintsJointDeclaration("int l1,l2,l3,l4 = 2;")
+
+			);
+		}
+
+		@Test
+		void test_fieldPrinting() {
+			testSniper(
+					"sniperPrinter.jointDeclaration.Field",
+					(type) -> type.getTypeMembers().forEach(TestSniperPrinter::markElementForSniperPrinting),
+					assertPrintsJointDeclaration("String f1,f2,f3 = \"42\",f4;")
+			);
+		}
+	}
+
 	/**
 	 * 1) Runs spoon using sniper mode,
 	 * 2) runs `typeChanger` to modify the code,

--- a/src/test/java/spoon/test/variable/VariableTest.java
+++ b/src/test/java/spoon/test/variable/VariableTest.java
@@ -33,9 +33,9 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class VariableTest {
 
@@ -55,6 +55,32 @@ public class VariableTest {
         assertEquals(true, localVariables.get(8).isPartOfJointDeclaration());
         assertEquals(true, localVariables.get(9).isPartOfJointDeclaration());
 
+    }
+
+    @Test
+    void testVariableIsInSameJointDeclarationAsProvidedVariable() {
+        Launcher launcher = new Launcher();
+        launcher.addInputResource("src/test/resources/isPartOfJointDeclaration/LocalVariable.java");
+
+        CtModel model = launcher.buildModel();
+
+        List<CtLocalVariable<?>> localVariables = model.getElements(new TypeFilter<>(CtLocalVariable.class));
+        Boolean[][] jointlyDeclared = {
+                {true,  true,  false, false, false, false},
+                {true,  true,  false, false, false, false},
+                {false, false, false, false, false, false},
+                {false, false, false, true,  true,  true },
+                {false, false, false, true,  true,  true },
+                {false, false, false, true,  true,  true },
+        };
+        for (int i=0; i < localVariables.size(); ++i) {
+            CtLocalVariable<?> first = localVariables.get(i);
+            for (int j=0; j < localVariables.size(); ++j) {
+                CtLocalVariable<?> second = localVariables.get(j);
+                assertEquals(jointlyDeclared[i][j], first.isInSameJointDeclarationAs(second), first + " " + second);
+                assertEquals(jointlyDeclared[i][j], second.isInSameJointDeclarationAs(first), second + " " + first);
+            }
+        }
     }
 
         @Test

--- a/src/test/resources/isPartOfJointDeclaration/Field.java
+++ b/src/test/resources/isPartOfJointDeclaration/Field.java
@@ -1,0 +1,7 @@
+public class Field {
+    private static final int a,b;
+
+    static String c,d,e;
+
+    Short f;
+}

--- a/src/test/resources/isPartOfJointDeclaration/LocalVariable.java
+++ b/src/test/resources/isPartOfJointDeclaration/LocalVariable.java
@@ -1,0 +1,9 @@
+public class LocalVariable {
+    void doNothing() {
+        int x,y = 2;
+
+        int a;
+
+        String b,c,d;
+    }
+}

--- a/src/test/resources/sniperPrinter/jointDeclaration/Field.java
+++ b/src/test/resources/sniperPrinter/jointDeclaration/Field.java
@@ -1,0 +1,5 @@
+package sniperPrinter.jointDeclaration;
+
+public class Field {
+    String f1,f2,f3 = "42",f4;
+}

--- a/src/test/resources/sniperPrinter/jointDeclaration/LocalVariable.java
+++ b/src/test/resources/sniperPrinter/jointDeclaration/LocalVariable.java
@@ -1,0 +1,7 @@
+package sniperPrinter.jointDeclaration;
+
+public class LocalVariable {
+    void doNothing() {
+        int l1,l2,l3,l4 = 2;
+    }
+}


### PR DESCRIPTION
Fixes #3386 

I think the problem lies in how `PositionBuilder` computes the source position of the individual elements in the joint declaration. I am still looking for a fix.
