### PR TITLE
test: migrate EnumsTypeTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/enums/EnumsTypeTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTypeTest.java
@@ -16,12 +16,10 @@
  */
 package spoon.test.enums;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.Launcher;
 import spoon.compiler.SpoonResource;
@@ -33,6 +31,9 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class EnumsTypeTest {
 


### PR DESCRIPTION
@SirYwell
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testEnumsType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEnumsFromInterface`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testEnumsType`
- Transformed junit4 assert to junit 5 assertion in `testEnumsFromInterface`