### PR TITLE
review: feat: Do not trim surefire stacktraces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,6 +283,7 @@
         <configuration>
           <classpathDependencyExcludes>
             <classpathDependencyExclude>ch.qos.logback:logback-classic</classpathDependencyExclude>
+            <trimStackTrace>false</trimStackTrace>
           </classpathDependencyExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
This ensures CI logs actually show you all information about failures instead of only the topmost few frames.

Found as the CI runs in #4672 were utterly useless. The real error was a lot further down and only found as java 17 included the variable name in the null pointer explanation.

Example before: https://github.com/INRIA/spoon/runs/5960899222?check_suite_focus=true#step:10:419

Example after: https://github.com/INRIA/spoon/runs/5960957519?check_suite_focus=true#step:10:720

This option will also be the default in upcoming surefire releases (starting with [3.0.0-M6](https://github.com/apache/maven-surefire/pull/502)). I can also update the surefire plugin instead of configuring this, if you want.