### PR TITLE
fix: remove unnecessary junit dep from spoon-smpl pom.xml

### DIFF
--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -107,16 +107,5 @@
             <artifactId>spoon-control-flow</artifactId>
             <version>0.0.2-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-        <!--<dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
-            <version>1.7.30</version>
-        </dependency>-->
     </dependencies>
 </project>


### PR DESCRIPTION
This fix stops depclean complaining about unused dependencies when building the spoon-smpl submodule. Running tests still works. I guess junit gets pulled in from the parent `../spoon-pom/pom.xml`?

I also removed a commented-out dependency which I should not have committed in the first place.