### PR TITLE
test: migrate StaticNoOrdered to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/imports/testclasses/StaticNoOrdered.java
+++ b/src/test/java/spoon/test/imports/testclasses/StaticNoOrdered.java
@@ -1,11 +1,12 @@
 package spoon.test.imports.testclasses;
 
-
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import static java.nio.charset.Charset.forName;
 import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
+
+import org.junit.Test;
+
+import static java.nio.charset.Charset.forName;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testMachin`

Is this even a testclass?