### PR TITLE
refactor: String.equals("") instead  of String.isEmpty()

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -29,7 +29,6 @@ import spoon.compiler.SpoonFolder;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
 
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.compiler;
 
-import org.slf4j.Logger;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.BuildBase;
 import org.apache.maven.model.Model;
@@ -21,6 +20,7 @@ import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
 import spoon.Launcher;
 import spoon.MavenLauncher;
 import spoon.SpoonException;
@@ -28,6 +28,7 @@ import spoon.compiler.Environment;
 import spoon.compiler.SpoonFolder;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
+
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -503,7 +504,7 @@ public class SpoonPom implements SpoonResource {
 					sb.append(line);
 					line = br.readLine();
 				}
-				if (!"".equals(sb.toString())) {
+				if (!sb.toString().isEmpty()) {
 					String[] classpath = sb.toString().split(File.pathSeparator);
 					for (String cpe : classpath) {
 						if (!classpathElements.contains(cpe)) {


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## EmptyStringCheck
Checking if a string is empty should be done by `String#isEmpty` instead of `String.equals("")`

## The following has changed in the code:
### EmptyStringCheck
- Empty String check was written as `sb.toString().equals("")` and refactored to `sb.toString().isEmpty()`