### PR TITLE
shore(deps) Update DepClean to version 2.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -291,15 +291,14 @@
         <!-- see https://github.com/castor-software/depclean -->
         <groupId>se.kth.castor</groupId>
         <artifactId>depclean-maven-plugin</artifactId>
-        <version>2.0.1</version>
+        <version>2.0.2</version>
         <executions>
           <execution>
               <goals>
                 <goal>depclean</goal>
               </goals>
              <configuration>
-                <ignoreDependencies>org.kohsuke.metainf-services:metainf-services:1.9:test</ignoreDependencies>
-               <!-- the build fails if there are unused direct dependencies -->
+               <!-- the build should fail if there are unused direct dependencies -->
                <failIfUnusedDirect>true</failIfUnusedDirect>
              </configuration>
            </execution>


### PR DESCRIPTION
Version 2.0.2 of DepClean has [been released](https://github.com/castor-software/depclean/releases/tag/2.0.2), which includes several improvements such as static analysis of dependencies at the source code level. For Spoon, this means that the exclusion of `org.kohsuke.metainf-services:metainf-services` is no longer needed in the `pom` of Spoon because now DepClean correctly identifies this dependency as used.