### PR TITLE
wip: refactor: Add ModelTest annotation

### DIFF
--- a/src/test/java/spoon/CompilationUnitPrintTest.java
+++ b/src/test/java/spoon/CompilationUnitPrintTest.java
@@ -10,15 +10,15 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.support.JavaOutputProcessor;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CompilationUnitPrintTest {
 
-    @Test
-    public void test() {
-
-        /* Testing scenario:
+    @ModelTest("src/test/java/spoon/CompilationUnitPrintTest.java")
+    public void test(Factory factory) {
+		/* Testing scenario:
             Build a model with a class
             Clone this class
             Modify the clone by adding a method
@@ -28,12 +28,6 @@ public class CompilationUnitPrintTest {
          */
 
         // build original class
-        Launcher launcher = new Launcher();
-        launcher.addInputResource("src/test/java/spoon/CompilationUnitPrintTest.java");
-        launcher.getEnvironment().setNoClasspath(true);
-        launcher.buildModel();
-        final Factory factory = launcher.getFactory();
-
         // clone
         final CtClass<?> compilationUnitPrintTest = factory.Class().get("spoon.CompilationUnitPrintTest");
         final CtClass<?> clone = compilationUnitPrintTest.clone();
@@ -61,7 +55,7 @@ public class CompilationUnitPrintTest {
         assertEquals(1 , compilationUnitPrintTest.getMethods().size());
 
         // building now a new model from the java file outputted just before
-        launcher = new Launcher();
+        Launcher launcher = new Launcher();
         launcher.addInputResource("target/spoon/CompilationUnitPrintTest.java");
         launcher.getEnvironment().setNoClasspath(true);
         launcher.buildModel();

--- a/src/test/java/spoon/LauncherTest.java
+++ b/src/test/java/spoon/LauncherTest.java
@@ -33,6 +33,7 @@ import spoon.reflect.CtModel;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.support.JavaOutputProcessor;
 import spoon.support.compiler.VirtualFile;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -114,13 +115,9 @@ public class LauncherTest {
 		}
 	}
 
-	@Test
-	public void testLLauncherBuildModelReturnAModel() {
+	@ModelTest("./src/test/resources/spoon/test/api/Foo.java")
+	public void testLLauncherBuildModelReturnAModel(CtModel model) {
 		// contract: Launcher#buildModel should return a consistent CtModel
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/api/Foo.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		assertNotNull(model);
 
 		assertEquals(2, model.getAllTypes().size());

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -48,6 +48,7 @@ import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.support.visitor.equals.CloneHelper;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -245,14 +246,9 @@ public class CloneTest {
 		}
 	}
 
-	@Test
-	public void testIssue3389() {
+	@ModelTest("src/test/resources/JavaCode.java")
+	public void testIssue3389(Launcher launcher) {
 		// test case for https://github.com/INRIA/spoon/issues/3389
-		Launcher launcher = new Launcher();
-		launcher.addInputResource( "./src/test/resources/JavaCode.java" );
-		launcher.buildModel();
-		CtModel model = launcher.getModel();
-
 		CtType<?> c = launcher.getFactory().Type().get("HelloWorld");
 
 		// sanity check: the field is at the end as in the source

--- a/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
+++ b/src/test/java/spoon/reflect/declaration/CtTypeInformationTest.java
@@ -34,6 +34,7 @@ import spoon.reflect.declaration.testclasses.TestInterface;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.adaption.TypeAdaptor;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -114,11 +115,8 @@ public class CtTypeInformationTest {
 		}
 	}
 
-	@Test
-	public void testGetAllMethodsReturnsTheRightNumber() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/ExtendsObject.java");
-		launcher.buildModel();
+	@ModelTest("src/test/resources/noclasspath/ExtendsObject.java")
+	public void testGetAllMethodsReturnsTheRightNumber(Launcher launcher) {
 		int nbMethodsObject = launcher.getFactory().Type().get(Object.class).getAllMethods().size();
 
 		final CtType<?> extendsObject = launcher.getFactory().Type().get("test.ExtendsObject");

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -37,6 +37,7 @@ import spoon.metamodel.MMMethod;
 import spoon.metamodel.MMMethodKind;
 import spoon.metamodel.Metamodel;
 import spoon.metamodel.MetamodelConcept;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.cu.CompilationUnit;
@@ -52,6 +53,7 @@ import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.reflect.visitor.processors.CheckScannerTestProcessor;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -112,13 +114,9 @@ public class CtScannerTest {
 		return sc1.signature;
 	}
 
-	@Test
-	public void testScannerCallsAllProperties() {
+	@ModelTest("./src/main/java/spoon/reflect/")
+	public void testScannerCallsAllProperties(Launcher launcher) {
 		// contract: CtScanner must visit all metamodel properties and use correct CtRole!
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/main/java/spoon/reflect/");
-		launcher.run();
-
 		CtTypeReference<?> ctElementRef = launcher.getFactory().createCtTypeReference(CtElement.class);
 		CtTypeReference<?> ctRefRef = launcher.getFactory().createCtTypeReference(CtReference.class);
 

--- a/src/test/java/spoon/support/compiler/jdt/JDTBasedSpoonCompilerTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBasedSpoonCompilerTest.java
@@ -19,6 +19,7 @@ package spoon.support.compiler.jdt;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.testing.utils.ModelTest;
 
 import java.util.List;
 
@@ -26,10 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JDTBasedSpoonCompilerTest {
 
-	@Test
-	public void testOrderCompilationUnits() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/main/java");
+	@ModelTest("./src/main/java")
+	public void testOrderCompilationUnits(Launcher launcher) {
 		JDTBasedSpoonCompiler spoonCompiler = (JDTBasedSpoonCompiler) launcher.getModelBuilder();
 
 		CompilationUnitDeclaration[] compilationUnitDeclarations = spoonCompiler.buildUnits(null, spoonCompiler.sources, spoonCompiler.getSourceClasspath(), "");

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -103,6 +103,7 @@ import spoon.test.pkg.PackageTest;
 import spoon.test.pkg.cyclic.Outside;
 import spoon.test.pkg.cyclic.direct.Cyclic;
 import spoon.test.pkg.cyclic.indirect.Indirect;
+import spoon.testing.utils.ModelTest;
 
 public class JavaReflectionTreeBuilderTest {
 
@@ -640,12 +641,9 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals("Bidon", annotatedParameter.getAnnotations().get(0).getAnnotationType().getSimpleName());
 	}
 
-	@Test
-	public void testInnerClassOfSourceCodeClass() {
+	@ModelTest("src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java")
+	public void testInnerClass(Launcher launcher) {
 		// contract: JavaReflectionTreeBuilder does not rescan the type if source information is available
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java");
-		launcher.buildModel();
 		CtType ctType = launcher.getFactory().Type().get(Diff.class);
 		assertEquals("Diff", ctType.getSimpleName());
 		assertEquals(false, ctType.isAnonymous());
@@ -685,8 +683,8 @@ public class JavaReflectionTreeBuilderTest {
 	}
 
 
-	@Test
-	public void testAnonymousClass() {
+	@ModelTest("src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java")
+	public void testAnonymousClass(Launcher launcher) {
 		// contract: JavaReflectionTreeBuilder works on anonymous classes
 
 		// the test object: an anonymous class
@@ -695,9 +693,6 @@ public class JavaReflectionTreeBuilderTest {
 
 			}
 		};
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java");
-		launcher.buildModel();
 		CtType ctType = launcher.getModel().getElements(new TypeFilter<CtType>(CtType.class) {
 			@Override
 			public boolean matches(CtType element) {

--- a/src/test/java/spoon/test/annotation/AnnotationTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationTest.java
@@ -103,6 +103,7 @@ import spoon.test.annotation.testclasses.repeatandarrays.TagArrays;
 import spoon.test.annotation.testclasses.shadow.DumbKlass;
 import spoon.test.annotation.testclasses.spring.AliasFor;
 import spoon.test.annotation.testclasses.typeandfield.SimpleClass;
+import spoon.testing.utils.ModelTest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -134,38 +135,26 @@ public class AnnotationTest {
 		assertEquals("PropertyGetter", annotation.getName());
 	}
 
-	@Test
-	public void testModelBuildingAnnotationBound() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Bound.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
-		CtType<spoon.test.annotation.testclasses.Bound> type = factory.Type().get("spoon.test.annotation.testclasses.Bound");
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Bound.java")
+	public void testModelBuildingAnnotationBound(Factory factory) {
+		CtType<Bound> type = factory.Type().get("spoon.test.annotation.testclasses.Bound");
 		assertEquals("Bound", type.getSimpleName());
 		assertEquals(1, type.getAnnotations().size());
 
 		// contract one can build an annotation from the annotation type
-		CtAnnotation<?> annot = launcher.getFactory().createAnnotation(type.getReference());
+		CtAnnotation<?> annot = factory.createAnnotation(type.getReference());
 		assertEquals("@spoon.test.annotation.testclasses.Bound", annot.toString());
 	}
 
-	@Test
-	public void testWritingAnnotParamArray() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotParam.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotParam.java")
+	public void testWritingAnnotParamArray(Factory factory) {
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.AnnotParam");
 		assertEquals("@java.lang.SuppressWarnings({ \"unused\", \"rawtypes\" })",
 				type.getElements(new TypeFilter<>(CtAnnotation.class)).get(0).toString());
 	}
 
-	@Test
-	public void testModelBuildingAnnotationBoundUsage() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Main.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Main.java")
+	public void testModelBuildingAnnotationBoundUsage(Factory factory) {
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.Main");
 		assertEquals("Main", type.getSimpleName());
 
@@ -204,12 +193,8 @@ public class AnnotationTest {
 		assertEquals("8", a.getAllValues().get("max").toString());
 	}
 
-	@Test
-	public void testPersistenceProperty() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/PersistenceProperty.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/PersistenceProperty.java")
+	public void testPersistenceProperty(Factory factory) {
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.PersistenceProperty");
 		assertEquals("PersistenceProperty", type.getSimpleName());
 		assertEquals(2, type.getAnnotations().size());
@@ -224,12 +209,8 @@ public class AnnotationTest {
 		assertTrue(a2.getValues().containsKey("value"));
 	}
 
-	@Test
-	public void testAnnotationParameterTypes() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Main.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Main.java")
+	public void testAnnotationParameterTypes(Factory factory) {
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.Main");
 
 		CtMethod<?> m1 = type.getElements(new NamedElementFilter<>(CtMethod.class, "m1")).get(0);
@@ -315,12 +296,8 @@ public class AnnotationTest {
 		assertEquals("dddd", annot.ia().value());
 	}
 
-	@Test
-	public void testAnnotatedElementTypes() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/")
+	public void testAnnotatedElementTypes(Factory factory) {
 		// load package of the test classes
 		CtPackage pkg = factory.Package().get("spoon.test.annotation.testclasses");
 
@@ -435,13 +412,11 @@ public class AnnotationTest {
 		assertEquals(CtAnnotatedElementType.ANNOTATION_TYPE, annotations.get(0).getAnnotatedElementType());
 	}
 
-	@Test
-	public void testAnnotationWithDefaultArrayValue() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java");
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotArray.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest({
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java",
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotArray.java",
+	})
+	public void testAnnotationWithDefaultArrayValue(Factory factory) {
 		final String res = "public java.lang.Class<?>[] value() default {  };";
 
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.AnnotArrayInnerClass");
@@ -456,12 +431,8 @@ public class AnnotationTest {
 		assertEquals(res, annotation.getMethod("value").toString());
 	}
 
-	@Test
-	public void testInnerAnnotationsWithArray() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Foo.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Foo.java")
+	public void testInnerAnnotationsWithArray(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.Foo");
 		final CtMethod<?> testMethod = ctClass.getMethodsByName("test").get(0);
 		final List<CtAnnotation<? extends Annotation>> testMethodAnnotations = testMethod.getAnnotations();
@@ -488,28 +459,20 @@ public class AnnotationTest {
 		assertEquals("hello again", getLiteralValueInAnnotation(innerAnnotationInSecondMiddleAnnotation).getValue());
 	}
 
-	@Test
-	public void testAccessAnnotationValue() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Main.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Main.java")
+	public void testAccessAnnotationValue(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.Main");
 		CtMethod<?> testMethod = ctClass.getMethodsByName("testValueWithArray").get(0);
 		Class<?>[] value = testMethod.getAnnotation(AnnotArray.class).value();
-		assertArrayEquals(new Class[] { RuntimeException.class }, value);
+		assertArrayEquals(new Class[]{RuntimeException.class}, value);
 
 		testMethod = ctClass.getMethodsByName("testValueWithoutArray").get(0);
 		value = testMethod.getAnnotation(AnnotArray.class).value();
-		assertArrayEquals(new Class[] { RuntimeException.class }, value);
+		assertArrayEquals(new Class[]{RuntimeException.class}, value);
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationInNewInstance() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationInNewInstance(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtConstructorCall<?> ctConstructorCall = ctClass.getElements(new AbstractFilter<CtConstructorCall<?>>(CtConstructorCall.class) {
@@ -526,12 +489,8 @@ public class AnnotationTest {
 		assertEquals("new java.lang.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "String()", ctConstructorCall.toString(), "New class with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationInCast() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationInCast(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtReturn<?> returns = ctClass.getElements(new AbstractFilter<CtReturn<?>>(CtReturn.class) {
@@ -549,12 +508,8 @@ public class AnnotationTest {
 		assertEquals("((java.lang.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "String) (s))", returnedExpression.toString(), "Cast with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationBeforeExceptionInSignatureOfMethod() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationBeforeExceptionInSignatureOfMethod(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtMethod<?> method = ctClass.getMethodsByName("m").get(0);
@@ -567,13 +522,11 @@ public class AnnotationTest {
 		assertEquals("public void m() throws java.lang.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "Exception {" + System.lineSeparator() + "}", method.toString(), "Thrown type with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationInReturnTypeInMethod() {
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(false);
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest(
+		value = "./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java",
+		noClasspath = false
+	)
+	public void testUsageOfTypeAnnotationInReturnTypeInMethod(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtMethod<?> method = ctClass.getMethodsByName("m3").get(0);
@@ -585,13 +538,11 @@ public class AnnotationTest {
 		assertEquals("public java.lang.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "String m3() {" + System.lineSeparator() + "    return \"\";" + System.lineSeparator() + "}", method.toString(), "Return type with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationOnParameterInMethod() {
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(false);
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest(
+		value = "./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java",
+		noClasspath = false
+	)
+	public void testUsageOfTypeAnnotationOnParameterInMethod(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsAppliedOnAnyTypeInAClass.class);
 
 		final CtMethod<?> method = ctClass.getMethodsByName("m6").get(0);
@@ -605,14 +556,11 @@ public class AnnotationTest {
 	}
 
 
-
-	@Test
-	public void testUsageOfTypeAnnotationOnLocalVariableInMethod() {
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(false);
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest(
+		value = "./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java",
+		noClasspath = false
+	)
+	public void testUsageOfTypeAnnotationOnLocalVariableInMethod(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsAppliedOnAnyTypeInAClass.class);
 
 		final CtMethod<?> method = ctClass.getMethodsByName("m6").get(0);
@@ -630,12 +578,8 @@ public class AnnotationTest {
 		assertEquals("java.lang.@spoon.test.annotation.testclasses.TypeAnnotation" + System.lineSeparator() + "String s = \"\"", ctLocalVariable.toString(), "Local variable type with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationInExtendsImplementsOfAClass() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationInExtendsImplementsOfAClass(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtClass<?> innerClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class, "DummyClass")).get(0);
@@ -677,12 +621,8 @@ public class AnnotationTest {
 		assertEquals(interfaceExpected, interfaceActual.toString(), "Implements in a interface with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationWithGenericTypesInClassDeclaration() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationWithGenericTypesInClassDeclaration(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtClass<?> genericClass = ctClass.getElements(new NamedElementFilter<>(CtClass.class, "DummyGenericClass")).get(0);
@@ -698,12 +638,8 @@ public class AnnotationTest {
 		assertEquals(expected, superInterface.toString(), "Super interface has a generic type with type annotation");
 	}
 
-	@Test
-	public void testUsageOfTypeAnnotationWithGenericTypesInStatements() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfTypeAnnotationWithGenericTypesInStatements(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 
 		final CtMethod<?> method = ctClass.getMethodsByName("m4").get(0);
@@ -744,12 +680,8 @@ public class AnnotationTest {
 		assertEquals(expectedThirdStatement, body.getStatement(2).toString(), "Type in generic parameter with an type annotation must be well printed");
 	}
 
-	@Test
-	public void testUsageOfParametersInTypeAnnotation() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java")
+	public void testUsageOfParametersInTypeAnnotation(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.AnnotationsAppliedOnAnyTypeInAClass");
 		final CtMethod<?> method = ctClass.getMethodsByName("m5").get(0);
 
@@ -787,12 +719,11 @@ public class AnnotationTest {
 		assertEquals(complexArrayParam, method.getBody().getStatement(10).toString(), "array of complexes parameters in type annotation");
 	}
 
-	@Test
-	public void testOutputGeneratedByTypeAnnotation() {
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(false);
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		launcher.buildModel();
+	@ModelTest(
+		value = "./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java",
+		noClasspath = false
+	)
+	public void testOutputGeneratedByTypeAnnotation(Launcher launcher) {
 		// we only write to disk here
 		launcher.setSourceOutputDirectory(new File("./target/spooned-annotation-output/"));
 		launcher.getModelBuilder().generateProcessedSourceFiles(OutputType.CLASSES);
@@ -800,12 +731,8 @@ public class AnnotationTest {
 		canBeBuilt(new File("./target/spooned-annotation-output/spoon/test/annotation/testclasses/"), 8);
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnClass() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnClass(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 
 		final List<CtAnnotation<? extends Annotation>> annotations = ctClass.getAnnotations();
@@ -816,12 +743,8 @@ public class AnnotationTest {
 		assertEquals("Second", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Second\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnField() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnField(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 		final CtField<?> field = ctClass.getField("field");
 
@@ -833,12 +756,8 @@ public class AnnotationTest {
 		assertEquals("Field 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Field 2\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnMethod() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnMethod(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 		final CtMethod<?> method = ctClass.getMethodsByName("method").get(0);
 
@@ -850,12 +769,8 @@ public class AnnotationTest {
 		assertEquals("Method 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Method 2\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnConstructor() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnConstructor(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 		final CtConstructor<?> ctConstructor = ctClass.getConstructors().toArray(new CtConstructor<?>[0])[0];
 
@@ -867,12 +782,8 @@ public class AnnotationTest {
 		assertEquals("Constructor 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Constructor 2\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnParameter() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnParameter(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 		final CtMethod<?> method = ctClass.getMethodsByName("methodWithParameter").get(0);
 		final CtParameter<?> ctParameter = method.getParameters().get(0);
@@ -885,12 +796,8 @@ public class AnnotationTest {
 		assertEquals("Param 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Param 2\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnLocalVariable() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java")
+	public void testRepeatSameAnnotationOnLocalVariable(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnotationsRepeated.class);
 		final CtMethod<?> method = ctClass.getMethodsByName("methodWithLocalVariable").get(0);
 		final CtLocalVariable<?> ctLocalVariable = method.getBody().getElements(new AbstractFilter<CtLocalVariable<?>>(CtLocalVariable.class) {
@@ -908,13 +815,11 @@ public class AnnotationTest {
 		assertEquals("Local 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Local 2\"");
 	}
 
-	@Test
-	public void testRepeatSameAnnotationOnPackage() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java");
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/package-info.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest({
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotationsRepeated.java",
+		"./src/test/java/spoon/test/annotation/testclasses/package-info.java"
+	})
+	public void testRepeatSameAnnotationOnPackage(Factory factory) {
 		final CtPackage pkg = factory.Package().get("spoon.test.annotation.testclasses");
 
 		final List<CtAnnotation<? extends Annotation>> annotations = pkg.getAnnotations();
@@ -925,12 +830,8 @@ public class AnnotationTest {
 		assertEquals("Package 2", ((CtLiteral) (annotations.get(1).getValue("value"))).getValue(), "Argument of the second annotation is \"Package 2\"");
 	}
 
-	@Test
-	public void testDefaultValueInAnnotationsForAnnotationFields() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationDefaultAnnotation.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationDefaultAnnotation.java")
+	public void testDefaultValueInAnnotationsForAnnotationFields(Factory factory) {
 		final CtType<?> annotation = factory.Type().get(AnnotationDefaultAnnotation.class);
 
 		final CtAnnotationMethod<?> ctAnnotations = annotation.getMethods().toArray(new CtAnnotationMethod<?>[0])[0];
@@ -938,34 +839,29 @@ public class AnnotationTest {
 		assertSame(InnerAnnot.class, ctAnnotations.getDefaultExpression().getType().getActualClass(), "Default value of a field typed by an annotation must be an annotation");
 	}
 
-	@Test
-	public void testGetAnnotationOuter() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Foo.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Foo.java")
+	public void testGetAnnotationOuter(Factory factory) {
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get("spoon.test.annotation.testclasses.Foo");
 		final CtMethod<?> testMethod = ctClass.getMethodsByName("test").get(0);
-		Foo.OuterAnnotation annot = testMethod.getAnnotation(Foo.OuterAnnotation.class);
+		OuterAnnotation annot = testMethod.getAnnotation(OuterAnnotation.class);
 		assertNotNull(annot);
 		assertEquals(2, annot.value().length);
 	}
 
-	@Test
-	public void testAbstractAllAnnotationProcessor() {
-		Launcher spoon = new Launcher();
-		spoon.getEnvironment().setNoClasspath(false);
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/BasicAnnotation.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/TypeAnnotation.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Inception.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/TestAnnotation.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java");
-		Factory factory = spoon.getFactory();
-		spoon.buildModel();
-
+	@ModelTest(
+		value = {
+			"./src/test/java/spoon/test/annotation/testclasses/AnnotationsAppliedOnAnyTypeInAClass.java",
+			"./src/test/java/spoon/test/annotation/testclasses/BasicAnnotation.java",
+			"./src/test/java/spoon/test/annotation/testclasses/TypeAnnotation.java",
+			"./src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java",
+			"./src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java",
+			"./src/test/java/spoon/test/annotation/testclasses/Inception.java",
+			"./src/test/java/spoon/test/annotation/testclasses/TestAnnotation.java",
+			"./src/test/java/spoon/test/annotation/testclasses/AnnotArrayInnerClass.java"
+		},
+		noClasspath = false
+	)
+	public void testAbstractAllAnnotationProcessor(Factory factory) {
 		// create the processor
 		final ProcessingManager p = new QueueProcessingManager(factory);
 		final TypeAnnotationProcessor processor = new TypeAnnotationProcessor();
@@ -975,19 +871,16 @@ public class AnnotationTest {
 		assertEquals(29, processor.elements.size());
 	}
 
-	@Test
-	public void testAbstractAllAnnotationProcessorWithGlobalAnnotation() {
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/ClassProcessed.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/TypeAnnotation.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Inception.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/GlobalAnnotation.java");
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/TestAnnotation.java");
-		Factory factory = spoon.getFactory();
-		spoon.buildModel();
-
+	@ModelTest({
+		"./src/test/java/spoon/test/annotation/testclasses/ClassProcessed.java",
+		"./src/test/java/spoon/test/annotation/testclasses/TypeAnnotation.java",
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotParamTypeEnum.java",
+		"./src/test/java/spoon/test/annotation/testclasses/InnerAnnot.java",
+		"./src/test/java/spoon/test/annotation/testclasses/Inception.java",
+		"./src/test/java/spoon/test/annotation/testclasses/GlobalAnnotation.java",
+		"./src/test/java/spoon/test/annotation/testclasses/TestAnnotation.java"
+	})
+	public void testAbstractAllAnnotationProcessorWithGlobalAnnotation(Factory factory) {
 		// create the processor
 		final ProcessingManager p = new QueueProcessingManager(factory);
 		final GlobalProcessor processor = new GlobalProcessor();
@@ -1000,12 +893,8 @@ public class AnnotationTest {
 		assertEquals(2, methodProcessor.elements.size());
 	}
 
-	@Test
-	public void testAnnotationIntrospection() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationIntrospection.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/AnnotationIntrospection.java")
+	public void testAnnotationIntrospection(Factory factory) {
 		CtClass<Object> aClass = factory.Class().get(AnnotationIntrospection.class);
 		CtMethod<?> mMethod = aClass.getMethod("m");
 		CtStatement statement = mMethod.getBody().getStatement(1);
@@ -1030,12 +919,8 @@ public class AnnotationTest {
 		assertEquals(2, aTypeAnnotation.getMethods().size());
 	}
 
-	@Test
-	public void testAnnotationInterfacePreserveMethods() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/PortRange.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/PortRange.java")
+	public void testAnnotationInterfacePreserveMethods(Factory factory) {
 		final CtAnnotationType<?> ctAnnotationType = (CtAnnotationType) factory.Type().get(PortRange.class);
 		List<CtMethod<?>> ctMethodMin = ctAnnotationType.getMethodsByName("min");
 		assertEquals(1, ctMethodMin.size(), "Method min is preserved after transformation");
@@ -1130,17 +1015,9 @@ public class AnnotationTest {
 		assertEquals("spoon.test.annotation.testclasses.PortRange", annotation.getAnnotationType().getQualifiedName(), "Annotation should be @spoon.test.annotation.testclasses.PortRange");
 	}
 
-	@Test
-	public void testGetAnnotationFromParameter() {
+	@ModelTest("src/test/resources/noclasspath/Initializer.java")
+	public void testGetAnnotationFromParameter(Launcher launcher, Factory factory) {
 		// contract: Java 8 receiver parameters are handled
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("src/test/resources/noclasspath/Initializer.java");
-		String output = "target/spooned-" + this.getClass().getSimpleName() + "-firstspoon/";
-		spoon.setSourceOutputDirectory(output);
-		spoon.getEnvironment().setNoClasspath(true);
-		Factory factory = spoon.getFactory();
-		spoon.buildModel();
-
 		List<CtMethod> methods = factory.getModel().getElements(new NamedElementFilter<>(CtMethod.class, "setField"));
 		assertThat(methods.size(), is(1));
 
@@ -1168,15 +1045,8 @@ public class AnnotationTest {
 		assertThat(raw.getAnnotationType().getSimpleName(), is("Raw"));
 	}
 
-	@Test
-	public void annotationAddValue() {
-		Launcher spoon = new Launcher();
-
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Bar.java");
-		spoon.buildModel();
-
-		Factory factory = spoon.getFactory();
-
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Bar.java")
+	public void annotationAddValue(Factory factory) {
 		List<CtMethod> methods = factory.getModel().getElements(new NamedElementFilter<>(CtMethod.class, "bidule"));
 
 		assertThat(methods.size(), is(1));
@@ -1188,14 +1058,8 @@ public class AnnotationTest {
 		assertThat(anno.getValue("params").getType(), is(factory.Type().createReference(String[].class)));
 	}
 
-	@Test
-	public void annotationOverrideFQNIsOK() {
-		Launcher spoon = new Launcher();
-		Factory factory = spoon.getFactory();
-		factory.getEnvironment().setNoClasspath(true);
-		spoon.addInputResource("./src/test/resources/noclasspath/annotation/issue1307/SpecIterator.java");
-		spoon.buildModel();
-
+	@ModelTest("./src/test/resources/noclasspath/annotation/issue1307/SpecIterator.java")
+	public void annotationOverrideFQNIsOK(Factory factory) {
 		List<CtAnnotation> overrideAnnotations = factory.getModel().getElements(new TypeFilter<>(CtAnnotation.class));
 
 		for (CtAnnotation annotation : overrideAnnotations) {
@@ -1208,19 +1072,15 @@ public class AnnotationTest {
 
 	@Test
 	public void testCreateAnnotation() {
-		final Launcher launcher = new Launcher();
+		Launcher launcher = new Launcher();
 		Factory factory = launcher.getFactory();
 		CtType<?> type = factory.Annotation().create("spoon.test.annotation.testclasses.NewAnnot");
 		assertTrue(type.isAnnotationType());
 		assertSame(type, type.getReference().getDeclaration());
 	}
 
-	@Test
-	public void testReplaceAnnotationValue() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/Main.java");
-		launcher.buildModel();
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/Main.java")
+	public void testReplaceAnnotationValue(Factory factory) {
 		CtType<?> type = factory.Type().get("spoon.test.annotation.testclasses.Main");
 
 		CtMethod<?> m1 = type.getElements(new NamedElementFilter<>(CtMethod.class, "m1")).get(0);
@@ -1290,14 +1150,10 @@ public class AnnotationTest {
 		assertTrue(type.getTypeMembers().get(0) instanceof CtAnnotationMethod);
 	}
 
-	@Test
-	public void testRepeatableAnnotationAreManaged() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/repeatable")
+	public void testRepeatableAnnotationAreManaged(Factory factory) {
 		// contract: when two identical repeatable annotation are used, they should be displayed in two different annotations and not factorized
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/repeatable");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(Repeated.class);
+		CtType type = factory.Type().get(Repeated.class);
 		CtMethod firstMethod = (CtMethod) type.getMethodsByName("method").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
@@ -1312,24 +1168,19 @@ public class AnnotationTest {
 		assertTrue(classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"truc\")"), "Content of the file: " + classContent);
 	}
 
-	@Test
-	public void testCreateRepeatableAnnotation() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/repeatable")
+	public void testCreateRepeatableAnnotation(Factory factory) {
 		// contract: when creating two repeatable annotations, two annotations should be created
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/repeatable");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(Repeated.class);
+		CtType type = factory.Type().get(Repeated.class);
 		CtMethod firstMethod = (CtMethod) type.getMethodsByName("withoutAnnotation").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertTrue(annotations.isEmpty());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class, "value", "foo");
+		factory.Annotation().annotate(firstMethod, Tag.class, "value", "foo");
 		assertEquals(1, firstMethod.getAnnotations().size());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, Tag.class, "value", "bar");
+		factory.Annotation().annotate(firstMethod, Tag.class, "value", "bar");
 
 		annotations = firstMethod.getAnnotations();
 		assertEquals(2, annotations.size());
@@ -1343,14 +1194,10 @@ public class AnnotationTest {
 		assertTrue(classContent.contains("@spoon.test.annotation.testclasses.repeatable.Tag(\"bar\")"), "Content of the file: " + classContent);
 	}
 
-	@Test
-	public void testRepeatableAnnotationAreManagedWithArrays() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/repeatandarrays")
+	public void testRepeatableAnnotationAreManagedWithArrays(Factory factory) {
 		// contract: when two identical repeatable annotation with arrays are used, they should be displayed in two different annotations and not factorized
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/repeatandarrays");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(RepeatedArrays.class);
+		CtType type = factory.Type().get(RepeatedArrays.class);
 		CtMethod firstMethod = (CtMethod) type.getMethodsByName("method").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
@@ -1365,23 +1212,19 @@ public class AnnotationTest {
 		assertTrue(classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays({ \"truc\", \"bidule\" })"), "Content of the file: " + classContent);
 	}
 
-	@Test
-	public void testCreateRepeatableAnnotationWithArrays() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/repeatandarrays")
+	public void testCreateRepeatableAnnotationWithArrays(Factory factory) {
 		// contract: when using annotate with a repeatable annotation, it will create a new annotation, even if an annotation with an array already exists
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/repeatandarrays");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(Repeated.class);
+		CtType type = factory.Type().get(Repeated.class);
 		CtMethod firstMethod = (CtMethod) type.getMethodsByName("withoutAnnotation").get(0);
 		List<CtAnnotation<?>> annotations = firstMethod.getAnnotations();
 
 		assertTrue(annotations.isEmpty());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class, "value", "foo");
+		factory.Annotation().annotate(firstMethod, TagArrays.class, "value", "foo");
 		assertEquals(1, firstMethod.getAnnotations().size());
 
-		spoon.getFactory().Annotation().annotate(firstMethod, TagArrays.class, "value", "bar");
+		factory.Annotation().annotate(firstMethod, TagArrays.class, "value", "bar");
 		annotations = firstMethod.getAnnotations();
 		assertEquals(2, annotations.size());
 
@@ -1394,23 +1237,19 @@ public class AnnotationTest {
 		assertTrue(classContent.contains("@spoon.test.annotation.testclasses.repeatandarrays.TagArrays(\"bar\")"), "Content of the file: " + classContent);
 	}
 
-	@Test
-	public void testAnnotationNotRepeatableNotArrayAnnotation() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/notrepeatable/StringAnnot.java")
+	public void testAnnotationNotRepeatableNotArrayAnnotation(Factory factory) {
 		// contract: when trying to annotate multiple times with same not repeatable, not array annotation, it should throw an exception
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/annotation/testclasses/notrepeatable/StringAnnot.java");
-		spoon.buildModel();
+		CtMethod aMethod = factory.createMethod().setSimpleName(("mamethod"));
 
-		CtMethod aMethod = spoon.getFactory().createMethod().setSimpleName(("mamethod"));
-
-		spoon.getFactory().Annotation().annotate(aMethod, StringAnnot.class, "value", "foo");
+		factory.Annotation().annotate(aMethod, StringAnnot.class, "value", "foo");
 		assertEquals(1, aMethod.getAnnotations().size());
 
 		String methodContent = aMethod.toString();
 		assertTrue(methodContent.contains("@spoon.test.annotation.testclasses.notrepeatable.StringAnnot(\"foo\")"), "Content: " + methodContent);
 
 		try {
-			spoon.getFactory().Annotation().annotate(aMethod, StringAnnot.class, "value", "bar");
+			factory.Annotation().annotate(aMethod, StringAnnot.class, "value", "bar");
 			methodContent = aMethod.toString();
 			fail("You should not be able to add two values to StringAnnot annotation: " + methodContent);
 		} catch (SpoonException e) {
@@ -1418,16 +1257,13 @@ public class AnnotationTest {
 		}
 	}
 
-	@Test
-	public void testAnnotationTypeAndFieldOnField() throws IOException {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/typeandfield")
+	public void testAnnotationTypeAndFieldOnField(Launcher launcher) throws IOException {
 		// contract: annotation on field with an annotation type which supports type and field, should be attached both on type and field
 		// see: https://docs.oracle.com/javase/specs/jls/se9/html/jls-9.html#jls-9.7.3
 		// in this case, we want to print it only once before the type
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/typeandfield");
-		launcher.getEnvironment().setNoClasspath(true);
 		launcher.setSourceOutputDirectory("./target/spooned-typeandfield");
-		launcher.run();
+		launcher.prettyprint();
 
 		CtType type = launcher.getFactory().Type().get(SimpleClass.class);
 
@@ -1451,12 +1287,9 @@ public class AnnotationTest {
 		assertTrue(fileContent.contains("public java.lang.String mandatoryField;"), "Content :" + fileContent);
 	}
 
-	@Test
-	public void testAnnotationAndShadowDefaultRetentionPolicy() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/shadow")
+	public void testAnnotationAndShadowDefaultRetentionPolicy(CtModel model) {
 		// contract: When the default retention policy is used in an annotation, it's lost in shadow classes
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
-		CtModel model = launcher.buildModel();
 		CtClass<?> dumbKlass = model.getElements(new NamedElementFilter<>(CtClass.class, "DumbKlass")).get(0);
 		CtMethod<?> fooMethod = dumbKlass.getMethodsByName("foo").get(0);
 
@@ -1467,12 +1300,9 @@ public class AnnotationTest {
 		assertEquals(0, shadowFooMethod.getAnnotations().size());
 	}
 
-	@Test
-	public void testAnnotationAndShadowClassRetentionPolicy() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/shadow")
+	public void testAnnotationAndShadowClassRetentionPolicy(CtModel model) {
 		// contract: When the Class retention policy is used in an annotation, it's lost in shadow classes
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
-		CtModel model = launcher.buildModel();
 		CtClass<?> dumbKlass = model.getElements(new NamedElementFilter<>(CtClass.class, "DumbKlass")).get(0);
 		CtMethod<?> fooMethod = dumbKlass.getMethodsByName("fooClass").get(0);
 
@@ -1483,12 +1313,9 @@ public class AnnotationTest {
 		assertEquals(0, shadowFooMethod.getAnnotations().size());
 	}
 
-	@Test
-	public void testAnnotationAndShadowRuntimeRetentionPolicy() {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/shadow")
+	public void testAnnotationAndShadowRuntimeRetentionPolicy(CtModel model) {
 		// contract: When the runtime retention policy is used in an annotation, it's available through shadow classes
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
-		CtModel model = launcher.buildModel();
 		CtClass<?> dumbKlass = model.getElements(new NamedElementFilter<>(CtClass.class, "DumbKlass")).get(0);
 		CtMethod<?> fooMethod = dumbKlass.getMethodsByName("barOneValue").get(0);
 
@@ -1499,8 +1326,8 @@ public class AnnotationTest {
 		assertEquals(fooMethod.getAnnotations().size(), shadowFooMethod.getAnnotations().size());
 	}
 
-	@Test
-	public void testAnnotationArray() throws Exception {
+	@ModelTest("./src/test/java/spoon/test/annotation/testclasses/shadow")
+	public void testAnnotationArray(CtModel model) throws Exception {
 		// contract: getValue should return a value as close as possible from the sourcecode:
 		// i.e. even if the annotation should return an Array, it should return a single element
 		// if the value is given without the braces. The same behaviour should be used both for
@@ -1532,9 +1359,6 @@ public class AnnotationTest {
 		assertEquals(shadowAnnotationOne.getValue("role"), shadowAnnotationMultiple.getValue("role"), "[Shadow] Annotation one and multiples values are not the same");
 
 		// but with Spoon, we consider two different values
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/shadow");
-		CtModel model = launcher.buildModel();
 		CtClass<?> dumbKlass = model.getElements(new NamedElementFilter<>(CtClass.class, "DumbKlass")).get(0);
 		CtMethod<?> barOneValue = dumbKlass.getMethodsByName("barOneValue").get(0);
 		CtAnnotation annotationOne = barOneValue.getAnnotations().get(0);
@@ -1570,13 +1394,12 @@ public class AnnotationTest {
 		assertEquals("[str" + File.pathSeparator + "]", Arrays.toString((Object[]) annot_s.getValueAsObject("value")));
 	}
 
-	@Test
-	public void testCatchAnnotation() {
+	@ModelTest({
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotationCatch.java",
+		"./src/test/java/spoon/test/annotation/testclasses/CustomAnnotation.java",
+	})
+	public void testCatchAnnotation(CtModel model) {
 		// contract: annotations should be attached to CtCatchVariable and not to CtCatch itself.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationCatch.java");
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/CustomAnnotation.java");
-		CtModel model = launcher.buildModel();
 		CtClass<?> clazz = model.getElements(new NamedElementFilter<>(CtClass.class, "AnnotationCatch")).get(0);
 		CtMethod<?> m1 = clazz.getMethodsByName("m1").get(0);
 		CtCatch ctCatch = m1.getElements(new TypeFilter<>(CtCatch.class)).get(0);
@@ -1586,13 +1409,12 @@ public class AnnotationTest {
 		assertEquals("@spoon.test.annotation.testclasses.CustomAnnotation(something = \"annotation string\")", ctCatchVariable.getAnnotations().get(0).toString());
 	}
 
-	@Test
-	public void testCatchExpressionAnnotation() {
+	@ModelTest({
+		"./src/test/java/spoon/test/annotation/testclasses/AnnotationCatchExpression.java",
+		"./src/test/java/spoon/test/annotation/testclasses/CustomAnnotation.java",
+	})
+	public void testCatchExpressionAnnotation(CtModel model) {
 		// contract: annotations should be attached to CtCatchVariable and not to CtCatch itself.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/AnnotationCatchExpression.java");
-		launcher.addInputResource("./src/test/java/spoon/test/annotation/testclasses/CustomAnnotation.java");
-		CtModel model = launcher.buildModel();
 		CtClass<?> clazz = model.getElements(new NamedElementFilter<>(CtClass.class, "AnnotationCatchExpression")).get(0);
 
 		//Annotated CatchVariable with multiple type are properly attached
@@ -1613,12 +1435,9 @@ public class AnnotationTest {
 
 	}
 
-	@Test
-	public void testAnnotationMethodModifiers() {
+	@ModelTest("src/test/java/spoon/test/annotation/testclasses/AnnotationMethodModifiers.java")
+	public void testAnnotationMethodModifiers(CtModel model) {
 		// contract: Annotation methods should have modifiers.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/annotation/testclasses/AnnotationMethodModifiers.java");
-		CtModel model = launcher.buildModel();
 		CtAnnotationType<?> annotation = (CtAnnotationType<?>) model.getAllTypes().iterator().next();
 
 		CtMethod<?> implicitAbstract = annotation.getMethodsByName("implicitAbstract").get(0);

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.SpoonAPI;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -40,6 +41,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.annotation.testclasses.AnnotationValues;
 import spoon.test.annotation.testclasses.BoundNumber;
 import spoon.test.annotation.testclasses.Summary;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -138,17 +140,14 @@ public class AnnotationValuesTest {
 		assertTrue(on(byteOrder).giveMeAnnotationValue("byteOrder").element instanceof CtFieldRead);
 	}
 
-	@Test
-	public void testAnnotationPrintAnnotation() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/printer-test/spoon/test/AnnotationSpecTest.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.getEnvironment().setCommentEnabled(false); // avoid getting the comment for the equals
-		launcher.buildModel();
-
+	@ModelTest(
+		value = "src/test/resources/printer-test/spoon/test/AnnotationSpecTest.java",
+		commentsEnabled = false
+	)
+	public void testAnnotationPrintAnnotation(Factory factory) {
 		assertEquals(
 				strCtClassOracle,
-				launcher.getFactory().Class().getAll().get(0).getElements(new TypeFilter<>(CtClass.class)).get(2).toString()
+				factory.Class().getAll().get(0).getElements(new TypeFilter<>(CtClass.class)).get(2).toString()
 		);
 	}
 

--- a/src/test/java/spoon/test/arrays/ArraysTest.java
+++ b/src/test/java/spoon/test/arrays/ArraysTest.java
@@ -32,6 +32,7 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.arrays.testclasses.VaragParam;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -121,12 +122,9 @@ public class ArraysTest {
 		assertEquals("new com.example.Type[list.size()]", local.toString());
 	}
 
-	@Test
-	public void testCtNewArrayInnerCtNewArray() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/arrays/testclasses/Foo.java");
+	@ModelTest("src/test/java/spoon/test/arrays/testclasses/Foo.java")
+	public void testCtNewArrayInnerCtNewArray(Launcher launcher) {
 		launcher.setSourceOutputDirectory("target/foo");
-		launcher.buildModel();
 		launcher.prettyprint();
 		try {
 			launcher.getModelBuilder().compile();
@@ -135,13 +133,9 @@ public class ArraysTest {
 		}
 	}
 
-	@Test
-	public void testCtNewArrayWitComments() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/arrays/testclasses/NewArrayWithComment.java");
-		launcher.getEnvironment().setCommentEnabled(true);
+	@ModelTest("src/test/java/spoon/test/arrays/testclasses/NewArrayWithComment.java")
+	public void testCtNewArrayWitComments(Launcher launcher) {
 		launcher.setSourceOutputDirectory("target/foo2");
-		launcher.buildModel();
 		launcher.prettyprint();
 		try {
 			launcher.getModelBuilder().compile();

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -1155,20 +1155,20 @@ public class CommentTest {
 	public void testCommentGetRawContent(Launcher launcher) {
 		CtClass<?> type = (CtClass<?>) launcher.getFactory().Type().get("spoon.test.comment.testclasses.JavaDocComment");
 		//contract: getContent always returns cleaned comment content with \n as EOL
-		assertEquals("JavaDoc test class.\n" + 
-				"\n" + 
-				"Long description", type.getComments().get(0).getContent());
+		assertEquals("JavaDoc test class.\n" +
+			"\n" +
+			"Long description", type.getComments().get(0).getContent());
 		// contract: return the full original comment with prefix and suffix, incl. the original EOL (\r as EOL here)
-		assertEquals("/**\r" + 
-				" * JavaDoc test class.\r" + 
-				" *\r" + 
-				" * Long description\r" + 
-				" *\r" + 
-				" * @deprecated\r" + 
-				" * @since 1.3\r" + 
-				" * @author Thomas Durieux\r" + 
-				" * @version 1.0\r" + 
-				" */", type.getComments().get(0).getRawContent());
+		assertEquals("/**\r" +
+			" * JavaDoc test class.\r" +
+			" *\r" +
+			" * Long description\r" +
+			" *\r" +
+			" * @deprecated\r" +
+			" * @since 1.3\r" +
+			" * @author Thomas Durieux\r" +
+			" * @version 1.0\r" +
+			" */", type.getComments().get(0).getRawContent());
 	}
 
 	@ModelTest("./src/test/java/spoon/test/comment/testclasses/EmptyStatementComments.java")

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -60,6 +60,7 @@ import spoon.support.compiler.jdt.JDTBatchCompiler;
 import spoon.test.compilation.testclasses.Bar;
 import spoon.test.compilation.testclasses.IBar;
 import spoon.test.compilation.testclasses.Ifoo;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.hamcrest.CoreMatchers.not;
@@ -123,20 +124,15 @@ public class CompilationTest {
 		assertTrue(new File(compiledFile).exists());
 	}
 
-	@Test
-	public void compileTest() throws Exception {
+	@ModelTest("./src/test/resources/noclasspath/Simple.java")
+	public void compileTest(Launcher launcher, Factory factory) throws Exception {
 		// contract: the modified version of classes is the one that is compiled to binary code
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Simple.java");
 		File outputBinDirectory = new File("./target/class-simple");
 		if (!outputBinDirectory.exists()) {
 			outputBinDirectory.mkdirs();
 		}
 		launcher.setBinaryOutputDirectory(outputBinDirectory);
-		launcher.getEnvironment().setShouldCompile(true);
-		launcher.buildModel();
 
-		Factory factory = launcher.getFactory();
 		CoreFactory core = factory.Core();
 		CodeFactory code = factory.Code();
 

--- a/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
+++ b/src/test/java/spoon/test/compilationunit/TestCompilationUnit.java
@@ -41,10 +41,12 @@ import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.support.reflect.cu.position.PartialSourcePositionImpl;
 import spoon.test.api.testclasses.Bar;
+import spoon.testing.utils.ModelTest;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -79,11 +81,8 @@ public class TestCompilationUnit {
 		assertEquals(content, cu.getOriginalSourceCode());
 	}
 
-	@Test
-	public void testGetUnitTypeWorksWithDeclaredType() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses/Bar.java");
-		launcher.buildModel();
+	@ModelTest("./src/test/java/spoon/test/api/testclasses/Bar.java")
+	public void testGetUnitTypeWorksWithDeclaredType(Launcher launcher) {
 
 		CtType type = launcher.getFactory().Type().get(Bar.class);
 		CompilationUnit compilationUnit = type.getPosition().getCompilationUnit();
@@ -91,11 +90,8 @@ public class TestCompilationUnit {
 		assertEquals(CompilationUnit.UNIT_TYPE.TYPE_DECLARATION, compilationUnit.getUnitType());
 	}
 
-	@Test
-	public void testGetUnitTypeWorksWithDeclaredPackage() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/pkg/package-info.java");
-		launcher.buildModel();
+	@ModelTest("./src/test/java/spoon/test/pkg/package-info.java")
+	public void testGetUnitTypeWorksWithDeclaredPackage(Launcher launcher) {
 
 		CtPackage ctPackage = launcher.getFactory().Package().get("spoon.test.pkg");
 		CompilationUnit compilationUnit = ctPackage.getPosition().getCompilationUnit();
@@ -330,13 +326,8 @@ public class TestCompilationUnit {
 		assertNotEquals(utf8Type.getField("s2"), cp1251Type.getField("s2"));
 	}
 
-	@Test
-	public void testPrintImport() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/simple-import/TestClass.java");
-		launcher.getEnvironment().setAutoImports(true);
-		launcher.buildModel();
-
+	@ModelTest("src/test/resources/simple-import/TestClass.java")
+	public void testPrintImport(Launcher launcher) {
 		CtType t = launcher.getModel().getRootPackage().getPackage("matchers").getType("TestClass");
 
 		CompilationUnit cu = launcher.getFactory().CompilationUnit().getOrCreate(t);

--- a/src/test/java/spoon/test/condition/ConditionalTest.java
+++ b/src/test/java/spoon/test/condition/ConditionalTest.java
@@ -32,6 +32,7 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.condition.testclasses.Foo;
 import spoon.test.condition.testclasses.Foo2;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -134,16 +135,12 @@ public class ConditionalTest {
 		assertEquals("System.out.println();", conditions.get(0).getElseStatement().prettyprint().trim());
 	}
 
-	@Test
-	public void testNoThenBlockBug2() throws Exception {
+	@ModelTest("src/test/java/spoon/test/condition/testclasses/Foo2.java")
+	public void testNoThenBlockBug2(CtModel model) throws Exception {
 		// contract: an empty statement is correctly handled
 		// no NPE should be produced during the model build
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/condition/testclasses/Foo2.java");
-		CtModel m = launcher.buildModel();
-
 		// check if we have correct then-else statements
-		CtType<?> aFoo = m.getAllTypes().stream()
+		CtType<?> aFoo = model.getAllTypes().stream()
 				.filter(t -> t.getSimpleName().equals("Foo2"))
 				.findFirst()
 				.get();

--- a/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
+++ b/src/test/java/spoon/test/constructorcallnewclass/NewClassTest.java
@@ -36,6 +36,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.constructorcallnewclass.testclasses.Bar;
 import spoon.test.constructorcallnewclass.testclasses.Foo;
 import spoon.test.constructorcallnewclass.testclasses.Foo2;
+import spoon.testing.utils.ModelTest;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -183,14 +184,10 @@ public class NewClassTest {
 		assertEquals(Foo2.class.getCanonicalName() + "$12$1", elements.get(12).getAnonymousClass().getQualifiedName());
 	}
 
-	@Test
-	public void testCtNewClassInNoClasspath() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/new-class");
+	@ModelTest("./src/test/resources/new-class")
+	public void testCtNewClassInNoClasspath(Launcher launcher) {
 		launcher.setSourceOutputDirectory("./target/new-class");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
+		launcher.prettyprint();
 		final CtClass<Object> aClass = launcher.getFactory().Class().get("IndexWriter");
 		final List<CtNewClass> ctNewClasses = aClass.getElements(new TypeFilter<>(CtNewClass.class));
 		final CtNewClass ctNewClass = ctNewClasses.get(0);

--- a/src/test/java/spoon/test/ctBlock/TestCtBlock.java
+++ b/src/test/java/spoon/test/ctBlock/TestCtBlock.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtIf;
@@ -28,8 +29,10 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtSwitch;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.test.ctBlock.testclasses.Toto;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -40,13 +43,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class TestCtBlock {
 
-	@Test
-	public void testRemoveStatement() {
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java");
-		spoon.buildModel();
-
-		List<CtMethod> methods = spoon.getModel().getElements(new NamedElementFilter<>(CtMethod.class, "foo"));
+	@ModelTest("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java")
+	public void testRemoveStatement(CtModel model) {
+		List<CtMethod> methods = model.getElements(new NamedElementFilter<>(CtMethod.class, "foo"));
 
 		assertEquals(1, methods.size());
 
@@ -65,22 +64,17 @@ public class TestCtBlock {
 		assertTrue(newLastStatement instanceof CtIf);
 	}
 
-	@Test
-	public void testAddStatementInBlock() {
+	@ModelTest("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java")
+	public void testAddStatementInBlock(Factory factory) {
 		// contract: we can add a statement at a specific index
 		// the statements with a higher index are pushed after
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java");
-		spoon.buildModel();
-
-		CtClass<?> toto = spoon.getFactory().Class().get(Toto.class);
+		CtClass<?> toto = factory.Class().get(Toto.class);
 		CtMethod foo = toto.getMethodsByName("foo").get(0);
 		CtBlock block = foo.getBody();
 		CtBlock originalBlock = block.clone();
 
 		assertEquals(4, block.getStatements().size());
-		block.addStatement(1, (CtStatement) spoon.getFactory().createInvocation().setExecutable(foo.getReference()));
+		block.addStatement(1, (CtStatement) factory.createInvocation().setExecutable(foo.getReference()));
 
 		assertEquals(5, block.getStatements().size());
 
@@ -91,16 +85,11 @@ public class TestCtBlock {
 		}
 	}
 
-	@Test
-	public void testAddStatementInCase() {
+	@ModelTest("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java")
+	public void testAddStatementInCase(Factory factory) {
 		// contract: we can add a statement at a specific index
 		// the statements with a higher index are pushed after
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/ctBlock/testclasses/Toto.java");
-		spoon.buildModel();
-
-		CtClass<?> toto = spoon.getFactory().Class().get(Toto.class);
+		CtClass<?> toto = factory.Class().get(Toto.class);
 		CtMethod bar = toto.getMethodsByName("bar").get(0);
 		CtSwitch<?> ctSwitch = (CtSwitch) bar.getBody().getStatement(0);
 
@@ -112,7 +101,7 @@ public class TestCtBlock {
 
 
 		assertEquals(3, firstCase.getStatements().size());
-		firstCase.addStatement(3, spoon.getFactory().createBreak());
+		firstCase.addStatement(3, factory.createBreak());
 		assertEquals(4, firstCase.getStatements().size());
 
 		for (int i = 0; i < 3; i++) {
@@ -120,7 +109,7 @@ public class TestCtBlock {
 		}
 
 		assertEquals(2, secondCase.getStatements().size());
-		secondCase.addStatement(1, (CtStatement) spoon.getFactory().createInvocation().setExecutable(bar.getReference()));
+		secondCase.addStatement(1, (CtStatement) factory.createInvocation().setExecutable(bar.getReference()));
 		assertEquals(3, secondCase.getStatements().size());
 
 		assertEquals(originalSecondCase.getStatements().get(0), secondCase.getStatements().get(0));

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -54,6 +54,7 @@ import spoon.test.SpoonTestHelpers;
 import spoon.test.ctClass.testclasses.AnonymousClass;
 import spoon.test.ctClass.testclasses.Foo;
 import spoon.test.ctClass.testclasses.Pozole;
+import spoon.testing.utils.ModelTest;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -219,16 +220,12 @@ public class CtClassTest {
 		factory.Code().createCodeSnippetStatement(aPozole.toString()).compile();
 	}
 
-	@Test
-	public void testSpoonShouldInferImplicitPackageInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/issue1293/com/cristal/ircica/applicationcolis/userinterface/fragments/TransporteurFragment.java")
+	public void testSpoonShouldInferImplicitPackageInNoClasspath(Factory factory) {
 		// contract: in noClasspath, when a type is used and no import is specified, then Spoon
 		// should infer that this type is in the same package as the current class.
-		final Launcher launcher2 = new Launcher();
-		launcher2.addInputResource("./src/test/resources/noclasspath/issue1293/com/cristal/ircica/applicationcolis/userinterface/fragments/TransporteurFragment.java");
-		launcher2.getEnvironment().setNoClasspath(true);
-		launcher2.buildModel();
 
-		final CtClass<Object> aClass2 = launcher2.getFactory().Class().get("com.cristal.ircica.applicationcolis.userinterface.fragments.TransporteurFragment");
+		final CtClass<Object> aClass2 = factory.Class().get("com.cristal.ircica.applicationcolis.userinterface.fragments.TransporteurFragment");
 		final String type2 = aClass2.getSuperclass().getQualifiedName();
 
 		CtField field = aClass2.getField("transporteurRadioGroup");
@@ -237,16 +234,11 @@ public class CtClassTest {
 		assertThat(type2, is("com.cristal.ircica.applicationcolis.userinterface.fragments.CompletableFragment"));
 	}
 
-	@Test
-	public void toStringWithImports() {
+	@ModelTest("./src/test/java/spoon/test/ctClass/")
+	public void toStringWithImports(Factory factory, Launcher launcher) {
 		String newLine = System.getProperty("line.separator");
-
-		final Launcher launcher2 = new Launcher();
-		launcher2.addInputResource("./src/test/java/spoon/test/ctClass/");
-		launcher2.getEnvironment().setNoClasspath(true);
-		launcher2.buildModel();
-		final CtClass<Object> aClass2 = launcher2.getFactory().Class().get(AnonymousClass.class);
-		DefaultJavaPrettyPrinter djpp = new DefaultJavaPrettyPrinter(launcher2.getEnvironment());
+		final CtClass<Object> aClass2 = factory.Class().get(AnonymousClass.class);
+		DefaultJavaPrettyPrinter djpp = new DefaultJavaPrettyPrinter(launcher.getEnvironment());
 		aClass2.accept(djpp);
 
 		// contract: a class can be printed with full context
@@ -282,7 +274,7 @@ public class CtClassTest {
 		// contract: toStringWithImports works with a new class with no position
 		assertEquals("package foo;" + newLine +
 				"import java.io.File;" + newLine +
-				"class Bar extends File {}", launcher2.getFactory().createClass("foo.Bar").setSuperclass(launcher2.getFactory().Type().get(File.class).getReference()).toStringWithImports());
+				"class Bar extends File {}", factory.createClass("foo.Bar").setSuperclass(factory.Type().get(File.class).getReference()).toStringWithImports());
 	}
 
 	@Test
@@ -304,17 +296,10 @@ public class CtClassTest {
 		canBeBuilt("./target/issue1306", 8, true);
 	}
 
-	@Test
-	public void testCloneAnonymousClassInvocation() {
+	@ModelTest("./src/test/java/spoon/test/ctClass/testclasses/AnonymousClass.java")
+	public void testCloneAnonymousClassInvocation(CtModel model) {
 		// contract: after cloning an anonymous class invocation, we still should be able to print it, when not using autoimport
-
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/ctClass/testclasses/AnonymousClass.java");
-		launcher.getEnvironment().setAutoImports(false);
-		launcher.buildModel();
-
-		CtModel model = launcher.getModel();
-		CtNewClass newClassInvocation = launcher.getModel().getElements(new TypeFilter<>(CtNewClass.class)).get(0);
+		CtNewClass newClassInvocation = model.getElements(new TypeFilter<>(CtNewClass.class)).get(0);
 		CtNewClass newClassInvocationCloned = newClassInvocation.clone();
 
 		CtClass anonymousClass = newClassInvocation.getAnonymousClass();
@@ -332,17 +317,10 @@ public class CtClassTest {
 		assertEquals(newClassInvocation.toString(), newClassInvocationCloned.toString());
 	}
 
-	@Test
-	public void testCloneAnonymousClassInvocationWithAutoimports() {
+	@ModelTest("./src/test/java/spoon/test/ctClass/testclasses/AnonymousClass.java")
+	public void testCloneAnonymousClassInvocationWithAutoimports(CtModel model) {
 		// contract: after cloning an anonymous class invocation, we still should be able to print it, when using autoimport
-
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/ctClass/testclasses/AnonymousClass.java");
-		launcher.getEnvironment().setAutoImports(true);
-		launcher.buildModel();
-
-		CtModel model = launcher.getModel();
-		CtNewClass newClassInvocation = launcher.getModel().getElements(new TypeFilter<>(CtNewClass.class)).get(0);
+		CtNewClass newClassInvocation = model.getElements(new TypeFilter<>(CtNewClass.class)).get(0);
 		CtNewClass newClassInvocationCloned = newClassInvocation.clone();
 
 		CtClass anonymousClass = newClassInvocation.getAnonymousClass();

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -78,12 +78,8 @@ public class CtTypeTest {
 		assertFalse(clazz.hasMethod(null));
 	}
 
-	@Test
-	public void testHasMethodInSuperClass() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/ctType/testclasses/X.java");
-		launcher.run();
-
+	@ModelTest("./src/test/java/spoon/test/ctType/testclasses/X.java")
+	public void testHasMethodInSuperClass(Launcher launcher) {
 		final CtClass<?> xClass = launcher.getFactory().Class().get("spoon.test.ctType.testclasses.X");
 		final CtClass<?> yClass = launcher.getFactory().Class().get("spoon.test.ctType.testclasses.Y");
 		final CtMethod<?> superMethod = xClass.getMethods().iterator().next();
@@ -262,44 +258,33 @@ public class CtTypeTest {
 
 		assertSame(reFetchedTypeDecl, typeDecl);
 	}
-  
-	@Test
-	public void testSneakyThrowsInSubClasses() {
+
+	@ModelTest("src/test/resources/npe")
+	public void testSneakyThrowsInSubClasses(CtModel model) {
 		// contract: Sneaky throws doesn't crash spoons method return type resolution.
 		// see e.g https://projectlombok.org/features/SneakyThrows for explanation
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/npe");
-		CtModel model = launcher.buildModel();
 		assertDoesNotThrow(() -> model.getAllTypes().stream().forEach(CtType::getAllExecutables));
-  }
-  
-  @Test
-	public void testGetAllExecutablesOnTypeImplementingNestedInterface() {
+	}
+
+	@ModelTest("src/test/resources/extendsStaticInnerType")
+	public void testGetAllExecutablesOnTypeImplementingNestedInterface(CtModel model) {
 		// contract: implicit static nested interfaces are correct handled in getAllExecutables.
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/extendsStaticInnerType");
-		CtModel model = launcher.buildModel();
 		CtType<?> type = model.getAllTypes().stream().filter(v -> v.getSimpleName().contains("BarBaz")).findAny().get();
 		int expectedNumExecutablesInJDK8 = 13;
 		int expectedNumExecutablesPostJDK8 = 14;
 		int numExecutables = type.getAllExecutables().size();
 		assertThat(numExecutables, anyOf(
-				equalTo(expectedNumExecutablesInJDK8),
-				equalTo(expectedNumExecutablesPostJDK8))
-		);	
+			equalTo(expectedNumExecutablesInJDK8),
+			equalTo(expectedNumExecutablesPostJDK8))
+		);
 	}
 
 	/**
 	 * This test captures keyword constraint in CtReferenceImpl based on the compliance level, since the keyword
 	 * "enum" was only introduced in Java 5
 	 */
-	@Test
-	public void testEnumPackage() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/keywordCompliance/enum/Foo.java");
-		launcher.getEnvironment().setComplianceLevel(4);
-		launcher.run();
-
+	@ModelTest(value = "./src/test/resources/keywordCompliance/enum/Foo.java", complianceLevel = 4)
+	public void testEnumPackage(Launcher launcher) {
 		Collection<CtType<?>> types = launcher.getModel().getAllTypes();
 		assertThat(types.size(), is(1));
 		assertThat(types.stream().findFirst().get(), notNullValue());

--- a/src/test/java/spoon/test/enums/EnumsTypeTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTypeTest.java
@@ -31,6 +31,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -43,6 +43,7 @@ import spoon.support.reflect.eval.EvalHelper;
 import spoon.support.reflect.eval.InlinePartialEvaluator;
 import spoon.support.reflect.eval.VisitorPartialEvaluator;
 import spoon.test.eval.testclasses.Foo;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -268,31 +269,25 @@ public class EvalTest {
 			VisitorPartialEvaluator eval = new VisitorPartialEvaluator();
 			CtElement elnew = eval.evaluate(el);
 			assertEquals("{" + System.lineSeparator()
-					+ "    java.lang.System.out.println(\"bar\");" + System.lineSeparator()
-					+ "}", elnew.toString());
+				+ "    java.lang.System.out.println(\"bar\");" + System.lineSeparator()
+				+ "}", elnew.toString());
 		}
 	}
 
-	@Test
-	public void testVisitorPartialEvaluatorScanner() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/eval/testclasses/Foo.java");
-		launcher.buildModel();
-		PartialEvaluator eval = launcher.getFactory().Eval().createPartialEvaluator();
-		CtType<?> foo = launcher.getFactory().Type().get((Class<?>) Foo.class);
+	@ModelTest("src/test/java/spoon/test/eval/testclasses/Foo.java")
+	public void testVisitorPartialEvaluatorScanner(Factory factory) {
+		PartialEvaluator eval = factory.Eval().createPartialEvaluator();
+		CtType<?> foo = factory.Type().get((Class<?>) Foo.class);
 		foo.accept(new InlinePartialEvaluator(eval));
 		assertEquals("false", foo.getElements(new TypeFilter<>(CtLocalVariable.class)).get(0).getDefaultExpression().toString());
 		// the if has been removed
 		assertEquals(0, foo.getElements(new TypeFilter<>(CtIf.class)).size());
 	}
 
-	@Test
-	public void testconvertElementToRuntimeObject() {
+	@ModelTest("src/test/java/spoon/test/eval/testclasses/Foo.java")
+	public void testconvertElementToRuntimeObject(Factory factory) {
 		// contract: getCorrespondingRuntimeObject works well for all kinds of expression
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/eval/testclasses/Foo.java");
-		launcher.buildModel();
-		CtType<?> foo = launcher.getFactory().Type().get((Class<?>) Foo.class);
+		CtType<?> foo = factory.Type().get((Class<?>) Foo.class);
 
 		// also works for non-enum fields with partial evaluation embedded in convertElementToRuntimeObject
 		assertEquals(false, EvalHelper.convertElementToRuntimeObject(foo.getField("b6").getDefaultExpression()));

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -43,6 +43,7 @@ import spoon.support.StandardEnvironment;
 import spoon.support.reflect.declaration.CtMethodImpl;
 import spoon.test.SpoonTestHelpers;
 import spoon.test.factory.testclasses.Foo;
+import spoon.testing.utils.ModelTest;
 
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -250,13 +251,10 @@ public class FactoryTest {
 		}
 	}
 
-	@Test
-	public void factoryTest() throws Exception {
+	@ModelTest("src/main/java/spoon/reflect/factory/Factory.java")
+	public void factoryTest(Factory factory) throws Exception {
 		// contract: all methods of Factory can be called without exception, returning a correct object
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("src/main/java/spoon/reflect/factory/Factory.java");
-		spoon.buildModel();
-		for (CtMethod<?> m : spoon.getFactory().Type().get("spoon.reflect.factory.Factory").getMethods()) {
+		for (CtMethod<?> m : factory.Type().get("spoon.reflect.factory.Factory").getMethods()) {
 			if (!m.getSimpleName().startsWith("create")
 				|| "createSourcePosition".equals(m.getSimpleName()) // method with implicit contracts on int parameters
 				|| "createBodyHolderSourcePosition".equals(m.getSimpleName()) // method with implicit contracts on int parameters
@@ -285,7 +283,7 @@ public class FactoryTest {
 			rm = m.getReference().getActualMethod();
 			//rm = spoon.getFactory().getClass().getDeclaredMethod(m.getSimpleName(), argsClass); // works also
 			//System.out.println(rm);
-			Object res = rm.invoke(spoon.getFactory(), args);
+			Object res = rm.invoke(factory, args);
 			assertNotNull(res);
 
 		}

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -45,6 +45,7 @@ import spoon.test.field.testclasses.A;
 import spoon.test.field.testclasses.AddFieldAtTop;
 import spoon.test.field.testclasses.BaseClass;
 import spoon.testing.utils.LineSeperatorExtension;
+import spoon.testing.utils.ModelTest;
 
 public class FieldTest {
 
@@ -127,14 +128,12 @@ public class FieldTest {
 		return first;
 	}
 
-	@Test
-	public void testGetDefaultExpression() {
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/field/testclasses/A.java");
-		spoon.addInputResource("./src/test/java/spoon/test/field/testclasses/BaseClass.java");
-		spoon.buildModel();
-
-		final CtClass<A> aClass = spoon.getFactory().Class().get(A.class);
+	@ModelTest({
+		"./src/test/java/spoon/test/field/testclasses/A.java",
+		"./src/test/java/spoon/test/field/testclasses/BaseClass.java",
+	})
+	public void testGetDefaultExpression(Factory factory) {
+		final CtClass<A> aClass = factory.Class().get(A.class);
 
 		// contract: isPartOfJointDeclaration works per the specification in the javadoc
 		assertEquals(false,aClass.getField("alone1").isPartOfJointDeclaration());
@@ -175,14 +174,10 @@ public class FieldTest {
 		assertNotNull(retour);
 	}
 
-	@Test
-	public void getFQNofFieldReference() {
+	@ModelTest("./src/test/resources/spoon/test/noclasspath/fields/Toto.java")
+	public void getFQNofFieldReference(CtModel model) {
 		// contract: when a reference field origin cannot be determined a call to its qualified name returns an explicit value
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/noclasspath/fields/Toto.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel ctModel = launcher.buildModel();
-		List<CtFieldReference> elements = ctModel.getElements(new TypeFilter<>(CtFieldReference.class));
+		List<CtFieldReference> elements = model.getElements(new TypeFilter<>(CtFieldReference.class));
 		assertEquals(1, elements.size());
 
 		CtFieldReference fieldReference = elements.get(0);

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -58,6 +58,7 @@ import spoon.test.fieldaccesses.testclasses.MyClass;
 import spoon.test.fieldaccesses.testclasses.Panini;
 import spoon.test.fieldaccesses.testclasses.Pozole;
 import spoon.test.fieldaccesses.testclasses.Tacos;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -246,14 +247,8 @@ public class FieldAccessTest {
 	}
 
 
-	@Test
-	public void testFieldAccessNoClasspath() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/import-resources/fr/inria/");
-		launcher.getEnvironment().setNoClasspath(true);
-
-		launcher.run();
-
+	@ModelTest("src/test/resources/import-resources/fr/inria/")
+	public void testFieldAccessNoClasspath(Launcher launcher) {
 		CtType<?> ctType = launcher.getFactory().Class().get("FooNoClassPath");
 
 		CtFieldAccess ctFieldAccess = ctType
@@ -400,18 +395,11 @@ public class FieldAccessTest {
 		assertEquals("spoon.test.fieldaccesses.testclasses.Mole.Delicious delicious", aType.getMethodsByName("m").get(0).getParameters().get(0).toString());
 	}
 
-	@Test
-	public void testFieldAccessOnUnknownType() {
-		final Launcher launcher = new Launcher();
-
-		launcher.addInputResource("./src/test/resources/noclasspath/FieldAccessRes.java");
-
-		launcher.getEnvironment().setNoClasspath(true);
-
-		launcher.buildModel();
-
+	@ModelTest("./src/test/resources/noclasspath/FieldAccessRes.java")
+	public void testFieldAccessOnUnknownType(Factory factory) {
 		class CounterScanner extends CtScanner {
 			private int visited = 0;
+
 			@Override
 			public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
 				visited++;
@@ -421,7 +409,7 @@ public class FieldAccessTest {
 		}
 
 		CounterScanner scanner = new CounterScanner();
-		launcher.getFactory().Class().get("FieldAccessRes").accept(scanner);
+		factory.Class().get("FieldAccessRes").accept(scanner);
 
 		assertEquals(1, scanner.visited);
 	}

--- a/src/test/java/spoon/test/filters/CUFilterTest.java
+++ b/src/test/java/spoon/test/filters/CUFilterTest.java
@@ -22,21 +22,18 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtReturn;
 import spoon.support.compiler.jdt.CompilationUnitFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CUFilterTest {
 
-    @Test
-    public void testWithoutFilters() {
-        final Launcher launcher = new Launcher();
-        launcher.addInputResource("./src/test/resources/noclasspath/same-package");
-        launcher.buildModel();
-        final CtModel model = launcher.getModel();
-        assertEquals(2, model.getAllTypes().size());
-        assertEquals("spoon.test.same.B", model.getAllTypes().iterator().next()
-                .getMethod("createB").getType().getQualifiedName());
-    }
+	@ModelTest("./src/test/resources/noclasspath/same-package")
+	public void testWithoutFilters(CtModel model) {
+		assertEquals(2, model.getAllTypes().size());
+		assertEquals("spoon.test.same.B", model.getAllTypes().iterator().next()
+			.getMethod("createB").getType().getQualifiedName());
+	}
 
     @Test
     public void testSingleExcludeWithFilter() {

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.legacy.NameFilter;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
@@ -87,6 +88,7 @@ import spoon.test.filters.testclasses.SubTostada;
 import spoon.test.filters.testclasses.Tacos;
 import spoon.test.filters.testclasses.Tostada;
 import spoon.test.imports.testclasses.internal4.Constants;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import java.util.ArrayList;
@@ -1379,15 +1381,10 @@ public class FilterTest {
 		assertEquals(1, c2.counter);
 	}
 
-	@Test
-	public void testNameFilterWithGenericType() {
+	@ModelTest("./src/test/java/spoon/test/imports/testclasses/internal4/Constants.java")
+	public void testNameFilterWithGenericType(Factory factory) {
 		// contract: NamedElementFilter of T should only return T elements
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/internal4/Constants.java");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(Constants.class);
+		CtType type = factory.Type().get(Constants.class);
 		List<CtMethod> ctMethods = type.getElements(new NamedElementFilter<>(CtMethod.class, "CONSTANT"));
 		assertTrue(ctMethods.isEmpty());
 
@@ -1396,31 +1393,21 @@ public class FilterTest {
 		assertTrue(ctFields.get(0) instanceof CtField);
 	}
 
-	@Test
-	public void testSubTypeFilter() {
+	@ModelTest("./src/test/java/spoon/test/filters/testclasses")
+	public void testSubTypeFilter(Factory factory, CtModel model) {
 		// contract: SubtypeFilter correctly filters subtypes
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/filters/testclasses");
-		spoon.buildModel();
-
-		CtType type = spoon.getFactory().Type().get(AbstractTostada.class);
-		List<CtType<?>> types = spoon.getModel().getRootPackage().getElements(new SubtypeFilter(type.getReference()));
+		CtType type = factory.Type().get(AbstractTostada.class);
+		List<CtType<?>> types = model.getRootPackage().getElements(new SubtypeFilter(type.getReference()));
 		assertEquals(6, types.size());
 
-		List<CtType<?>> types2 = spoon.getModel().getRootPackage().getElements(new SubtypeFilter(type.getReference()).includingSelf(false));
+		List<CtType<?>> types2 = model.getRootPackage().getElements(new SubtypeFilter(type.getReference()).includingSelf(false));
 		assertEquals(5, types2.size());
 	}
 
-	@Test
-	public void testFilterContains() {
+	@ModelTest("./src/test/java/spoon/test/filters/testclasses")
+	public void testFilterContains(Factory factory) {
 		// ref: https://github.com/INRIA/spoon/issues/3058
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/filters/testclasses");
-		spoon.buildModel();
-
-		CtType<?> type = spoon.getFactory().Type().get(Foo.class);
+		CtType<?> type = factory.Type().get(Foo.class);
 		CtStatement s = type.getMethodsByName("foo").get(0).getBody().getStatement(0);
 		assertEquals("int x = 3", s.toString());
 
@@ -1434,7 +1421,7 @@ public class FilterTest {
 		}
 
 		// we look for this AST in the new class
-		List<CtElement> l = spoon.getFactory().Type().get(FooLine.class).filterChildren(new ContainFilter(s)).list();
+		List<CtElement> l = factory.Type().get(FooLine.class).filterChildren(new ContainFilter(s)).list();
 
 		assertEquals(1, l.size());
 

--- a/src/test/java/spoon/test/initializers/InitializerTest.java
+++ b/src/test/java/spoon/test/initializers/InitializerTest.java
@@ -17,7 +17,6 @@
 package spoon.test.initializers;
 
 import org.junit.jupiter.api.Test;
-import spoon.Launcher;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtLiteral;
@@ -28,6 +27,7 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.imports.ImportTest;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -74,13 +74,8 @@ public class InitializerTest {
 		assertEquals("x = 3", ex.getBody().getStatements().get(0).toString());
 	}
 
-	@Test
-	public void testModelBuildingInitializerNoclasspath() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/initializer/Utf8HttpResponse.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.getEnvironment().setAutoImports(true);
-		CtModel model = launcher.buildModel();
+	@ModelTest(value = "./src/test/resources/noclasspath/initializer/Utf8HttpResponse.java", autoImport = true)
+	public void testModelBuildingInitializerNoclasspath(CtModel model) {
 		CtClass<?> ctClass = model.getElements(new NamedElementFilter<>(CtClass.class, "Utf8HttpResponse")).get(0);
 
 		CtAnonymousExecutable ex = ctClass.getElements(new TypeFilter<>(CtAnonymousExecutable.class)).get(0);

--- a/src/test/java/spoon/test/interfaces/InterfaceTest.java
+++ b/src/test/java/spoon/test/interfaces/InterfaceTest.java
@@ -38,6 +38,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -183,15 +184,10 @@ public class InterfaceTest {
 		));
 	}
 
-	@Test
-	public void testNestedTypesInInterfaceArePublic() {
+	@ModelTest("src/test/resources/nestedInInterface")
+	public void testNestedTypesInInterfaceArePublic(CtModel model) {
 		// contract: nested types in interfaces are implicitly public
 		// (https://docs.oracle.com/javase/specs/jls/se16/html/jls-9.html#jls-9.5)
-
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/nestedInInterface");
-		CtModel model = launcher.buildModel();
-
 		Collection<CtType<?>> types = model.getAllTypes()
 				.stream()
 				.flatMap(it -> it.getNestedTypes().stream())
@@ -211,15 +207,10 @@ public class InterfaceTest {
 		}
 	}
 
-	@Test
-	public void testNestedTypesInInterfaceAreStatic() {
+	@ModelTest("src/test/resources/nestedInInterface")
+	public void testNestedTypesInInterfaceAreStatic(CtModel model) {
 		// contract: nested types in interfaces are implicitly static
 		// (https://docs.oracle.com/javase/specs/jls/se16/html/jls-9.html#jls-9.5)
-
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/nestedInInterface");
-		CtModel model = launcher.buildModel();
-
 		Collection<CtType<?>> types = model.getAllTypes()
 				.stream()
 				.flatMap(it -> it.getNestedTypes().stream())

--- a/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
+++ b/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.interfaces;
 
+import spoon.reflect.factory.Factory;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.declaration.CtType;
@@ -24,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import spoon.Launcher;
 import spoon.reflect.declaration.CtMethod;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.util.Set;
 import java.io.IOException;
@@ -36,15 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestInterfaceWithoutSetup {
 
-	@Test
-	public void testModifierFromInterfaceFieldAndMethod() {
+	@ModelTest("./src/test/resources/spoon/test/itf/DumbItf.java")
+	public void testModifierFromInterfaceFieldAndMethod(Factory factory) {
 		// contract: methods defined in interface are all public and fields are all public and static
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/spoon/test/itf/DumbItf.java");
-		spoon.getEnvironment().setNoClasspath(false);
-		spoon.buildModel();
-
-		CtType dumbType = spoon.getFactory().Type().get("toto.DumbItf");
+		CtType dumbType = factory.Type().get("toto.DumbItf");
 
 		assertEquals(2, dumbType.getFields().size());
 

--- a/src/test/java/spoon/test/javadoc/JavaDocTest.java
+++ b/src/test/java/spoon/test/javadoc/JavaDocTest.java
@@ -38,6 +38,7 @@ import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.imports.ImportTest;
 import spoon.test.javadoc.testclasses.Bar;
+import spoon.testing.utils.ModelTest;
 
 import java.util.List;
 
@@ -141,15 +142,9 @@ public class JavaDocTest {
 		assertEquals("foo", j.getTags().get(0).getContent());
 	}
 
-	@Test
-	public void testTagsParameters() {
+	@ModelTest("./src/test/java/spoon/test/javadoc/testclasses/A.java")
+	public void testTagsParameters(CtModel model) {
 		// contract: @throws and @exception should have proper params
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/javadoc/testclasses/A.java");
-		launcher.getEnvironment().setCommentEnabled(true);
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
-
 		List<CtJavaDoc> javadocs = model.getElements(new TypeFilter<>(CtJavaDoc.class));
 
 		CtJavaDocTag throwsTag = javadocs.get(0).getTags().get(0);
@@ -159,15 +154,9 @@ public class JavaDocTest {
 		assertEquals("FileNotFoundException", exceptionTag.getParam());
 	}
 
-	@Test
-	public void testJavadocTagNames() {
+	@ModelTest("./src/test/java/spoon/test/javadoc/testclasses/B.java")
+	public void testJavadocTagNames(CtModel model) {
 		//contract: we should handle all possible javadoc tags properly
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/javadoc/testclasses/B.java");
-		launcher.getEnvironment().setCommentEnabled(true);
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
-
 		CtType<?> type = model.getAllTypes().stream().findFirst().get();
 		assertEquals(TagType.VERSION, type.getElements(new TypeFilter<>(CtEnum.class)).get(0).getElements(new TypeFilter<>(CtJavaDoc.class)).get(0).getTags().get(0).getType());
 		assertEquals(TagType.AUTHOR, type.getMethodsByName("m1").get(0).getElements(new TypeFilter<>(CtJavaDoc.class)).get(0).getTags().get(0).getType());

--- a/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
+++ b/src/test/java/spoon/test/jdtimportbuilder/ImportBuilderTest.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.jdtimportbuilder;
 
+import spoon.reflect.factory.Factory;
 import spoon.test.imports.testclasses.A;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.test.jdtimportbuilder.testclasses.StaticImport;
@@ -31,6 +32,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.test.jdtimportbuilder.testclasses.StarredImport;
 import spoon.test.imports.testclasses.ClassWithInvocation;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.util.stream.Collectors;
 import java.util.Set;
@@ -45,29 +47,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class ImportBuilderTest {
 
-	@Test
-	public void testWithNoImport() {
+	@ModelTest("./src/test/java/spoon/test/imports/testclasses/A.java")
+	public void testWithNoImport(Factory factory) {
 		// contract: when the source code has no import, none is created when building model
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/A.java");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.buildModel();
-
-		CtClass classA = spoon.getFactory().Class().get(A.class);
-		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
+		CtClass classA = factory.Class().get(A.class);
+		CompilationUnit unitA = factory.CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
 		assertTrue(unitA.getImports().isEmpty());
 	}
 
-	@Test
-	public void testWithSimpleImport() {
+	@ModelTest("./src/test/java/spoon/test/imports/testclasses/ClassWithInvocation.java")
+	public void testWithSimpleImport(Factory factory) {
 		// contract: when the source has one import, the same import is created as a reference in auto-import mode
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses/ClassWithInvocation.java");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.buildModel();
-
-		CtClass classA = spoon.getFactory().Class().get(ClassWithInvocation.class);
-		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
+		CtClass classA = factory.Class().get(ClassWithInvocation.class);
+		CompilationUnit unitA = factory.CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitA.getImports();
 
 		assertEquals(1, imports.size());
@@ -94,17 +86,11 @@ public class ImportBuilderTest {
 		assertTrue(unitA.getImports().isEmpty());
 	}
 
-	@Test
-	public void testInternalImportWhenNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/Attachment.java")
+	public void testInternalImportWhenNoClasspath(Factory factory) {
 		// contract: in no-classpath anything which is not loaded becomes CtUnresolvedImport, even if original source code has imports
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/noclasspath/Attachment.java");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.getEnvironment().setNoClasspath(true);
-		spoon.buildModel();
-
-		CtClass classA = spoon.getFactory().Class().get("it.feio.android.omninotes.models.Attachment");
-		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
+		CtClass classA = factory.Class().get("it.feio.android.omninotes.models.Attachment");
+		CompilationUnit unitA = factory.CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
 
 		assertTrue(unitA.getImports().stream().filter(i -> !(i instanceof CtUnresolvedImport)).collect(Collectors.toList()).isEmpty());
 		assertEquals(3, unitA.getImports().size());
@@ -115,16 +101,11 @@ public class ImportBuilderTest {
 		assertTrue(importRefs.contains("android.os.Parcelable"));
 	}
 
-	@Test
-	public void testSimpleStaticImport() {
+	@ModelTest("./src/test/java/spoon/test/jdtimportbuilder/testclasses/StaticImport.java")
+	public void testSimpleStaticImport(Factory factory) {
 		// contract: simple static import are imported correctly
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/jdtimportbuilder/testclasses/StaticImport.java");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.buildModel();
-
-		CtClass classA = spoon.getFactory().Class().get(StaticImport.class);
-		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
+		CtClass classA = factory.Class().get(StaticImport.class);
+		CompilationUnit unitA = factory.CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitA.getImports();
 
 		assertEquals(1, imports.size());
@@ -135,17 +116,14 @@ public class ImportBuilderTest {
 		assertEquals("spoon.test.jdtimportbuilder.testclasses.staticimport.Dependency#ANY", ((CtFieldReference) ref.getReference()).getQualifiedName());
 	}
 
-	@Test
-	public void testWithStaticStarredImportFromInterface() {
+	@ModelTest({
+		"./src/test/java/spoon/test/jdtimportbuilder/testclasses/StarredImport.java",
+		"./src/test/java/spoon/test/jdtimportbuilder/testclasses/fullpack/",
+	})
+	public void testWithStaticStarredImportFromInterface(Factory factory) {
 		// contract: when a starred import is used with a target package, all classes of the package should be imported
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/jdtimportbuilder/testclasses/StarredImport.java");
-		spoon.addInputResource("./src/test/java/spoon/test/jdtimportbuilder/testclasses/fullpack/");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.buildModel();
-
-		CtClass classA = spoon.getFactory().Class().get(StarredImport.class);
-		CompilationUnit unitA = spoon.getFactory().CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
+		CtClass classA = factory.Class().get(StarredImport.class);
+		CompilationUnit unitA = factory.CompilationUnit().getMap().get(classA.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitA.getImports();
 
 		assertEquals(1, imports.size());
@@ -161,19 +139,14 @@ public class ImportBuilderTest {
 		assertEquals("spoon.test.jdtimportbuilder.testclasses.fullpack", ref.getQualifiedName());
 	}
 
-	@Test
-	public void testWithStaticInheritedImport() {
+	@ModelTest({
+		"./src/test/java/spoon/test/jdtimportbuilder/testclasses/StaticImportWithInheritance.java",
+		"./src/test/java/spoon/test/jdtimportbuilder/testclasses/staticimport",
+	})
+	public void testWithStaticInheritedImport(Launcher launcher, Factory factory) {
 		// contract: When using starred static import of a type, it imports a starred type
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/jdtimportbuilder/testclasses/StaticImportWithInheritance.java");
-		spoon.addInputResource("./src/test/java/spoon/test/jdtimportbuilder/testclasses/staticimport");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.getEnvironment().setShouldCompile(true);
-		spoon.setSourceOutputDirectory("./target/spoon-jdtimport-inheritedstatic");
-		spoon.run();
-
-		CtClass classStatic = spoon.getFactory().Class().get(StaticImportWithInheritance.class);
-		CompilationUnit unitStatic = spoon.getFactory().CompilationUnit().getMap().get(classStatic.getPosition().getFile().getPath());
+		CtClass classStatic = factory.Class().get(StaticImportWithInheritance.class);
+		CompilationUnit unitStatic = factory.CompilationUnit().getMap().get(classStatic.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitStatic.getImports();
 
 		assertEquals(1, imports.size());
@@ -182,18 +155,11 @@ public class ImportBuilderTest {
 		assertEquals("import static spoon.test.jdtimportbuilder.testclasses.staticimport.DependencySubClass.*;", ctImport.toString());
 	}
 
-	@Test
-	public void testWithImportFromItf() {
+	@ModelTest("./src/test/resources/jdtimportbuilder/")
+	public void testWithImportFromItf(Launcher launcher, Factory factory) {
 		// contract: When using starred static import of an interface, it imports a starred type
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/jdtimportbuilder/");
-		spoon.getEnvironment().setAutoImports(true);
-		spoon.getEnvironment().setShouldCompile(true);
-		spoon.setSourceOutputDirectory("./target/spoon-jdtimport-itfimport");
-		spoon.run();
-
-		CtClass classStatic = spoon.getFactory().Class().get("jdtimportbuilder.ItfImport");
-		CompilationUnit unitStatic = spoon.getFactory().CompilationUnit().getMap().get(classStatic.getPosition().getFile().getPath());
+		CtClass classStatic = factory.Class().get("jdtimportbuilder.ItfImport");
+		CompilationUnit unitStatic = factory.CompilationUnit().getMap().get(classStatic.getPosition().getFile().getPath());
 		Collection<CtImport> imports = unitStatic.getImports();
 
 		assertEquals(1, imports.size(), imports.toString());

--- a/src/test/java/spoon/test/labels/TestLabels.java
+++ b/src/test/java/spoon/test/labels/TestLabels.java
@@ -28,8 +28,10 @@ import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtDo;
 import spoon.reflect.code.CtContinue;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.util.List;
 
@@ -42,13 +44,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Created by urli on 19/06/2017.
  */
 public class TestLabels {
-    @Test
-    public void testLabelsAreDetected() {
-        Launcher launcher = new Launcher();
-        launcher.addInputResource("./src/test/java/spoon/test/labels/testclasses/ManyLabels.java");
-        launcher.buildModel();
 
-        CtMethod mainMethod = launcher.getFactory().getModel().getElements(new NamedElementFilter<>(CtMethod.class,"main")).get(0);
+    @ModelTest("./src/test/java/spoon/test/labels/testclasses/ManyLabels.java")
+    public void testLabelsAreDetected(Factory factory) {
+        CtMethod mainMethod = factory.getModel().getElements(new NamedElementFilter<>(CtMethod.class,"main")).get(0);
 
         CtBlock body = mainMethod.getBody();
         assertEquals(2, body.getStatements().size());

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -28,6 +28,7 @@ import spoon.reflect.code.LiteralBase;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.declaration.CtClass;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.util.TreeSet;
 
@@ -147,16 +148,9 @@ public class LiteralTest {
 		assertEquals(factory.Type().stringType(), literal.getType());
 	}
 
-	@Test
-	public void testEscapedString() {
-
+	@ModelTest(value = "./src/test/java/spoon/test/literal/testclasses/EscapedLiteral.java", autoImport = true)
+	public void testEscapedString(Launcher launcher) {
 		/* test escaped char: spoon change octal values by equivalent unicode values */
-
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/literal/testclasses/EscapedLiteral.java");
-		launcher.getEnvironment().setCommentEnabled(true);
-		launcher.getEnvironment().setAutoImports(true);
-		launcher.buildModel();
 		final CtClass<?> ctClass = launcher.getFactory().Class().get("spoon.test.literal.testclasses.EscapedLiteral");
 
 		assertTrue('\u0000' == (char) ((CtLiteral) ctClass.getField("c1").getDefaultExpression()).getValue());
@@ -182,13 +176,10 @@ public class LiteralTest {
 		assertTrue('\u0002' == (char) ((CtLiteral) ctClass.getField("c9").getDefaultExpression()).getValue());
 	}
 
-	@Test
-	public void testLiteralBase() {
+	@ModelTest("./src/test/java/spoon/test/literal/testclasses/BasedLiteral.java")
+	public void testLiteralBase(Factory factory) {
 		// contract: CtLiteral should provide correct base (2, 8, 10, 16 or empty)
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/literal/testclasses/BasedLiteral.java");
-		launcher.buildModel();
-		final CtClass<?> ctClass = launcher.getFactory().Class().get("spoon.test.literal.testclasses.BasedLiteral");
+		final CtClass<?> ctClass = factory.Class().get("spoon.test.literal.testclasses.BasedLiteral");
 
 		assertEquals(LiteralBase.DECIMAL, ((CtLiteral) ctClass.getField("i1").getDefaultExpression()).getBase());
 		assertEquals(LiteralBase.DECIMAL, ((CtLiteral) ctClass.getField("i2").getDefaultExpression()).getBase());
@@ -223,15 +214,12 @@ public class LiteralTest {
 
 		assertNull(((CtLiteral) ctClass.getField("c1").getDefaultExpression()).getBase());
 		assertNull(((CtLiteral) ctClass.getField("s1").getDefaultExpression()).getBase());
-    }
+	}
 
-	@Test
-	public void testLiteralBasePrinter() {
+	@ModelTest("./src/test/java/spoon/test/literal/testclasses/BasedLiteral.java")
+	public void testLiteralBasePrinter(Factory factory) {
 		// contract: PrettyPrinter should output literals in the specified base
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/literal/testclasses/BasedLiteral.java");
-		launcher.buildModel();
-		final CtClass<?> ctClass = launcher.getFactory().Class().get("spoon.test.literal.testclasses.BasedLiteral");
+		final CtClass<?> ctClass = factory.Class().get("spoon.test.literal.testclasses.BasedLiteral");
 
 		assertEquals("42", ctClass.getField("i1").getDefaultExpression().toString());
 		((CtLiteral) ctClass.getField("i1").getDefaultExpression()).setBase(LiteralBase.OCTAL);

--- a/src/test/java/spoon/test/loop/LoopTest.java
+++ b/src/test/java/spoon/test/loop/LoopTest.java
@@ -30,6 +30,7 @@ import spoon.reflect.code.CtFor;
 import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtClass;
 import org.junit.jupiter.api.Test;
+import spoon.testing.utils.ModelTest;
 
 import java.io.File;
 
@@ -74,11 +75,8 @@ public class LoopTest {
 		assertEquals(expectedDebug, ctLoop.toString());
 	}
 
-	@Test
-	public void testEmptyForLoopExpression() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/loop/testclasses/EmptyLoops.java");
-		CtModel model = launcher.buildModel();
+	@ModelTest("./src/test/java/spoon/test/loop/testclasses/EmptyLoops.java")
+	public void testEmptyForLoopExpression(CtModel model) {
 		CtFor ctFor = model.getElements(new TypeFilter<>(CtFor.class)).get(0);
 		assertTrue(ctFor.getForInit().isEmpty());
 		assertNull(ctFor.getExpression());

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -18,6 +18,7 @@ import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.AllTypeMembersFunction;
+import spoon.testing.utils.ModelTest;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/test/java/spoon/test/modifiers/ModifiersTest.java
+++ b/src/test/java/spoon/test/modifiers/ModifiersTest.java
@@ -24,11 +24,13 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.path.CtRole;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.test.modifiers.testclasses.AbstractClass;
 import spoon.test.modifiers.testclasses.MethodVarArgs;
 import spoon.test.modifiers.testclasses.StaticMethod;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import java.util.Collection;
@@ -42,35 +44,26 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 public class ModifiersTest {
 
-    @Test
-    public void testMethodWithVarargsDoesNotBecomeTransient() {
+    @ModelTest("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java")
+    public void testMethodWithVarargsDoesNotBecomeTransient(Factory factory) {
         // contract: method with varsargs should not become transient
-        Launcher spoon = new Launcher();
-        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java");
-        spoon.buildModel();
-
-        CtType<?> myClass = spoon.getFactory().Type().get(MethodVarArgs.class);
+        CtType<?> myClass = factory.Type().get(MethodVarArgs.class);
         CtMethod methodVarargs = myClass.getMethodsByName("getInitValues").get(0);
 
         Set<ModifierKind> expectedModifiers = Collections.singleton(ModifierKind.PROTECTED);
 
         assertEquals(expectedModifiers, methodVarargs.getModifiers());
 
-        spoon = new Launcher();
+        Launcher spoon = new Launcher();
         spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java");
         spoon.getEnvironment().setShouldCompile(true);
         spoon.run();
     }
 
-    @Test
-    public void testCtModifiableAddRemoveReturnCtModifiable() {
+    @ModelTest("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java")
+    public void testCtModifiableAddRemoveReturnCtModifiable(Factory factory) {
         // contract: CtModifiable#addModifier and CtModifiable#removeModifier should return CtModifiable
-
-        Launcher spoon = new Launcher();
-        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/MethodVarArgs.java");
-        spoon.buildModel();
-
-        CtType<?> myClass = spoon.getFactory().Type().get(MethodVarArgs.class);
+        CtType<?> myClass = factory.Type().get(MethodVarArgs.class);
         CtMethod methodVarargs = myClass.getMethodsByName("getInitValues").get(0);
 
         Object o = methodVarargs.addModifier(ModifierKind.FINAL);
@@ -80,15 +73,10 @@ public class ModifiersTest {
         assertEquals(methodVarargs, o);
     }
 
-    @Test
-    public void testSetVisibility() {
+    @ModelTest("./src/test/java/spoon/test/modifiers/testclasses/StaticMethod.java")
+    public void testSetVisibility(Factory factory) {
         // contract: setVisibility should only work with public/private/protected modifiers
-
-        Launcher spoon = new Launcher();
-        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/StaticMethod.java");
-        spoon.buildModel();
-
-        CtType<?> myClass = spoon.getFactory().Type().get(StaticMethod.class);
+        CtType<?> myClass = factory.Type().get(StaticMethod.class);
         CtMethod methodPublicStatic = myClass.getMethodsByName("maMethod").get(0);
 
         assertEquals(ModifierKind.PUBLIC, methodPublicStatic.getVisibility());
@@ -103,17 +91,13 @@ public class ModifiersTest {
         assertEquals(ModifierKind.PROTECTED, methodPublicStatic.getVisibility());
     }
 
-    @Test
-    public void testGetModifiersHelpers() {
+    @ModelTest({
+        "./src/test/java/spoon/test/modifiers/testclasses/AbstractClass.java",
+        "./src/test/java/spoon/test/modifiers/testclasses/ConcreteClass.java",
+    })
+    public void testGetModifiersHelpers(Launcher launcher, Factory factory) {
         // contract: the CtModifiable helpers like isPublic, isFinal etc returns right values
-
-        Launcher spoon = new Launcher();
-        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/AbstractClass.java");
-        spoon.addInputResource("./src/test/java/spoon/test/modifiers/testclasses/ConcreteClass.java");
-        spoon.getEnvironment().setShouldCompile(true);
-        spoon.run();
-
-        CtType<?> abstractClass = spoon.getFactory().Type().get(AbstractClass.class);
+        CtType<?> abstractClass = factory.Type().get(AbstractClass.class);
 
         checkCtModifiableHelpersAssertion(abstractClass, true, false, false, true, false, false, false, false, false, false, false);
 
@@ -186,7 +170,7 @@ public class ModifiersTest {
             }
         }
 
-        CtType<?> concreteClass = spoon.getFactory().Type().get("spoon.test.modifiers.testclasses.ConcreteClass");
+        CtType<?> concreteClass = factory.Type().get("spoon.test.modifiers.testclasses.ConcreteClass");
         checkCtModifiableHelpersAssertion(concreteClass, false, false, false, false, true, false, false, false, false, false, false);
 
         assertEquals(2, concreteClass.getFields().size());

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -41,10 +41,12 @@ import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtUsedService;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtModuleReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
 import spoon.support.compiler.jdt.JDTBatchCompiler;
+import spoon.testing.utils.ModelTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -101,20 +103,14 @@ public class TestModule {
 		}
 	}
 
-	@Test
-	public void testCompleteModuleInfoContentNoClasspath() {
+	@ModelTest(value = "./src/test/resources/spoon/test/module/simple_module/module-info.java", complianceLevel = 9)
+	public void testCompleteModuleInfoContentNoClasspath(CtModel model, Factory factory) {
 		// contract: all information of the module-info should be available through the model
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/module/simple_module/module-info.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.getEnvironment().setComplianceLevel(9);
-		launcher.buildModel();
+		assertEquals(2, model.getAllModules().size());
 
-		assertEquals(2, launcher.getModel().getAllModules().size());
-
-		CtModule unnamedModule = launcher.getFactory().Module().getOrCreate(CtModule.TOP_LEVEL_MODULE_NAME);
-		assertSame(unnamedModule, launcher.getModel().getUnnamedModule());
-		CtModule moduleGreetings = launcher.getFactory().Module().getOrCreate("simple_module");
+		CtModule unnamedModule = factory.Module().getOrCreate(CtModule.TOP_LEVEL_MODULE_NAME);
+		assertSame(unnamedModule, model.getUnnamedModule());
+		CtModule moduleGreetings = factory.Module().getOrCreate("simple_module");
 
 		assertEquals("simple_module", moduleGreetings.getSimpleName());
 

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -21,13 +21,16 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -35,16 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ParameterTest {
 
-	@Test
-	public void testParameterInNoClasspath() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/parameter");
-		launcher.setSourceOutputDirectory("./target/parameter");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
+	@ModelTest("./src/test/resources/parameter")
+	public void testParameterInNoClasspath(final Launcher launcher) {
 		final CtClass<Object> aClass = launcher.getFactory().Class().get("org.eclipse.draw2d.text.FlowUtilities");
-		final CtParameter<?> parameter = aClass.getElements(new NamedElementFilter<>(CtParameter.class,"font")).get(0);
+		final CtParameter<?> parameter = aClass.getElements(new NamedElementFilter<>(CtParameter.class, "font")).get(0);
 
 		assertEquals("font", parameter.getSimpleName());
 		assertNotNull(parameter.getType());
@@ -52,14 +49,9 @@ public class ParameterTest {
 		assertEquals("org.eclipse.swt.graphics.Font font", parameter.toString());
 	}
 
-	@Test
-	public void testGetParameterReferenceInLambdaNoClasspath() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Tacos.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtMethod<?> ctMethod = launcher.getFactory().Type().get("Tacos").getMethodsByName("setStarRatings").get(0);
+	@ModelTest("./src/test/resources/noclasspath/Tacos.java")
+	public void testGetParameterReferenceInLambdaNoClasspath(Factory factory) {
+		CtMethod<?> ctMethod = factory.Type().get("Tacos").getMethodsByName("setStarRatings").get(0);
 		CtParameter ctParameter = ctMethod.getBody().getStatement(0).getElements(new TypeFilter<CtParameter>(CtParameter.class) {
 			@Override
 			public boolean matches(CtParameter element) {
@@ -81,40 +73,35 @@ public class ParameterTest {
 		}
 	}
 
-	@Test
 	@SuppressWarnings("unchecked")
-	public void testMultiParameterLambdaTypeReference() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/lambdas/MultiParameterLambda.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
+	@ModelTest("./src/test/resources/noclasspath/lambdas/MultiParameterLambda.java")
+	public void testMultiParameterLambdaTypeReference(CtModel model, Factory factory) {
 		List<CtParameter> parameters;
 
 		// test string parameters
-		parameters = launcher.getModel()
+		parameters = model
 						.getElements(new NamedElementFilter<>(CtMethod.class,"stringLambda"))
 						.get(0)
 						.getElements(new TypeFilter<>(CtParameter.class));
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(launcher.getFactory().Type().STRING, refType);
+			assertEquals(factory.Type().STRING, refType);
 		}
 
 		// test integer parameters
-		parameters = launcher.getModel()
+		parameters = model
 				.getElements(new NamedElementFilter<>(CtMethod.class,"integerLambda"))
 				.get(0)
 				.getElements(new TypeFilter<>(CtParameter.class));
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(launcher.getFactory().Type().INTEGER, refType);
+			assertEquals(factory.Type().INTEGER, refType);
 		}
 
 		// test unknown parameters
-		parameters = launcher.getModel()
+		parameters = model
 				.getElements(new NamedElementFilter<>(CtMethod.class,"unknownLambda"))
 				.get(0)
 				.getElements(new TypeFilter<>(CtParameter.class));
@@ -126,13 +113,10 @@ public class ParameterTest {
 		}
 	}
 
-	@Test
-	public void testGetParentAfterGetParameterReference() {
+	@ModelTest("./src/test/resources/parameter/ParameterResource.java")
+	public void testGetParentAfterGetParameterReference(CtModel model) {
 		// contract: after getting a parameter reference, the parent of the parameter type reference should still be the parameter itself
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/parameter/ParameterResource.java");
-		spoon.buildModel();
-		CtParameter parameter = spoon.getModel().getRootPackage().getElements(new TypeFilter<>(CtParameter.class)).get(0);
+		CtParameter parameter = model.getRootPackage().getElements(new TypeFilter<>(CtParameter.class)).get(0);
 		CtParameterReference pref = parameter.getReference();
 		assertEquals(parameter, parameter.getType().getParent());
 	}

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -189,40 +189,31 @@ public class PackageTest {
 		canBeBuilt("./target/spooned/packageAndTemplate/spoon/test/pkg/package-info.java", 8);
 	}
 
-	@Test
-	public void testRenamePackageAndPrettyPrint() {
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/pkg/testclasses/Foo.java");
-		spoon.buildModel();
-
-		CtPackage ctPackage = spoon.getModel().getElements(new NamedElementFilter<>(CtPackage.class, "spoon")).get(0);
+	@ModelTest("./src/test/java/spoon/test/pkg/testclasses/Foo.java")
+	public void testRenamePackageAndPrettyPrint(CtModel model, Launcher launcher, Factory factory) {
+		CtPackage ctPackage = model.getElements(new NamedElementFilter<>(CtPackage.class, "spoon")).get(0);
 		ctPackage.setSimpleName("otherName");
 
-		CtClass foo = spoon.getModel().getElements(new NamedElementFilter<>(CtClass.class, "Foo")).get(0);
+		CtClass foo = model.getElements(new NamedElementFilter<>(CtClass.class, "Foo")).get(0);
 		assertEquals("otherName.test.pkg.testclasses.Foo", foo.getQualifiedName());
 
-		PrettyPrinter prettyPrinter = new DefaultJavaPrettyPrinter(spoon.getEnvironment());
-		prettyPrinter.calculate(spoon.getFactory().CompilationUnit().getOrCreate("./src/test/java/spoon/test/pkg/testclasses/Foo.java"), Collections.singletonList(foo));
+		PrettyPrinter prettyPrinter = new DefaultJavaPrettyPrinter(launcher.getEnvironment());
+		prettyPrinter.calculate(factory.CompilationUnit().getOrCreate("./src/test/java/spoon/test/pkg/testclasses/Foo.java"), Collections.singletonList(foo));
 		String result = prettyPrinter.getResult();
 
 		assertTrue(result.contains("package otherName.test.pkg.testclasses;"));
 	}
 
-	@Test
-	public void testRenamePackageAndPrettyPrintNoclasspath() {
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/noclasspath/app/Test.java");
-		spoon.getEnvironment().setNoClasspath(true);
-		spoon.buildModel();
-
-		CtPackage ctPackage = spoon.getModel().getElements(new NamedElementFilter<>(CtPackage.class, "app")).get(0);
+	@ModelTest("./src/test/resources/noclasspath/app/Test.java")
+	public void testRenamePackageAndPrettyPrintNoclasspath(CtModel model, Launcher launcher, Factory factory) {
+		CtPackage ctPackage = model.getElements(new NamedElementFilter<>(CtPackage.class, "app")).get(0);
 		ctPackage.setSimpleName("otherName");
 
-		CtClass foo = spoon.getModel().getElements(new NamedElementFilter<>(CtClass.class, "Test")).get(0);
+		CtClass foo = model.getElements(new NamedElementFilter<>(CtClass.class, "Test")).get(0);
 		assertEquals("otherName.Test", foo.getQualifiedName());
 
-		PrettyPrinter prettyPrinter = new DefaultJavaPrettyPrinter(spoon.getEnvironment());
-		prettyPrinter.calculate(spoon.getFactory().CompilationUnit().getOrCreate("./src/test/resources/noclasspath/app/Test.java"), Collections.singletonList(foo));
+		PrettyPrinter prettyPrinter = new DefaultJavaPrettyPrinter(launcher.getEnvironment());
+		prettyPrinter.calculate(factory.CompilationUnit().getOrCreate("./src/test/resources/noclasspath/app/Test.java"), Collections.singletonList(foo));
 		String result = prettyPrinter.getResult();
 
 		assertTrue(result.contains("package otherName;"));
@@ -249,27 +240,17 @@ public class PackageTest {
 		}
 	}
 
-	@Test
-	public void testRenameRootPackage() {
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/noclasspath/app/Test.java");
-		spoon.getEnvironment().setNoClasspath(true);
-		spoon.buildModel();
-
-		CtPackage rootPackage = spoon.getFactory().Package().getRootPackage();
+	@ModelTest("./src/test/resources/noclasspath/app/Test.java")
+	public void testRenameRootPackage(Factory factory) {
+		CtPackage rootPackage = factory.Package().getRootPackage();
 		String rootPackageName = rootPackage.getSimpleName();
 		rootPackage.setSimpleName("test");
 		assertEquals(rootPackageName, rootPackage.getSimpleName());
 	}
 
-	@Test
-	public void testRenameRootPackageWithNullOrEmpty() {
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/noclasspath/app/Test.java");
-		spoon.getEnvironment().setNoClasspath(true);
-		spoon.buildModel();
-
-		CtPackage rootPackage = spoon.getFactory().Package().getRootPackage();
+	@ModelTest("./src/test/resources/noclasspath/app/Test.java")
+	public void testRenameRootPackageWithNullOrEmpty(Factory factory) {
+		CtPackage rootPackage = factory.Package().getRootPackage();
 		String rootPackageName = rootPackage.getSimpleName();
 		assertEquals(CtPackage.TOP_LEVEL_PACKAGE_NAME, rootPackageName);
 
@@ -330,14 +311,10 @@ public class PackageTest {
 		assertTrue(pkgRef.isImplicit());
 	}
 
-	@Test
-	public void testGetFQNSimple() {
+	@ModelTest("./src/test/java/spoon/test/pkg/testclasses/Foo.java")
+	public void testGetFQNSimple(Factory factory) {
 		// contract: CtPackageReference simple name is also the fully qualified name of its referenced package
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/pkg/testclasses/Foo.java");
-		spoon.buildModel();
-
-		CtClass fooClass = spoon.getFactory().Class().get(Foo.class);
+		CtClass fooClass = factory.Class().get(Foo.class);
 		CtField field = fooClass.getField("fieldList");
 		CtPackageReference fieldPkg = field.getType().getPackage();
 
@@ -345,15 +322,10 @@ public class PackageTest {
 		assertEquals("java.util", fieldPkg.getQualifiedName());
 	}
 
-	@Test
-	public void testGetFQNInNoClassPath() {
+	@ModelTest("./src/test/resources/noclasspath/TorIntegration.java")
+	public void testGetFQNInNoClassPath(Factory factory) {
 		// contract: CtPackageReference simple name is also the fully qualified name of its referenced package, even in noclasspath
-		final Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/resources/noclasspath/TorIntegration.java");
-		spoon.getEnvironment().setNoClasspath(true);
-		spoon.buildModel();
-
-		CtClass torClass = spoon.getFactory().Class().get("com.duckduckgo.mobile.android.util.TorIntegration");
+		CtClass torClass = factory.Class().get("com.duckduckgo.mobile.android.util.TorIntegration");
 
 		CtField field = torClass.getField("orbotHelper");
 		CtPackageReference fieldPkg = field.getType().getPackage();

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -106,6 +106,7 @@ import spoon.test.position.testclasses.PositionTry;
 import spoon.test.position.testclasses.SomeEnum;
 import spoon.test.position.testclasses.TypeParameter;
 import spoon.test.query_function.testclasses.VariableReferencesModelTest;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -693,14 +694,11 @@ public class PositionTest {
 		assertEquals(SourcePosition.NOPOSITION, implicitSuperCall.getPosition());
 	}
 
-	@Test
-	public void getPositionOfImplicitBlock() {
+	@ModelTest("./src/test/java/spoon/test/position/testclasses/ImplicitBlock.java")
+	public void getPositionOfImplicitBlock(CtModel model) {
 		// contract: position of implicit block in if (cond) [implicit block] else [implicit block] should be the source position of implicit block content.
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/position/testclasses/ImplicitBlock.java");
-		launcher.buildModel();
 
-		CtIf ifElement = launcher.getModel().getElements(new TypeFilter<>(CtIf.class)).get(0);
+		CtIf ifElement = model.getElements(new TypeFilter<>(CtIf.class)).get(0);
 		CtStatement thenStatement = ifElement.getThenStatement();
 
 		assertTrue(thenStatement instanceof CtBlock);
@@ -1347,19 +1345,15 @@ public class PositionTest {
 			CtClass cl = Launcher.parseClass("class A { void foo() {");
 			assertTrue(cl.getSimpleName().equals("A"));
 			assertTrue(cl.getMethods().size() == 1);
-		} catch(Exception e) {
-			fail("Error while parsing incomplete class declaration "+e);
+		} catch (Exception e) {
+			fail("Error while parsing incomplete class declaration " + e);
 		}
 	}
 
-	@Test
-	public void testNoClasspathVariableAccessInInnerClass1() {
+	@ModelTest("./src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda1.java")
+	public void testNoClasspathVariableAccessInInnerClass1(CtModel model) {
 		// contract: creating variable access in no classpath should not break source position
 		// https://github.com/INRIA/spoon/issues/3052
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda1.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		List<CtClass> allClasses = model.getElements(new TypeFilter<>(CtClass.class));
 		assertEquals(3, allClasses.size());
 		CtClass failing = allClasses.stream().filter(t -> t.getSimpleName().equals("Failing")).findFirst().get();
@@ -1372,14 +1366,10 @@ public class PositionTest {
 		assertEquals("com.pkg.InheritedClassesWithLambda1.Failing", field.getVariable().getDeclaringType().toString());
 	}
 
-	@Test
-	public void testNoClasspathVariableAccessInInnerClass2() {
+	@ModelTest("./src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda2.java")
+	public void testNoClasspathVariableAccessInInnerClass2(CtModel model) {
 		// contract: same as for testNoClasspathVariableAccessInInnerClass1,
 		// but here we have inner class inside another inner class
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/lambdas/InheritedClassesWithLambda2.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		List<CtClass> allClasses = model.getElements(new TypeFilter<>(CtClass.class));
 		assertEquals(4, allClasses.size());
 		CtClass failing = allClasses.stream().filter(t -> t.getSimpleName().equals("Failing")).findFirst().get();
@@ -1392,14 +1382,10 @@ public class PositionTest {
 		assertEquals("InheritedClassesWithLambda2.OneMoreClass.Failing", field.getVariable().getDeclaringType().toString());
 	}
 
-	@Test
-	public void testNoClasspathVariableAccessInInnerInterface() {
+	@ModelTest("./src/test/resources/noclasspath/lambdas/InheritedInterfacesWithLambda.java")
+	public void testNoClasspathVariableAccessInInnerInterface(CtModel model) {
 		// contract: same as for testNoClasspathVariableAccessInInnerClass1,
 		// but here we have interface instead of class
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/lambdas/InheritedInterfacesWithLambda.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		List<CtInterface> allInterfaces = model.getElements(new TypeFilter<>(CtInterface.class));
 		assertEquals(1, allInterfaces.size());
 		CtInterface failing = allInterfaces.stream().filter(t -> t.getSimpleName().equals("Failing")).findFirst().get();

--- a/src/test/java/spoon/test/position/TestSourceFragment.java
+++ b/src/test/java/spoon/test/position/TestSourceFragment.java
@@ -52,6 +52,7 @@ import spoon.test.position.testclasses.FooField;
 import spoon.test.position.testclasses.FooSourceFragments;
 import spoon.test.position.testclasses.NewArrayList;
 import spoon.test.prettyprinter.testclasses.OneLineMultipleVariableDeclaration;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,20 +62,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestSourceFragment {
 
-	@Test
-	public void testSourceFragmentField() {
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/prettyprinter/testclasses/OneLineMultipleVariableDeclaration.java");
-		spoon.buildModel();
-
-		CtType t = spoon.getFactory().Type().get(OneLineMultipleVariableDeclaration.class);
+	@ModelTest("./src/test/java/spoon/test/prettyprinter/testclasses/OneLineMultipleVariableDeclaration.java")
+	public void testSourceFragmentField(Factory factory) {
+		CtType t = factory.Type().get(OneLineMultipleVariableDeclaration.class);
 
 		ElementSourceFragment fragment = ElementSourceFragment.createSourceFragmentsFrom(t);
 
 		// contract: there is no full fragment for joint fields
 		// the fragment of the type of field a
 		assertEquals("|int|", fragment.getChildrenFragments().get(8).toString());
-
 	}
 
 

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -45,6 +45,7 @@ import spoon.reflect.visitor.PrinterHelper;
 import spoon.reflect.visitor.TokenWriter;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.prettyprinter.testclasses.MissingVariableDeclaration;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -579,15 +580,12 @@ public class PrinterTest {
 			assertEquals("(a + b).toString()", invocations.get(2).toString());
 		}
 
-	@Test
-	public void testCustomPrettyPrinter() throws Exception {
+	@ModelTest("src/test/resources/JavaCode.java")
+	public void testCustomPrettyPrinter(Launcher launcher, Factory factory) throws Exception {
 		// contract: one can use Spoon to write a custom pretty-printer
 		// here the pretty-printer writes two spaces before each keyword of the language
-		Launcher spoon = new Launcher();
-		// Java file to be pretty-printed, can be a folder as well
-		spoon.addInputResource("src/test/resources/JavaCode.java");
-		spoon.getFactory().getEnvironment().setPrettyPrinterCreator(() -> {
-				DefaultJavaPrettyPrinter defaultJavaPrettyPrinter = new DefaultJavaPrettyPrinter(spoon.getFactory().getEnvironment());
+		factory.getEnvironment().setPrettyPrinterCreator(() -> {
+				DefaultJavaPrettyPrinter defaultJavaPrettyPrinter = new DefaultJavaPrettyPrinter(factory.getEnvironment());
 				// here we create the custom version of the token writer
 				defaultJavaPrettyPrinter.setPrinterTokenWriter(new DefaultTokenWriter() {
 					@Override
@@ -599,7 +597,7 @@ public class PrinterTest {
 				});
 				return defaultJavaPrettyPrinter;
 		});
-		spoon.run();
+		launcher.prettyprint();
 		// the pretty-printed code is in folder ./spooned (default value that can be set with setOutputDirectory)
 
 		assertTrue(FileUtils.readFileToString(new File("spooned/HelloWorld.java"), "UTF-8").contains("  class"));

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -45,6 +45,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.Level;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
@@ -52,6 +53,7 @@ import spoon.test.processing.processors.CtClassProcessor;
 import spoon.test.processing.processors.CtInterfaceProcessor;
 import spoon.test.processing.processors.CtTypeProcessor;
 import spoon.test.processing.processors.RenameProcessor;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ProcessorUtils;
 
 
@@ -335,17 +337,12 @@ public class ProcessingTest {
 		assertEquals(mamap, p.mapStringDouble);
 	}
 
-	@Test
-	public void testProcessorWithGenericType() {
+	@ModelTest("./src/test/java/spoon/test/imports/testclasses")
+	public void testProcessorWithGenericType(Launcher launcher) {
 		// contract: we can use generic type for another abstract processor
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses");
-
 		CtClassProcessor classProcessor = new CtClassProcessor();
-		spoon.addProcessor(classProcessor);
-
-		spoon.run();
+		launcher.addProcessor(classProcessor);
+		launcher.process();
 
 		assertFalse(classProcessor.elements.isEmpty());
 
@@ -354,23 +351,19 @@ public class ProcessingTest {
 		}
 	}
 
-	@Test
-	public void testCallProcessorWithMultipleTypes() {
+	@ModelTest("./src/test/java/spoon/test/imports/testclasses")
+	public void testCallProcessorWithMultipleTypes(Launcher launcher) {
 		// contract: when calling a processor capable of treating CtClass and another capable of treating CtType, they are called on the right types
-
-		Launcher spoon = new Launcher();
-		spoon.addInputResource("./src/test/java/spoon/test/imports/testclasses");
-
 		CtClassProcessor classProcessor = new CtClassProcessor();
-		spoon.addProcessor(classProcessor);
+		launcher.addProcessor(classProcessor);
 
 		CtTypeProcessor typeProcessor = new CtTypeProcessor();
-		spoon.addProcessor(typeProcessor);
+		launcher.addProcessor(typeProcessor);
 
 		CtInterfaceProcessor interfaceProcessor = new CtInterfaceProcessor();
-		spoon.addProcessor(interfaceProcessor);
+		launcher.addProcessor(interfaceProcessor);
 
-		spoon.run();
+		launcher.process();
 
 		assertFalse(classProcessor.elements.isEmpty());
 
@@ -425,8 +418,8 @@ public class ProcessingTest {
 		assertTrue(fileContent.contains("private D a = new D();"));
 	}
 
-	@Test
-	public void testNullableSettingForProcessor() throws IOException {
+	@ModelTest("src/test/resources/spoon/test/processor/test")
+	public void testNullableSettingForProcessor(Launcher launcher, Factory factory) {
 		//contract: nullable( = notNullable == false) properties with a null value must not throw a exception.
 		class AProcessor extends AbstractProcessor<CtElement> {
 			@Property(notNullable = false)
@@ -445,10 +438,8 @@ public class ProcessingTest {
 			public void process(CtElement element) {
 			}
 		}
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
 		Processor<CtElement> processor = new AProcessor();
-		processor.setFactory(launcher.getFactory());
+		processor.setFactory(factory);
 		ProcessorProperties props = new ProcessorPropertiesImpl();
 
 		props.set("aString", null);
@@ -458,13 +449,13 @@ public class ProcessingTest {
 
 		ProcessorUtils.initProperties(processor, props);
 		launcher.addProcessor(processor);
-		launcher.run();
+		launcher.process();
 		int warnings = launcher.getEnvironment().getWarningCount();
 		assertTrue(warnings == 0);
 	}
 
-	@Test
-	public void testNullableSettingForProcessor2() throws IOException {
+	@ModelTest("src/test/resources/spoon/test/processor/test")
+	public void testNullableSettingForProcessor2(Launcher launcher, Factory factory) {
 		//contract: notNullable( = notNullable == true) properties with a null value must throw a spoonexception.
 
 		class AProcessor extends AbstractProcessor<CtElement> {
@@ -484,10 +475,8 @@ public class ProcessingTest {
 			public void process(CtElement element) {
 			}
 		}
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/spoon/test/processor/test");
 		Processor<CtElement> processor = new AProcessor();
-		processor.setFactory(launcher.getFactory());
+		processor.setFactory(factory);
 		ProcessorProperties props = new ProcessorPropertiesImpl();
 
 		props.set("aString", null);

--- a/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
+++ b/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
@@ -28,6 +28,7 @@ import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,18 +46,12 @@ public class ElasticsearchStackoverflowTest {
 		}
 	}
 
-	@Test
-	public void testStackOverflow() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/elasticsearch-stackoverflow");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtModel model = launcher.getModel();
+	@ModelTest("./src/test/resources/noclasspath/elasticsearch-stackoverflow")
+	public void testStackOverflow(CtModel model) {
 		Scanner scanner = new Scanner();
 		scanner.scan(model.getRootPackage());
 
-		List<CtExecutableReference> executables = launcher.getModel().getElements(new TypeFilter<>(CtExecutableReference.class));
+		List<CtExecutableReference> executables = model.getElements(new TypeFilter<>(CtExecutableReference.class));
 		assertFalse(executables.isEmpty());
 
 		boolean result = false;

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -66,6 +66,7 @@ import spoon.test.reference.testclasses.EnumValue;
 import spoon.test.reference.testclasses.Panini;
 import spoon.test.reference.testclasses.ParamRefs;
 import spoon.test.reference.testclasses.SuperAccess;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 
@@ -253,13 +254,8 @@ public class TypeReferenceTest {
 		assertNotEquals(firstTypeParam, secondTypeParam);
 	}
 
-	@Test
-	public void testRecursiveTypeReference() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses/Tacos.java");
-		launcher.setSourceOutputDirectory("./target/spoon-test");
-		launcher.run();
-
+	@ModelTest("./src/test/java/spoon/test/reference/testclasses/Tacos.java")
+	public void testRecursiveTypeReference(Launcher launcher) {
 		final CtInvocation<?> inv = Query.getElements(launcher.getFactory(), new TypeFilter<CtInvocation<?>>(CtInvocation.class) {
 			@Override
 			public boolean matches(CtInvocation<?> element) {
@@ -287,13 +283,8 @@ public class TypeReferenceTest {
 		assertTrue(genericExtends.getBoundingType() instanceof CtTypeReference);
 	}
 
-	@Test
-	public void testRecursiveTypeReferenceInGenericType() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/reference/testclasses/EnumValue.java");
-		launcher.setSourceOutputDirectory("./target/spoon-test");
-		launcher.run();
-
+	@ModelTest("./src/test/java/spoon/test/reference/testclasses/EnumValue.java")
+	public void testRecursiveTypeReferenceInGenericType(Launcher launcher) {
 		final CtClass<EnumValue> aClass = launcher.getFactory().Class().get(EnumValue.class);
 		final CtMethod<?> asEnum = aClass.getMethodsByName("asEnum").get(0);
 
@@ -310,31 +301,18 @@ public class TypeReferenceTest {
 		assertNotNull(circularRef);
 	}
 
-	@Test
-	public void testUnknownSuperClassWithSameNameInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/Attachment.java")
+	public void testUnknownSuperClassWithSameNameInNoClasspath(Launcher launcher, Factory factory) {
 		// contract: Gets the import of a type specified in the declaration of a class.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Attachment.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		CtClass<?> ctType = (CtClass<?>) launcher.getFactory().Class().getAll().get(0);
+		CtClass<?> ctType = (CtClass<?>) factory.Class().getAll().get(0);
 		assertNotEquals(ctType.getSuperclass(), ctType.getReference());
 		assertEquals("it.feio.android.omninotes.commons.models.Attachment", ctType.getSuperclass().toString());
 		assertEquals("it.feio.android.omninotes.models.Attachment", ctType.getReference().toString());
-
 	}
 
-	@Test
-	public void testPackageInNoClasspath () {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Demo.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> aClass = launcher.getFactory().Class().get("Demo");
+	@ModelTest("./src/test/resources/noclasspath/Demo.java")
+	public void testPackageInNoClasspath(Launcher launcher, Factory factory) {
+		final CtClass<Object> aClass = factory.Class().get("Demo");
 		final Set<CtTypeReference<?>> referencedTypes = aClass.getReferencedTypes();
 
 		boolean containsDemoReference = false;
@@ -359,16 +337,10 @@ public class TypeReferenceTest {
 		assertTrue(containsJoinerReference, "Reference to Joiner is missing");
 	}
 
-	@Test
-	public void testTypeReferenceSpecifiedInClassDeclarationInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/Demo.java")
+	public void testTypeReferenceSpecifiedInClassDeclarationInNoClasspath(Launcher launcher, Factory factory) {
 		// contract: Gets the import of a type specified in the declaration of a class.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Demo.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> aClass = launcher.getFactory().Class().get("Demo");
+		final CtClass<Object> aClass = factory.Class().get("Demo");
 
 		assertNotNull(aClass.getSuperclass());
 		assertEquals("com.google.common.base.Function", aClass.getSuperclass().getQualifiedName());
@@ -385,16 +357,10 @@ public class TypeReferenceTest {
 		}
 	}
 
-	@Test
-	public void testTypeReferenceSpecifiedInClassDeclarationInNoClasspathWithGenerics() {
+	@ModelTest("./src/test/resources/noclasspath/Demo2.java")
+	public void testTypeReferenceSpecifiedInClassDeclarationInNoClasspathWithGenerics(Launcher launcher, Factory factory) {
 		// contract: Gets the import of a type specified in the declaration of a class.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Demo2.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> aClass = launcher.getFactory().Class().get("Demo2");
+		final CtClass<Object> aClass = factory.Class().get("Demo2");
 		Set<CtTypeReference<?>> superInterfaces = aClass.getSuperInterfaces();
 		final CtTypeReference superInterface = superInterfaces.toArray(new CtTypeReference[superInterfaces.size()])[0];
 		assertEquals("Bar", superInterface.getSimpleName());
@@ -415,16 +381,10 @@ public class TypeReferenceTest {
 		assertEquals("example.FooBar<?, ? extends Tacos<?>>.Bar<?, ? extends Tacos<?>>", superInterface.toString());
 	}
 
-	@Test
-	public void testArgumentOfAInvocationIsNotATypeAccess() {
+	@ModelTest("./src/test/resources/noclasspath/Demo3.java")
+	public void testArgumentOfAInvocationIsNotATypeAccess(Launcher launcher, Factory factory) {
 		// contract: In no classpath, an unknown field specified as argument isn't a CtTypeAccess.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Demo3.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> demo3 = launcher.getFactory().Class().get("Demo3");
+		final CtClass<Object> demo3 = factory.Class().get("Demo3");
 		final List<CtFieldRead> fields = demo3.getElements(new TypeFilter<CtFieldRead>(CtFieldRead.class) {
 			@Override
 			public boolean matches(CtFieldRead element) {
@@ -434,16 +394,10 @@ public class TypeReferenceTest {
 		assertEquals(1, fields.size());
 	}
 
-	@Test
-	public void testInvocationWithFieldAccessInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/Demo4.java")
+	public void testInvocationWithFieldAccessInNoClasspath(Launcher launcher, Factory factory) {
 		// contract: In no classpath mode, if we have field accesses in an invocation, we should build field access and not type access.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Demo4.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> demo4 = launcher.getFactory().Class().get("Demo4");
+		final CtClass<Object> demo4 = factory.Class().get("Demo4");
 		final CtMethod<?> doSomething = demo4.getMethodsByName("doSomething").get(0);
 		final CtInvocation topInvocation = doSomething.getElements(new TypeFilter<>(CtInvocation.class)).get(0);
 		assertNotNull(topInvocation.getTarget());
@@ -458,18 +412,12 @@ public class TypeReferenceTest {
 		canBeBuilt("./src/test/resources/noclasspath/TestBot.java", 8, true);
 	}
 
-	@Test
-	public void testAnnotationOnMethodWithPrimitiveReturnTypeInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/A.java")
+	public void testAnnotationOnMethodWithPrimitiveReturnTypeInNoClasspath(Launcher launcher, Factory factory) {
 		// contract: In no classpath mode, if we have an annotation declared on a method and overridden
 		// from a super class in an anonymous class, we should rewrite correctly the annotation and don't
 		// throw a NPE.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/A.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> aClass = launcher.getFactory().Class().get("A");
+		final CtClass<Object> aClass = factory.Class().get("A");
 		final CtClass anonymousClass = aClass.getElements(new TypeFilter<>(CtNewClass.class)).get(0).getAnonymousClass();
 		final CtMethod run = anonymousClass.getMethod("run");
 		assertNotNull(run);
@@ -477,16 +425,10 @@ public class TypeReferenceTest {
 		assertEquals("@java.lang.Override", run.getAnnotations().get(0).toString());
 	}
 
-	@Test
-	public void testAnonymousClassesHaveAnEmptyStringForItsNameInNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/A.java")
+	public void testAnonymousClassesHaveAnEmptyStringForItsNameInNoClasspath(Launcher launcher, Factory factory) {
 		// contract: In no classpath mode, a type reference have an empty string for its name.
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/A.java");
-		launcher.setSourceOutputDirectory("./target/class-declaration");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
-		final CtClass<Object> aClass = launcher.getFactory().Class().get("A");
+		final CtClass<Object> aClass = factory.Class().get("A");
 		final CtClass anonymousClass = aClass.getElements(new TypeFilter<>(CtNewClass.class)).get(0).getAnonymousClass();
 		assertEquals("1", anonymousClass.getReference().getSimpleName());
 		Set<CtTypeReference<?>> referencedTypes = aClass.getReferencedTypes();
@@ -609,18 +551,15 @@ public class TypeReferenceTest {
 		CtType<Panini> paniniCtType = buildClass(Panini.class);
 
 		CtClass anonymousClass = ((CtNewClass) ((CtReturn) paniniCtType
-				.getMethod("entryIterator").getBody().getStatement(0))
-				.getReturnedExpression()).getAnonymousClass();
+			.getMethod("entryIterator").getBody().getStatement(0))
+			.getReturnedExpression()).getAnonymousClass();
 
 		assertTrue(anonymousClass.getReference().isSubtypeOf(paniniCtType.getFactory().Type().createReference("spoon.test.reference.testclasses.Panini$Itr")));
 	}
 
-	@Test
-	public void testGetTypeDeclaration() {
-		Launcher l = new Launcher();
-		l.addInputResource("src/test/resources/compilation/compilation-tests/");
-		l.buildModel();
-		CtType<?> bar = l.getFactory().Type().get("compilation.Bar");
+	@ModelTest("src/test/resources/compilation/compilation-tests/")
+	public void testGetTypeDeclaration(Factory factory) {
+		CtType<?> bar = factory.Type().get("compilation.Bar");
 		CtType iBar = bar.getSuperInterfaces().toArray(new CtTypeReference[0])[0].getTypeDeclaration();
 		assertNotNull(iBar);
 		assertEquals("compilation.IBar", iBar.getQualifiedName());
@@ -693,13 +632,9 @@ public class TypeReferenceTest {
 		assertEquals("spoon.test.reference.testclasses.Parent", typeRef.toString());
 	}
 
-	@Test
-	public void testIsInTheSamePackageNoClasspath() {
+	@ModelTest("./src/test/resources/noclasspath/A5.java")
+	public void testIsInTheSamePackageNoClasspath(CtModel model) {
 		// contract: we should not get NPE within canAccess() in noclasspath mode
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/A5.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		CtType<?> type = model.getAllTypes().stream().findFirst().get();
 
 		List<CtLocalVariable> vars = type.getElements(new TypeFilter<>(CtLocalVariable.class));
@@ -742,15 +677,11 @@ public class TypeReferenceTest {
 		return (CtTypeReference<?>) ref;
 	}
 
-	@Test
-	public void testUnqualifiedExternalTypeMemberAccess() {
+	@ModelTest("./src/test/resources/noclasspath/UnqualifiedExternalTypeMemberAccess.java")
+	public void testUnqualifiedExternalTypeMemberAccess(CtModel model) {
 		// contract: if a type member is accessed without qualification, but it is not part of the current
 		// compilation unit, any qualification attached to it through import resolution must remain implicit
 		// See #3363 for details
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/UnqualifiedExternalTypeMemberAccess.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		List<CtTypeReference<?>> typeReferences = model.getElements(e -> e.getSimpleName().equals("SOMETHING"));
 
 		assertEquals(1, typeReferences.size(), "There should only be one reference to SOMETHING, check the resource!");
@@ -805,31 +736,19 @@ public class TypeReferenceTest {
 		assertThat(reference.isLocalType(), is(false));
 	}
 
-	@Test
-	public void testTypeReferenceToChildClass() {
+	@ModelTest("./src/test/resources/reference-to-child-class/ReferenceToChildClass.java")
+	public void testTypeReferenceToChildClass(CtModel model) {
 		// contract: a reference to a child class should retain the parent class name
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/reference-to-child-class/ReferenceToChildClass.java");
-		launcher.getEnvironment().setAutoImports(true);
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtClass cls = launcher.getModel().getElements(new TypeFilter<>(CtClass.class)).get(0);
+		CtClass cls = model.getElements(new TypeFilter<>(CtClass.class)).get(0);
 		CtTypeReference<?> interfaceTypeRef = cls.getSuperInterfaces().stream().findFirst().get();
 
 		assertEquals("Foo<ReferenceToChildClass.Bar<?>>", interfaceTypeRef.toString());
 	}
 
-	@Test
-	public void testProblemTypeReferenceToChildClass() {
+	@ModelTest("./src/test/resources/reference-to-child-class/ProblemReferenceToChildClass.java")
+	public void testProblemTypeReferenceToChildClass(CtModel model) {
 		// contract: a reference to a child class in a not compilable file should retain the parent class name
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/reference-to-child-class/ProblemReferenceToChildClass.java");
-		launcher.getEnvironment().setAutoImports(true);
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtClass cls = launcher.getModel().getElements(new TypeFilter<>(CtClass.class)).get(0);
+		CtClass cls = model.getElements(new TypeFilter<>(CtClass.class)).get(0);
 		CtTypeReference<?> interfaceTypeRef = cls.getSuperInterfaces().stream().findFirst().get();
 
 		assertEquals("Foo<ProblemReferenceToChildClass.Bar<?>>", interfaceTypeRef.toString());

--- a/src/test/java/spoon/test/reference/VariableAccessTest.java
+++ b/src/test/java/spoon/test/reference/VariableAccessTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtArrayWrite;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
@@ -33,6 +34,7 @@ import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtParameterReference;
 import spoon.reflect.reference.CtVariableReference;
@@ -42,6 +44,7 @@ import spoon.reflect.visitor.filter.LocalVariableReferenceFunction;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.reference.testclasses.Pozole;
 import spoon.test.reference.testclasses.Tortillas;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -82,23 +85,14 @@ public class VariableAccessTest {
 		assertEquals(expected, ((CtVariableAccess) ctArrayWrite.getTarget()).getVariable().getDeclaration());
 	}
 
-	@Test
-	public void testParameterReferenceInConstructorNoClasspath () {
-		final Launcher launcher = new Launcher();
-		// throws `NullPointerException` before PR #1098
-		launcher.addInputResource("./src/test/resources/noclasspath/org/elasticsearch/indices/analysis/HunspellService.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
+	@ModelTest("./src/test/resources/noclasspath/org/elasticsearch/indices/analysis/HunspellService.java")
+	public void testParameterReferenceInConstructorNoClasspath(Launcher launcher) {
+		// Model is built
 	}
 
-	@Test
-	public void testDeclarationOfVariableReference() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/Foo2.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		launcher.getModel().getElements(new TypeFilter<CtVariableReference>(CtVariableReference.class) {
+	@ModelTest("./src/test/resources/noclasspath/Foo2.java")
+	public void testDeclarationOfVariableReference(CtModel model) {
+		model.getElements(new TypeFilter<CtVariableReference>(CtVariableReference.class) {
 			@Override
 			public boolean matches(CtVariableReference element) {
 				try {
@@ -111,15 +105,9 @@ public class VariableAccessTest {
 		});
 	}
 
-	@Test
-	public void testDeclaringTypeOfALambdaReferencedByParameterReference() {
-		final spoon.Launcher launcher = new spoon.Launcher();
-		launcher.addInputResource("src/test/resources/noclasspath/Foo3.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.getEnvironment().setComplianceLevel(8);
-		launcher.buildModel();
-
-		launcher.getModel().getElements(new TypeFilter<CtExecutable<?>>(CtExecutable.class) {
+	@ModelTest(value = "src/test/resources/noclasspath/Foo3.java", complianceLevel = 8)
+	public void testDeclaringTypeOfALambdaReferencedByParameterReference(CtModel model) {
+		model.getElements(new TypeFilter<CtExecutable<?>>(CtExecutable.class) {
 			@Override
 			public boolean matches(CtExecutable<?> exec) {
 				final List<CtParameterReference<?>> guiParams = exec.getParameters().stream().map(CtParameter::getReference).collect(Collectors.toList());
@@ -143,14 +131,9 @@ public class VariableAccessTest {
 		});
 	}
 
-	@Test
-	public void testGetDeclarationAfterClone() {
-		final Launcher launcher = new Launcher();
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.addInputResource("./src/test/resources/noclasspath/A2.java");
-		launcher.buildModel();
-
-		final CtClass<Object> a2 = launcher.getFactory().Class().get("A2");
+	@ModelTest("./src/test/resources/noclasspath/A2.java")
+	public void testGetDeclarationAfterClone(Launcher launcher, Factory factory) {
+		final CtClass<Object> a2 = factory.Class().get("A2");
 		final CtClass<Object> a2Cloned = a2.clone();
 
 		assertEquals(a2, a2Cloned);

--- a/src/test/java/spoon/test/serializable/SourcePositionTest.java
+++ b/src/test/java/spoon/test/serializable/SourcePositionTest.java
@@ -32,6 +32,7 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.support.SerializationModelStreamer;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,14 +49,9 @@ public class SourcePositionTest {
 		outstr.writeTo(fileStream);
 	}
 
-	@Test
-	public void testSourcePosition() throws IOException {
+	@ModelTest("./src/test/resources/serialization/SomeClass.java")
+	public void testSourcePosition(Factory factory) throws IOException {
 		File modelFile = new File("./target/SourcePositionTest-model");
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/serialization/SomeClass.java");
-		launcher.buildModel();
-
-		Factory factory = launcher.getFactory();
 
 		saveFactory(factory, modelFile);
 
@@ -74,17 +70,15 @@ public class SourcePositionTest {
 		assertTrue(elem1.getPosition().getFile().equals(elem2.getPosition().getFile()));
 	}
 
-	@Test
-	public void test_sourcePositionOfTypeInFieldExists() {
+	@ModelTest({
+		"src/test/resources/spoon/test/sourcePosition/FieldType.java",
+		"src/test/resources/spoon/test/sourcePosition/SourcePartitionValidator.java",
+	})
+	public void test_sourcePositionOfTypeInFieldExists(CtModel model) {
 		// contract: the type reference of type of the field should have a source position
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/spoon/test/sourcePosition/FieldType.java");
-		launcher.addInputResource("src/test/resources/spoon/test/sourcePosition/SourcePartitionValidator.java");
-		CtModel model = launcher.buildModel();
-
 		CtField<?> field = (CtField<?>) model.getElements(
-				element -> element instanceof CtField &&
-						((CtField<?>) element).getSimpleName().equals("pleaseAttachSourcePositionToMyType")).stream().findFirst().get();
+			element -> element instanceof CtField &&
+				((CtField<?>) element).getSimpleName().equals("pleaseAttachSourcePositionToMyType")).stream().findFirst().get();
 		assertTrue(field.getType().getPosition().isValidPosition(), "Source position unknown for type of field");
 	}
 }

--- a/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
+++ b/src/test/java/spoon/test/sourcePosition/SourcePositionTest.java
@@ -41,6 +41,7 @@ import spoon.support.reflect.cu.position.DeclarationSourcePositionImpl;
 import spoon.support.reflect.cu.position.SourcePositionImpl;
 import spoon.support.reflect.declaration.CtClassImpl;
 import spoon.test.sourcePosition.testclasses.Brambora;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -119,13 +120,12 @@ public class SourcePositionTest {
 				"body = |8;9|89|", bhsp.getSourceDetails());
 	}
 
-	@Test
-	public void testSourcePositionWhenCommentInAnnotation() {
+	@ModelTest({
+		"./src/test/resources/spoon/test/sourcePosition/ClassWithAnnotation.java",
+		"./src/test/resources/spoon/test/sourcePosition/TestAnnotation.java",
+	})
+	public void testSourcePositionWhenCommentInAnnotation(CtModel model) {
 		// contract: comment characters as element values in annotations should not break position assignment to modifiers
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/sourcePosition/ClassWithAnnotation.java");
-		launcher.addInputResource("./src/test/resources/spoon/test/sourcePosition/TestAnnotation.java");
-		CtModel model = launcher.buildModel();
 		List<CtClassImpl> list = model.getElements(new TypeFilter<>(CtClassImpl.class));
 		assertEquals(4,list.get(0).getPosition().getLine());
 	}

--- a/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
+++ b/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
@@ -32,6 +32,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -98,22 +99,20 @@ public class SpoonifierTest {
 	 * This test is too long for CI, but it checks that SpoonifierVisitor does produce equivalent CtElement for all
 	 * CtElement in Rule
 	 */
-	
-	@Test
+
 	@Disabled
-	public void testSpoonifierElement() throws ClassNotFoundException, MalformedURLException, InvocationTargetException, IllegalAccessException, NoSuchMethodException {
+	@ModelTest("src/test/java/spoon/test/prettyprinter/testclasses/Rule.java")
+	public void testSpoonifierElement(CtModel model) throws MalformedURLException, ClassNotFoundException, InvocationTargetException, NoSuchMethodException, IllegalAccessException {
 		int i = 0;
 
 		//Build the model of the given class
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/java/spoon/test/prettyprinter/testclasses/Rule.java");
-		CtModel model = launcher.buildModel();
+
 		List<CtType> l = model.getElements(new TypeFilter<CtType>(CtType.class));
 		if (l.isEmpty()) return;
 		CtType targetType = l.get(0);
-		Iterator<CtElement> iterator =  targetType.descendantIterator();
+		Iterator<CtElement> iterator = targetType.descendantIterator();
 		while (iterator.hasNext()) {
-			testSpoonifierWith(iterator.next(),i++);
+			testSpoonifierWith(iterator.next(), i++);
 		}
 
 

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -54,6 +54,7 @@ import spoon.test.targeted.testclasses.InternalSuperCall;
 import spoon.test.targeted.testclasses.Pozole;
 import spoon.test.targeted.testclasses.SuperClass;
 import spoon.test.targeted.testclasses.Tapas;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -484,14 +485,10 @@ public class TargetedExpressionTest {
 		assertEqualsFieldAccess(new ExpectedTargetedExpression().declaringType(expectedFoo).target(expectedThisAccess).result("this.bar"), elements.get(0));
 	}
 
-	@Test
-	public void testUnqualifiedStaticMethodCallNoclasspath() {
+	@ModelTest("./src/test/resources/noclasspath/UnqualifiedStaticMethodCall.java")
+	public void testUnqualifiedStaticMethodCallNoclasspath(CtModel model) {
 		// contract: If a static method of some other type is accessed without qualification, any qualification attached
 		// to it must be implicit. See #3370 for details
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/UnqualifiedStaticMethodCall.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		CtModel model = launcher.buildModel();
 		List<CtTypeAccess<?>> typeAccesses = model.getElements(e -> e.getAccessedType().getSimpleName().equals("SomeClass"));
 
 		assertEquals(1, typeAccesses.size(), "There should only be one reference to SomeClass, check the resource!");

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -61,6 +61,7 @@ import spoon.test.template.testclasses.inheritance.SuperTemplate;
 import spoon.test.template.testclasses.logger.Logger;
 import spoon.test.template.testclasses.logger.LoggerTemplateProcessor;
 import spoon.testing.utils.LineSeperatorExtension;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import java.io.File;

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -50,6 +50,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.test.trycatch.testclasses.Foo;
 import spoon.test.trycatch.testclasses.Main;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.LineSeperatorExtension;
 
 
@@ -395,8 +396,8 @@ public class TryCatchTest {
 		assertFalse(paramTypes.get(1).isSimplyQualified(), "second type reference should be qualified");
 	}
 
-	@Test
-	public void testNonCloseableGenericTypeInTryWithResources() {
+	@ModelTest("src/test/resources/NonClosableGenericInTryWithResources.java")
+	public void testNonCloseableGenericTypeInTryWithResources(CtModel model) {
 		// contract: When a non-closeable generic type is used in a try-with-resources, it's type
 		// becomes a problem type in JDT, with the type parameters included in the compound name.
 		// This is as opposed to a parameterized type, so we need to take special care in parsing
@@ -406,10 +407,6 @@ public class TryCatchTest {
 		//
 		// This previously caused a crash, see https://github.com/INRIA/spoon/issues/3951
 
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/NonClosableGenericInTryWithResources.java");
-
-		CtModel model = launcher.buildModel();
 		CtLocalVariableReference<?> varRef = model.filterChildren(CtLocalVariableReference.class::isInstance).first();
 
 		assertThat(varRef.getType().getQualifiedName(), equalTo("NonClosableGenericInTryWithResources.GenericType"));

--- a/src/test/java/spoon/test/type/TypeTest.java
+++ b/src/test/java/spoon/test/type/TypeTest.java
@@ -51,6 +51,7 @@ import spoon.support.SpoonClassNotFoundException;
 import spoon.test.type.testclasses.Mole;
 import spoon.test.type.testclasses.Pozole;
 import spoon.test.type.testclasses.TypeMembersOrder;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -112,16 +113,9 @@ public class TypeTest {
 		assertFalse(op.getRightHandOperand().getType().isPrimitive());
 	}
 
-	@Test
-	public void testTypeAccessForTypeAccessInInstanceOf() {
+	@ModelTest("./src/test/java/spoon/test/type/testclasses")
+	public void testTypeAccessForTypeAccessInInstanceOf(Launcher launcher) {
 		// contract: the right hand operator must be a CtTypeAccess.
-		final String target = "./target/type";
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/type/testclasses");
-		launcher.setSourceOutputDirectory(target);
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
 		final CtClass<Pozole> aPozole = launcher.getFactory().Class().get(Pozole.class);
 		final CtMethod<?> eat = aPozole.getMethodsByName("eat").get(0);
 
@@ -183,14 +177,9 @@ public class TypeTest {
 		assertFalse(typeAccesses.getAccessedType().isImplicit());
 	}
 
-	@Test
-	public void test() {
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/TorIntegration.java");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtType<?> ctType = launcher.getFactory().Class().getAll().get(0);
+	@ModelTest("./src/test/resources/noclasspath/TorIntegration.java")
+	public void test(Factory factory) {
+		CtType<?> ctType = factory.Class().getAll().get(0);
 		List<CtNewClass> elements = ctType.getElements(new TypeFilter<>(CtNewClass.class));
 		assertEquals(4, elements.size());
 		for (CtNewClass ctNewClass : elements) {
@@ -328,21 +317,16 @@ public class TypeTest {
 		assertNotNull(factory.Enum().create("fr.inria.ETest").getReference().getDeclaration());
 	}
 
-	@Test
-	public void testPolyTypBindingInTernaryExpression() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/noclasspath/ternary-bug");
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.buildModel();
-
-		CtType<Object> aType = launcher.getFactory().Type().get("de.uni_bremen.st.quide.persistence.transformators.IssueTransformator");
+	@ModelTest("./src/test/resources/noclasspath/ternary-bug")
+	public void testPolyTypBindingInTernaryExpression(Factory factory) {
+		CtType<Object> aType = factory.Type().get("de.uni_bremen.st.quide.persistence.transformators.IssueTransformator");
 		CtConstructorCall ctConstructorCall = aType.getElements(new TypeFilter<CtConstructorCall>(CtConstructorCall.class) {
 			@Override
 			public boolean matches(CtConstructorCall element) {
 				return "TOIssue".equals(element.getExecutable().getType().getSimpleName()) && super.matches(element);
 			}
 		}).get(0);
-		assertEquals(launcher.getFactory().Type().objectType(), ctConstructorCall.getExecutable().getParameters().get(9));
+		assertEquals(factory.Type().objectType(), ctConstructorCall.getExecutable().getParameters().get(9));
 	}
 
 	@Test
@@ -402,16 +386,9 @@ public class TypeTest {
 
 	}
 
-	@Test
-	public void testTypeMemberOrder() {
-		// contract: The TypeMembers keeps order of members same like in source file 
-		final String target = "./target/type";
-		final Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/java/spoon/test/type/testclasses/TypeMembersOrder.java");
-		launcher.setSourceOutputDirectory(target);
-		launcher.getEnvironment().setNoClasspath(true);
-		launcher.run();
-
+	@ModelTest("./src/test/java/spoon/test/type/testclasses/TypeMembersOrder.java")
+	public void testTypeMemberOrder(Launcher launcher) {
+		// contract: The TypeMembers keeps order of members same like in source file
 		Factory f = launcher.getFactory();
 		final CtClass<?> aTypeMembersOrder = f.Class().get(TypeMembersOrder.class);
 		{

--- a/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
+++ b/src/test/java/spoon/test/visitor/AssignmentsEqualsTest.java
@@ -8,19 +8,15 @@ import spoon.reflect.code.CtAssignment;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class AssignmentsEqualsTest {
 
-	@Test
-	public void testEquals() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/visitor/Assignments.java");
-		launcher.buildModel();
-
-		Factory factory = launcher.getFactory();
+	@ModelTest("./src/test/resources/spoon/test/visitor/Assignments.java")
+	public void testEquals(Factory factory) {
 		List<CtAssignment> assignments = Query.getElements(factory, new TypeFilter<>(CtAssignment.class));
 		assertEquals(assignments.size(), 10);
 		assertNotEquals(assignments.get(0), assignments.get(1));

--- a/src/test/java/spoon/test/visitor/VisitorTest.java
+++ b/src/test/java/spoon/test/visitor/VisitorTest.java
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.CtScanner;
+import spoon.testing.utils.ModelTest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -36,14 +38,10 @@ public class VisitorTest {
 		}
 	}
 
-	@Test
-	public void testRecursiveDescent() {
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("./src/test/resources/spoon/test/visitor/Foo.java");
-		launcher.buildModel();
-
+	@ModelTest("./src/test/resources/spoon/test/visitor/Foo.java")
+	public void testRecursiveDescent(Factory factory) {
 		final MyVisitor visitor = new MyVisitor(2);
-		visitor.scan(launcher.getFactory().Package().getRootPackage());
+		visitor.scan(factory.Package().getRootPackage());
 		assertTrue(visitor.equals);
 	}
 }


### PR DESCRIPTION
This aims to clean up tests by adding a `ModelTest` annotation to provide a launcher, factory and model.

The usages were mostly found using intellijs structural search (template):
```xml
<searchConfiguration name="@Test&#10;public $ReturnType$ $Method$() {…" uuid="0cbc6611-f554-3bd0-809a-388dc95a615b" text="@Test&#10;public $ReturnType$ $Method$() {&#10;&#9;$Statements$;&#10;&#9;Launcher $launcher$ = new Launcher();&#10;&#9;$launcher$.addInputResource(&quot;$input$&quot;);&#10;&#9;$Statements2$;&#10;}" recursive="true" type="JAVA" pattern_context="member" search_injected="false" case_sensitive="true">
  <constraint name="__context__" within="" contains="" />
  <constraint name="ReturnType" within="" contains="" />
  <constraint name="Method" within="" contains="" />
  <constraint name="Statements" minCount="0" maxCount="2147483647" within="" contains="" />
  <constraint name="launcher" within="" contains="" />
  <constraint name="input" within="" contains="" />
  <constraint name="Statements2" minCount="0" maxCount="2147483647" within="" contains="" />
</searchConfiguration>
```
And then replaced using its structural replacement
```xml
<replaceConfiguration name="@Test&#10;public $ReturnType$ $Method$() {…" uuid="0cbc6611-f554-3bd0-809a-388dc95a615b" text="@Test&#10;public $ReturnType$ $Method$() {&#10;&#9;$Statements$;&#10;&#9;Launcher $launcher$ = new Launcher();&#10;&#9;$launcher$.addInputResource(&quot;$input$&quot;);&#10;&#9;$Statements2$;&#10;}" recursive="false" type="JAVA" pattern_context="member" search_injected="false" reformatAccordingToStyle="true" shortenFQN="true" replacement="&#9;@ModelTest(&quot;$input$&quot;)&#10;&#9;public $ReturnType$ $Method$(spoon.Launcher launcher) {&#10;&#9;&#9;$Statements$; &#10;&#9;&#9;$Statements2$;&#10;&#9;}" case_sensitive="true">
  <constraint name="__context__" within="" contains="" />
  <constraint name="ReturnType" within="" contains="" />
  <constraint name="Method" within="" contains="" />
  <constraint name="Statements" minCount="0" maxCount="2147483647" within="" contains="" />
  <constraint name="launcher" within="" contains="" />
  <constraint name="input" within="" contains="" />
  <constraint name="Statements2" minCount="0" maxCount="2147483647" within="" contains="" />
</replaceConfiguration>
```

![grafik](https://user-images.githubusercontent.com/20284688/163437384-9be11610-0771-41d0-ae54-5eff188ab8a7.png)
As you can see on the lefthand side, we went through quite a few iterations and the reproduced queries above are just an excerpt.

Replacement was done automatically but cleaned up manually, as usages varied too widely and new flags needed to be added to the annotation. Finally, the whole thing was manually committed using `git add -p`, as intellij fixed thousands of absolutely awful formatting mistakes in the code that would have bloated the diff.