### PR TITLE
test: migrate TestLabels to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/labels/TestLabels.java
+++ b/src/test/java/spoon/test/labels/TestLabels.java
@@ -16,27 +16,27 @@
  */
 package spoon.test.labels;
 
-import org.junit.Test;
-import spoon.Launcher;
-import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBreak;
-import spoon.reflect.code.CtCase;
-import spoon.reflect.code.CtContinue;
-import spoon.reflect.code.CtDo;
-import spoon.reflect.code.CtFor;
-import spoon.reflect.code.CtIf;
-import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtWhile;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtCase;
+import spoon.Launcher;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.code.CtDo;
+import spoon.reflect.code.CtContinue;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.visitor.filter.NamedElementFilter;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Created by urli on 19/06/2017.


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testLabelsAreDetected`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testLabelsAreDetected`