### PR TITLE
test: migrate MethodTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/method/MethodTest.java
+++ b/src/test/java/spoon/test/method/MethodTest.java
@@ -16,36 +16,36 @@
  */
 package spoon.test.method;
 
-import org.junit.Test;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.declaration.CtParameter;
+import spoon.test.method.testclasses.Tacos;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.NamedElementFilter;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.test.delete.testclasses.Adobada;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.CtType;
 import spoon.Launcher;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtParameter;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.CtTypeParameter;
-import spoon.reflect.declaration.ModifierKind;
-import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.visitor.filter.NamedElementFilter;
-import spoon.test.delete.testclasses.Adobada;
 import spoon.test.method.testclasses.Methods;
-import spoon.test.method.testclasses.Tacos;
+import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.ConcurrentModificationException;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.ConcurrentModificationException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Arrays;
 
+import static spoon.testing.utils.ModelUtils.buildClass;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
-import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MethodTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testClone`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSearchMethodWithGeneric`
- Replaced junit 4 test annotation with junit 5 test annotation in `testMethodSignature`
- Replaced junit 4 test annotation with junit 5 test annotation in `testAddSameMethodsTwoTimes`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetAllMethods`
- Replaced junit 4 test annotation with junit 5 test annotation in `testGetAllMethodsAdaptingType`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addParameterAt_addsParameterToSpecifiedPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addFormalCtTypeParameterAt_addsTypeParameterToSpecifiedPosition`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addFormalCtTypeParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testClone`
- Transformed junit4 assert to junit 5 assertion in `testSearchMethodWithGeneric`
- Transformed junit4 assert to junit 5 assertion in `testMethodSignature`
- Transformed junit4 assert to junit 5 assertion in `testAddSameMethodsTwoTimes`
- Transformed junit4 assert to junit 5 assertion in `testGetAllMethods`
- Transformed junit4 assert to junit 5 assertion in `testGetAllMethodsAdaptingType`
- Transformed junit4 assert to junit 5 assertion in `test_addParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds`
- Transformed junit4 assert to junit 5 assertion in `test_addFormalCtTypeParameterAt_throwsOutOfBoundsException_whenPositionIsOutOfBounds`