### PR TITLE
test: migrate NameScopeTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/imports/name_scope/NameScopeTest.java
+++ b/src/test/java/spoon/test/imports/name_scope/NameScopeTest.java
@@ -16,7 +16,14 @@
  */
 package spoon.test.imports.name_scope;
 
-import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtElement;
@@ -30,16 +37,10 @@ import spoon.reflect.visitor.chain.ScanningMode;
 import spoon.test.imports.name_scope.testclasses.Renata;
 import spoon.testing.utils.ModelUtils;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class NameScopeTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testNameScopeScanner`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testNameScopeScanner`
- Transformed junit4 assert to junit 5 assertion in `checkThatScopeContains`