### PR TITLE
chore: improve CI logs with test case names

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,8 +64,9 @@ jobs:
         run: timeout 20 mvn -B test || echo "Done fetching dependencies"
         shell: bash
       - name: Test
-        run: mvn test
-
+        run: 
+          mvn test
+          grep testcase target/surefire-reports/*xml # output the name of executed test cases in CI log
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
         run: 
           mvn test
       - name: print run tests
-        run: cat testResults.md
+        run: cat testResults.spoon
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,6 @@ jobs:
       - name: Test
         run: 
           mvn test
-          grep testcase target/surefire-reports/*xml # output the name of executed test cases in CI log
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,8 @@ jobs:
       - name: Test
         run: 
           mvn test
+      - name: print run tests
+        run: cat testResults.md
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ spooned-classes/
 spooned/
 doc/_jekyll/_site/
 *.tmp
+testResults.spoon
 
 # Nodejs
 node_modules/
@@ -56,4 +57,3 @@ gradle-app.setting
 
 ## Gradle Enterprise ID File ##
 .mvn/.gradle-enterprise/gradle-enterprise-workspace-id
-testResults.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ gradle-app.setting
 
 ## Gradle Enterprise ID File ##
 .mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+testResults.md

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,6 @@
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
       <version>1.8</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,18 +171,6 @@
       <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.kohsuke.metainf-services</groupId>
-      <artifactId>metainf-services</artifactId>
-      <version>1.8</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-      <version>1.8.2</version>
-    <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,7 @@
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
       <version>1.8</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,18 @@
       <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+      <version>1.1</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <version>1.8.2</version>
+    <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,13 @@
       <version>1.2.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.kohsuke.metainf-services</groupId>
+      <artifactId>metainf-services</artifactId>
+      <version>1.8</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -297,6 +304,7 @@
                 <goal>depclean</goal>
               </goals>
              <configuration>
+                <ignoreDependencies>org.kohsuke.metainf-services:metainf-services:1.8:test</ignoreDependencies>
                <!-- the build fails if there are unused direct dependencies -->
                <failIfUnusedDirect>true</failIfUnusedDirect>
              </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
-      <version>1.1</version>
+      <version>1.8</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -54,6 +54,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+            <version>1.8.2</version>
+            <scope>test</scope>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>4.3.1</version>
@@ -68,7 +73,12 @@
             <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.kohsuke.metainf-services</groupId>
+            <artifactId>metainf-services</artifactId>
+            <version>1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <organization>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -148,7 +148,7 @@
                         <annotationProcessorPath>
                             <groupId>org.kohsuke.metainf-services</groupId>
                             <artifactId>metainf-services</artifactId>
-                            <version>1.1</version>
+                            <version>1.8</version>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                 </configuration>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -58,6 +58,7 @@
             <artifactId>junit-platform-launcher</artifactId>
             <version>1.8.2</version>
             <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -74,12 +74,6 @@
             <version>1.19.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.kohsuke.metainf-services</groupId>
-            <artifactId>metainf-services</artifactId>
-            <version>1.8</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <organization>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -144,6 +144,13 @@
                     <!-- useIncrementalCompilation=false actually means that we won't recompile everything each time -->
                     <!-- it's not a joke, test by yourself :-) -->
                     <useIncrementalCompilation>false</useIncrementalCompilation>
+                    <annotationProcessorPaths>
+                        <annotationProcessorPath>
+                            <groupId>org.kohsuke.metainf-services</groupId>
+                            <artifactId>metainf-services</artifactId>
+                            <version>1.1</version>
+                        </annotationProcessorPath>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 

--- a/src/test/java/spoon/test/TestExecutionLogger.java
+++ b/src/test/java/spoon/test/TestExecutionLogger.java
@@ -1,0 +1,34 @@
+package spoon.test;
+
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.kohsuke.MetaInfServices;
+
+
+@MetaInfServices
+public class TestExecutionLogger implements TestExecutionListener {
+
+	@Override
+	public void executionFinished(TestIdentifier testIdentifier,
+			TestExecutionResult testExecutionResult) {
+				// here we check if the execution was a test and not something like container or otherwise (like a suite)
+				if (testIdentifier.getType().isTest()) {
+					// now we simply print the result to sysout here could be a real logger(Our logger is off during testing?), markdown to a file
+					// our more advanced logging happen.
+					System.out.println("executionFinished: " + testIdentifier.getClass() + "#"
+							+ testIdentifier.getDisplayName() + " with result: "
+							+ testExecutionResult.getStatus());
+				}
+	}
+
+	@Override
+	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+		// here land the skipped executions either by assumptions, annotations or by some other reason
+	}
+
+	@Override
+	public void executionStarted(TestIdentifier testIdentifier) {
+		// here land all started executions for example test methods, test classes, test containers.
+	}
+}

--- a/src/test/java/spoon/test/TestExecutionLogger.java
+++ b/src/test/java/spoon/test/TestExecutionLogger.java
@@ -17,24 +17,31 @@ import org.kohsuke.MetaInfServices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
+/**
+ * This class is used to log the execution of tests with their execution time.
+ * It is used to generate a report at the end of the test execution.
+ * JUnit 5 loads this class automatically when tests are run.
+ * <p>
+ * The runtime should <b>not</b> be used for performance mesurements.
+ */
 @MetaInfServices
 public class TestExecutionLogger implements TestExecutionListener {
 
+	private static final String TEST_RESULTS_FILE_NAME = "testResults.spoon";
 	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 	private static Map<TestIdentifier, LocalDateTime> timers = new HashMap<>();
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier,
 			TestExecutionResult testExecutionResult) {
+		long duration = getTestRuntime(testIdentifier);
 		// here we check if the execution was a test and not something like container or otherwise (like a suite)
 		if (testIdentifier.getType().isTest()) {
-			long duration = getTestRunTime(testIdentifier);
-			String classname = getClassName(testIdentifier);
-			String result = "executionFinished: " + classname + "#" + testIdentifier.getDisplayName()
+			String testName = getTestName(testIdentifier);
+			String result = "executionFinished: " + testName
 					+ " with result: " + testExecutionResult.getStatus() + " in duration: " + duration
-					+ " miliseconds\n";
+					+ " ms\n";
 			try {
-				Files.writeString(Path.of("testResults.spoon"), result, StandardOpenOption.APPEND,
+				Files.writeString(Path.of(TEST_RESULTS_FILE_NAME), result, StandardOpenOption.APPEND,
 						StandardOpenOption.CREATE);
 			} catch (IOException e) {
 				LOGGER.error("Error writing to file", e);
@@ -46,45 +53,35 @@ public class TestExecutionLogger implements TestExecutionListener {
 	 * @param testIdentifier  the test identifier
 	 * @return  the time in milliseconds since the test started or 0 if any error occurred.
 	 */
-	private long getTestRunTime(TestIdentifier testIdentifier) {
+	private long getTestRuntime(TestIdentifier testIdentifier) {
 		LocalDateTime finish = LocalDateTime.now();
 		LocalDateTime startTime = timers.get(testIdentifier);
 		timers.remove(testIdentifier);
-		long duration = 0;
-		if (startTime != null) {
-			duration = startTime.until(finish, ChronoUnit.MILLIS);
-		}
-		return duration;
+		return startTime != null ? ChronoUnit.MILLIS.between(startTime, finish) : 0;
 	}
 	/**
-	 * Returns the classname or empty string if the testIdentifier is not a methodsource.
-	 * @param testIdentifier  the testIdentifier to get the classname from.
-	 * @return  the classname or empty string if the testIdentifier is not a methodsource.
+	 * Returns the test name in the format <className>#<methodName>.
+	 * @param testIdentifier  the testIdentifier to get the test name from.
+	 * @return  the testname or empty string if the testIdentifier is not a methodsource.
 	 */
-  private String getClassName(TestIdentifier testIdentifier) {
+  private String getTestName(TestIdentifier testIdentifier) {
 		return testIdentifier.getSource().stream()
 				.filter(MethodSource.class::isInstance)
 				.map(MethodSource.class::cast)
-				.map(v -> v.getClassName())
+				.map(v -> v.getClassName() + "#" + v.getMethodName())
 				.findFirst()
 				.orElse("");
   }
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {
-		LocalDateTime finish = LocalDateTime.now();
-		LocalDateTime startTime = timers.get(testIdentifier);
-		timers.remove(testIdentifier);
-		long duration = 0;
-		if (startTime != null) {
-			duration = startTime.until(finish, java.time.temporal.ChronoUnit.MILLIS);
-		}
+		long duration = getTestRuntime(testIdentifier);
 		if (testIdentifier.getType().isTest()) {
-			String classname = getClassName(testIdentifier);
-			String result = "executionSkipped: " + classname + "#" + testIdentifier.getDisplayName() +" duration: "+ duration + "miliseconds"
+			String testName = getTestName(testIdentifier);
+			String result = "executionSkipped: " + testName +" in duration: "+ duration + " ms"
 					+ " with reason: " + reason+"\n";
 			try {
-				Files.writeString(Path.of("testResults.spoon"), result, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+				Files.writeString(Path.of(TEST_RESULTS_FILE_NAME), result, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
 			} catch (IOException e) {
 				LOGGER.error("Error writing to file", e);
 			}
@@ -94,6 +91,5 @@ public class TestExecutionLogger implements TestExecutionListener {
 	@Override
 	public void executionStarted(TestIdentifier testIdentifier) {
 		timers.put(testIdentifier, LocalDateTime.now());
-		// here land all started executions for example test methods, test classes, test containers.
 	}
 }

--- a/src/test/java/spoon/test/TestExecutionLogger.java
+++ b/src/test/java/spoon/test/TestExecutionLogger.java
@@ -1,26 +1,54 @@
 package spoon.test;
 
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
 import org.kohsuke.MetaInfServices;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @MetaInfServices
 public class TestExecutionLogger implements TestExecutionListener {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
 	@Override
 	public void executionFinished(TestIdentifier testIdentifier,
 			TestExecutionResult testExecutionResult) {
-				// here we check if the execution was a test and not something like container or otherwise (like a suite)
-				if (testIdentifier.getType().isTest()) {
-					// now we simply print the result to sysout here could be a real logger(Our logger is off during testing?), markdown to a file
-					// our more advanced logging happen.
-					System.out.println("executionFinished: "
-							+ testIdentifier.getDisplayName() + " with result: "
-							+ testExecutionResult.getStatus());
-				}
+		// here we check if the execution was a test and not something like container or otherwise (like a suite)
+		if (testIdentifier.getType().isTest()) {
+			String classname = getClassName(testIdentifier);
+			// now we simply print the result to sysout here could be a real logger(Our logger is off during testing?), markdown to a file
+			// our more advanced logging happen.
+			String result = "executionFinished: `" + classname + "#" + testIdentifier.getDisplayName()
+					+ "` with result: `" + testExecutionResult.getStatus() + "`";
+			try {
+				Files.writeString(Path.of("testResults.md"), result, StandardOpenOption.APPEND, StandardOpenOption.CREATE);
+			} catch (IOException e) {
+				LOGGER.error("Error writing to file", e);
+			}
+		}
 	}
+	/**
+	 * Returns the classname or empty string if the testIdentifier is not a methodsource.
+	 * @param testIdentifier  the testIdentifier to get the classname from.
+	 * @return  the classname or empty string if the testIdentifier is not a methodsource.
+	 */
+  private String getClassName(TestIdentifier testIdentifier) {
+		return testIdentifier.getSource().stream()
+				.filter(MethodSource.class::isInstance)
+				.map(MethodSource.class::cast)
+				.map(v -> v.getClassName())
+				.findFirst()
+				.orElse("");
+  }
 
 	@Override
 	public void executionSkipped(TestIdentifier testIdentifier, String reason) {

--- a/src/test/java/spoon/test/TestExecutionLogger.java
+++ b/src/test/java/spoon/test/TestExecutionLogger.java
@@ -16,7 +16,7 @@ public class TestExecutionLogger implements TestExecutionListener {
 				if (testIdentifier.getType().isTest()) {
 					// now we simply print the result to sysout here could be a real logger(Our logger is off during testing?), markdown to a file
 					// our more advanced logging happen.
-					System.out.println("executionFinished: " + testIdentifier.getClass() + "#"
+					System.out.println("executionFinished: "
 							+ testIdentifier.getDisplayName() + " with result: "
 							+ testExecutionResult.getStatus());
 				}


### PR DESCRIPTION
Goal: we want to have the list of all executed test cases in the CI log.

Bonus: this gives us execution time in the logs for performance analysis