### PR TITLE
Use Codescanning instead of annotations.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,3 +164,7 @@ jobs:
           results-dir:  "${{ github.workspace }}/result"
           changes: true
           fail-threshold: 0
+          use-annotations: false
+      - uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: "${{ github.workspace }}/result/qodana.sarif.json"


### PR DESCRIPTION
The Github Codescanning API is accessible by **forks** and also allows creating annotations based on a SARIF file.

So instead of using the Checks API (not accessible by forks) to create annotations we using Codescanning.
I think this should probably give us the same results.

As an example see
https://github.com/intrigus-lgtm/spoon/pull/10/files.
The PR has been created by @intrigus (i.e. is from a fork) and successfully received annotations :tada: 