### PR TITLE
refactor(FactoryImpl): use ThreadLocal.initialValue

### DIFF
--- a/src/main/java/spoon/reflect/factory/FactoryImpl.java
+++ b/src/main/java/spoon/reflect/factory/FactoryImpl.java
@@ -81,17 +81,18 @@ import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
+import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModule;
-import spoon.reflect.declaration.CtPackageExport;
-import spoon.reflect.declaration.CtProvidedService;
-import spoon.reflect.declaration.CtRecord;
-import spoon.reflect.declaration.CtRecordComponent;
 import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtPackageDeclaration;
+import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtProvidedService;
+import spoon.reflect.declaration.CtRecord;
+import spoon.reflect.declaration.CtRecordComponent;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.declaration.CtUsedService;
@@ -102,19 +103,18 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtFieldReference;
-import spoon.reflect.declaration.CtImport;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtTypeMemberWildcardImportReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.reference.CtWildcardReference;
-import spoon.reflect.reference.CtTypeMemberWildcardImportReference;
 import spoon.reflect.visitor.chain.CtQuery;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.StandardEnvironment;
@@ -402,12 +402,7 @@ public class FactoryImpl implements Factory, Serializable {
 	 * targeted to each Spoon Launching, that could differ a lot by
 	 * frequently used symbols.
 	 */
-	private transient ThreadLocal<Dedup> threadLocalDedup = new ThreadLocal<Dedup>() {
-		@Override
-		protected Dedup initialValue() {
-			return new Dedup();
-		}
-	};
+	private transient ThreadLocal<Dedup> threadLocalDedup = ThreadLocal.withInitial(Dedup::new);
 
 	/**
 	 * Returns a String equal to the given symbol. Performs probablilistic
@@ -433,12 +428,7 @@ public class FactoryImpl implements Factory, Serializable {
 	 * Needed to restore state of transient fields during reading from stream
 	 */
 	private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
-		threadLocalDedup = new ThreadLocal<Dedup>() {
-			@Override
-			protected Dedup initialValue() {
-				return new Dedup();
-			}
-		};
+		threadLocalDedup = ThreadLocal.withInitial(Dedup::new);
 		in.defaultReadObject();
 	}
 


### PR DESCRIPTION
# Change Log
The following bad smells are refactored:
## LambdaInsteadOfExecutableReference
Lambda is used instead of executable reference
- https://rules.sonarsource.com/java/RSPEC-1612
## ThreadLocalWithInitialValue
`ThreadLocal` with initialValue override shall be replaced by `ThreadLocal.withInitialValue`
- https://rules.sonarsource.com/java/RSPEC-4065

## The following has changed in the code:
### ThreadLocalWithInitialValue
- `ThreadLocal` with initialValue `new spoon.reflect.factory.FactoryImpl.Dedup()` was replaced by `ThreadLocal.withInitialValue(java.lang.ThreadLocal.withInitial(() -> new spoon.reflect.factory.FactoryImpl.Dedup()))`
- `ThreadLocal` with initialValue `new spoon.reflect.factory.FactoryImpl.Dedup()` was replaced by `ThreadLocal.withInitialValue(java.lang.ThreadLocal.withInitial(() -> new spoon.reflect.factory.FactoryImpl.Dedup()))`
### LambdaInsteadOfExecutableReference
- Replaced lambda `() -> new spoon.reflect.factory.FactoryImpl.Dedup()` with executable ref `spoon.reflect.factory.FactoryImpl.Dedup::new`
- Replaced lambda `() -> new spoon.reflect.factory.FactoryImpl.Dedup()` with executable ref `spoon.reflect.factory.FactoryImpl.Dedup::new`


The changes in the import statements is simple alphabetic order. Seems strange to me that we don't enforce a real order. 