### PR TITLE
test: migrate TypeFactoryTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/factory/TypeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/TypeFactoryTest.java
@@ -14,8 +14,12 @@
  */
 package spoon.test.factory;
 
+
 import com.mysema.query.types.expr.ComparableExpressionBase;
-import org.junit.Test;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.declaration.CtMethod;
@@ -27,12 +31,10 @@ import spoon.test.factory.testclasses3.Cooking;
 import spoon.test.factory.testclasses3.Prepare;
 import spoon.testing.utils.ModelUtils;
 
-import java.io.File;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypeFactoryTest {
@@ -63,10 +65,6 @@ public class TypeFactoryTest {
 		assertAll(
 			() -> assertEquals("String", s.getSimpleName()),
 			() -> assertEquals("java.lang.String", s.getQualifiedName()),
-			/*
-			In java 12 string got 2 new interfaces (see https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/String.html)
-			Constable, ConstantDesc. To support the CI with jdk8 and newer CIs for local testing this assertion is needed.
-			*/
 			() -> assertTrue(3 == s.getSuperInterfaces().size() || 5 == s.getSuperInterfaces().size()),
 			() -> assertEquals(2, s.getMethodsByName("toLowerCase").size()));
 	}

--- a/src/test/java/spoon/test/factory/TypeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/TypeFactoryTest.java
@@ -65,6 +65,10 @@ public class TypeFactoryTest {
 		assertAll(
 			() -> assertEquals("String", s.getSimpleName()),
 			() -> assertEquals("java.lang.String", s.getQualifiedName()),
+			/*
+			In java 12 string got 2 new interfaces (see https://docs.oracle.com/en/java/javase/12/docs/api/java.base/java/lang/String.html)
+			Constable, ConstantDesc. To support the CI with jdk8 and newer CIs for local testing this assertion is needed.
+			*/
 			() -> assertTrue(3 == s.getSuperInterfaces().size() || 5 == s.getSuperInterfaces().size()),
 			() -> assertEquals(2, s.getMethodsByName("toLowerCase").size()));
 	}


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCreateTypeRef`
- Replaced junit 4 test annotation with junit 5 test annotation in `reflectionAPI`
- Replaced junit 4 test annotation with junit 5 test annotation in `reflectionAPIWithTypeParameter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetClassInAnInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetClassWithDollarAndNestedClass`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testCreateTypeRef`
- Transformed junit4 assert to junit 5 assertion in `reflectionAPI`
- Transformed junit4 assert to junit 5 assertion in `reflectionAPIWithTypeParameter`
- Transformed junit4 assert to junit 5 assertion in `testGetClassInAnInterface`
- Transformed junit4 assert to junit 5 assertion in `testGetClassWithDollarAndNestedClass`