### PR TITLE
test: migrate CodeFactoryTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.factory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.code.CtTypeAccess;
@@ -27,9 +27,9 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class CodeFactoryTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testThisAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreateVariableAssignement`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testThisAccess`
- Transformed junit4 assert to junit 5 assertion in `testCreateVariableAssignement`