### PR TITLE
review: refactor: remove useless toString calls

### DIFF
--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -542,7 +542,7 @@ public class ContractVerifier {
 			} catch (CtPathException e) {
 				throw new AssertionError("Path " + pathStr + " is either incorrectly generated or incorrectly read", e);
 			} catch (AssertionError e) {
-				throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element.toString(), e);
+				throw new AssertionError("Path " + pathStr + " detection failed on " + element.getClass().getSimpleName() + ": " + element, e);
 			}
 		});
 	}

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -257,12 +257,26 @@ public class SpoonifierVisitor extends CtScanner {
 		@Override
 		public void visitCtLiteral(CtLiteral element) {
 			if (element.getType().isPrimitive()) {
-				result.append(printTabs() + variableName + ".setValue((" + element.getType().getSimpleName() + ") " + element + ");\n");
+				result.append(printTabs())
+							.append(variableName)
+							.append(".setValue((")
+							.append(element.getType().getSimpleName())
+							.append(") ")
+							.append(element)
+							.append(");\n");
 				if (element.getBase() != null) {
-					result.append(printTabs() + variableName + ".setBase(LiteralBase." + element.getBase().name() + ");\n");
+					result.append(printTabs())
+							.append(variableName)
+							.append(".setBase(LiteralBase.")
+							.append(element.getBase().name())
+							.append(");\n");
 				}
 			} else if (element.getType().getQualifiedName().equals("java.lang.String")) {
-				result.append(printTabs() + variableName + ".setValue(\"" + StringEscapeUtils.escapeJava((String) element.getValue()) + "\");\n");
+				result.append(printTabs())
+							.append(variableName)
+							.append(".setValue(\"")
+							.append(StringEscapeUtils.escapeJava((String) element.getValue()))
+							.append("\");\n");
 			}
 			super.visitCtLiteral(element);
 		}

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -253,7 +253,7 @@ public class SpoonifierVisitor extends CtScanner {
 		@Override
 		public void visitCtLiteral(CtLiteral element) {
 			if (element.getType().isPrimitive()) {
-				result.append(printTabs() + variableName + ".setValue((" + element.getType().getSimpleName() + ") " + element.toString() + ");\n");
+				result.append(printTabs() + variableName + ".setValue((" + element.getType().getSimpleName() + ") " + element + ");\n");
 				if (element.getBase() != null) {
 					result.append(printTabs() + variableName + ".setBase(LiteralBase." + element.getBase().name() + ");\n");
 				}

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -228,8 +228,10 @@ public class SpoonifierVisitor extends CtScanner {
 				result.append(printTabs())
 						.append(parentName.peek())
 						.append(".setValueByRole(CtRole.")
-						.append(role.name()).append(", ")
-						.append(variableName).append(");\n");
+						.append(role.name())
+						.append(", ")
+						.append(variableName)
+						.append(");\n");
 			}
 		}
 		parentName.pop();

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -225,7 +225,11 @@ public class SpoonifierVisitor extends CtScanner {
 		if (!roleContainer.peek().isEmpty()) {
 			for (CtRole role: roleContainer.peek().keySet()) {
 				String variableName = roleContainer.peek().get(role);
-				result.append(printTabs() + parentName.peek() + ".setValueByRole(CtRole." + role.name() + ", " + variableName + ");\n");
+				result.append(printTabs())
+						.append(parentName.peek())
+						.append(".setValueByRole(CtRole.")
+						.append(role.name()).append(", ")
+						.append(variableName).append(");\n");
 			}
 		}
 		parentName.pop();

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -370,7 +370,8 @@ public class MetamodelProperty {
 
 	private int getIdxOfBestMatchByInputParameter(List<MMMethod> methods, MMMethodKind key, CtTypeReference<?> expectedValueType)  {
 		int idx = -1;
-		MatchLevel maxMatchLevel = null;
+		
+		maxMatchLevel = null;
 		if (key.isMulti()) {
 			expectedValueType = getTypeofItems(expectedValueType);
 		}
@@ -425,7 +426,7 @@ public class MetamodelProperty {
 	private enum MatchLevel {
 		SUBTYPE,
 		ERASED_EQUALS,
-		EQUALS;
+		EQUALS
 	}
 
 	/**

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -370,8 +370,7 @@ public class MetamodelProperty {
 
 	private int getIdxOfBestMatchByInputParameter(List<MMMethod> methods, MMMethodKind key, CtTypeReference<?> expectedValueType)  {
 		int idx = -1;
-		
-		maxMatchLevel = null;
+		MatchLevel maxMatchLevel = null;
 		if (key.isMulti()) {
 			expectedValueType = getTypeofItems(expectedValueType);
 		}

--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -327,7 +327,7 @@ public class MetamodelProperty {
 
 	private int getIdxOfBestMatchByReturnType(List<MMMethod> methods, MMMethodKind key) {
 		if (methods.size() > 2) {
-			throw new SpoonException("Resolving of more then 2 conflicting getters is not supported. There are: " + methods.toString());
+			throw new SpoonException("Resolving of more then 2 conflicting getters is not supported. There are: " + methods);
 		}
 		// There is no input parameter. We are resolving getter field.
 		// choose the getter whose return value is a collection
@@ -425,7 +425,7 @@ public class MetamodelProperty {
 	private enum MatchLevel {
 		SUBTYPE,
 		ERASED_EQUALS,
-		EQUALS
+		EQUALS;
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -339,7 +339,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT
+		OTHER_IS_PARENT;
 	}
 
 	/**
@@ -412,7 +412,7 @@ public class ElementSourceFragment implements SourceFragment {
 					//we have found exact match
 					if (element != null && getElement() != element) {
 						if (firstChild == null) {
-							throw new SpoonException("There is no source fragment for element " + element.toString() + ". There is one for class " + getElement().toString());
+							throw new SpoonException("There is no source fragment for element " + element + ". There is one for class " + getElement().toString());
 						}
 						return firstChild.getSourceFragmentOf(element, start, end);
 					}

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -339,7 +339,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT;
+		OTHER_IS_PARENT
 	}
 
 	/**


### PR DESCRIPTION
This removes not needed toString calls. I'm still unsure about when a `toString()` call is not needed, but these changes seem correct. The detection was done by Qodana and this fixes 4 issues. Calling `toString` in String concatenation adds zero value to the code and should be removed.