### PR TITLE
refactor: use StringJoiner where appropriate

### DIFF
--- a/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
+++ b/src/main/java/spoon/reflect/path/impl/AbstractPathElement.java
@@ -12,8 +12,8 @@ import spoon.reflect.visitor.CtScanner;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 
 /**
@@ -53,16 +53,10 @@ public abstract class AbstractPathElement<P extends CtElement, T extends CtEleme
 		if (arguments.isEmpty()) {
 			return "";
 		}
-		StringBuilder builder = new StringBuilder("[");
-
-		for (Iterator<Map.Entry<String, String>> iter = arguments.entrySet().iterator(); iter.hasNext();) {
-			Map.Entry<String, String> value = iter.next();
-			builder.append(value.getKey() + "=" + value.getValue());
-			if (iter.hasNext()) {
-				builder.append(";");
-			}
+		StringJoiner joiner = new StringJoiner(";", "[", "]");
+		for (Map.Entry<String, String> entry : arguments.entrySet()) {
+			joiner.add(entry.getKey() + "=" + entry.getValue());
 		}
-
-		return builder.append("]").toString();
+		return joiner.toString();
 	}
 }

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -74,6 +74,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.StringJoiner;
 
 import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.getModifiers;
 import static spoon.support.compiler.jdt.JDTTreeBuilderQuery.isLhsAssignment;
@@ -105,12 +106,11 @@ public class JDTTreeBuilderHelper {
 	 * @return Qualified name.
 	 */
 	static String createQualifiedTypeName(char[][] typeName) {
-		StringBuilder s = new StringBuilder();
-		for (int i = 0; i < typeName.length - 1; i++) {
-			s.append(CharOperation.charToString(typeName[i])).append(".");
+		StringJoiner joiner = new StringJoiner(".");
+		for (char[] typeNamePart : typeName) {
+			joiner.add(CharOperation.charToString(typeNamePart));
 		}
-		s.append(CharOperation.charToString(typeName[typeName.length - 1]));
-		return s.toString();
+		return joiner.toString();
 	}
 
 	/**


### PR DESCRIPTION
Using StringJoiner allows to simplify a few places in code and make them more clear.