### PR TITLE
test: migrate TypeTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -19,7 +19,6 @@ import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.AllTypeMembersFunction;
 
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -6,8 +6,7 @@
  * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
  */
 package spoon.test.model;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.compiler.ModelBuildingException;
 import spoon.reflect.CtModel;
@@ -20,17 +19,19 @@ import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.AllTypeMembersFunction;
 
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
@@ -163,13 +164,15 @@ public class TypeTest {
 		checkIsSomething("generics", ctTypeParam);
 	}
 
-	@Test(expected = ModelBuildingException.class)
+	@Test
 	public void testMultiClassNotEnable() {
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("src/test/resources/multiclass/module1");
-		spoon.addInputResource("src/test/resources/multiclass/module2");
-		spoon.buildModel();
-	}
+		assertThrows(ModelBuildingException.class, () -> {
+			Launcher spoon = new Launcher();
+			spoon.addInputResource("src/test/resources/multiclass/module1");
+			spoon.addInputResource("src/test/resources/multiclass/module2");
+			spoon.buildModel();
+		});
+	} 
 
 	@Test
 	public void testMultiClassEnable() {

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.type;
 
+
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -16,7 +16,6 @@
  */
 package spoon.test.type;
 
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## ExpectedException
The expected annotation value should be removed from test methods, and replaced with JUnit 5 `assertThrows`.
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDifferentElements`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAllTypeMembersFunctionMode`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetUsedTypes`
- Replaced junit 4 test annotation with junit 5 test annotation in `superclassTest`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetUsedTypesForTypeInRootPackage`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDeclaredOrIheritedFieldOnType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDeclaredOrIheritedFieldOnTypeRef`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetDeclaredOrIheritedFieldByReflection`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeInfoIsInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiClassNotEnable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiClassEnable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMultiClassEnableWithStaticFieldAccessToNestedType`
### ExpectedException
- Removed expected annotation from test method `testMultiClassNotEnable`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testGetDifferentElements`
- Transformed junit4 assert to junit 5 assertion in `testAllTypeMembersFunctionMode`
- Transformed junit4 assert to junit 5 assertion in `testGetUsedTypes`
- Transformed junit4 assert to junit 5 assertion in `superclassTest`
- Transformed junit4 assert to junit 5 assertion in `testGetUsedTypesForTypeInRootPackage`
- Transformed junit4 assert to junit 5 assertion in `testGetDeclaredOrIheritedFieldOnType`
- Transformed junit4 assert to junit 5 assertion in `testGetDeclaredOrIheritedFieldOnTypeRef`
- Transformed junit4 assert to junit 5 assertion in `testGetDeclaredOrIheritedFieldByReflection`
- Transformed junit4 assert to junit 5 assertion in `testMultiClassEnable`
- Transformed junit4 assert to junit 5 assertion in `testMultiClassEnableWithStaticFieldAccessToNestedType`
- Transformed junit4 assert to junit 5 assertion in `_checkIsSomething`
