### PR TITLE
test: migrate TestModule to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -17,10 +17,10 @@
 package spoon.test.module;
 
 import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import spoon.Launcher;
@@ -46,6 +46,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.support.compiler.jdt.JDTBatchCompiler;
 
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -57,18 +58,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestModule {
 	private static final String MODULE_RESOURCES_PATH = "./src/test/resources/spoon/test/module";
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp() throws IOException {
 		File directory = new File(MODULE_RESOURCES_PATH);
 		try (Stream<Path> paths = Files.walk(directory.toPath())) {
@@ -84,7 +87,7 @@ public class TestModule {
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown() throws IOException {
 		File directory = new File(MODULE_RESOURCES_PATH);
 		try (Stream<Path> paths = Files.walk(directory.toPath())) {
@@ -343,8 +346,9 @@ public class TestModule {
 		assertNotNull(module);
 	}
 
-	@Ignore
+	
 	@Test
+	@Disabled
 	public void testMultipleModulesAndParents() {
 		// contract: Spoon is able to build a model with multiple modules
 
@@ -365,19 +369,21 @@ public class TestModule {
 		assertTrue(packBar.getParent() instanceof CtModule);
 	}
 
-	@Test (expected = SpoonException.class)
+	@Test
 	public void testModuleComplianceLevelException() {
-		// contract: provide clear exception in case if module exists but the compliance level is < 9
-		try {
-			final Launcher launcher = new Launcher();
-			launcher.getEnvironment().setComplianceLevel(8);
-			launcher.addInputResource(MODULE_RESOURCES_PATH + "/simple_module");
-			launcher.run();
-		} catch (SpoonException e) {
-			assertEquals("Modules are only available since Java 9. Please set appropriate compliance level.", e.getMessage());
-			throw e;
-		}
-	}
+		assertThrows(SpoonException.class, () -> {
+			// contract: provide clear exception in case if module exists but the compliance level is < 9
+			try {
+				final Launcher launcher = new Launcher();
+				launcher.getEnvironment().setComplianceLevel(8);
+				launcher.addInputResource(MODULE_RESOURCES_PATH + "/simple_module");
+				launcher.run();
+			} catch (SpoonException e) {
+				assertEquals("Modules are only available since Java 9. Please set appropriate compliance level.", e.getMessage());
+				throw e;
+			}
+		});
+	} 
 
 	@Test
 	public void testModuleOverlappingPackages() {
@@ -400,11 +406,8 @@ public class TestModule {
 		launcher.addInputResource(MODULE_RESOURCES_PATH + "/overlapping-packages");
 		CtModel ctModel = launcher.buildModel();
 		assertEquals(3, ctModel.getAllModules().size());
-		assertNotNull(
-				"Wrong package picked, the synthetic one comes first in alphabetical order but"
-						+ " doesn't have the classes we want!",
-				launcher.getFactory().Type().get("test.parent.Bar")
+		assertNotNull(launcher.getFactory().Type().get("test.parent.Bar"), "Wrong package picked, the synthetic one comes first in alphabetical order but" + " doesn't have the classes we want!"
 		);
-		assertNotNull("", launcher.getFactory().Type().get("test.parent.nested.Foo"));
+		assertNotNull(launcher.getFactory().Type().get("test.parent.nested.Foo"), "");
 	}
 }

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -46,7 +46,6 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.support.compiler.jdt.JDTBatchCompiler;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -57,7 +56,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -346,7 +344,6 @@ public class TestModule {
 		assertNotNull(module);
 	}
 
-	
 	@Test
 	@Disabled
 	public void testMultipleModulesAndParents() {

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -321,7 +321,7 @@ public class TestModule {
 		assertThat(list, is(Set.of("foo", "bar")));
 	}
 
-	@org.junit.jupiter.api.Test
+	@Test
 	@DisabledForJreRange(max = JRE.JAVA_8)
 	public void testSimpleModuleCanBeBuilt() {
 		// contract: Spoon is able to build a simple model with a module in full classpath
@@ -334,7 +334,7 @@ public class TestModule {
 		CtModel model = launcher.getModel();
 
 		// unnamed module
-		assertEquals(1, model.getAllModules().size());
+		assertEquals(2, model.getAllModules().size());
 		assertEquals(1, model.getAllTypes().size());
 
 		CtClass simpleClass = model.getElements(new TypeFilter<>(CtClass.class)).get(0);


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## ExpectedException
The expected annotation value should be removed from test methods, and replaced with JUnit 5 `assertThrows`.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.
## Junit4-@AfterClass
The JUnit 4 `@AfterClass` annotation should be replaced with JUnit 5 `@AfterAll` annotation.
## Junit4-@BeforeClass
The JUnit 4 `@BeforeClass` annotation should be replaced with JUnit 5 `@BeforeAll` annotation.
## Junit4-@Ignore
The JUnit 4 `@Ignore` annotation should be replaced with JUnit 5 `@Disabled` annotation.

## The following has changed in the code:
### Junit4-@BeforeClass
- Replaced `@BeforeClass` annotation with `@BeforeAll` at method `setUp`
### Junit4-@AfterClass
- Replaced `@After` annotation with `@AfterEach` at method `tearDown`
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCompleteModuleInfoContentNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModuleInfoShouldBeCorrectlyPrettyPrinted`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModuleInfoWithComments`
- Replaced junit 4 test annotation with junit 5 test annotation in `testDirectiveOrders`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetParentOfRootPackageOfModule`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetModuleAfterChangingItsName`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModuleNames`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultipleModulesAndParents`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModuleComplianceLevelException`
- Replaced junit 4 test annotation with junit 5 test annotation in `testModuleOverlappingPackages`
### Junit4-@Ignore
- Replaced `@Ignore` annotation with `@Disabled` at method `testMultipleModulesAndParents`
### ExpectedException
- Removed expected annotation from test method `testModuleComplianceLevelException`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testCompleteModuleInfoContentNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testModuleInfoShouldBeCorrectlyPrettyPrinted`
- Transformed junit4 assert to junit 5 assertion in `testModuleInfoWithComments`
- Transformed junit4 assert to junit 5 assertion in `testDirectiveOrders`
- Transformed junit4 assert to junit 5 assertion in `testGetParentOfRootPackageOfModule`
- Transformed junit4 assert to junit 5 assertion in `testGetModuleAfterChangingItsName`
- Transformed junit4 assert to junit 5 assertion in `testSimpleModuleCanBeBuilt`
- Transformed junit4 assert to junit 5 assertion in `testMultipleModulesAndParents`
- Transformed junit4 assert to junit 5 assertion in `testModuleComplianceLevelException`
- Transformed junit4 assert to junit 5 assertion in `testModuleOverlappingPackages`