### PR TITLE
test: migrate ImportBuilderTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
+++ b/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
@@ -16,29 +16,29 @@
  */
 package spoon.test.jdtimportbuilder;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.cu.CompilationUnit;
-import spoon.reflect.declaration.CtClass;
-import spoon.experimental.CtUnresolvedImport;
+import spoon.test.imports.testclasses.A;
 import spoon.reflect.reference.CtFieldReference;
+import spoon.test.jdtimportbuilder.testclasses.StaticImport;
+import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtImport;
+import spoon.test.jdtimportbuilder.testclasses.StaticImportWithInheritance;
+import spoon.reflect.declaration.CtImportKind;
+import spoon.experimental.CtUnresolvedImport;
 import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
-import spoon.reflect.declaration.CtImportKind;
-import spoon.test.imports.testclasses.A;
-import spoon.test.imports.testclasses.ClassWithInvocation;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
 import spoon.test.jdtimportbuilder.testclasses.StarredImport;
-import spoon.test.jdtimportbuilder.testclasses.StaticImport;
-import spoon.test.jdtimportbuilder.testclasses.StaticImportWithInheritance;
+import spoon.test.imports.testclasses.ClassWithInvocation;
+import org.junit.jupiter.api.Test;
 
+import java.util.stream.Collectors;
+import java.util.Set;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Created by urli on 09/08/2017.
@@ -196,7 +196,7 @@ public class ImportBuilderTest {
 		CompilationUnit unitStatic = spoon.getFactory().CompilationUnit().getMap().get(classStatic.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitStatic.getImports();
 
-		assertEquals(imports.toString(), 1, imports.size());
+		assertEquals(1, imports.size(), imports.toString());
 		CtImport ctImport = imports.iterator().next();
 
 		assertEquals(CtImportKind.ALL_STATIC_MEMBERS, ctImport.getImportKind());


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithNoImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithSimpleImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithSimpleImportNoAutoimport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testInternalImportWhenNoClasspath`
- Replaced junit 4 test annotation with junit 5 test annotation in `testSimpleStaticImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithStaticStarredImportFromInterface`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithStaticInheritedImport`
- Replaced junit 4 test annotation with junit 5 test annotation in `testWithImportFromItf`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testWithNoImport`
- Transformed junit4 assert to junit 5 assertion in `testWithSimpleImport`
- Transformed junit4 assert to junit 5 assertion in `testWithSimpleImportNoAutoimport`
- Transformed junit4 assert to junit 5 assertion in `testInternalImportWhenNoClasspath`
- Transformed junit4 assert to junit 5 assertion in `testSimpleStaticImport`
- Transformed junit4 assert to junit 5 assertion in `testWithStaticStarredImportFromInterface`
- Transformed junit4 assert to junit 5 assertion in `testWithStaticInheritedImport`
- Transformed junit4 assert to junit 5 assertion in `testWithImportFromItf`