### PR TITLE
test: migrate RemoveTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/intercession/RemoveTest.java
+++ b/src/test/java/spoon/test/intercession/RemoveTest.java
@@ -16,18 +16,19 @@
  */
 package spoon.test.intercession;
 
-import static org.junit.Assert.assertEquals;
-import static spoon.testing.utils.ModelUtils.createFactory;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class RemoveTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testRemoveAllStatements`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testRemoveAllStatements`