### PR TITLE
test: migrate SniperPrettyPrinterJavaxTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/issue3321/SniperPrettyPrinterJavaxTest.java
+++ b/src/test/java/spoon/test/issue3321/SniperPrettyPrinterJavaxTest.java
@@ -5,13 +5,6 @@ import spoon.Launcher;
 import spoon.compiler.Environment;
 import org.junit.jupiter.api.Test;
 
-
-
-/**
- * @author Gibah Joseph
- * Email: gibahjoe@gmail.com
- * Apr, 2020
- **/
 public class SniperPrettyPrinterJavaxTest {
     @Test
     public void testThatCanGenerateSniperPrettyPrintedSourceForJavaxAnnotatedClasses() {
@@ -27,7 +20,5 @@ public class SniperPrettyPrinterJavaxTest {
         l.addInputResource("src/test/java/spoon/test/issue3321/source/JavaxImportTestSource.java");
         l.setSourceOutputDirectory("src/test/resources");
         l.run();
-
-
     }
 }

--- a/src/test/java/spoon/test/issue3321/SniperPrettyPrinterJavaxTest.java
+++ b/src/test/java/spoon/test/issue3321/SniperPrettyPrinterJavaxTest.java
@@ -1,9 +1,11 @@
 package spoon.test.issue3321;
 
-import org.junit.Test;
+import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.Launcher;
 import spoon.compiler.Environment;
-import spoon.support.sniper.SniperJavaPrettyPrinter;
+import org.junit.jupiter.api.Test;
+
+
 
 /**
  * @author Gibah Joseph


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testThatCanGenerateSniperPrettyPrintedSourceForJavaxAnnotatedClasses`


I removed the useless comment about authorship and 2 newlines