### PR TITLE
test: migrate AnonymousInLambdaTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/lambda/AnonymousInLambdaTest.java
+++ b/src/test/java/spoon/test/lambda/AnonymousInLambdaTest.java
@@ -1,6 +1,6 @@
 package spoon.test.lambda;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.processing.AbstractProcessor;
 import spoon.reflect.declaration.CtClass;
@@ -8,7 +8,7 @@ import spoon.reflect.declaration.CtClass;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AnonymousInLambdaTest {
 	@Test
@@ -25,7 +25,7 @@ public class AnonymousInLambdaTest {
 
 		cp.classes.forEach(
 				t -> {
-					assertFalse(t.getSimpleName() + " is not good " + t.getPosition(), t.getSimpleName().contains("<unknown>"));
+					assertFalse(t.getSimpleName().contains("<unknown>"), t.getSimpleName() + " is not good " + t.getPosition());
 				}
 		);
 	}


### PR DESCRIPTION
#3919
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testAnonymousInLambda`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testAnonymousInLambda`
