### PR TITLE
review: refactor: Use NIO to read compilation unit source code

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtCompilationUnitImpl.java
@@ -9,7 +9,7 @@ package spoon.support.reflect.declaration;
 
 
 import java.io.File;
-import java.io.FileInputStream;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -324,10 +324,11 @@ public class CtCompilationUnitImpl extends CtElementImpl implements CtCompilatio
 	public String getOriginalSourceCode() {
 
 		if (originalSourceCode == null && getFile() != null && getFile().exists()) {
-			try (FileInputStream s = new FileInputStream(getFile())) {
-				byte[] elementBytes = new byte[s.available()];
-				s.read(elementBytes);
-				originalSourceCode = new String(elementBytes, this.getFactory().getEnvironment().getEncoding());
+			try {
+				originalSourceCode = Files.readString(
+					getFile().toPath(),
+					this.getFactory().getEnvironment().getEncoding()
+				);
 			} catch (Exception e) {
 				throw new RuntimeException(e);
 			}


### PR DESCRIPTION
This was discovered while fixing #4672. I don't believe the `available` method makes any guarantees about its length, this looks like it could silently truncate the read source code.