### PR TITLE
doc: Clarify stance on supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ If you need professional support on Spoon (development, training, extension), yo
 
 ## Getting started in 2 seconds
 
-> **Java version:** Spoon version 10 and up requires Java 11 or later. Spoon 9.1.0 is the final Spoon release compatible with Java 8.
+> **Java version:** Spoon version 10 and up requires Java 11 or later. Spoon 9.1.0 is the final Spoon release compatible
+> with Java 8, and we do not plan to backport any bug fixes or features to Spoon 9. Note that Spoon can of course still
+> consume source code for older versions of Java, but it needs JDK 11+ to run.
 
 Get latest stable version with Maven, see <https://search.maven.org/artifact/fr.inria.gforge.spoon/spoon-core>
 


### PR DESCRIPTION
We still get a lot of issues using JDK 8 and old versions of Spoon. I think we should clarify that we don't intend to support JDK 8 or older versions of Spoon that uses it.

The new bug report template I've added in #4793 also takes some steps in this direction.