### PR TITLE
test: migrate IntercessionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -16,8 +16,14 @@
  */
 package spoon.test.intercession;
 
-import org.junit.Ignore;
-import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAssignment;
@@ -45,16 +51,11 @@ import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.support.UnsettableProperty;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class IntercessionTest {
@@ -251,7 +252,7 @@ public class IntercessionTest {
 	}
 
 	@Test
-	@Ignore // interesting but too fragile with conventions
+	@Disabled // interesting but too fragile with conventions
 	public void testResetCollectionInSetters() {
 		final Launcher launcher = new Launcher();
 		launcher.setArgs(new String[] {"--output-type", "nooutput" });


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Ignore
The JUnit 4 `@Ignore` annotation should be replaced with JUnit 5 `@Disabled` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertBegin`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertEnd`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEqualConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_setThrownExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertIfIntercession`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertAfter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSettersAreAllGood`
- Replaced junit 4 test annotation with junit 5 test annotation in `testResetCollectionInSetters`
### Junit4-@Ignore
- Replaced `@Ignore` annotation with `@Disabled` at method `testResetCollectionInSetters`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testInsertBegin`
- Transformed junit4 assert to junit 5 assertion in `testInsertEnd`
- Transformed junit4 assert to junit 5 assertion in `testEqualConstructor`
- Transformed junit4 assert to junit 5 assertion in `test_setThrownExpression`
- Transformed junit4 assert to junit 5 assertion in `testInsertIfIntercession`
- Transformed junit4 assert to junit 5 assertion in `testInsertAfter`
- Transformed junit4 assert to junit 5 assertion in `testSettersAreAllGood`
- Transformed junit4 assert to junit 5 assertion in `process`