### PR TITLE
rewview: chore(Qodana): Let Qodana fail CI again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,4 +162,35 @@ jobs:
           inspected-dir: ./src/main/java # only main spoon project at first
           results-dir:  "${{ github.workspace }}/result"
           changes: true
-          fail-threshold: 0
+          fail-threshold: 1
+          upload-result: false
+      - name: Print problems(full)
+        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
+      - name: Print problems(short)
+        run: |
+          jq -r '.runs
+          | .[0].results
+          | map(
+             select (.baselineState == "new") |
+             {
+                 text: .message.text,
+                 location: .locations | map({
+                       snippet: .physicalLocation.contextRegion.snippet.text,
+                       file: .physicalLocation.artifactLocation.uri,
+                       position: ((.physicalLocation.contextRegion.startLine | tostring) + ":" + (.physicalLocation.contextRegion.startColumn | tostring))
+                   })
+             }
+          )
+          | map(
+             "## " + .text + "\n" +
+             (.location
+               | map(
+                 "In file " + .file + " at " + .position + "\n```java\n" + .snippet + "\n```"
+               )
+               | join("\n")
+             )
+          )
+          | join("\n\n----\n\n")' \
+          ${{ github.workspace }}/result/qodana.sarif.json
+          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
+          if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -156,7 +156,6 @@ jobs:
         run: cd pull_request && git fetch && git reset --soft origin/master
       - name: Qodana - Code Inspection
         uses: JetBrains/qodana-action@6df92dd1240ad63ed7956fa74069d636067d574d # renovate: tag=v4.2.5
-        continue-on-error: true
         with:
           linter: ${{ env.QODANA_LINTER }}
           project-dir: "${{ github.workspace }}/pull_request"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,5 +191,5 @@ jobs:
           )
           | join("\n\n----\n\n")' \
           ${{ github.workspace }}/result/qodana.sarif.json
-          VIOLATIONS=$(jq '.runs | .[0].results | map(select (.baselineState == "new")) | length' ${{ github.workspace }}/result/qodana.sarif.json)
+          VIOLATIONS=$(jq '.runs | .[0].results | length' ${{ github.workspace }}/result/qodana.sarif.json)
           if [ "$VIOLATIONS" -gt "0" ]; then exit 1; fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,7 +165,7 @@ jobs:
           fail-threshold: 1
           upload-result: false
       - name: Print problems(full)
-        run: jq '.runs | .[0].results ${{ github.workspace }}/result/qodana.sarif.json
+        run: jq '.runs | .[0].results' ${{ github.workspace }}/result/qodana.sarif.json
       - name: Print problems(short)
         run: |
           jq -r '.runs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -165,13 +165,12 @@ jobs:
           fail-threshold: 1
           upload-result: false
       - name: Print problems(full)
-        run: jq '.runs | .[0].results | map(select (.baselineState == "new"))' ${{ github.workspace }}/result/qodana.sarif.json
+        run: jq '.runs | .[0].results ${{ github.workspace }}/result/qodana.sarif.json
       - name: Print problems(short)
         run: |
           jq -r '.runs
           | .[0].results
-          | map(
-             select (.baselineState == "new") |
+          |
              {
                  text: .message.text,
                  location: .locations | map({

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,7 +170,7 @@ jobs:
         run: |
           jq -r '.runs
           | .[0].results
-          |
+          | map(
              {
                  text: .message.text,
                  location: .locations | map({

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -36,6 +36,7 @@ public class ChangeCollector {
 	 * @return {@link ChangeCollector} attached to the `env` or null if there is none
 	 */
 	public static ChangeCollector getChangeCollector(Environment env) {
+		new NullPointerException();
 		FineModelChangeListener mcl = env.getModelChangeListener();
 		if (mcl instanceof ChangeListener) {
 			return ((ChangeListener) mcl).getChangeCollector();

--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -36,7 +36,6 @@ public class ChangeCollector {
 	 * @return {@link ChangeCollector} attached to the `env` or null if there is none
 	 */
 	public static ChangeCollector getChangeCollector(Environment env) {
-		new NullPointerException();
 		FineModelChangeListener mcl = env.getModelChangeListener();
 		if (mcl instanceof ChangeListener) {
 			return ((ChangeListener) mcl).getChangeCollector();


### PR DESCRIPTION
While adding the new flag, `--changes` I forgot to remove the `continue-on-error:` flag. @I-Al-Istannen found this(see https://github.com/INRIA/spoon/runs/5170049523?check_suite_focus=true). Classical how to test your CI problem.