### PR TITLE
test: migrate GenericsTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/generics/GenericsTest.java
+++ b/src/test/java/spoon/test/generics/GenericsTest.java
@@ -16,7 +16,13 @@
  */
 package spoon.test.generics;
 
-import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.ContractVerifier;
 import spoon.Launcher;
 import spoon.SpoonModelBuilder;
@@ -65,15 +71,6 @@ import spoon.test.ctType.testclasses.ErasureModelA;
 import spoon.test.generics.testclasses.Banana;
 import spoon.test.generics.testclasses.CelebrationLunch;
 import spoon.test.generics.testclasses.CelebrationLunch.WeddingLunch;
-import spoon.test.generics.testclasses2.LikeCtClass;
-import spoon.test.generics.testclasses2.LikeCtClassImpl;
-import spoon.test.generics.testclasses2.SameSignature2;
-import spoon.test.generics.testclasses2.SameSignature3;
-import spoon.test.generics.testclasses3.Bar;
-import spoon.test.generics.testclasses3.ClassThatBindsAGenericType;
-import spoon.test.generics.testclasses3.ClassThatDefinesANewTypeArgument;
-import spoon.test.generics.testclasses3.Foo;
-import spoon.test.generics.testclasses3.GenericConstructor;
 import spoon.test.generics.testclasses.EnumSetOf;
 import spoon.test.generics.testclasses.FakeTpl;
 import spoon.test.generics.testclasses.Lunch;
@@ -85,22 +82,27 @@ import spoon.test.generics.testclasses.Panini;
 import spoon.test.generics.testclasses.SameSignature;
 import spoon.test.generics.testclasses.Spaghetti;
 import spoon.test.generics.testclasses.Tacos;
+import spoon.test.generics.testclasses2.LikeCtClass;
+import spoon.test.generics.testclasses2.LikeCtClassImpl;
+import spoon.test.generics.testclasses2.SameSignature2;
+import spoon.test.generics.testclasses2.SameSignature3;
+import spoon.test.generics.testclasses3.Bar;
+import spoon.test.generics.testclasses3.ClassThatBindsAGenericType;
+import spoon.test.generics.testclasses3.ClassThatDefinesANewTypeArgument;
+import spoon.test.generics.testclasses3.Foo;
+import spoon.test.generics.testclasses3.GenericConstructor;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.EnumSet;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.buildNoClasspath;
@@ -383,11 +385,11 @@ public class GenericsTest {
 		final List<CtTypeParameter> barTypeParamGenerics = bar.getFormalCtTypeParameters();
 		final CtTypeReference<?> anonymousBar = newAnonymousBar.getType();
 
-		assertEquals("Name of the first generic parameter in Bar interface must to be I.", "I", barTypeParamGenerics.get(0).getSimpleName());
-		assertEquals("Name of the first generic parameter in Bar usage must to be K.", "K", anonymousBar.getActualTypeArguments().get(0).getSimpleName());
+		assertEquals("I", barTypeParamGenerics.get(0).getSimpleName(), "Name of the first generic parameter in Bar interface must to be I.");
+		assertEquals("K", anonymousBar.getActualTypeArguments().get(0).getSimpleName(), "Name of the first generic parameter in Bar usage must to be K.");
 
-		assertEquals("Name of the second generic parameter in Bar interface must to be O.", "O", barTypeParamGenerics.get(1).getSimpleName());
-		assertEquals("Name of the second generic parameter in Bar usage must to be V.", "V", anonymousBar.getActualTypeArguments().get(1).getSimpleName());
+		assertEquals("O", barTypeParamGenerics.get(1).getSimpleName(), "Name of the second generic parameter in Bar interface must to be O.");
+		assertEquals("V", anonymousBar.getActualTypeArguments().get(1).getSimpleName(), "Name of the second generic parameter in Bar usage must to be V.");
 	}
 
 	@Test
@@ -697,7 +699,7 @@ public class GenericsTest {
 		assertFalse(genericTypeRef.getActualTypeArguments().isEmpty());
 		assertEquals(aTacos.getFormalCtTypeParameters().size(), genericTypeRef.getActualTypeArguments().size());
 		for(int i=0; i<aTacos.getFormalCtTypeParameters().size(); i++) {
-			assertSame("TypeParameter reference idx="+i+" is different", aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
+			assertSame(aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration(), "TypeParameter reference idx=" + i + " is different");
 
 			// contract: getTypeParameterDeclaration goes back to the declaration, even without context
 			assertSame(aTacos.getFormalCtTypeParameters().get(i), genericTypeRef.getActualTypeArguments().get(i).getTypeParameterDeclaration());
@@ -896,17 +898,17 @@ public class GenericsTest {
 				+ "spoon.test.generics.testclasses.Paella, "
 				+ "X"
 				+ ">",trWeddingLunch_Mole.getSuperclass().toString());
-		//future suggested behavior of CtTypeReference#getSuperclass() - the 3rd argument is Mole.
-//		assertEquals("spoon.test.generics.testclasses.CelebrationLunch<"
-//				+ "spoon.test.generics.testclasses.Tacos, "
-//				+ "spoon.test.generics.testclasses.Paella, "
-//				+ "spoon.test.generics.testclasses.Mole"
-//				+ ">",trWeddingLunch_Mole.getSuperclass().toString());
-		//future suggested behavior of CtTypeReference#getSuperclass() 
-//		assertEquals("spoon.test.generics.testclasses.Lunch<"
-//				+ "spoon.test.generics.testclasses.Mole, "
-//				+ "spoon.test.generics.testclasses.Tacos"
-//				+ ">",trWeddingLunch_Mole.getSuperclass().getSuperclass().toString());
+		// future suggested behavior of CtTypeReference#getSuperclass() - the 3rd argument is Mole.
+		// assertEquals("spoon.test.generics.testclasses.CelebrationLunch<"
+		// + "spoon.test.generics.testclasses.Tacos, "
+		// + "spoon.test.generics.testclasses.Paella, "
+		// + "spoon.test.generics.testclasses.Mole"
+		// + ">",trWeddingLunch_Mole.getSuperclass().toString());
+		// future suggested behavior of CtTypeReference#getSuperclass()
+		// assertEquals("spoon.test.generics.testclasses.Lunch<"
+		// + "spoon.test.generics.testclasses.Mole, "
+		// + "spoon.test.generics.testclasses.Tacos"
+		// + ">",trWeddingLunch_Mole.getSuperclass().getSuperclass().toString());
 	}
 
 	@Test


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testBugComparableComparator`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingTree`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingGenericConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDiamond2`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDiamond1`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingSimilarSignatureMethods`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeParameterReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeParameterDeclarer`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericMethodCallWithExtend`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBugCommonCollection`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRecursiveUpperBound`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInstanceOfMapEntryGeneric`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAccessToGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testConstructorCallGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInvocationGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNewClassGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodsWithGenericsWhoExtendsObject`
- Replaced junit 4 test annotation with junit 5 test annotation in `testName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericWithExtendsInDeclaration`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericInField`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericsInQualifiedNameInConstructorCall`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericsOnLocalType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericsInConstructorCall`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWildcard`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDeclarationOnGenericReturnType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeclarationOfTypeParameterReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsGenericsMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeParameterReferenceAsActualTypeArgument`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericTypeReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testisGeneric`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtTypeReference_getSuperclass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeAdapted`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClassTypingContext`
- Replaced junit 4 test annotation with junit 5 test annotation in `testRecursiveTypeAdapting`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodTypingContext`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodTypingContextAdaptMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClassTypingContextMethodSignature`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClassContextOnInnerClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWildCardonShadowClass`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDiamondComplexGenericsRxJava`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDeclarationOfTypeParameterReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsSameSignatureWithGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsSameSignatureWithMethodGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetExecDeclarationOfEnumSetOf`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsSameSignatureWithReferencedGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsGenericTypeEqual`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCannotAdaptTypeOfNonTypeScope`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGenericsOverriding`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDeepGenericsInExecutableReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTopLevelIsGenerics`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIsParameterized`
- Replaced junit 4 test annotation with junit 5 test annotation in `testExecutableTypeParameter`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testBugComparableComparator`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingTree`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingGenericConstructor`
- Transformed junit4 assert to junit 5 assertion in `testDiamond2`
- Transformed junit4 assert to junit 5 assertion in `testDiamond1`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingSimilarSignatureMethods`
- Transformed junit4 assert to junit 5 assertion in `testTypeParameterReference`
- Transformed junit4 assert to junit 5 assertion in `testTypeParameterDeclarer`
- Transformed junit4 assert to junit 5 assertion in `testGenericMethodCallWithExtend`
- Transformed junit4 assert to junit 5 assertion in `testBugCommonCollection`
- Transformed junit4 assert to junit 5 assertion in `testRecursiveUpperBound`
- Transformed junit4 assert to junit 5 assertion in `testInstanceOfMapEntryGeneric`
- Transformed junit4 assert to junit 5 assertion in `testAccessToGenerics`
- Transformed junit4 assert to junit 5 assertion in `testConstructorCallGenerics`
- Transformed junit4 assert to junit 5 assertion in `testInvocationGenerics`
- Transformed junit4 assert to junit 5 assertion in `testNewClassGenerics`
- Transformed junit4 assert to junit 5 assertion in `testMethodsWithGenericsWhoExtendsObject`
- Transformed junit4 assert to junit 5 assertion in `testName`
- Transformed junit4 assert to junit 5 assertion in `testGenericWithExtendsInDeclaration`
- Transformed junit4 assert to junit 5 assertion in `testGenericInField`
- Transformed junit4 assert to junit 5 assertion in `testGenericsInQualifiedNameInConstructorCall`
- Transformed junit4 assert to junit 5 assertion in `testGenericsOnLocalType`
- Transformed junit4 assert to junit 5 assertion in `testGenericsInConstructorCall`
- Transformed junit4 assert to junit 5 assertion in `testWildcard`
- Transformed junit4 assert to junit 5 assertion in `testGetDeclarationOnGenericReturnType`
- Transformed junit4 assert to junit 5 assertion in `testDeclarationOfTypeParameterReference`
- Transformed junit4 assert to junit 5 assertion in `testIsGenericsMethod`
- Transformed junit4 assert to junit 5 assertion in `testTypeParameterReferenceAsActualTypeArgument`
- Transformed junit4 assert to junit 5 assertion in `testGenericTypeReference`
- Transformed junit4 assert to junit 5 assertion in `testisGeneric`
- Transformed junit4 assert to junit 5 assertion in `testCtTypeReference_getSuperclass`
- Transformed junit4 assert to junit 5 assertion in `testTypeAdapted`
- Transformed junit4 assert to junit 5 assertion in `testClassTypingContext`
- Transformed junit4 assert to junit 5 assertion in `testRecursiveTypeAdapting`
- Transformed junit4 assert to junit 5 assertion in `testMethodTypingContext`
- Transformed junit4 assert to junit 5 assertion in `testMethodTypingContextAdaptMethod`
- Transformed junit4 assert to junit 5 assertion in `testClassTypingContextMethodSignature`
- Transformed junit4 assert to junit 5 assertion in `testClassContextOnInnerClass`
- Transformed junit4 assert to junit 5 assertion in `checkFakeTpl`
- Transformed junit4 assert to junit 5 assertion in `testDiamondComplexGenericsRxJava`
- Transformed junit4 assert to junit 5 assertion in `testGetDeclarationOfTypeParameterReference`
- Transformed junit4 assert to junit 5 assertion in `testIsSameSignatureWithGenerics`
- Transformed junit4 assert to junit 5 assertion in `testIsSameSignatureWithMethodGenerics`
- Transformed junit4 assert to junit 5 assertion in `testGetExecDeclarationOfEnumSetOf`
- Transformed junit4 assert to junit 5 assertion in `testIsSameSignatureWithReferencedGenerics`
- Transformed junit4 assert to junit 5 assertion in `testIsGenericTypeEqual`
- Transformed junit4 assert to junit 5 assertion in `testCannotAdaptTypeOfNonTypeScope`
- Transformed junit4 assert to junit 5 assertion in `testGenericsOverriding`
- Transformed junit4 assert to junit 5 assertion in `testDeepGenericsInExecutableReference`
- Transformed junit4 assert to junit 5 assertion in `testTopLevelIsGenerics`
- Transformed junit4 assert to junit 5 assertion in `testIsParameterized`
- Transformed junit4 assert to junit 5 assertion in `testExecutableTypeParameter`