### PR TITLE
test: migrate UnicodeBugTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/literal/UnicodeBugTest.java
+++ b/src/test/java/spoon/test/literal/UnicodeBugTest.java
@@ -1,17 +1,18 @@
 package spoon.test.literal;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.processing.AbstractProcessor;
-import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtField;
+import spoon.Launcher;
+import spoon.processing.AbstractProcessor;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.reflect.CtModel;
 import spoon.support.compiler.VirtualFile;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // bug case kindly provided by @Banbury
 // in https://github.com/INRIA/spoon/issues/3203


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testUnicodeBug`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testUnicodeBug`