### PR TITLE
review: fix: Stop adding duplicated modules when cloning them

### DIFF
--- a/src/main/java/spoon/reflect/factory/ModuleFactory.java
+++ b/src/main/java/spoon/reflect/factory/ModuleFactory.java
@@ -128,6 +128,7 @@ public class ModuleFactory extends SubFactory {
 			ctModule = factory.Core().createModule().setSimpleName(moduleName);
 			ctModule.setRootPackage(new CtModelImpl.CtRootPackage());
 			ctModule.setParent(getUnnamedModule());
+			getUnnamedModule().addModule(ctModule);
 		}
 
 		return ctModule;

--- a/src/main/java/spoon/support/DefaultCoreFactory.java
+++ b/src/main/java/spoon/support/DefaultCoreFactory.java
@@ -1124,7 +1124,7 @@ public class DefaultCoreFactory extends SubFactory implements CoreFactory {
 	public CtModule createModule() {
 		CtModule module = new CtModuleImpl();
 		module.setFactory(getMainFactory());
-		this.getMainFactory().Module().getUnnamedModule().addModule(module);
+		module.setParent(this.getMainFactory().Module().getUnnamedModule());
 		return module;
 	}
 

--- a/src/test/java/spoon/test/module/TestModule.java
+++ b/src/test/java/spoon/test/module/TestModule.java
@@ -407,4 +407,17 @@ public class TestModule {
 		);
 		assertNotNull(launcher.getFactory().Type().get("test.parent.nested.Foo"), "");
 	}
+
+	@Test
+	public void testModulePrintDoesNotDuplicate() {
+		// contract: Printing a module does not duplicate it in Model#getAllModules()
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.addInputResource(MODULE_RESOURCES_PATH + "/code-multiple-modules");
+		CtModel ctModel = launcher.buildModel();
+		assertEquals(3, ctModel.getAllModules().size());
+		//noinspection ResultOfMethodCallIgnored   I wish it had no effect too, unspecified static analysis tool
+		launcher.getFactory().Module().getModule("bar").toString();
+		assertEquals(3, ctModel.getAllModules().size());
+	}
 }


### PR DESCRIPTION
This issue was discovered while trying to reproduce #4746. Printing a module caused it to be cloned, leading to a duplicate insertion into the global module list. This in turn triggered the "overlapping modules found" sanity check (thankfully!).