### PR TITLE
wip: refactor: use JDK nullOutputStream

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBatchCompiler.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.apache.commons.io.output.NullOutputStream;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.CompilationProgress;
@@ -50,7 +49,7 @@ public class JDTBatchCompiler extends org.eclipse.jdt.internal.compiler.batch.Ma
 		// by default we don't want anything from JDT
 		// the reports are sent with callbakcs to the reporter
 		// for debuggging, you may use System.out/err instead
-		this(jdtCompiler, new NullOutputStream(), new NullOutputStream());
+		this(jdtCompiler, OutputStream.nullOutputStream(), OutputStream.nullOutputStream());
 	}
 
 	JDTBatchCompiler(JDTBasedSpoonCompiler jdtCompiler, OutputStream outWriter, OutputStream errWriter) {


### PR DESCRIPTION
Construction a `NullOutputStream` is already deprecated, and we can use a JDK method here.

Note that the implementations are slighly different, the output stream provided by the JDK does not allow to write to it after it was closed. This shouldn't be an issue though, as this is the expected behavior for other output stream implementations anyways.