### PR TITLE
review: fix: set source position of type pattern

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -421,6 +421,8 @@ public class ParentExiter extends CtInheritanceScanner {
 		if (child instanceof CtLocalVariable && operator.getKind() == INSTANCEOF && operator.getLeftHandOperand() != null) {
 			CtTypePattern typePattern = child.getFactory().Core().createTypePattern();
 			typePattern.setVariable((CtLocalVariable<?>) child);
+			// as we create the type pattern just here, we need to set its source position - which is luckily the same
+			typePattern.setPosition(child.getPosition());
 			child = typePattern; // replace the local variable with a pattern (which is a CtExpression)
 		}
 		if (child instanceof CtExpression) {

--- a/src/test/java/spoon/test/pattern/TypePatternTest.java
+++ b/src/test/java/spoon/test/pattern/TypePatternTest.java
@@ -15,13 +15,19 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtTypePattern;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.VirtualFile;
 import spoon.support.reflect.code.CtTypePatternImpl;
+import spoon.testing.utils.ModelTest;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TypePatternTest {
 
@@ -66,5 +72,14 @@ public class TypePatternTest {
 		assertDoesNotThrow(() -> pattern.setParent(null));
 		// setting something else as parent must fail
 		assertThrows(SpoonException.class, () -> pattern.setParent(launcher.getFactory().createBlock()));
+	}
+
+	@ModelTest(value = "src/test/resources/patternmatching/InstanceofPatternmatch.java", complianceLevel = 16)
+	void testTypePatternSourcePosition(Factory factory) {
+		// contract: the source position of the CtTypePattern is equal to its CtLocalVariableDeclaration
+		CtType<?> x = factory.Type().get("X");
+		CtTypePattern typePattern = x.getElements(new TypeFilter<>(CtTypePattern.class)).get(0);
+		assertTrue(typePattern.getPosition().isValidPosition());
+		assertThat(typePattern.getPosition(), equalTo(typePattern.getVariable().getPosition()));
 	}
 }

--- a/src/test/java/spoon/test/pattern/TypePatternTest.java
+++ b/src/test/java/spoon/test/pattern/TypePatternTest.java
@@ -74,7 +74,7 @@ public class TypePatternTest {
 		assertThrows(SpoonException.class, () -> pattern.setParent(launcher.getFactory().createBlock()));
 	}
 
-	@ModelTest(value = "src/test/resources/patternmatching/InstanceofPatternmatch.java", complianceLevel = 16)
+	@ModelTest(value = "src/test/resources/patternmatching/InstanceofPatternMatch.java", complianceLevel = 16)
 	void testTypePatternSourcePosition(Factory factory) {
 		// contract: the source position of the CtTypePattern is equal to its CtLocalVariableDeclaration
 		CtType<?> x = factory.Type().get("X");

--- a/src/test/resources/patternmatching/InstanceofPatternMatch.java
+++ b/src/test/resources/patternmatching/InstanceofPatternMatch.java
@@ -1,0 +1,8 @@
+class X {
+	String typePattern(Object obj) {
+		if (obj instanceof String s) {
+			return s;
+		}
+		return "";
+	}
+}


### PR DESCRIPTION
Fixes #4723.

As the CtTypePattern instance basically only wraps the CtLocalVariable, we should also use its SourcePosition.