### PR TITLE
tests: add a failing test case for MavenLauncher

### DIFF
--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -219,4 +219,13 @@ public class MavenLauncherTest {
 		assertTrue(mavenHome.exists());
 		assertTrue(mavenHome.isDirectory());
 	}
+
+	@Test
+	public void testClasspathShouldBeResolvedForATestResourceInsideSorald() {
+		// contract: it should resolve the classpath
+		File c = new File("src/test/resources/maven-launcher/classpath-dependent-project");
+		MavenLauncher launcher =
+				new MavenLauncher(c.getAbsolutePath(), MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		assertTrue(launcher.getEnvironment().getSourceClasspath().length > 0);
+	}
 }

--- a/src/test/resources/maven-launcher/classpath-dependent-project/pom.xml
+++ b/src/test/resources/maven-launcher/classpath-dependent-project/pom.xml
@@ -1,0 +1,22 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>sorald.test</groupId>
+  <artifactId>sorald.test.project</artifactId>
+  <properties>
+    <maven.compiler.target>8</maven.compiler.target>
+    <maven.compiler.source>8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>sorald.test.project</name>
+  <url>http://maven.apache.org</url>
+  <dependencies>
+    <dependency>
+      <groupId>fr.inria.gforge.spoon.labs</groupId>
+      <artifactId>gumtree-spoon-ast-diff</artifactId>
+      <version>1.24</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/maven-launcher/classpath-dependent-project/src/main/java/sorald/test/App.java
+++ b/src/test/resources/maven-launcher/classpath-dependent-project/src/main/java/sorald/test/App.java
@@ -1,0 +1,18 @@
+package maven-launcher.classpath-dependent-project.sorald.test;
+
+import java.nio.file.Path;
+import gumtree.spoon.diff.Diff;
+import gumtree.spoon.AstComparator;
+
+/**
+ * App that computes the ratio of root operations to all opertions with gumtree-spoon!
+ */
+public class App {
+    public static void main(String[] args) throws Exception {
+        Path leftPath = Path.of(args[0]);
+        Path rightPath = Path.of(args[1]);
+        Diff diff = new AstComparator().compare(leftPath.toFile(), rightPath.toFile());
+        double ratio = diff.getRootOperations().size() / diff.getAllOperations().size(); // Noncompliant; rule 2184 (cast arithmetic operator)
+        System.out.println(ratio);
+    }
+}


### PR DESCRIPTION
[Sorald](https://github.com/SpoonLabs/sorald) has a [test case](https://github.com/SpoonLabs/sorald/blob/master/sorald/src/test/java/sorald/miner/WarningMinerTest.java#L187) that depends upon resolving classpath using `MavenLauncher`. However, it has been failing for a few days. I narrowed down the reason for its failure and it is the inability of the `MavenLauncher` to resolve the classpath correctly. I have reproduced the behaviour there as a failing test case here. Could anyone tell me what could be the reason for the empty classpath returned by the method? It is weird that such a behaviour started happening all of a sudden without any changes to our source code. Also, we use Spoon `10.1.1`.

Please note that I thought I would directly open a PR with a test case rather than an issue as I feel it is much easier to explain my issue with a test case.