### PR TITLE
test: migrate InvocationTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/invocations/InvocationTest.java
+++ b/src/test/java/spoon/test/invocations/InvocationTest.java
@@ -16,35 +16,35 @@
  */
 package spoon.test.invocations;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.SpoonAPI;
-import spoon.reflect.CtModel;
-import spoon.reflect.code.CtInvocation;
-import spoon.reflect.code.CtTypeAccess;
-import spoon.reflect.declaration.CtClass;
-import spoon.reflect.declaration.CtExecutable;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtType;
-import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.visitor.filter.AbstractFilter;
+import spoon.reflect.code.CtTypeAccess;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.test.invocations.testclasses.Bar;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.SpoonAPI;
 import spoon.test.invocations.testclasses.Foo;
+import spoon.reflect.declaration.CtExecutable;
+import spoon.reflect.declaration.CtType;
+import spoon.test.invocations.testclasses.Bar;
+import spoon.Launcher;
+import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static spoon.testing.utils.ModelUtils.build;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class InvocationTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testTypeOfStaticInvocation`
- Replaced junit 4 test annotation with junit 5 test annotation in `testTargetNullForStaticMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testIssue1753`
- Replaced junit 4 test annotation with junit 5 test annotation in `test_addArgumentAt_addsArgumentAtSpecifiedPosition`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testTypeOfStaticInvocation`
- Transformed junit4 assert to junit 5 assertion in `testTargetNullForStaticMethod`
- Transformed junit4 assert to junit 5 assertion in `testIssue1753`