### PR TITLE
doc: Add security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,15 @@ How to become integrator? The integrators are the developers who have made signi
 Current integrators:
 
 - Simon Larsén [@slarse](https://github.com/slarse/)
+    - Email: slarse@slar.se
+    - GPG fingerprint: 70345F27028C791C8D82D3DE1CEF06827CEA5C29
 - Nicolas Harrand [@nharrand](https://github.com/nharrand/)
+    - Email: nicolas.harrand@gmail.com
 - Martin Monperrus [@monperrus](https://github.com/monperrus/)
+    - Email: martin.monperrus@gnieh.org
+    - GPG fingerprint: 074F73B36D8DD649B132BAC18035014A2B7BFA92
 - Martin Wittlinger [@MartinWitt](https://github.com/MartinWitt)
+    - Email: wittlinger.martin@gmail.com
 
 Guidelines for pull requests
 ----------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,12 @@ Current integrators:
 
 - Simon Larsén [@slarse](https://github.com/slarse/)
     - Email: slarse@slar.se
-    - GPG fingerprint: 70345F27028C791C8D82D3DE1CEF06827CEA5C29
+    - GPG fingerprint: [70345F27028C791C8D82D3DE1CEF06827CEA5C29](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x70345F27028C791C8D82D3DE1CEF06827CEA5C29)
 - Nicolas Harrand [@nharrand](https://github.com/nharrand/)
     - Email: nicolas.harrand@gmail.com
 - Martin Monperrus [@monperrus](https://github.com/monperrus/)
     - Email: martin.monperrus@gnieh.org
-    - GPG fingerprint: 074F73B36D8DD649B132BAC18035014A2B7BFA92
+    - GPG fingerprint: [074F73B36D8DD649B132BAC18035014A2B7BFA92](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x074F73B36D8DD649B132BAC18035014A2B7BFA92)
 - Martin Wittlinger [@MartinWitt](https://github.com/MartinWitt)
     - Email: wittlinger.martin@gmail.com
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+The only supported version is the latest major version. Security fixes are not
+backported to earlier releases.
+
+## Reporting a Vulnerability
+
+If you find a vulnerability in Spoon, please disclose it by email to any of the
+integrators listed in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+If you have the capability to do so, we appreciate if the email body is
+encrypted. You can get the GPG key of a contributor with the `gpg --recv-keys
+<key_id/fingerprint>` command. Integrator key fingerprints are listed alongside
+email addresses in the [CONTRIBUTING.md](CONTRIBUTING.md) file.


### PR DESCRIPTION
Fix #4603 

Here's a proposal for a security policy.

I also added emails and the PGP key fingerprints hat I know of in the CONTRIBUTING.md file. I refer to them as GPG keys, though,  because I think that's more common nowadays, even though it's technically incorrect. I mean, even I say GPG key, and I'm pretty uptight about being correct ...

@monperrus @nharrand @MartinWitt please have a look.