### PR TITLE
test: migrate InternalTest to JUnit 5

### DIFF
--- a/src/test/java/spoon/test/limits/utils/InternalTest.java
+++ b/src/test/java/spoon/test/limits/utils/InternalTest.java
@@ -16,7 +16,7 @@
  */
 package spoon.test.limits.utils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.visitor.filter.NamedElementFilter;
@@ -25,8 +25,8 @@ import spoon.test.limits.utils.testclasses.ContainInternalClass;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class InternalTest {


### PR DESCRIPTION
#3919 
# Change Log
The following bad smells are refactored:
## JUnit4-@Test
The JUnit 4 `@Test` annotation should be replaced with JUnit 5 `@Test` annotation.
## JUnit4Assertion
The JUnit4 assertion should be replaced with JUnit5 Assertions.

## The following has changed in the code:
### JUnit4-@Test
- Replaced junit 4 test annotation with junit 5 test annotation in `testInternalClasses`
- Replaced junit 4 test annotation with junit 5 test annotation in `testStaticFinalFieldInAnonymousClass`
### JUnit4Assertion
- Transformed junit4 assert to junit 5 assertion in `testInternalClasses`
- Transformed junit4 assert to junit 5 assertion in `testStaticFinalFieldInAnonymousClass`
