### PR TITLE
fix: fix qodana warning with proper call to Array.toString()

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -721,7 +721,7 @@ public class ElementSourceFragment implements SourceFragment {
 			}
 			// nothing has matched, best effort token
 			if (longestMatcher == null) {
-				// this case only exists currently because we have problems with sniper printing and joint variable declarations
+				consumer.accept(new TokenSourceFragment(str.toString(), TokenType.CODE_SNIPPET));
 				return;
 			}
 			consumer.accept(new TokenSourceFragment(longestMatcher.toString(), longestMatcher.getType()));

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.sniper.internal;
 
+
 import spoon.SpoonException;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLiteral;
@@ -29,6 +30,7 @@ import spoon.reflect.visitor.EarlyTerminatingScanner;
 import spoon.support.Experimental;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.cu.position.SourcePositionImpl;
+
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -338,7 +340,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT
+		OTHER_IS_PARENT;
 	}
 
 	/**
@@ -720,7 +722,7 @@ public class ElementSourceFragment implements SourceFragment {
 			}
 			// nothing has matched, best effort token
 			if (longestMatcher == null) {
-				consumer.accept(new TokenSourceFragment(str.toString(), TokenType.CODE_SNIPPET));
+				consumer.accept(new TokenSourceFragment(Arrays.toString(str), TokenType.CODE_SNIPPET));
 				return;
 			}
 			consumer.accept(new TokenSourceFragment(longestMatcher.toString(), longestMatcher.getType()));

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -694,14 +694,14 @@ public class ElementSourceFragment implements SourceFragment {
 			consumer.accept(new TokenSourceFragment(buff.toString(), TokenType.SPACE));
 			return;
 		}
-		char[] str = new char[buff.length()];
-		buff.getChars(0, buff.length(), str, 0);
+		char[] charArray = new char[buff.length()];
+		buff.getChars(0, buff.length(), charArray, 0);
 		int off = 0;
-		while (off < str.length) {
+		while (off < charArray.length) {
 			//detect java identifier or keyword
-			int lenOfIdentifier = detectJavaIdentifier(str, off);
+			int lenOfIdentifier = detectJavaIdentifier(charArray, off);
 			if (lenOfIdentifier > 0) {
-				String identifier = new String(str, off, lenOfIdentifier);
+				String identifier = new String(charArray, off, lenOfIdentifier);
 				if (javaKeywords.contains(identifier)) {
 					//it is a java keyword
 					consumer.accept(new TokenSourceFragment(identifier, TokenType.KEYWORD));
@@ -715,13 +715,13 @@ public class ElementSourceFragment implements SourceFragment {
 			//detect longest match in matchers
 			StringMatcher longestMatcher = null;
 			for (StringMatcher strMatcher : matchers) {
-				if (strMatcher.isMatch(str, off)) {
+				if (strMatcher.isMatch(charArray, off)) {
 					longestMatcher = strMatcher.getLonger(longestMatcher);
 				}
 			}
 			// nothing has matched, best effort token
 			if (longestMatcher == null) {
-				consumer.accept(new TokenSourceFragment(Arrays.toString(str), TokenType.CODE_SNIPPET));
+				consumer.accept(new TokenSourceFragment(Arrays.toString(charArray), TokenType.CODE_SNIPPET));
 				return;
 			}
 			consumer.accept(new TokenSourceFragment(longestMatcher.toString(), longestMatcher.getType()));

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -721,7 +721,7 @@ public class ElementSourceFragment implements SourceFragment {
 			}
 			// nothing has matched, best effort token
 			if (longestMatcher == null) {
-				consumer.accept(new TokenSourceFragment(Arrays.toString(charArray), TokenType.CODE_SNIPPET));
+				// this case only exists currently because we have problems with sniper printing and joint variable declarations
 				return;
 			}
 			consumer.accept(new TokenSourceFragment(longestMatcher.toString(), longestMatcher.getType()));

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -721,7 +721,7 @@ public class ElementSourceFragment implements SourceFragment {
 			}
 			// nothing has matched, best effort token
 			if (longestMatcher == null) {
-				consumer.accept(new TokenSourceFragment(str.toString(), TokenType.CODE_SNIPPET));
+				consumer.accept(new TokenSourceFragment(Arrays.toString(charArray), TokenType.CODE_SNIPPET));
 				return;
 			}
 			consumer.accept(new TokenSourceFragment(longestMatcher.toString(), longestMatcher.getType()));

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -31,7 +31,6 @@ import spoon.support.Experimental;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.reflect.cu.position.SourcePositionImpl;
 
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -340,7 +339,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT;
+		OTHER_IS_PARENT
 	}
 
 	/**


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## ArraysToString
`array.toString()` is not the best way to print an array. Use `Arrays.toString(array)` instead.
- https://rules.sonarsource.com/java/RSPEC-2116

## The following has changed in the code:
### ArraysToString
- Replaced `str.toString()` with `Arrays.toString(str)`.