### PR TITLE
test: migrate JarTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/jar/JarTest.java
+++ b/src/test/java/spoon/test/jar/JarTest.java
@@ -16,27 +16,27 @@
  */
 package spoon.test.jar;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.SpoonModelBuilder;
-import spoon.compiler.SpoonFile;
 import spoon.compiler.SpoonResource;
-import spoon.compiler.SpoonResourceHelper;
+import spoon.SpoonModelBuilder;
 import spoon.reflect.factory.Factory;
+import spoon.compiler.SpoonResourceHelper;
+import spoon.compiler.SpoonFile;
 import spoon.support.compiler.VirtualFile;
 import spoon.support.compiler.ZipFolder;
+import spoon.Launcher;
+import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.util.List;
+import java.io.File;
+import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JarTest {
 


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testJarResources`
- Replaced junit 4 test annotation with junit 5 test annotation in `testJar`
- Replaced junit 4 test annotation with junit 5 test annotation in `testFile`
- Replaced junit 4 test annotation with junit 5 test annotation in `testResource`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testJarResources`
- Transformed junit4 assert to junit 5 assertion in `testJar`
- Transformed junit4 assert to junit 5 assertion in `testFile`
- Transformed junit4 assert to junit 5 assertion in `testResource`
