### PR TITLE
test: migrate CUFilterTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/filters/CUFilterTest.java
+++ b/src/test/java/spoon/test/filters/CUFilterTest.java
@@ -16,14 +16,14 @@
  */
 package spoon.test.filters;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtReturn;
 import spoon.support.compiler.jdt.CompilationUnitFilter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CUFilterTest {
 


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

#3919 
## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithoutFilters`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSingleExcludeWithFilter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSingleExcludeWithoutFilter`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testWithoutFilters`
- Transformed junit4 assert to junit 5 assertion in `testSingleExcludeWithFilter`
- Transformed junit4 assert to junit 5 assertion in `testSingleExcludeWithoutFilter`