### PR TITLE
chore: kickstart next snapshot 10.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <artifactId>spoon-core</artifactId>
   <packaging>jar</packaging>
-  <version>10.1.0-SNAPSHOT</version>
+  <version>10.2.0-SNAPSHOT</version>
   <name>Spoon Core</name>
   <description>Spoon is a tool for meta-programming, analysis and transformation of Java programs.</description>
   <url>http://spoon.gforge.inria.fr/</url>


### PR DESCRIPTION
Now that 10.1.0 is live, we start building 10.2.0.