### PR TITLE
test: migrate AnnotationPositionTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
+++ b/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
@@ -1,24 +1,26 @@
 package spoon.test.issue3321;
 
-import org.junit.Ignore;
-import org.junit.Test;
-import spoon.Launcher;
+import spoon.test.GitHubIssue;
 import spoon.reflect.cu.SourcePosition;
+import spoon.Launcher;
+import spoon.reflect.factory.Factory;
+import spoon.test.issue3321.testclasses.AnnoUser;
+import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtParameter;
-import spoon.reflect.factory.Factory;
-import spoon.test.GitHubIssue;
-import spoon.test.issue3321.testclasses.AnnoUser;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AnnotationPositionTest {
 
-	@Ignore("Unresolved Bug")
+	
 	@GitHubIssue(issueNumber = 3358)
 	@Test
+	@Disabled("Unresolved Bug")
 	public void testUsageOfTypeAnnotationOnParameterInMethod() {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(false);
@@ -71,9 +73,10 @@ public class AnnotationPositionTest {
 	}
 
 
-	@Ignore("UnresolvedBug")
+	
 	@GitHubIssue(issueNumber = 3358)
 	@Test
+	@Disabled("UnresolvedBug")
 	public void testSneakyAnnotationsOnParameters() {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(false);

--- a/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
+++ b/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
@@ -11,7 +11,6 @@ import spoon.reflect.declaration.CtMethod;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.
## Junit4-@Ignore
The JUnit 4 `@Ignore` annotation should be replaced with JUnit 5 `@Disabled` annotation.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testUsageOfTypeAnnotationOnParameterInMethod`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSneakyAnnotationsOnParameters`
### Junit4-@Ignore
- Replaced `@Ignore` annotation with `@Disabled` at method `testUsageOfTypeAnnotationOnParameterInMethod`
- Replaced `@Ignore` annotation with `@Disabled` at method `testSneakyAnnotationsOnParameters`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testUsageOfTypeAnnotationOnParameterInMethod`
- Transformed junit4 assert to junit 5 assertion in `testSneakyAnnotationsOnParameters`
