### PR TITLE
test: migrate TestInterfaceWithoutSetup to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
+++ b/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
@@ -16,24 +16,23 @@
  */
 package spoon.test.interfaces;
 
-import org.apache.commons.lang3.StringUtils;
-import org.junit.Test;
-
-import spoon.Launcher;
-import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ModifierKind;
 import spoon.support.reflect.CtExtendedModifier;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtField;
+import org.apache.commons.lang3.StringUtils;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtMethod;
+import org.junit.jupiter.api.Test;
 
-import java.io.File;
+import java.util.Set;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Set;
+import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestInterfaceWithoutSetup {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testModifierFromInterfaceFieldAndMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInterfacePrettyPrinting`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testModifierFromInterfaceFieldAndMethod`
- Transformed junit4 assert to junit 5 assertion in `testInterfacePrettyPrinting`