### PR TITLE
review: refactor: replace usages of IOUtils with Java NIO API

### DIFF
--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -16,7 +16,6 @@
  */
 package spoon.test.comment;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
@@ -79,19 +78,20 @@ import spoon.test.comment.testclasses.CommentsOnStatements;
 import spoon.test.comment.testclasses.InlineComment;
 import spoon.test.comment.testclasses.JavaDocComment;
 import spoon.test.comment.testclasses.JavaDocEmptyCommentAndTags;
+import spoon.test.comment.testclasses.JavaDocWithLink;
 import spoon.test.comment.testclasses.OtherJavaDoc;
 import spoon.test.comment.testclasses.TestClassWithComments;
 import spoon.test.comment.testclasses.WildComments;
 import spoon.test.comment.testclasses.WindowsEOL;
 import spoon.testing.utils.LineSeperatorExtension;
-import spoon.test.comment.testclasses.JavaDocWithLink;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -101,9 +101,9 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 
 
@@ -890,7 +890,7 @@ public class CommentTest {
 		launcher.buildModel();
 
 		StringBuffer codeElementsDocumentationPage = new StringBuffer();
-		codeElementsDocumentationPage.append(IOUtils.toString(new FileReader("doc/code_elements_header.md")));
+		codeElementsDocumentationPage.append(Files.readString(Path.of("doc/code_elements_header.md"), StandardCharsets.UTF_8));
 		codeElementsDocumentationPage.append("\n\n");
 		launcher.getModel().getElements(new TypeFilter<>(CtInterface.class)).stream().forEach(x -> {
 
@@ -970,10 +970,12 @@ public class CommentTest {
 		}
 		);
 
+		String actual = codeElementsDocumentationPage.toString();
 		try {
-			assertEquals(IOUtils.toString(new FileReader("doc/code_elements.md")), codeElementsDocumentationPage.toString(), "doc outdated, please commit doc/code_elements.md");
+			String expected = Files.readString(Path.of("doc/code_elements.md"), StandardCharsets.UTF_8);
+			assertEquals(expected, actual, "doc outdated, please commit doc/code_elements.md");
 		} finally {
-			IOUtils.write(codeElementsDocumentationPage.toString(), new FileOutputStream("doc/code_elements.md"));
+			Files.writeString(Path.of("doc/code_elements.md"), actual, StandardCharsets.UTF_8);
 		}
 	}
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -17,6 +17,7 @@
 package spoon.test.imports;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
@@ -1021,10 +1022,10 @@ public class ImportTest {
 	}
 
 	@Test
-	public void testmportInCu() throws  Exception{
+	public void testmportInCu(@TempDir Path tempDir) throws  Exception{
 		// contract: auto-import works for compilation units with multiple classes
 		String[] options = {"--output-type", "compilationunits",
-				"--output", "target/testmportInCu", "--with-imports"};
+				"--output", tempDir.toString(), "--with-imports"};
 
 		String path = "spoon/test/prettyprinter/testclasses/A.java";
 
@@ -1033,7 +1034,7 @@ public class ImportTest {
 		launcher.addInputResource("./src/test/java/"+path);
 		launcher.run();
 
-		Path output = Path.of("target/testmportInCu/" + path);
+		Path output = tempDir.resolve(path);
 		String code = Files.readString(output);
 
 		// the ArrayList is imported and used in short mode
@@ -1044,9 +1045,6 @@ public class ImportTest {
 
 		// sanity check: the actual code
 		assertThat(code, containsString("ArrayList<String> list = new ArrayList<>()"));
-
-		// cleaning
-		Files.delete(output);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -16,7 +16,6 @@
  */
 package spoon.test.imports;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonException;
@@ -75,11 +74,11 @@ import spoon.testing.utils.ModelUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1034,8 +1033,8 @@ public class ImportTest {
 		launcher.addInputResource("./src/test/java/"+path);
 		launcher.run();
 
-		File output = new File("target/testmportInCu/"+path);
-		String code = IOUtils.toString(new FileReader(output));
+		Path output = Path.of("target/testmportInCu/" + path);
+		String code = Files.readString(output);
 
 		// the ArrayList is imported and used in short mode
 		assertThat(code, containsString("import java.util.ArrayList"));
@@ -1047,7 +1046,7 @@ public class ImportTest {
 		assertThat(code, containsString("ArrayList<String> list = new ArrayList<>()"));
 
 		// cleaning
-		output.delete();
+		Files.delete(output);
 	}
 
 	@Test
@@ -1061,16 +1060,15 @@ public class ImportTest {
 
 		canBeBuilt(outputDir, 7);
 
-		String pathA = "spoon/test/imports/testclasses/multiplecu/A.java";
-		String pathB = "spoon/test/imports/testclasses/multiplecu/B.java";
+		Path outputDirPath = Path.of(outputDir);
+		Path pathA = outputDirPath.resolve("spoon/test/imports/testclasses/multiplecu/A.java");
+		Path pathB = outputDirPath.resolve("spoon/test/imports/testclasses/multiplecu/B.java");
 
-		File outputA = new File(outputDir+"/"+pathA);
-		String codeA = IOUtils.toString(new FileReader(outputA));
+		String codeA = Files.readString(pathA);
 
 		assertThat(codeA, containsString("import java.util.List;"));
 
-		File outputB = new File(outputDir+"/"+pathB);
-		String codeB = IOUtils.toString(new FileReader(outputB));
+		String codeB = Files.readString(pathB);
 
 		assertThat(codeB, containsString("import java.awt.List;"));
 	}

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -17,11 +17,8 @@
 package spoon.test.prettyprinter;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.model.Profile;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
@@ -36,13 +33,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import spoon.Launcher;
-import spoon.MavenLauncher;
-import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.Environment;
 import spoon.compiler.SpoonResource;
 import spoon.compiler.SpoonResourceHelper;
-import spoon.pattern.Match;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtCodeSnippetStatement;
 import spoon.reflect.code.CtConstructorCall;
@@ -70,11 +64,12 @@ import spoon.testing.utils.LineSeperatorExtension;
 import spoon.testing.utils.ModelUtils;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -352,7 +347,7 @@ public class DefaultPrettyPrinterTest {
 		assertTrue(javaFile.exists());
 
 		assertEquals("package foo;" + nl + "class Bar {}",
-				IOUtils.toString(new FileInputStream(javaFile), "UTF-8"));
+				Files.readString(javaFile.toPath(), StandardCharsets.UTF_8));
 	}
 
 	@Test


### PR DESCRIPTION
I replaced remaining usages of IOUtils with modern Java APIs.

From what I've seen, `commons-io` isn't in use anymore, so we can probably remove it in a following PR.