### PR TITLE
test: migrate to ExecutableTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -16,7 +16,10 @@
  */
 package spoon.test.executable;
 
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.ContractVerifier;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -33,11 +36,9 @@ import spoon.test.executable.testclasses.Pozole;
 import spoon.test.executable.testclasses.WithEnum;
 import spoon.testing.utils.ModelUtils;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ExecutableTest {
 	@Test


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testInfoInsideAnonymousExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBlockInExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testShadowValueOf`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testInfoInsideAnonymousExecutable`
- Transformed junit4 assert to junit 5 assertion in `testBlockInExecutable`
- Transformed junit4 assert to junit 5 assertion in `testGetReference`
- Transformed junit4 assert to junit 5 assertion in `testShadowValueOf`