### PR TITLE
test: migrate ConstructorFactoryTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/factory/ConstructorFactoryTest.java
+++ b/src/test/java/spoon/test/factory/ConstructorFactoryTest.java
@@ -16,7 +16,13 @@
  */
 package spoon.test.factory;
 
-import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtParameter;
@@ -30,12 +36,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class ConstructorFactoryTest {


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreate`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreateDefault`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testCreate`
- Transformed junit4 assert to junit 5 assertion in `testCreateDefault`
