### PR TITLE
test: migrate AnnotationFactoryTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/factory/AnnotationFactoryTest.java
+++ b/src/test/java/spoon/test/factory/AnnotationFactoryTest.java
@@ -16,15 +16,15 @@
  */
 package spoon.test.factory;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.factory.AnnotationFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class AnnotationFactoryTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotate`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testAnnotate`