### PR TITLE
fix: add for-loop elements to UnsupportedElementSwapper and add warning messages (issue #4716)

### DIFF
--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
@@ -62,8 +62,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
 
 import static fr.inria.controlflow.NaiveExceptionControlFlowStrategy.Options.AddPathsForEmptyTryBlocks;
 import static fr.inria.controlflow.NaiveExceptionControlFlowStrategy.Options.ReturnWithoutFinalizers;

--- a/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
+++ b/spoon-smpl/src/main/java/spoon/smpl/SmPLMethodCFG.java
@@ -60,6 +60,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -192,28 +193,21 @@ public class SmPLMethodCFG {
 		 * @param e Element about to be replaced
 		 */
 		private void logReplacementWarning(CtElement e) {
-			// orElse(f: () -> str, els: str) -> f() if f() != null and does not throw exception, otherwise els
-			BiFunction<Supplier<String>, String, String> orElse = (Supplier<String> f, String els) -> {
-				try {
-					return (f.get() != null) ? f.get() : els;
-				} catch (Exception ignored) {
-					return els;
-				}
-			};
+			String file = Optional.ofNullable(e.getPosition())
+									.map(x -> x.getFile())
+									.map(x -> x.getName())
+									.orElse("[unknown file]");
 
-			String file = orElse.apply(() ->
-				e.getOriginalSourceFragment()
-					.getSourcePosition()
-					.getFile()
-					.getName(), "[unknown file]");
+			String line = Optional.ofNullable(e.getPosition())
+									.map(x -> x.getLine())
+									.map(x -> Integer.toString(x))
+									.orElse("-");
 
-			String line = orElse.apply(() ->
-				Integer.toString(e.getOriginalSourceFragment()
-							.getSourcePosition()
-							.getLine()), "-");
-
-			String code = orElse.apply(() ->
-				e.getOriginalSourceFragment().getSourceCode(), e.toString());
+			String code = Optional.ofNullable(e.getPosition())
+									.map(x -> x.getFile())
+									.map(x -> e.getOriginalSourceFragment())
+									.map(x -> x.getSourceCode())
+									.orElse(e.toString());
 
 			code = code.strip()
 				.replace("\n", " ")

--- a/spoon-smpl/src/test/java/spoon/smpl/SmPLMethodCFGTest.java
+++ b/spoon-smpl/src/test/java/spoon/smpl/SmPLMethodCFGTest.java
@@ -25,8 +25,11 @@ package spoon.smpl;
 import fr.inria.controlflow.*;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.code.CtForEach;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.VirtualFile;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -131,5 +134,53 @@ public class SmPLMethodCFGTest {
 		ues.restore();
 
 		assertFalse(method.toString().contains("__SmPLUnsupported__"));
+	}
+
+	@Test
+	public void testForLoopUnsupportedSwap() {
+
+		// contract: the UnsupportedElementSwapper should replace CtFor elements
+
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(false);
+		launcher.addInputResource(new VirtualFile("class A {\n" +
+												  "  private void forLoop() {\n" +
+												  "    for (int i = 0; i < 10; ++i) {\n" +
+												  "      System.out.println(i);\n" +
+												  "    }\n" +
+												  "  }\n" +
+												  "}\n"));
+		launcher.buildModel();
+		CtMethod<?> method = launcher.getModel().getRootPackage().getType("A").getMethodsByName("forLoop").get(0);
+
+		assertTrue(method.filterChildren(new TypeFilter<>(CtFor.class)).list().size() == 1);
+
+		SmPLMethodCFG.UnsupportedElementSwapper ues = new SmPLMethodCFG.UnsupportedElementSwapper(method);
+
+		assertTrue(method.filterChildren(new TypeFilter<>(CtFor.class)).list().size() == 0);
+	}
+
+	@Test
+	public void testForEachLoopUnsupportedSwap() {
+
+		// contract: the UnsupportedElementSwapper should replace CtForEach elements
+
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setAutoImports(false);
+		launcher.addInputResource(new VirtualFile("class A {\n" +
+												  "  private void forEachLoop() {\n" +
+												  "    for (int i : Arrays.asList(1, 2, 3, 4)) {\n" +
+												  "      System.out.println(i);\n" +
+												  "    }\n" +
+												  "  }\n" +
+												  "}\n"));
+		launcher.buildModel();
+		CtMethod<?> method = launcher.getModel().getRootPackage().getType("A").getMethodsByName("forEachLoop").get(0);
+
+		assertTrue(method.filterChildren(new TypeFilter<>(CtForEach.class)).list().size() == 1);
+
+		SmPLMethodCFG.UnsupportedElementSwapper ues = new SmPLMethodCFG.UnsupportedElementSwapper(method);
+
+		assertTrue(method.filterChildren(new TypeFilter<>(CtForEach.class)).list().size() == 0);
 	}
 }


### PR DESCRIPTION
This adds `CtFor` and `CtForEach` to the set of elements swapped out by spoon-smpl's `UnsupportedElementSwapper` along with a warning log message for each replaced element.

Should be a slight improvement on the current user experience (see #4716).