### PR TITLE
test: migrate BlockTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/model/BlockTest.java
+++ b/src/test/java/spoon/test/model/BlockTest.java
@@ -16,14 +16,7 @@
  */
 package spoon.test.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static spoon.testing.utils.ModelUtils.createFactory;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCodeSnippetStatement;
@@ -31,6 +24,13 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class BlockTest {
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testIterationStatements`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddEmptyBlock`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testIterationStatements`
- Transformed junit4 assert to junit 5 assertion in `testAddEmptyBlock`