### PR TITLE
test: migrate to ExceptionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/exceptions/ExceptionTest.java
+++ b/src/test/java/spoon/test/exceptions/ExceptionTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.exceptions;
 
-import org.junit.Test;
+
+import java.io.FileNotFoundException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.InvalidClassPathException;
@@ -28,11 +32,9 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import java.io.FileNotFoundException;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class ExceptionTest {
@@ -108,19 +110,16 @@ public class ExceptionTest {
 		}
 	}
 
-	@Test(expected = ModelBuildingException.class)
-	public void testExceptionDuplicateClass() throws Exception {
+	@Test
+	public void testExceptionDuplicateClass() throws Exception{
+		assertThrows(ModelBuildingException.class, () -> {
 			Launcher spoon = new Launcher();
 			Factory factory = spoon.createFactory();
-
 			// contains twice the same class in the same package
 			// an exception should be thrown, even in noclasspath mode
-			spoon.createCompiler(
-					factory,
-					SpoonResourceHelper
-							.resources("./src/test/resources/spoon/test/duplicateclasses/Foo.java", "./src/test/resources/spoon/test/duplicateclasses/Bar.java"))
-					.build();
-	}
+			spoon.createCompiler(factory, SpoonResourceHelper.resources("./src/test/resources/spoon/test/duplicateclasses/Foo.java", "./src/test/resources/spoon/test/duplicateclasses/Bar.java")).build();
+		});
+	} 
 
 	@Test
 	public void testUnionCatchExceptionInsideLambdaInNoClasspath() {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## ExpectedException
The expected annotation value should be removed from test methods, and replaced with JUnit 5 `assertThrows`.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testExceptionIfNotCompilable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExceptionNoFile`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExceptionInSnippet`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExceptionInvalidAPI`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExceptionDuplicateClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnionCatchExceptionInsideLambdaInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIssue2860`
### ExpectedException
- Removed expected annotation from test method `testExceptionDuplicateClass`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testExceptionIfNotCompilable`
- Transformed junit4 assert to junit 5 assertion in `testExceptionNoFile`
- Transformed junit4 assert to junit 5 assertion in `testExceptionInSnippet`
- Transformed junit4 assert to junit 5 assertion in `testExceptionInvalidAPI`
- Transformed junit4 assert to junit 5 assertion in `testUnionCatchExceptionInsideLambdaInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testIssue2860`