### PR TITLE
test: migrate ExecutableRefTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/executable/ExecutableRefTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableRefTest.java
@@ -16,7 +16,12 @@
  */
 package spoon.test.executable;
 
-import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtBlock;
@@ -37,13 +42,9 @@ import spoon.test.executable.testclasses.MyIntf;
 import spoon.test.executable.testclasses.Pozole;
 import spoon.testing.utils.ModelUtils;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `methodTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `constructorTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetActualClassTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSameTypeInConstructorCallBetweenItsObjectAndItsExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testOverridingMethod`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `methodTest`
- Transformed junit4 assert to junit 5 assertion in `constructorTest`
- Transformed junit4 assert to junit 5 assertion in `testGetActualClassTest`
- Transformed junit4 assert to junit 5 assertion in `testSameTypeInConstructorCallBetweenItsObjectAndItsExecutable`
- Transformed junit4 assert to junit 5 assertion in `getInvocationFromMethod`
- Transformed junit4 assert to junit 5 assertion in `testOverridingMethod`