### PR TITLE
test: migrate LoopTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -16,27 +16,27 @@
  */
 package spoon.test.loop;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.CtModel;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtFor;
-import spoon.reflect.code.CtForEach;
-import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtLoop;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtConstructor;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.loop.testclasses.Condition;
 import spoon.test.loop.testclasses.Join;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.reflect.code.CtForEach;
+import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.code.CtLoop;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.code.CtBlock;
+import spoon.Launcher;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtClass;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.build;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LoopTest {
 	private static final String nl = System.lineSeparator();


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnnotationInForLoop`
- Replaced junit 4 test annotation with junit 5 test annotation in `testForeachShouldHaveAlwaysABlockInItsBody`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEmptyForLoopExpression`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testAnnotationInForLoop`
- Transformed junit4 assert to junit 5 assertion in `testForeachShouldHaveAlwaysABlockInItsBody`
- Transformed junit4 assert to junit 5 assertion in `testEmptyForLoopExpression`