### PR TITLE
test: migrate InitializerTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/initializers/InitializerTest.java
+++ b/src/test/java/spoon/test/initializers/InitializerTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.initializers;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
@@ -29,9 +29,9 @@ import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.imports.ImportTest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class InitializerTest {
@@ -48,8 +48,11 @@ public class InitializerTest {
 		assertEquals(1, staticBlock.getBody().getStatements().size());
 
 		// this fails: regression or known bug?
+
 		// RP: this look OK. Spoon adds the full path
+
 		// assertEquals("InternalClass.tmp = \"nop\"",
+
 		// staticBlock.getBody().getStatements().get(0).toString());
 	}
 

--- a/src/test/java/spoon/test/initializers/InitializerTest.java
+++ b/src/test/java/spoon/test/initializers/InitializerTest.java
@@ -46,14 +46,6 @@ public class InitializerTest {
 		CtAnonymousExecutable staticBlock = type.getElements(new TypeFilter<>(CtAnonymousExecutable.class)).get(0);
 		assertTrue(staticBlock.getModifiers().contains(ModifierKind.STATIC));
 		assertEquals(1, staticBlock.getBody().getStatements().size());
-
-		// this fails: regression or known bug?
-
-		// RP: this look OK. Spoon adds the full path
-
-		// assertEquals("InternalClass.tmp = \"nop\"",
-
-		// staticBlock.getBody().getStatements().get(0).toString());
 	}
 
 	@Test


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingStaticInitializer`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingInitializer`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModelBuildingInitializerNoclasspath`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingStaticInitializer`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingInitializer`
- Transformed junit4 assert to junit 5 assertion in `testModelBuildingInitializerNoclasspath`