### PR TITLE
chore: Check reproducible state in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,3 +169,19 @@ jobs:
         if: always()
         with:
           sarif_file: "${{ github.workspace }}/result/qodana.sarif.json"
+
+  reproducible-builds:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+    name: reproducible-builds
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # renovate: tag=v2.4.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@f0bb91606209742fe3ea40199be2f3ef195ecabf # renovate: tag=v2.5.0
+        with:
+          java-version: 17
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - name: Check status
+        run: chore/check-reproducible-builds.sh

--- a/chore/check-reproducible-builds.sh
+++ b/chore/check-reproducible-builds.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# If anything fails we are done for
+set -e
+
+build() {
+  mvn clean package -DskipDepClean -DskipTests -Dmaven.javadoc.skip > /dev/null
+}
+
+compare_files() {
+  sudo docker run --rm -t -w $(pwd) -v $(pwd):$(pwd):ro \
+        registry.salsa.debian.org/reproducible-builds/diffoscope "$1" "$2"
+}
+
+
+# Build for the first time
+build
+
+# Save artifacts
+mkdir -p saved_artifacts
+cp target/spoon-core-*.jar saved_artifacts
+
+# Build again, will overwrite target jars
+build
+
+# Do not fail the script before both jars were compared and the results printed
+set +e
+
+# Comparison will drill down as deep as possible and print results
+compare_files target/spoon-core-*[^dependencies].jar saved_artifacts/spoon-core-*[^dependencies].jar
+CORE_EXIT="$?"
+
+compare_files target/spoon-core-*dependencies.jar saved_artifacts/spoon-core-*dependencies.jar
+DEPS_EXIT="$?"
+
+if [[ "$CORE_EXIT" == 0 && "$DEPS_EXIT" == 0 ]]; then
+  echo -e "\033[1;32mThe jars were reproducible!\033[0m"
+  exit 0
+fi
+
+# Print a pretty error message
+
+echo -e "\n\033[1;31mThe jars were not reproducible\033[0m"
+
+if [[ "$DEPS_EXIT" != 0 ]]; then
+  echo -e "  \033[31mspoon-core-VERSION-with-dependencies.jar was not reproducible!\033[0m"
+fi
+if [[ "$CORE_EXIT" != 0 ]]; then
+  echo -e "  \033[31mspoon-core-VERSION.jar was not reproducible!\033[0m"
+fi
+
+
+exit 1


### PR DESCRIPTION
This PR supersedes #4614 once it works. While the linked PR tried to check against maven central using the artifact compare plugin, this PR just builds twice and throws diffoscope at the results.


We should wait for #4652 before merging to not have a red CI in master :)