### PR TITLE
chore(qodana): use new flag "changes"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,19 +146,10 @@ jobs:
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
         with:
           path: pull_request
-      - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
-        with:
-          path: master
-          ref: master
-      - name: copy config file
-        run: cp pull_request/qodana.yml master/qodana.yml
       - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
         with:
           java-version: 17
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-      - name: "Create folder"
-        run: "mkdir -p ${{ github.workspace }}/result/master"
       - name: git reset
         run: cd pull_request && git fetch && git reset --soft origin/master
       - name: Qodana - Code Inspection
@@ -170,34 +161,4 @@ jobs:
           inspected-dir: ./src/main/java # only main spoon project at first
           results-dir:  "${{ github.workspace }}/result"
           changes: true
-          fail-threshold: 1
-      - name: Print problems(full)
-        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
-      - name: Print problems(short)
-        run: |
-          jq -r '.runs
-          | .[0].results
-          | map(
-             select (.baselineState == "new") |
-             {
-                 text: .message.text,
-                 location: .locations | map({
-                       snippet: .physicalLocation.contextRegion.snippet.text,
-                       file: .physicalLocation.artifactLocation.uri,
-                       position: ((.physicalLocation.contextRegion.startLine | tostring) + ":" + (.physicalLocation.contextRegion.startColumn | tostring))
-                   })
-             }
-          )
-          | map(
-             "## " + .text + "\n" +
-             (.location
-               | map(
-                 "In file " + .file + " at " + .position + "\n```java\n" + .snippet + "\n```"
-               )
-               | join("\n")
-             )
-          )
-          | join("\n\n----\n\n")' \
-          ${{ github.workspace }}/result/qodana.sarif.json
-          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
-          if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi
+          fail-threshold: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
       - name: "Create folder"
         run: "mkdir -p ${{ github.workspace }}/result/master"
       - name: git reset
-        run: cd pull_request && git fetch && git reset --soft master
+        run: cd pull_request && git fetch && git reset --soft origin/master
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@6df92dd1240ad63ed7956fa74069d636067d574d # renovate: tag=v4.2.5
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,7 @@ jobs:
       - name: "Create folder"
         run: "mkdir -p ${{ github.workspace }}/result/master"
       - name: git reset
-        run: cd pull_request && git reset --soft origin/master
+        run: cd pull_request && git fetch && git reset --soft master
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@6df92dd1240ad63ed7956fa74069d636067d574d # renovate: tag=v4.2.5
         continue-on-error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,13 +159,8 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: "Create folder"
         run: "mkdir -p ${{ github.workspace }}/result/master"
-      - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@6df92dd1240ad63ed7956fa74069d636067d574d # renovate: tag=v4.2.5
-        with:
-          linter: ${{ env.QODANA_LINTER }}
-          project-dir: "${{ github.workspace }}/master"
-          inspected-dir: ./src/main/java # only main spoon project at first
-          results-dir:  "${{ github.workspace }}/result/master"
+      - name: git reset
+        run: cd pull_request && git reset --soft origin/master
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@6df92dd1240ad63ed7956fa74069d636067d574d # renovate: tag=v4.2.5
         continue-on-error: true
@@ -173,11 +168,9 @@ jobs:
           linter: ${{ env.QODANA_LINTER }}
           project-dir: "${{ github.workspace }}/pull_request"
           inspected-dir: ./src/main/java # only main spoon project at first
-          baseline-path: "/data/results/master/qodana.sarif.json"
-          baseline-include-absent: true
           results-dir:  "${{ github.workspace }}/result"
+          changes: true
           fail-threshold: 1
-          upload-result: false
       - name: Print problems(full)
         run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
       - name: Print problems(short)

--- a/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
@@ -26,7 +26,7 @@ public class TokenSourceFragment implements SourceFragment {
 
 	@Override
 	public String getSourceCode() {
-		return null;
+		return source;
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenSourceFragment.java
@@ -26,7 +26,7 @@ public class TokenSourceFragment implements SourceFragment {
 
 	@Override
 	public String getSourceCode() {
-		return source;
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Qodana got a new flag `changes` which as you (don't) expect `Inspect uncommitted changes and report new problems.`. Uncommitted means here uncommitted and not the expected behaviour changed files in the PR. Therefore, we reset the git branch with `git reset --soft master`. This reduces the qodana runtime in less than half.
Qodana has an annotator included. We don't need @I-Al-Istannen JQ magic any more and use the included from now. See https://github.com/INRIA/spoon/pull/4584/files#annotation_2688909324.
The only risk is that for some reason `git reset --soft master` fails.

Edit: The bad smell and failing CI is currently only there for showcasing and gets removed after approval.
 