### PR TITLE
test: migrate MethodReferenceTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
+++ b/src/test/java/spoon/test/methodreference/MethodReferenceTest.java
@@ -16,8 +16,8 @@
  */
 package spoon.test.methodreference;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.OutputType;
 import spoon.SpoonModelBuilder;
@@ -51,19 +51,19 @@ import java.util.List;
 import java.util.function.Supplier;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
 
 public class MethodReferenceTest {
 	private static final String TEST_CLASS = "spoon.test.methodreference.testclasses.Foo.";
 	private CtClass<?> foo;
 
-	@Before
+	@BeforeEach
 	public void setUp() {
 		final Launcher launcher = new Launcher();
 		final Factory factory = launcher.getFactory();
@@ -287,12 +287,12 @@ public class MethodReferenceTest {
 	}
 
 	private void assertTypedBy(Class<?> expected, CtTypeReference<?> type) {
-		assertSame("Method reference must be typed.", expected, type.getActualClass());
+		assertSame(expected, type.getActualClass(), "Method reference must be typed.");
 	}
 
 	private void assertTargetedBy(String expected, CtExpression<?> target) {
-		assertNotNull("Method reference must have a target expression.", target);
-		assertEquals("Target reference correspond to the enclosing class.", expected, target.toString());
+		assertNotNull(target, "Method reference must have a target expression.");
+		assertEquals(expected, target.toString(), "Target reference correspond to the enclosing class.");
 	}
 
 	private void assertIsConstructorReference(CtExecutableReference<?> executable) {
@@ -300,12 +300,12 @@ public class MethodReferenceTest {
 	}
 
 	private void assertExecutableNamedBy(String expected, CtExecutableReference<?> executable) {
-		assertNotNull("Method reference must reference an executable.", executable);
-		assertEquals("Method reference must reference the right executable.", expected, executable.getSimpleName());
+		assertNotNull(executable, "Method reference must reference an executable.");
+		assertEquals(expected, executable.getSimpleName(), "Method reference must reference the right executable.");
 	}
 
 	private void assertIsWellPrinted(String methodReference, CtExecutableReferenceExpression<?,?> reference) {
-		assertEquals("Method reference must be well printed", methodReference, reference.toString());
+		assertEquals(methodReference, reference.toString(), "Method reference must be well printed");
 	}
 
 	private CtExecutableReferenceExpression<?,?> getCtExecutableReferenceExpression(final String methodReference) {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4-AssertThat
`AssertThat` in Junit 4 is deprecated. Use `AssertThat` in Hamcrest instead.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.
## Junit4-@Before
The JUnit 4 `@Before` annotation should be replaced with JUnit 5 `@BeforeEach` annotation.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAStaticMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAnInstanceMethodOfAParticularObject`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAnInstanceMethodOfMultiParticularObject`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAnInstanceMethodOfAnArbitraryObjectOfAParticularType`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAClassParametrizedConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceToAJavaUtilClassConstructor`
- Replaced junit 4 test annotation with junit 5 test annotation in `testCompileMethodReferenceGeneratedBySpoon`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTryRecoverTypeArgumentsHandlesNullTypeArguments`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathExecutableReferenceExpression`
- Replaced junit 4 test annotation with junit 5 test annotation in `testNoClasspathSuperExecutable`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetGenericMethodFromReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetGenericExecutableReference`
- Replaced junit 4 test annotation with junit 5 test annotation in `testReferenceBuilderWithComplexGenerics`
### JUnit4-AssertThat
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testGetGenericExecutableReference`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testGetGenericExecutableReference`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testGetGenericExecutableReference`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testReferenceBuilderWithComplexGenerics`
- Replaced `Assert.assertThat` with `MatcherAssert.assertThat` in `testReferenceBuilderWithComplexGenerics`
### Junit4-@Before
- Replaced `@Before` annotation with `@BeforeEach` at method `setUp`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAStaticMethod`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAnInstanceMethodOfAParticularObject`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAnInstanceMethodOfMultiParticularObject`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAnInstanceMethodOfAnArbitraryObjectOfAParticularType`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAConstructor`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAClassParametrizedConstructor`
- Transformed junit4 assert to junit 5 assertion in `testReferenceToAJavaUtilClassConstructor`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathExecutableReferenceExpression`
- Transformed junit4 assert to junit 5 assertion in `testNoClasspathSuperExecutable`
- Transformed junit4 assert to junit 5 assertion in `testGetGenericMethodFromReference`
- Transformed junit4 assert to junit 5 assertion in `testGetGenericExecutableReference`
- Transformed junit4 assert to junit 5 assertion in `assertTypedBy`
- Transformed junit4 assert to junit 5 assertion in `assertTargetedBy`
- Transformed junit4 assert to junit 5 assertion in `assertExecutableNamedBy`
- Transformed junit4 assert to junit 5 assertion in `assertIsWellPrinted`
- Transformed junit4 assert to junit 5 assertion in `testReferenceBuilderWithComplexGenerics`
