### PR TITLE
review: refactor: replace usages of CtExtendedModifier constructor

### DIFF
--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -1181,7 +1181,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory {
 	public CtRecord createRecord() {
 		CtRecord recordType = new CtRecordImpl();
 		Set<CtExtendedModifier> modifier = new HashSet<>(recordType.getExtendedModifiers());
-		modifier.add(new CtExtendedModifier(ModifierKind.FINAL, true));
+		modifier.add(CtExtendedModifier.implicit(ModifierKind.FINAL));
 		recordType.setExtendedModifiers(modifier);
 		recordType.setFactory(getMainFactory());
 		return recordType;

--- a/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
@@ -233,9 +233,9 @@ public class CtRecordImpl extends CtClassImpl<Object> implements CtRecord {
 	public <E extends CtElement> E setParent(CtElement parent) {
 		Set<CtExtendedModifier> extendedModifiers = new HashSet<>(getExtendedModifiers());
 		if (parent instanceof CtType) {
-			extendedModifiers.add(new CtExtendedModifier(ModifierKind.STATIC, true));
+			extendedModifiers.add(CtExtendedModifier.implicit(ModifierKind.STATIC));
 		} else {
-			extendedModifiers.remove(new CtExtendedModifier(ModifierKind.STATIC, true));
+			extendedModifiers.remove(CtExtendedModifier.implicit(ModifierKind.STATIC));
 		}
 		setExtendedModifiers(extendedModifiers);
 		return super.setParent(parent);

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -276,8 +276,8 @@ public class CloneTest {
 		// contract: When cloning an element the implicit state is kept as well
 		CtClass<?> test = new Launcher().getFactory().createClass("Test");
 		Set<CtExtendedModifier> modifiers = new HashSet<>();
-		modifiers.add(new CtExtendedModifier(ModifierKind.PUBLIC, true));
-		modifiers.add(new CtExtendedModifier(ModifierKind.ABSTRACT, false));
+		modifiers.add(CtExtendedModifier.implicit(ModifierKind.PUBLIC));
+		modifiers.add(CtExtendedModifier.explicit(ModifierKind.ABSTRACT));
 		test.setExtendedModifiers(modifiers);
 
 		CtClass<?> clonedTest = test.clone();
@@ -310,8 +310,8 @@ public class CloneTest {
 		// contract: When cloning an element the extended modifiers are cloned as well
 		CtClass<?> test = new Launcher().getFactory().createClass("Test");
 		Set<CtExtendedModifier> modifiers = new HashSet<>();
-		modifiers.add(new CtExtendedModifier(ModifierKind.PUBLIC, true));
-		modifiers.add(new CtExtendedModifier(ModifierKind.ABSTRACT, false));
+		modifiers.add(CtExtendedModifier.implicit(ModifierKind.PUBLIC));
+		modifiers.add(CtExtendedModifier.explicit(ModifierKind.ABSTRACT));
 		test.setExtendedModifiers(modifiers);
 
 		CtClass<?> clonedTest = test.clone();

--- a/src/test/java/spoon/test/enums/EnumsTest.java
+++ b/src/test/java/spoon/test/enums/EnumsTest.java
@@ -125,9 +125,9 @@ public class EnumsTest {
 	void testNestedPrivateEnumValues(CtEnum<?> type) {
 		// contract: enum values have correct modifiers matching the produced bytecode
 		assertThat(type.getField("VALUE").getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.PUBLIC, true),
-				new CtExtendedModifier(ModifierKind.STATIC, true),
-				new CtExtendedModifier(ModifierKind.FINAL, true)
+				CtExtendedModifier.implicit(ModifierKind.PUBLIC),
+				CtExtendedModifier.implicit(ModifierKind.STATIC),
+				CtExtendedModifier.implicit(ModifierKind.FINAL)
 		));
 	}
 
@@ -207,8 +207,8 @@ public class EnumsTest {
 		// package-level enum, isn't static but implicitly final
 		CtType<?> publicFinalEnum = build("spoon.test.enums.testclasses", "Burritos");
 		assertThat(publicFinalEnum.getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.PUBLIC, false),
-				new CtExtendedModifier(ModifierKind.FINAL, true)
+				CtExtendedModifier.explicit(ModifierKind.PUBLIC),
+				CtExtendedModifier.implicit(ModifierKind.FINAL)
 		));
 	}
 
@@ -218,7 +218,7 @@ public class EnumsTest {
 		// pre Java 17, enums aren't implicitly final if an enum value declares an anonymous type
 		CtType<?> publicEnum = build("spoon.test.enums.testclasses", "AnonEnum");
 		assertThat(publicEnum.getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.PUBLIC, false)
+				CtExtendedModifier.explicit(ModifierKind.PUBLIC)
 		));
 	}
 
@@ -231,7 +231,7 @@ public class EnumsTest {
 		// it has to be a CtNewClass, otherwise it wouldn't declare an anonymous type
 		assertTrue(defaultExpression instanceof CtNewClass);
 		assertThat(((CtNewClass<?>) defaultExpression).getAnonymousClass().getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.FINAL, true)
+				CtExtendedModifier.implicit(ModifierKind.FINAL)
 		));
 	}
 
@@ -259,8 +259,8 @@ public class EnumsTest {
 		assertThat(enumType.getEnumValues().size(), is(2));
 		assertThat(enumType.getMethods().size(), is(1));
 		assertThat(enumType.getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.STATIC, true),
-				new CtExtendedModifier(ModifierKind.FINAL, true)
+				CtExtendedModifier.implicit(ModifierKind.STATIC),
+				CtExtendedModifier.implicit(ModifierKind.FINAL)
 		));
 	}
 

--- a/src/test/java/spoon/test/interfaces/InterfaceTest.java
+++ b/src/test/java/spoon/test/interfaces/InterfaceTest.java
@@ -167,8 +167,8 @@ public class InterfaceTest {
 		assertThat(interfaceType.getFields().size(), is(1));
 		assertThat(interfaceType.getMethods().size(), is(1));
 		MatcherAssert.assertThat(interfaceType.getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.STATIC, true),
-				new CtExtendedModifier(ModifierKind.ABSTRACT, true)
+				CtExtendedModifier.implicit(ModifierKind.STATIC),
+				CtExtendedModifier.implicit(ModifierKind.ABSTRACT)
 		));
 	}
 
@@ -178,8 +178,8 @@ public class InterfaceTest {
 		// see https://docs.oracle.com/javase/specs/jls/se17/html/jls-9.html#jls-9.1.1
 		CtType<?> emptyInterface = build("spoon.test.interfaces.testclasses", "EmptyInterface");
 		assertThat(emptyInterface.getExtendedModifiers(), contentEquals(
-				new CtExtendedModifier(ModifierKind.ABSTRACT, true),
-				new CtExtendedModifier(ModifierKind.PUBLIC, false)
+				CtExtendedModifier.implicit(ModifierKind.ABSTRACT),
+				CtExtendedModifier.explicit(ModifierKind.PUBLIC)
 		));
 	}
 

--- a/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
+++ b/src/test/java/spoon/test/interfaces/TestInterfaceWithoutSetup.java
@@ -52,9 +52,9 @@ public class TestInterfaceWithoutSetup {
 
 		Set<CtExtendedModifier> extendedModifierSet = fieldImplicit.getExtendedModifiers();
 		assertEquals(3, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.FINAL, true)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, true)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.STATIC, true)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.FINAL)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.PUBLIC)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.STATIC)));
 
 		for (CtExtendedModifier extendedModifier : extendedModifierSet) {
 			assertTrue(extendedModifier.isImplicit());
@@ -69,9 +69,9 @@ public class TestInterfaceWithoutSetup {
 
 		extendedModifierSet = fieldExplicit.getExtendedModifiers();
 		assertEquals(3, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.FINAL, true)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, false)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.STATIC, false)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.FINAL)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.explicit(ModifierKind.PUBLIC)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.explicit(ModifierKind.STATIC)));
 
 		int counter = 0;
 		for (CtExtendedModifier extendedModifier : extendedModifierSet) {
@@ -101,8 +101,8 @@ public class TestInterfaceWithoutSetup {
 
 		extendedModifierSet = staticMethod.getExtendedModifiers();
 		assertEquals(2, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, true)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.STATIC, false)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.PUBLIC)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.explicit(ModifierKind.STATIC)));
 
 		CtMethod publicMethod = (CtMethod) dumbType.getMethodsByName("machin").get(0);
 		assertTrue(publicMethod.hasModifier(ModifierKind.PUBLIC));
@@ -110,8 +110,8 @@ public class TestInterfaceWithoutSetup {
 
 		extendedModifierSet = publicMethod.getExtendedModifiers();
 		assertEquals(2, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, true)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.ABSTRACT, true)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.PUBLIC)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.ABSTRACT)));
 
 		CtMethod defaultMethod = (CtMethod) dumbType.getMethodsByName("bla").get(0);
 		assertTrue(defaultMethod.hasModifier(ModifierKind.PUBLIC));
@@ -120,15 +120,15 @@ public class TestInterfaceWithoutSetup {
 
 		extendedModifierSet = defaultMethod.getExtendedModifiers();
 		assertEquals(1, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, true)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.PUBLIC)));
 
 		CtMethod explicitDefaultMethod = (CtMethod) dumbType.getMethodsByName("anotherOne").get(0);
 		assertTrue(explicitDefaultMethod.hasModifier(ModifierKind.PUBLIC));
 
 		extendedModifierSet = explicitDefaultMethod.getExtendedModifiers();
 		assertEquals(2, extendedModifierSet.size());
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.PUBLIC, false)));
-		assertTrue(extendedModifierSet.contains(new CtExtendedModifier(ModifierKind.ABSTRACT, true)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.explicit(ModifierKind.PUBLIC)));
+		assertTrue(extendedModifierSet.contains(CtExtendedModifier.implicit(ModifierKind.ABSTRACT)));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -302,7 +302,7 @@ public class TryCatchTest {
 		Set<CtExtendedModifier> extendedModifierSet = catchVariable.getExtendedModifiers();
 		assertEquals(1, extendedModifierSet.size());
 
-		assertEquals(new CtExtendedModifier(ModifierKind.FINAL, false), extendedModifierSet.iterator().next());
+		assertEquals(CtExtendedModifier.explicit(ModifierKind.FINAL), extendedModifierSet.iterator().next());
 
 		launcher = new Launcher();
 		launcher.addInputResource(inputResource);


### PR DESCRIPTION
I replaced remaining usages of the CtExtendedModifier constructor that takes a boolean. This makes the code easier to read.