### PR TITLE
refactor: empty String check

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -28,7 +28,6 @@ import spoon.support.reflect.code.CtStatementImpl;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
 import spoon.support.util.SignatureBasedSortedSet;
 
-
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -28,6 +28,7 @@ import spoon.support.reflect.code.CtStatementImpl;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
 import spoon.support.util.SignatureBasedSortedSet;
 
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -38,8 +39,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static spoon.reflect.path.CtRole.CONSTRUCTOR;
 import static spoon.reflect.path.CtRole.ANNONYMOUS_EXECUTABLE;
+import static spoon.reflect.path.CtRole.CONSTRUCTOR;
 import static spoon.reflect.path.CtRole.SUPER_TYPE;
 
 /**
@@ -173,7 +174,7 @@ public class CtClassImpl<T> extends CtTypeImpl<T> implements CtClass<T> {
 	@Override
 	public boolean isAnonymous() {
 		// case 1: the java.lang.Class convention
-		if ("".equals(getSimpleName())) {
+		if (getSimpleName().isEmpty()) {
 			return true;
 		}
 		// case 2: the Spoon convention (the number in the class file)


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## EmptyStringCheck
Checking if a string is empty should be done by `String#isEmpty` instead of `String.equals("")`

## The following has changed in the code:
### EmptyStringCheck
- Empty String check was written as `getSimpleName().equals("")` and refactored to `getSimpleName().isEmpty()`