### PR TITLE
review: fix: Use thread-local caching for actual class lookup

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -160,14 +160,16 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 			}
 			typeReference = componentTypeReference;
 		}
-		ClassLoader classLoader = getFactory().getEnvironment().getInputClassLoader();
+		Class<T> actualClass = getClassFromThreadLocalCacheOrLoad(typeReference);
+		return isArray() ? arrayType(actualClass) : actualClass;
+	}
 
+	@SuppressWarnings("unchecked")
+	private Class<T> getClassFromThreadLocalCacheOrLoad(CtTypeReference<?> typeReference) {
+		ClassLoader classLoader = getFactory().getEnvironment().getInputClassLoader();
 		checkCacheIntegrity(classLoader);
 		String qualifiedName = typeReference.getQualifiedName();
-		@SuppressWarnings("unchecked")
-		Class<T> clazz = (Class<T>) classByQName.get().computeIfAbsent(qualifiedName, key -> loadClassWithQName(classLoader, qualifiedName));
-
-		return isArray() ? arrayType(clazz) : clazz;
+		return (Class<T>) classByQName.get().computeIfAbsent(qualifiedName, key -> loadClassWithQName(classLoader, qualifiedName));
 	}
 
 	/**

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -56,8 +56,8 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	// We use thread-local storage for the caching to avoid having to lock when doing cache invalidation and lookup.
 	// See https://github.com/INRIA/spoon/issues/4668 for details.
-	private final static ThreadLocal<Map<String, Class<?>>> classByQName = ThreadLocal.withInitial(HashMap::new);
-	private final static ThreadLocal<ClassLoader> lastClassLoader = new ThreadLocal<>();
+	private static final ThreadLocal<Map<String, Class<?>>> classByQName = ThreadLocal.withInitial(HashMap::new);
+	private static final ThreadLocal<ClassLoader> lastClassLoader = new ThreadLocal<>();
 
 	@MetamodelPropertyField(role = TYPE_ARGUMENT)
 	List<CtTypeReference<?>> actualTypeArguments = CtElementImpl.emptyList();

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -56,7 +56,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 	// We use thread-local storage for the caching to avoid having to lock when doing cache invalidation and lookup.
 	// See https://github.com/INRIA/spoon/issues/4668 for details.
-	private final static ThreadLocal<Map<String, Class>> classByQName = ThreadLocal.withInitial(HashMap::new);
+	private final static ThreadLocal<Map<String, Class<?>>> classByQName = ThreadLocal.withInitial(HashMap::new);
 	private final static ThreadLocal<ClassLoader> lastClassLoader = new ThreadLocal<>();
 
 	@MetamodelPropertyField(role = TYPE_ARGUMENT)
@@ -151,7 +151,6 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	 *
 	 * Looks for the class in the standard Java classpath, but also in the sourceClassPath given as option.
 	 */
-	@SuppressWarnings("unchecked")
 	protected Class<T> findClass() {
 		CtTypeReference<?> typeReference = this;
 		if (isArray()) {
@@ -165,7 +164,8 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 
 		checkCacheIntegrity(classLoader);
 		String qualifiedName = typeReference.getQualifiedName();
-		Class<T> clazz =  classByQName.get().computeIfAbsent(qualifiedName, key -> loadClassWithQName(classLoader, qualifiedName));
+		@SuppressWarnings("unchecked")
+		Class<T> clazz = (Class<T>) classByQName.get().computeIfAbsent(qualifiedName, key -> loadClassWithQName(classLoader, qualifiedName));
 
 		return isArray() ? arrayType(clazz) : clazz;
 	}


### PR DESCRIPTION
Fix #4668

This is a quick-fix to avoid the cross-thread race condition when invalidating the cache and then doing a lookup in it. This is a problem as the current lock is per-instance but the cache is static, so in theory a thread A could check the cache integrity and state that it's fine, then there's a context switch to thread B which does the same thing and invalidates the cache and inserts something into the cache, and then we're back to thread B which does a lookup on a "bad cache" (according to thread A's view of the world).

By using thread-local storage, this situation cannot occur.