### PR TITLE
test: migrate LiteralTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -16,27 +16,27 @@
  */
 package spoon.test.literal;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.LiteralBase;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.factory.CodeFactory;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.comparator.DeepRepresentationComparator;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.factory.CodeFactory;
 import spoon.test.literal.testclasses.Tacos;
+import spoon.Launcher;
+import spoon.reflect.code.LiteralBase;
+import spoon.reflect.factory.TypeFactory;
+import spoon.reflect.declaration.CtClass;
+import org.junit.jupiter.api.Test;
 
 import java.util.TreeSet;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.canBeBuilt;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LiteralTest {
 


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testCharLiteralInNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLiteralInForEachWithNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testBuildLiternal`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFactoryLiternal`
- Replaced junit 4 test annotation with junit 5 test annotation in `testEscapedString`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLiteralBase`
- Replaced junit 4 test annotation with junit 5 test annotation in `testLiteralBasePrinter`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testCharLiteralInNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testBuildLiternal`
- Transformed junit4 assert to junit 5 assertion in `testFactoryLiternal`
- Transformed junit4 assert to junit 5 assertion in `testEscapedString`
- Transformed junit4 assert to junit 5 assertion in `testLiteralBase`
- Transformed junit4 assert to junit 5 assertion in `testLiteralBasePrinter`
