### PR TITLE
test: migrate ModifiersTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/modifiers/ModifiersTest.java
+++ b/src/test/java/spoon/test/modifiers/ModifiersTest.java
@@ -15,8 +15,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 package spoon.test.modifiers;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtField;
@@ -35,10 +34,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ModifiersTest {
 
@@ -223,17 +222,17 @@ public class ModifiersTest {
     }
 
     private void checkCtModifiableHelpersAssertion(CtModifiable element, boolean isPublic, boolean isProtected, boolean isPrivate, boolean isAbstract, boolean isFinal, boolean isStatic, boolean isTransient, boolean isVolatile, boolean isSynchronized, boolean isNative, boolean isStrictfp) {
-        assertEquals("isPublic for "+element+" is wrong", isPublic, element.isPublic());
-        assertEquals("isProtected for "+element+" is wrong", isProtected, element.isProtected());
-        assertEquals("isPrivate for "+element+" is wrong", isPrivate, element.isPrivate());
-        assertEquals("isAbstract for "+element+" is wrong", isAbstract, element.isAbstract());
-        assertEquals("isFinal for "+element+" is wrong", isFinal, element.isFinal());
-        assertEquals("isStatic for "+element+" is wrong", isStatic, element.isStatic());
-        assertEquals("isTransient for "+element+" is wrong", isTransient, element.isTransient());
-        assertEquals("isVolatile for "+element+" is wrong", isVolatile, element.isVolatile());
-        assertEquals("isSynchronized for "+element+" is wrong", isSynchronized, element.isSynchronized());
-        assertEquals("isNative for "+element+" is wrong", isNative, element.isNative());
-        assertEquals("isStrictfp for "+element+" is wrong", isStrictfp, element.isStrictfp());
+        assertEquals(isPublic, element.isPublic(), "isPublic for " + element + " is wrong");
+        assertEquals(isProtected, element.isProtected(), "isProtected for " + element + " is wrong");
+        assertEquals(isPrivate, element.isPrivate(), "isPrivate for " + element + " is wrong");
+        assertEquals(isAbstract, element.isAbstract(), "isAbstract for " + element + " is wrong");
+        assertEquals(isFinal, element.isFinal(), "isFinal for " + element + " is wrong");
+        assertEquals(isStatic, element.isStatic(), "isStatic for " + element + " is wrong");
+        assertEquals(isTransient, element.isTransient(), "isTransient for " + element + " is wrong");
+        assertEquals(isVolatile, element.isVolatile(), "isVolatile for " + element + " is wrong");
+        assertEquals(isSynchronized, element.isSynchronized(), "isSynchronized for " + element + " is wrong");
+        assertEquals(isNative, element.isNative(), "isNative for " + element + " is wrong");
+        assertEquals(isStrictfp, element.isStrictfp(), "isStrictfp for " + element + " is wrong");
     }
 
     @Test

--- a/src/test/java/spoon/test/modifiers/ModifiersTest.java
+++ b/src/test/java/spoon/test/modifiers/ModifiersTest.java
@@ -15,6 +15,7 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 package spoon.test.modifiers;
+
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodWithVarargsDoesNotBecomeTransient`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCtModifiableAddRemoveReturnCtModifiable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSetVisibility`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetModifiersHelpers`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClearModifiersByEmptySet`
- Replaced junit 4 test annotation with junit 5 test annotation in `testClearModifiersByNull`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testMethodWithVarargsDoesNotBecomeTransient`
- Transformed junit4 assert to junit 5 assertion in `testCtModifiableAddRemoveReturnCtModifiable`
- Transformed junit4 assert to junit 5 assertion in `testSetVisibility`
- Transformed junit4 assert to junit 5 assertion in `testGetModifiersHelpers`
- Transformed junit4 assert to junit 5 assertion in `checkCtModifiableHelpersAssertion`
- Transformed junit4 assert to junit 5 assertion in `testClearModifiersByEmptySet`
- Transformed junit4 assert to junit 5 assertion in `testClearModifiersByNull`