### PR TITLE
fix: minimise bracket printing in case of string operands of binary operator

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -445,10 +445,11 @@ public class ParentExiter extends CtInheritanceScanner {
 			} else if (jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof StringLiteralConcatenation) {
 				CtBinaryOperator<?> op = operator.getFactory().Core().createBinaryOperator();
 				op.setKind(BinaryOperatorKind.PLUS);
-				op.setLeftHandOperand(operator.getRightHandOperand());
-				op.setRightHandOperand((CtExpression<?>) child);
+				op.setLeftHandOperand(operator.getLeftHandOperand());
+				op.setRightHandOperand(operator.getRightHandOperand());
 				op.setType((CtTypeReference) operator.getFactory().Type().STRING.clone());
-				operator.setRightHandOperand(op);
+				operator.setLeftHandOperand(op);
+				operator.setRightHandOperand(((CtExpression<?>) child));
 				int[] lineSeparatorPositions = jdtTreeBuilder.getContextBuilder().getCompilationUnitLineSeparatorPositions();
 				SourcePosition leftPosition = op.getLeftHandOperand().getPosition();
 				SourcePosition rightPosition = op.getRightHandOperand().getPosition();

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -22,13 +22,14 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.support.modelobs.FineModelChangeListener;
+import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtThrow;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
@@ -42,6 +43,7 @@ import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.util.internal.ElementNameMap;
 import spoon.support.util.ModelList;
 
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -50,9 +52,34 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AstCheckerTest {
+
+	@Test
+	void leftOperandShouldBeGivenPriorityForStoringTheNestedOperator_stringLiteralConcatenation() {
+		// contract: string concatenation should be left associative.
+		// arrange
+		Launcher launcher = new Launcher();
+		Factory factory = launcher.getFactory();
+		CtClass<?> classContainingStringLiteral = Launcher.parseClass("class A { private String x = \"a\" + \"b\" + \"c\" }");
+
+		// act
+		CtBinaryOperator<?> binaryOperator = classContainingStringLiteral
+				.filterChildren(element -> element instanceof CtBinaryOperator)
+				.first();
+
+		// assert
+		CtExpression<?> firstOperand = ((CtBinaryOperator<?>)binaryOperator.getLeftHandOperand()).getLeftHandOperand();
+		CtExpression<?> secondOperand = ((CtBinaryOperator<?>)binaryOperator.getLeftHandOperand()).getRightHandOperand();
+		CtExpression<?> thirdOperand = binaryOperator.getRightHandOperand();
+
+		assertThat(firstOperand, equalTo(factory.createLiteral("a")));
+		assertThat(secondOperand, equalTo(factory.createLiteral("b")));
+		assertThat(thirdOperand, equalTo(factory.createLiteral("c")));
+	}
 
 	@Test
 	public void testExecutableReference() {

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -43,7 +43,6 @@ import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.util.internal.ElementNameMap;
 import spoon.support.util.ModelList;
 
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -57,7 +57,8 @@ public class DefaultJavaPrettyPrinterTest {
     @ValueSource(strings = {
             "int sum = 1 + 2 + 3",
             "java.lang.String s = \"Sum: \" + (1 + 2)",
-            "java.lang.String s = \"Sum: \" + 1 + 2"
+            "java.lang.String s = \"Sum: \" + 1 + 2",
+            "java.lang.System.out.println(\"1\" + \"2\" + \"3\" + \"4\")"
     })
     public void testParenOptimizationCorrectlyPrintsParenthesesForStatements(String rawStatement) {
         // contract: When input expressions as part of statements are minimally parenthesized,

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -465,9 +465,9 @@ public class CommentTest {
 
 
 		CtLocalVariable ctLocalVariableString = m1.getBody().getStatement(12);
-		assertEquals(createFakeComment(f, "comment multi line string"), ((CtBinaryOperator) ((CtBinaryOperator) ctLocalVariableString.getDefaultExpression()).getRightHandOperand()).getLeftHandOperand().getComments().get(0));
-		assertEquals("\"\" + (\"\"// comment multi line string" + newLine
-				+ " + \"\")", ctLocalVariableString.getDefaultExpression().toString());
+		assertEquals(createFakeComment(f, "comment multi line string"), (((CtBinaryOperator) ctLocalVariableString.getDefaultExpression()).getLeftHandOperand()).getComments().get(0));
+		assertEquals("(\"\" + \"\")// comment multi line string" + newLine
+				+ " + \"\"", ctLocalVariableString.getDefaultExpression().toString());
 
 		ctLocalVariable1 = m1.getBody().getStatement(13);
 		assertEquals("boolean c = (i == 1) ? // comment before then boolean CtConditional" + newLine


### PR DESCRIPTION
Fixes #4807

I have tried to reproduce #4807 with a related test case.
```
Expected: java.lang.System.out.println("1" + "2" + "3" + "4")
Actual: java.lang.System.out.println("1" + ("2" + "3" + "4"))
```

I have noticed that the test pass when I change each operand in the above expression to an integer, thanks to #3823. 