### PR TITLE
wip: test: Fix GitHubIssue annotation not failing surefire tests

### DIFF
--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -811,7 +811,7 @@ public class TestSniperPrinter {
 		testSniper("ArithmeticExpression", noOpModifyFieldAssignment, assertPrintsRoundBracketsCorrectly);
 	}
 
-	@GitHubIssue(issueNumber = 4218, fixed = false)
+	@GitHubIssue(issueNumber = 4218, fixed = true)
 	void testSniperDoesNotPrintTheDeletedAnnotation() {
 		Consumer<CtType<?>> deleteAnnotation = type -> {
 			type.getAnnotations().forEach(CtAnnotation::delete);


### PR DESCRIPTION
The previous implementation threw an exception in `testSuccessful` to fail the test. This was dutifully ignored by Junit, as the TestWatcher API explicitly *cannot* impact test results from its callbacks.

This patch switches to the AfterTestExecutionCallback, which does not specify anything in its javadoc and seems to work.