### PR TITLE
test: migrate InsertMethodsTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/intercession/insertBefore/InsertMethodsTest.java
+++ b/src/test/java/spoon/test/intercession/insertBefore/InsertMethodsTest.java
@@ -16,8 +16,11 @@
  */
 package spoon.test.intercession.insertBefore;
 
-import org.junit.Before;
-import org.junit.Test;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.code.CtBlock;
@@ -36,13 +39,11 @@ import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class InsertMethodsTest {
 
@@ -50,7 +51,7 @@ public class InsertMethodsTest {
 	private CtClass<?> assignmentClass;
 	private CtClass<?> insertExampleClass;
 
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		Launcher spoon = new Launcher();
 		factory = spoon.createFactory();


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertBefore`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertAfter`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertBeforeWithoutBrace`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertBeforeWithBrace`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertAfterWithoutBrace`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertAfterWithBrace`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertBeforeSwitchCase`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInsertAfterSwitchCase`
- Replaced junit 4 test annotation with junit 5 test annotation in `insertBeforeAndUpdateParent`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setup`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testInsertBefore`
- Transformed junit4 assert to junit 5 assertion in `testInsertAfter`
- Transformed junit4 assert to junit 5 assertion in `testInsertBeforeWithoutBrace`
- Transformed junit4 assert to junit 5 assertion in `testInsertBeforeWithBrace`
- Transformed junit4 assert to junit 5 assertion in `testInsertAfterWithoutBrace`
- Transformed junit4 assert to junit 5 assertion in `testInsertAfterWithBrace`
- Transformed junit4 assert to junit 5 assertion in `testInsertBeforeSwitchCase`
- Transformed junit4 assert to junit 5 assertion in `testInsertAfterSwitchCase`
- Transformed junit4 assert to junit 5 assertion in `insertBeforeAndUpdateParent`
