### PR TITLE
chore: add GPG plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,6 +305,20 @@
            </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
The [deployment might be failing](https://github.com/SpoonLabs/spoon-deploy/runs/5187204138?check_suite_focus=true) because spoon did not have a gpg plugin installed. Its docs [here](https://maven.apache.org/plugins/maven-gpg-plugin/usage.html) also suggest to configure it first before signing package with the GPG key.