### PR TITLE
Adjust the source position for annotated enum values

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -421,12 +421,12 @@ public class PositionBuilder {
 			if (allocationExpression.enumConstant != null) {
 				FieldDeclaration fieldDeclaration = allocationExpression.enumConstant;
 
-                Annotation[] annotations = allocationExpression.enumConstant.annotations;
-                if (annotations != null && annotations.length > 0) {
-                    Annotation lastAnnotation = annotations[annotations.length - 1];
-                    sourceStart = findNextNonWhitespace(contents, sourceEnd, lastAnnotation.sourceEnd);
-                }
-                
+				Annotation[] annotations = allocationExpression.enumConstant.annotations;
+				if (annotations != null && annotations.length > 0) {
+					Annotation lastAnnotation = annotations[annotations.length - 1];
+					sourceStart = findNextNonWhitespace(contents, sourceEnd, lastAnnotation.sourceEnd);
+				}
+
 				//1) skip comments
 				sourceStart = findNextNonWhitespace(contents, sourceEnd, sourceStart);
 				//2) move to beginning of enum construction

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -420,6 +420,13 @@ public class PositionBuilder {
 			AllocationExpression allocationExpression = (AllocationExpression) node;
 			if (allocationExpression.enumConstant != null) {
 				FieldDeclaration fieldDeclaration = allocationExpression.enumConstant;
+
+                Annotation[] annotations = allocationExpression.enumConstant.annotations;
+                if (annotations != null && annotations.length > 0) {
+                    Annotation lastAnnotation = annotations[annotations.length - 1];
+                    sourceStart = findNextNonWhitespace(contents, sourceEnd, lastAnnotation.sourceEnd);
+                }
+                
 				//1) skip comments
 				sourceStart = findNextNonWhitespace(contents, sourceEnd, sourceStart);
 				//2) move to beginning of enum construction

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -74,6 +74,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.VirtualFile;
 import spoon.support.reflect.CtExtendedModifier;
+import spoon.test.GitHubIssue;
 import spoon.test.comment.testclasses.BlockComment;
 import spoon.test.comment.testclasses.Comment1;
 import spoon.test.position.testclasses.AnnonymousClassNewIface;
@@ -84,6 +85,7 @@ import spoon.test.position.testclasses.CompilationUnitComments;
 import spoon.test.position.testclasses.Expressions;
 import spoon.test.position.testclasses.Foo;
 import spoon.test.position.testclasses.FooAbstractMethod;
+import spoon.test.position.testclasses.FooAnnotatedEnum;
 import spoon.test.position.testclasses.FooAnnotation;
 import spoon.test.position.testclasses.FooClazz;
 import spoon.test.position.testclasses.FooClazz2;
@@ -1457,5 +1459,17 @@ public class PositionTest {
 						p -> assertEquals(((CtParameter) p).getSimpleName(), contentAtPosition(classContent, ((CtParameter) p).getPosition()))
 				)
 		);
+	}
+	
+	@Test
+	@GitHubIssue(issueNumber = 4779, fixed = true)
+	public void testPositionOfAnnotatedEnumField() throws Exception {
+        final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/FooAnnotatedEnum.java"));
+	    CtType<FooAnnotatedEnum> type = buildClass(FooAnnotatedEnum.class);
+	    String classContent = getClassContent(type);
+	    
+	    CtField<?> field = type.getField("BAR");
+
+        assertEquals(10, field.getPosition().getLine());
 	}
 }

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1464,12 +1464,12 @@ public class PositionTest {
 	@Test
 	@GitHubIssue(issueNumber = 4779, fixed = true)
 	public void testPositionOfAnnotatedEnumField() throws Exception {
-        final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/FooAnnotatedEnum.java"));
-	    CtType<FooAnnotatedEnum> type = buildClass(FooAnnotatedEnum.class);
-	    String classContent = getClassContent(type);
-	    
-	    CtField<?> field = type.getField("BAR");
+		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/FooAnnotatedEnum.java"));
+		CtType<FooAnnotatedEnum> type = buildClass(FooAnnotatedEnum.class);
+		String classContent = getClassContent(type);
 
-        assertEquals(10, field.getPosition().getLine());
+		CtField<?> field = type.getField("BAR");
+
+		assertEquals(10, field.getPosition().getLine());
 	}
 }

--- a/src/test/java/spoon/test/position/testclasses/FooAnnotatedEnum.java
+++ b/src/test/java/spoon/test/position/testclasses/FooAnnotatedEnum.java
@@ -1,0 +1,11 @@
+package spoon.test.position.testclasses;
+
+public enum FooAnnotatedEnum {
+    FOO,
+    // A comment before the annotation ...
+    @Deprecated
+    /**
+     * And another one after
+     */
+    BAR;
+}

--- a/src/test/java/spoon/test/prettyprinter/SniperAnnotatedEnumTest.java
+++ b/src/test/java/spoon/test/prettyprinter/SniperAnnotatedEnumTest.java
@@ -1,0 +1,59 @@
+package spoon.test.prettyprinter;
+
+import org.apache.commons.io.*;
+import org.hamcrest.*;
+import org.junit.*;
+import static org.junit.Assert.*;
+
+import spoon.Launcher;
+import spoon.compiler.*;
+import spoon.reflect.*;
+import spoon.reflect.code.CtComment.*;
+import spoon.reflect.declaration.*;
+import spoon.reflect.visitor.filter.*;
+import spoon.support.sniper.*;
+import spoon.test.GitHubIssue;
+
+import java.io.*;
+import java.nio.charset.*;
+import java.nio.file.*;
+
+public class SniperAnnotatedEnumTest {
+  private static final Path INPUT_PATH = Paths.get("src/test/java/");
+  private static final Path OUTPUT_PATH = Paths.get("target/test-output");
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    FileUtils.deleteDirectory(OUTPUT_PATH.toFile());
+  }
+
+  @Test
+  @GitHubIssue(issueNumber = 4779, fixed = true)
+  public void annotatedEnumTest() throws IOException {
+    runSniperJavaPrettyPrinter("spoon/test/prettyprinter/testclasses/AnnotatedEnum.java");
+  }
+
+  private void runSniperJavaPrettyPrinter(String path) throws IOException {
+    final Launcher launcher = new Launcher();
+    final Environment e = launcher.getEnvironment();
+    e.setLevel("INFO");
+    e.setPrettyPrinterCreator(() -> new SniperJavaPrettyPrinter(e));
+
+    launcher.addInputResource(INPUT_PATH.resolve(path).toString());
+    launcher.setSourceOutputDirectory(OUTPUT_PATH.toString());
+
+    CtModel model = launcher.buildModel();
+    CtClass ctClass = model.getElements(new TypeFilter<>(CtClass.class)).get(0);
+
+    ctClass.addComment(launcher.getFactory().Code().createComment("test", CommentType.BLOCK));
+
+    launcher.process();
+    launcher.prettyprint();
+    // Verify result file exists and is not empty
+    assertThat("Output file for " + path + " should exist", OUTPUT_PATH.resolve(path).toFile().exists(),
+        CoreMatchers.equalTo(true));
+
+    String content = new String(Files.readAllBytes(OUTPUT_PATH.resolve(path)), StandardCharsets.UTF_8);
+    assertThat(content.trim(), CoreMatchers.containsString("/* test */public enum"));
+  }
+}

--- a/src/test/java/spoon/test/prettyprinter/testclasses/AnnotatedEnum.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/AnnotatedEnum.java
@@ -1,0 +1,22 @@
+package spoon.test.prettyprinter.testclasses;
+
+public enum AnnotatedEnum {
+    ONE(1, "one"),
+    TWO(2, "two"),
+    THREE(3, "three"),
+    /**
+     * @deprecated
+     */
+    @Deprecated
+    // There was a typo...
+    FOR(4, "for"),
+    FOUR(4, "four");
+    
+    private final int value;
+    private final String text;
+        
+    AnnotatedEnum(int value, String text) {
+        this.value = value;
+        this.text = text;
+    }
+}


### PR DESCRIPTION
- Unit tests illustrating the issue that the source position is not computed correctly, this leads to a SpoonException with message `"Cannot compare this:...` when trying to print the code with Sniper
- Adjust the calculation of the source start to account for annotations

The fix seems to work but I have very very little experience on the project so this might very well be misguided, there really seem to be a bug though!