### PR TITLE
test: migrate FieldFactoryTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/factory/FieldFactoryTest.java
+++ b/src/test/java/spoon/test/factory/FieldFactoryTest.java
@@ -16,7 +16,11 @@
  */
 package spoon.test.factory;
 
-import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -29,11 +33,8 @@ import spoon.test.targeted.testclasses.Bar;
 import spoon.test.targeted.testclasses.Foo;
 import spoon.test.targeted.testclasses.SuperClass;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class FieldFactoryTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreate`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreateFromSource`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testCreate`
- Transformed junit4 assert to junit 5 assertion in `testCreateFromSource`