### PR TITLE
chore: downgrade nexus-staging-maven-plugin because of deployment regression

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -168,7 +168,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.11</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>


### PR DESCRIPTION
[Beta deployment of spoon failed again](https://github.com/SpoonLabs/spoon-deploy/runs/5267921572?check_suite_focus=true). I am confident it is because of some issue in the plugin. One of the maintainers of nexus has also recommended avoiding `1.6.9`, `1.6.10`, and `1.6.11` versions of the plugin. See https://issues.sonatype.org/browse/NEXUS-31214?focusedCommentId=1140935&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1140935.

> At this time, it's best to avoid 1.6.9/1.6.10/1.6.11 releases of the plugin. We are triaging this internally and will see it through to completion. I can't provide an ETA on completion date until we dive deeper.