### PR TITLE
test: migrate FieldAccessTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -16,7 +16,12 @@
  */
 package spoon.test.fieldaccesses;
 
-import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtArrayWrite;
 import spoon.reflect.code.CtCodeSnippetExpression;
@@ -42,28 +47,24 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
-import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.ImportConflictDetector;
+import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.fieldaccesses.testclasses.B;
 import spoon.test.fieldaccesses.testclasses.Kuu;
 import spoon.test.fieldaccesses.testclasses.Mouse;
+import spoon.test.fieldaccesses.testclasses.MyClass;
 import spoon.test.fieldaccesses.testclasses.Panini;
 import spoon.test.fieldaccesses.testclasses.Pozole;
 import spoon.test.fieldaccesses.testclasses.Tacos;
-import spoon.test.fieldaccesses.testclasses.MyClass;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.logging.Logger;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.Assert.assertThat;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -166,9 +167,9 @@ public class FieldAccessTest {
 		assertEquals("BUG20160112", type.getSimpleName());
 		CtOperatorAssignment<?, ?> ass = type.getElements(
 				new TypeFilter<CtOperatorAssignment<?, ?>>(CtOperatorAssignment.class)).get(0);
-		assertNotNull("z+=a.us", ass);
+		assertNotNull(ass, "z+=a.us");
 		CtExpression<?> righthand = ass.getAssignment();
-		assertTrue("a.us should be CtFieldRead", righthand instanceof CtFieldRead);
+		assertTrue(righthand instanceof CtFieldRead, "a.us should be CtFieldRead");
 	}
 
 	@Test


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingFieldAccesses`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBCUBug20140402`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBUG20160112`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTargetedAccessPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessInLambda`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessInAnonymousClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIncrementationOnAVarIsAUnaryOperator`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldWriteWithPlusEqualsOperation`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeDeclaredInAnonymousClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessDeclaredInADefaultClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeOfFieldAccess`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessWithoutAnyImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessOnUnknownType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessAutoExplicit`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFieldAccessWithParenthesis`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingFieldAccesses`
- Transformed junit4 assert to junit 5 assertion in `testBCUBug20140402`
- Transformed junit4 assert to junit 5 assertion in `testBUG20160112`
- Transformed junit4 assert to junit 5 assertion in `testTargetedAccessPosition`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccess`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessInLambda`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessInAnonymousClass`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testIncrementationOnAVarIsAUnaryOperator`
- Transformed junit4 assert to junit 5 assertion in `testFieldWriteWithPlusEqualsOperation`
- Transformed junit4 assert to junit 5 assertion in `testTypeDeclaredInAnonymousClass`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessDeclaredInADefaultClass`
- Transformed junit4 assert to junit 5 assertion in `testTypeOfFieldAccess`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessWithoutAnyImport`
- Transformed junit4 assert to junit 5 assertion in `visitCtFieldWrite`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessOnUnknownType`
- Transformed junit4 assert to junit 5 assertion in `testGetReference`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessAutoExplicit`
- Transformed junit4 assert to junit 5 assertion in `testFieldAccessWithParenthesis`
