### PR TITLE
review: fix: clearer message when cannot compare fragments

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -369,7 +369,7 @@ public class ElementSourceFragment implements SourceFragment {
 			return CMP.OTHER_IS_PARENT;
 		}
 		//the fragments overlap - it is not allowed
-		throw new SpoonException("Cannot compare this: [" + getStart() + ", " + getEnd() + "] with other: [\"" + other.getStart() + "\", \"" + other.getEnd() + "\"]");
+		throw new SpoonException("Cannot compare this: [" + getStart() + ", " + getEnd() + "] with other: [" + other.getStart() + ", " + other.getEnd() + "]");
 	}
 
 	/**


### PR DESCRIPTION
The error message `Cannot compare this: [46, 115] with other: ["55", "185"]` is slightly unclear because of the double quotes for the other element. This might suggest that the types are different while the issue is really with the start and end positions.
This PR removes the unnecessary double quotes.