### PR TITLE
refactor: make use of InputStream#transferTo where appropriate

### DIFF
--- a/src/main/java/spoon/compiler/SpoonFile.java
+++ b/src/main/java/spoon/compiler/SpoonFile.java
@@ -7,7 +7,6 @@
  */
 package spoon.compiler;
 
-import org.apache.commons.io.IOUtils;
 import spoon.SpoonException;
 
 import java.io.ByteArrayOutputStream;
@@ -47,7 +46,7 @@ public interface SpoonFile extends SpoonResource {
 		byte[] bytes;
 		try (InputStream contentStream = getContent()) {
 			ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-			IOUtils.copy(contentStream, outputStream);
+			contentStream.transferTo(outputStream);
 			bytes = outputStream.toByteArray();
 		} catch (IOException e) {
 			throw new SpoonException(e);

--- a/src/main/java/spoon/compiler/builder/SourceOptions.java
+++ b/src/main/java/spoon/compiler/builder/SourceOptions.java
@@ -53,7 +53,7 @@ public class SourceOptions<T extends SourceOptions<T>> extends Options<T> {
 					File file = File.createTempFile(source.getName(), ".java");
 					file.deleteOnExit();
 					try (FileOutputStream fileOutputStream = new FileOutputStream(file);
-						 InputStream content = source.getContent()) {
+							InputStream content = source.getContent()) {
 						content.transferTo(fileOutputStream);
 					}
 					args.add(file.toString());

--- a/src/main/java/spoon/compiler/builder/SourceOptions.java
+++ b/src/main/java/spoon/compiler/builder/SourceOptions.java
@@ -7,12 +7,12 @@
  */
 package spoon.compiler.builder;
 
-import org.apache.commons.io.IOUtils;
 import spoon.compiler.SpoonFile;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,8 +52,9 @@ public class SourceOptions<T extends SourceOptions<T>> extends Options<T> {
 				try {
 					File file = File.createTempFile(source.getName(), ".java");
 					file.deleteOnExit();
-					try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
-						IOUtils.copy(source.getContent(), fileOutputStream);
+					try (FileOutputStream fileOutputStream = new FileOutputStream(file);
+						 InputStream content = source.getContent()) {
+						content.transferTo(fileOutputStream);
 					}
 					args.add(file.toString());
 				} catch (IOException e) {

--- a/src/main/java/spoon/support/compiler/ZipFolder.java
+++ b/src/main/java/spoon/support/compiler/ZipFolder.java
@@ -57,17 +57,12 @@ public class ZipFolder implements SpoonFolder {
 		// Indexing content
 		if (files == null) {
 			files = new ArrayList<>();
-			final int buffer = 2048;
 			try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
-				ByteArrayOutputStream output = new ByteArrayOutputStream(buffer)) {
+				ByteArrayOutputStream output = new ByteArrayOutputStream(2048)) {
+
 				ZipEntry entry;
 				while ((entry = zipInput.getNextEntry()) != null) {
-					// deflate in buffer
-					int count;
-					byte[] data = new byte[buffer];
-					while ((count = zipInput.read(data, 0, buffer)) != -1) {
-						output.write(data, 0, count);
-					}
+					zipInput.transferTo(output);
 					files.add(new ZipFile(this, entry.getName(), output.toByteArray()));
 					output.reset();
 				}
@@ -177,17 +172,11 @@ public class ZipFolder implements SpoonFolder {
 					continue;
 				}
 				// deflate in buffer
-				final int buffer = 2048;
 				// Force parent directory creation, sometimes directory was not yet handled
 				f.getParentFile().mkdirs();
 				// in the zip entry iteration
 				try (OutputStream output = new BufferedOutputStream(new FileOutputStream(f))) {
-					int count;
-					byte[] data = new byte[buffer];
-					while ((count = zipInput.read(data, 0, buffer)) != -1) {
-						output.write(data, 0, count);
-					}
-					output.flush();
+					zipInput.transferTo(output);
 				}
 			}
 		} catch (Exception e) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
@@ -564,8 +563,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 				// the path must be given relatively to to the working directory
 				try (InputStream is = getCompilationUnitInputStream(cu);
 					FileOutputStream outFile = new FileOutputStream(file)) {
-
-					IOUtils.copy(is, outFile);
+					is.transferTo(outFile);
 				}
 
 				if (!printedFiles.contains(file)) {


### PR DESCRIPTION
I found places where spoon manually read from an input stream just to write to an output stream. Since Java 9, there is a [InputStream#transferTo](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/io/InputStream.html#transferTo(java.io.OutputStream)) method that provides the same functionality and is easier to read.

To make it more consistent, I also replaced usages of `IOUtils#copy`, as it does the same than the new method.