### PR TITLE
fix: Enable creation of packages with repeated simple names in qualified name

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -45,13 +45,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 		@Override
 		public CtPackage put(String simpleName, CtPackage pack) {
-			if (pack == null) {
-				return null;
-			}
-			// they are the same
-			if (CtPackageImpl.this.getQualifiedName().equals(pack.getQualifiedName())) {
-				addAllTypes(pack, CtPackageImpl.this);
-				addAllPackages(pack, CtPackageImpl.this);
+			if (pack == null || pack == CtPackageImpl.this) {
 				return null;
 			}
 

--- a/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
+++ b/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
@@ -1,17 +1,16 @@
 package spoon.reflect.factory;
 
-import org.junit.jupiter.api.Test;
-
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import spoon.Launcher;
 import spoon.reflect.declaration.CtPackage;
+import spoon.test.GitHubIssue;
 
 class PackageFactoryTest {
 
-	@Test
+	@GitHubIssue(issueNumber = 4764, fixed = true)
 	void getOrCreate_returnsNestedPackageStructure_whenQualifiedNameRepeatsSimpleName() {
 		// contract: A qualified name that is simply repetitions of a single simple name results in the expected
 		// nested package structure

--- a/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
+++ b/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
@@ -1,0 +1,32 @@
+package spoon.reflect.factory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import spoon.Launcher;
+import spoon.reflect.declaration.CtPackage;
+
+class PackageFactoryTest {
+
+	@Test
+	void getOrCreate_returnsNestedPackageStructure_whenQualifiedNameRepeatsSimpleName() {
+		// contract: A qualified name that is simply repetitions of a single simple name results in the expected
+		// nested package structure
+
+		PackageFactory factory = new Launcher().getFactory().Package();
+		String topLevelPackageName = "spoon";
+		String nestedPackageName = topLevelPackageName + "." + topLevelPackageName;
+
+		CtPackage packageWithDuplicatedSimpleNames = factory.getOrCreate(nestedPackageName);
+		CtPackage topLevelPackage = factory.get(topLevelPackageName);
+
+		assertThat(topLevelPackage.getQualifiedName(), equalTo(topLevelPackageName));
+		assertThat(packageWithDuplicatedSimpleNames.getQualifiedName(), equalTo(nestedPackageName));
+
+		assertThat(topLevelPackage.getPackage(topLevelPackageName), sameInstance(packageWithDuplicatedSimpleNames));
+		assertThat(packageWithDuplicatedSimpleNames.getParent(), sameInstance(topLevelPackage));
+	}
+}


### PR DESCRIPTION
Fix #4764 

The problem was a check that I can't quite make sense of, see comment in code.