### PR TITLE
fix: Respect shadowCache in JavaReflectionTreeBuilder for enclosing classes

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -91,7 +91,7 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 		CtPackage ctPackage;
 		CtType<?> ctEnclosingClass;
 		if (clazz.getEnclosingClass() != null && !clazz.isAnonymousClass()) {
-			ctEnclosingClass = scan(clazz.getEnclosingClass());
+			ctEnclosingClass = factory.Type().get(clazz.getEnclosingClass());
 			return ctEnclosingClass.getNestedType(clazz.getSimpleName());
 		} else {
 			if (clazz.getPackage() == null) {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -637,8 +637,8 @@ public class JavaReflectionTreeBuilderTest {
 	}
 
 	@Test
-	public void testInnerClass() {
-		// contract: JavaReflectionTreeBuilder works on internal named classes
+	public void testInnerClassOfSourceCodeClass() {
+		// contract: JavaReflectionTreeBuilder does not rescan the type if source information is available
 		Launcher launcher = new Launcher();
 		launcher.addInputResource("src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java");
 		launcher.buildModel();
@@ -646,6 +646,28 @@ public class JavaReflectionTreeBuilderTest {
 		assertEquals("Diff", ctType.getSimpleName());
 		assertEquals(false, ctType.isAnonymous());
 		assertEquals(false, ctType.isShadow());
+
+		Class<?> klass = ctType.getActualClass();
+		assertEquals("spoon.support.visitor.java.JavaReflectionTreeBuilderTest$Diff", klass.getName());
+		assertEquals(false, klass.isAnonymousClass());
+
+		CtType<?> ctClass = new JavaReflectionTreeBuilder(launcher.getFactory()).scan(klass);
+		assertEquals("Diff", ctClass.getSimpleName());
+		assertEquals(false, ctClass.isAnonymous());
+		assertEquals(false, ctClass.isShadow());
+		assertEquals("element", ctClass.getFields().toArray(new CtField[0])[0].getSimpleName());
+	}
+
+	@Test
+	public void testPurelyReflectiveInnerClass() {
+		// contract: JavaReflectionTreeBuilder works for named nested classes
+		Launcher launcher = new Launcher();
+		// No resources, as we only want to check the reflection tree builder
+		launcher.buildModel();
+		CtType ctType = launcher.getFactory().Type().get(Diff.class);
+		assertEquals("Diff", ctType.getSimpleName());
+		assertEquals(false, ctType.isAnonymous());
+		assertEquals(true, ctType.isShadow());
 
 		Class<?> klass = ctType.getActualClass();
 		assertEquals("spoon.support.visitor.java.JavaReflectionTreeBuilderTest$Diff", klass.getName());


### PR DESCRIPTION
After two *way* too long debugging sessions, I ended up with this **one** line fix for #4698. The ReflectionTreeBuilder unconditionally scanned the enclosing class, bypassing the shadow class cache. This resulted in two different `CtClass` instances for `ArrayList`, causing the role reference equality check to fail.

The problem here is, that scanning a class only results in *that* class to be added to the shadow cache - but no nested classes. The `ImportConflictDetector`, added by default as a preprocessor for the pretty printer, then caused a nested class to be scanned (which was never added to the shadow cache), which promptly re-scanned the enclosing `ArrayList`. This new instance was then added to the package, overwriting the original class present in the shadow cache. Role lookups were performed on the original cached instance, which now no longer was present in any package -- the lookup in the parent failed and a `null` role was returned.

Scanning nested classes eagerly causes FIVE (5!) instances of the `ArrayList` class to be created in the test from this issue (#4703). Just performing the lookup where I placed it in this PR actually removes inconsistencies in `getNestedTypes` as well, as the member lookup somebody inserted there now actually does what it claims to do. I am not sure why nested types aren't directly added to the shadow cache in the first place (as they are already built and added as children to the enclosing CtType), but at least it is now consistent.

Debugging for this PR highlighted that the current shadow model was a bad idea IMHO. We really should have opted for a set of lazily-caching proxy classes that delegate to reflective lookups. This would allow the model to be immutable, prevent duplicate work more easily and only perform expensive reflection lookups when they are *actually* needed.

The current situation can therefore IMHO be summarized as
![image](https://user-images.githubusercontent.com/20284688/164971611-1e08fe5c-90f0-440b-ba75-42eaeb9f0df6.png)


Fixes: #4698