### PR TITLE
feat: Allow passing environment variables in maven launcher invocations

### DIFF
--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -177,8 +177,8 @@ public class MavenLauncher extends Launcher {
 	 * @param value its value
 	 * @see #rebuildClasspath() #rebuildClasspath() for changes to take effect
 	 */
-	public void addEnvironmentVariable(String key, String value) {
-		mavenOptions.addEnvironmentVariable(key, value);
+	public void setEnvironmentVariable(String key, String value) {
+		mavenOptions.setEnvironmentVariable(key, value);
 	}
 
 	private void init(String mavenProject, String[] classpath, Pattern profileFilter) {

--- a/src/main/java/spoon/MavenLauncher.java
+++ b/src/main/java/spoon/MavenLauncher.java
@@ -20,11 +20,13 @@ import java.util.regex.Pattern;
  * Create a Spoon launcher from a maven pom file
  */
 public class MavenLauncher extends Launcher {
+	private static final Logger LOGGER  = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
 	private String mvnHome;
 	private SOURCE_TYPE sourceType;
 	private SpoonPom model;
 	private boolean forceRefresh = false;
-	private static final Logger LOGGER  = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+	private final SpoonPom.MavenOptions mavenOptions = SpoonPom.MavenOptions.empty();
 
 	/**
 	 * @return SpoonPom corresponding to the pom file used by the launcher
@@ -166,6 +168,19 @@ public class MavenLauncher extends Launcher {
 		init(mavenProject, classpath, profileFilter);
 	}
 
+	/**
+	 * Adds an environment variable to the maven invocation.
+	 * <p>
+	 * <br><strong>Note that you need to call {@link #rebuildClasspath()} after calling this method for changes to take effect.</strong>
+	 *
+	 * @param key the name of the environment variable
+	 * @param value its value
+	 * @see #rebuildClasspath() #rebuildClasspath() for changes to take effect
+	 */
+	public void addEnvironmentVariable(String key, String value) {
+		mavenOptions.addEnvironmentVariable(key, value);
+	}
+
 	private void init(String mavenProject, String[] classpath, Pattern profileFilter) {
 		File mavenProjectFile = new File(mavenProject);
 		if (!mavenProjectFile.exists()) {
@@ -195,7 +210,7 @@ public class MavenLauncher extends Launcher {
 		}
 
 		if (classpath == null) {
-			classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, forceRefresh);
+			classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, forceRefresh, mavenOptions);
 			LOGGER.info("Running in FULLCLASSPATH mode. Source folders and dependencies are inferred from the pom.xml file (doc: http://spoon.gforge.inria.fr/launcher.html).");
 		} else {
 			LOGGER.info("Running in FULLCLASSPATH mode. Classpath is manually set (doc: http://spoon.gforge.inria.fr/launcher.html).");
@@ -218,7 +233,7 @@ public class MavenLauncher extends Launcher {
 	 * Triggers regeneration of the classpath that is used for building the model, based on pom.xml
 	 */
 	public void rebuildClasspath() {
-		String[] classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, true);
+		String[] classpath = model.buildClassPath(mvnHome, sourceType, LOGGER, true, mavenOptions);
 		this.getModelBuilder().setSourceClasspath(classpath);
 	}
 }

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -583,6 +583,7 @@ public class SpoonPom implements SpoonResource {
 	 * @param sourceType the source type (App, test, or all)
 	 * @param LOGGER Logger used for maven output
 	 * @param forceRefresh if true forces the invocation of maven to regenerate classpath
+	 * @return the complete classpath of the requested source types
 	 */
 	public String[] buildClassPath(String mvnHome, MavenLauncher.SOURCE_TYPE sourceType, Logger LOGGER, boolean forceRefresh) {
 		return this.buildClassPath(mvnHome, sourceType, LOGGER, forceRefresh, MavenOptions.empty());
@@ -688,22 +689,36 @@ public class SpoonPom implements SpoonResource {
 		return pomFile;
 	}
 
+	/**
+	 * Additional options for maven invocations.
+	 */
 	@Internal
 	public static class MavenOptions {
 		private final Map<String, String> environmentVariables;
 
-		public MavenOptions() {
+		private MavenOptions() {
 			this.environmentVariables = new HashMap<>();
 		}
 
+		/**
+		 * Adds a maven environment variable.
+		 * @param key the name of the variable
+		 * @param value its value
+		 */
 		public void addEnvironmentVariable(String key, String value) {
 			this.environmentVariables.put(key, value);
 		}
 
+		/**
+		 * @return all set environment variables
+		 */
 		public Map<String, String> getEnvironmentVariables() {
 			return environmentVariables;
 		}
 
+		/**
+		 * @return a new empty options instance
+		 */
 		public static MavenOptions empty() {
 			return new MavenOptions();
 		}

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -705,7 +705,7 @@ public class SpoonPom implements SpoonResource {
 		 * @param key the name of the variable
 		 * @param value its value
 		 */
-		public void addEnvironmentVariable(String key, String value) {
+		public void setEnvironmentVariable(String key, String value) {
 			this.environmentVariables.put(key, value);
 		}
 

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -249,6 +249,10 @@ public class MavenLauncherTest {
 			.stream(launcher.getEnvironment().getSourceClasspath())
 			.anyMatch(it -> it.matches(".*fr.inria.gforge.spoon.spoon-core.10.1.0.spoon-core-10.1.0.jar"));
 
-		assertTrue(containsSpoonDependency, "Spoon dependency not found. Was the environment variable set?");
+		assertTrue(
+			containsSpoonDependency,
+			"Spoon dependency not found. Was the environment variable set? Classpath: "
+				+ Arrays.toString(launcher.getEnvironment().getSourceClasspath())
+		);
 	}
 }

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -247,7 +247,7 @@ public class MavenLauncherTest {
 
 		boolean containsSpoonDependency = Arrays
 			.stream(launcher.getEnvironment().getSourceClasspath())
-			.anyMatch(it -> it.matches(".*fr.inria.gforge.spoon.spoon-core.10.1.0.spoon-core-10.1.0.jar"));
+			.anyMatch(it -> it.matches(".*fr.inria.gforge.spoon.spoon-core.10.1.0.spoon-core-10.1.0.jar.*"));
 
 		assertTrue(
 			containsSpoonDependency,

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -280,7 +280,7 @@ public class MavenLauncherTest {
 			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/with-environment-variables"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
-		launcher.addEnvironmentVariable("spoonVersion", "10.1.0");
+		launcher.addEnvironmentVariable("SPOON_VERSION", "10.1.0");
 		launcher.rebuildClasspath();
 
 		boolean containsSpoonDependency = Arrays

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -247,7 +247,7 @@ public class MavenLauncherTest {
 
 		boolean containsSpoonDependency = Arrays
 			.stream(launcher.getEnvironment().getSourceClasspath())
-			.anyMatch(it -> it.contains("fr/inria/gforge/spoon/spoon-core/10.1.0/spoon-core-10.1.0.jar"));
+			.anyMatch(it -> it.matches(".*fr.inria.gforge.spoon.spoon-core.10.1.0.spoon-core-10.1.0.jar"));
 
 		assertTrue(containsSpoonDependency, "Spoon dependency not found. Was the environment variable set?");
 	}

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -280,7 +280,7 @@ public class MavenLauncherTest {
 			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/with-environment-variables"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
-		launcher.addEnvironmentVariable("SPOON_VERSION", "10.1.0");
+		launcher.setEnvironmentVariable("SPOON_VERSION", "10.1.0");
 		launcher.rebuildClasspath();
 
 		boolean containsSpoonDependency = Arrays

--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -18,21 +18,19 @@ package spoon;
 
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import spoon.compiler.SpoonResource;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.reference.CtTypeReference;
@@ -47,20 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MavenLauncherTest {
-
-	@AfterEach
-	void tearDown() throws IOException {
-		// Clean up old classpath files to ensure tests actually re-run properly
-		try (Stream<Path> paths = Files.walk(Path.of("src/test/resources/maven-launcher"))) {
-			List<Path> filesToDelete = paths
-				.filter(it -> it.getFileName().toString().equals("spoon.classpath.tmp"))
-				.collect(Collectors.toList());
-
-			for (Path path : filesToDelete) {
-				Files.deleteIfExists(path);
-			}
-		}
-	}
 
 	// fixme: the test consumes too much memory for now
 	// we should reduce its footprint
@@ -86,111 +70,154 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void spoonMavenLauncherTest() {
+	public void spoonMavenLauncherTest(@TempDir Path tempDir) throws IOException {
+		String targetPathString = copyResourceToFolder(tempDir, ".");
+		Path targetPath = Path.of(targetPathString);
+
 		// without the tests
-		MavenLauncher launcher = new MavenLauncher("./", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
+		MavenLauncher launcher = new MavenLauncher(targetPathString, MavenLauncher.SOURCE_TYPE.APP_SOURCE);
 
 		//contract: classpath is not empty
 		assertNotEquals(0, launcher.getEnvironment().getSourceClasspath().length);
 		//contract: classpath contains only valid elements
-		for (String cpe: launcher.getEnvironment().getSourceClasspath()) {
+		for (String cpe : launcher.getEnvironment().getSourceClasspath()) {
 			assertTrue(new File(cpe).exists());
 		}
 
 		// contract: ModelBuilder contains all source folders
 		int numberOfJavaSrcFolder = new FileSystemFolder("src/main/java/spoon")
-				.getAllFiles()
-				.stream()
-				.map(SpoonResource::getParent)
-				.collect(Collectors.toSet())
-				.size();
-		assertTrue(launcher.getModelBuilder().getInputSources().size() >= numberOfJavaSrcFolder, "size: " + launcher.getModelBuilder().getInputSources().size());
+			.getAllFiles()
+			.stream()
+			.map(SpoonResource::getParent)
+			.collect(Collectors.toSet())
+			.size();
+
+		assertTrue(
+			launcher.getModelBuilder().getInputSources().size() >= numberOfJavaSrcFolder,
+			"size: " + launcher.getModelBuilder().getInputSources().size()
+		);
 
 		// with the tests, and test that if mavenProject leads to a directory containing a pom.xml it works
-		launcher = new MavenLauncher("./", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		launcher = new MavenLauncher(targetPathString, MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
 
 		//contract: classpath is not empty
 		assertNotEquals(0, launcher.getEnvironment().getSourceClasspath().length);
 		//contract: classpath contains only valid elements
-		for (String cpe: launcher.getEnvironment().getSourceClasspath()) {
+		for (String cpe : launcher.getEnvironment().getSourceClasspath()) {
 			assertTrue(new File(cpe).exists());
 		}
 
 		// number of the sub folders of src/main/java and src/test/java
 		int numberOfJavaTestFolder = new FileSystemFolder("src/test/java/spoon")
-				.getAllFiles()
-				.stream()
-				.map(SpoonResource::getParent)
-				.collect(Collectors.toSet())
-				.size();
+			.getAllFiles()
+			.stream()
+			.map(SpoonResource::getParent)
+			.collect(Collectors.toSet())
+			.size();
 		assertTrue(launcher.getModelBuilder().getInputSources().size() >= numberOfJavaSrcFolder + numberOfJavaTestFolder, "size: " + launcher.getModelBuilder().getInputSources().size());
 
 		// specify the pom.xml
-		launcher = new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
+		launcher = new MavenLauncher(
+			targetPath.resolve("pom.xml").toString(),
+			MavenLauncher.SOURCE_TYPE.APP_SOURCE
+		);
 		assertEquals(8, launcher.getEnvironment().getComplianceLevel());
 
 		// specify the pom.xml
-		launcher = new MavenLauncher("./src/test/resources/maven-launcher/java-11/pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
+		launcher = new MavenLauncher(
+			targetPath.resolve("src/test/resources/maven-launcher/java-11/pom.xml").toString(),
+			MavenLauncher.SOURCE_TYPE.APP_SOURCE
+		);
 		assertEquals(11, launcher.getEnvironment().getComplianceLevel());
 
 		// without calling maven to generate classpath
-		launcher = new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE, new String[]{});
+		launcher = new MavenLauncher(
+			targetPath.resolve("pom.xml").toString(),
+			MavenLauncher.SOURCE_TYPE.APP_SOURCE,
+			new String[]{}
+		);
 		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);
 	}
 
 	@Test
-	public void multiModulesProjectTest() {
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/pac4j", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+	public void multiModulesProjectTest(@TempDir Path tempDir) throws IOException {
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/pac4j"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(8, launcher.getEnvironment().getComplianceLevel());
 		assertEquals(0, launcher.getModelBuilder().getInputSources().size());
 		assertEquals(166, launcher.getEnvironment().getSourceClasspath().length);
 	}
 
 	@Test
-	public void mavenLauncherOnANotExistingFileTest() {
-		assertThrows(SpoonException.class, () -> {
-			new MavenLauncher("./pomm.xml", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
-		});
-	} 
+	public void mavenLauncherOnANotExistingFileTest(@TempDir Path tempDir) {
+		assertThrows(
+			SpoonException.class,
+			() -> new MavenLauncher(
+				tempDir.resolve("pom.xml").toAbsolutePath().toString(),
+				MavenLauncher.SOURCE_TYPE.APP_SOURCE
+			)
+		);
+	}
 
 	@Test
-	public void mavenLauncherOnDirectoryWithoutPomTest() {
-		assertThrows(SpoonException.class, () -> {
-			new MavenLauncher("./src", MavenLauncher.SOURCE_TYPE.APP_SOURCE);
-		});
-	} 
+	public void mavenLauncherOnDirectoryWithoutPomTest(@TempDir Path tempDir) {
+		assertThrows(
+			SpoonException.class,
+			() -> new MavenLauncher(
+				tempDir.toAbsolutePath().toString(),
+				MavenLauncher.SOURCE_TYPE.APP_SOURCE
+			)
+		);
+	}
 
 	@Test
-	public void testSystemDependency() {
+	public void testSystemDependency(@TempDir Path tempDir) throws IOException {
 		//contract: scope dependencies are added to classpath
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(1, launcher.getEnvironment().getSourceClasspath().length);
 		assertTrue(Path.of(launcher.getEnvironment().getSourceClasspath()[0]).endsWith(Path.of("lib/bridge-method-annotation-1.13.jar")));
 	}
 
 	@Test
-	public void testForceRefresh() throws FileNotFoundException {
+	public void testForceRefresh(@TempDir Path tempDir) throws IOException {
+		String targetPath = copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency");
+
 		// ensure classpath file exists so first constructor invocation won't build classpath
-		File file = new File("./src/test/resources/maven-launcher/system-dependency/spoon.classpath.tmp");
-		new PrintWriter(file).close();
+		Files.writeString(Path.of(targetPath).resolve("spoon.classpath.tmp"), "");
 
 		// contract: classpath is not built
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		MavenLauncher launcher = new MavenLauncher(
+			targetPath,
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);
 
 		// contract: calling constructor with forceRefresh=true should result in classpath being rebuilt
-		MavenLauncher newLauncher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE, true);
+		MavenLauncher newLauncher = new MavenLauncher(
+			targetPath,
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE,
+			true
+		);
 		assertEquals(1, newLauncher.getEnvironment().getSourceClasspath().length);
 	}
 
 	@Test
-	public void testRebuildClasspath() throws FileNotFoundException {
+	public void testRebuildClasspath(@TempDir Path tempDir) throws IOException {
+		String targetPath = copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency");
+
 		// ensure classpath file exists so first constructor invocation won't build classpath
-		File file = new File("./src/test/resources/maven-launcher/system-dependency/spoon.classpath.tmp");
-		new PrintWriter(file).close();
+		Files.writeString(Path.of(targetPath).resolve("spoon.classpath.tmp"), "");
 
 		// contract: classpath is not built
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/system-dependency", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		MavenLauncher launcher = new MavenLauncher(
+			targetPath,
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(0, launcher.getEnvironment().getSourceClasspath().length);
 
 		// contract: classpath should be rebuilt
@@ -199,21 +226,30 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void mavenLauncherTestWithVerySimpleProject() {
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/very-simple", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+	public void mavenLauncherTestWithVerySimpleProject(@TempDir Path tempDir) throws IOException {
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/very-simple"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(1, launcher.getModelBuilder().getInputSources().size());
 	}
 
 	@Test
-	public void testPomSourceDirectory() {
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/source-directory", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+	public void testPomSourceDirectory(@TempDir Path tempDir) throws IOException {
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/source-directory"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		assertEquals(2, launcher.getModelBuilder().getInputSources().size());
 	}
 
 	@Test
-	public void mavenLauncherTestMultiModulesAndVariables() {
+	public void mavenLauncherTestMultiModulesAndVariables(@TempDir Path tempDir) throws IOException {
 		// contract: variables coming from parent should be resolved
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/pac4j/pac4j-config", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/pac4j/pac4j-config"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		List<String> classpath = Arrays.asList(launcher.getEnvironment().getSourceClasspath());
 
 		// we cannot guarantee that the dependency is present in .m2 cache and the test might fail
@@ -239,9 +275,11 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	void mavenLauncherPassesEnvironmentVariables() {
-		// 10.1.0
-		MavenLauncher launcher = new MavenLauncher("./src/test/resources/maven-launcher/with-environment-variables", MavenLauncher.SOURCE_TYPE.ALL_SOURCE);
+	void mavenLauncherPassesEnvironmentVariables(@TempDir Path tempDir) throws IOException {
+		MavenLauncher launcher = new MavenLauncher(
+			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/with-environment-variables"),
+			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
+		);
 		launcher.addEnvironmentVariable("spoonVersion", "10.1.0");
 		launcher.rebuildClasspath();
 
@@ -254,5 +292,13 @@ public class MavenLauncherTest {
 			"Spoon dependency not found. Was the environment variable set? Classpath: "
 				+ Arrays.toString(launcher.getEnvironment().getSourceClasspath())
 		);
+	}
+
+	private static String copyResourceToFolder(Path tempDir, String resourcePath) throws IOException {
+		FileUtils.copyDirectory(
+			new File(resourcePath),
+			tempDir.toFile()
+		);
+		return tempDir.toAbsolutePath().toString();
 	}
 }

--- a/src/test/resources/maven-launcher/with-environment-variables/pom.xml
+++ b/src/test/resources/maven-launcher/with-environment-variables/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>${env.spoonVersion}</version>
+            <version>${env.SPOON_VERSION}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/resources/maven-launcher/with-environment-variables/pom.xml
+++ b/src/test/resources/maven-launcher/with-environment-variables/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>${SPOON_VERSION}</version>
+            <version>${env.SPOON_VERSION}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/resources/maven-launcher/with-environment-variables/pom.xml
+++ b/src/test/resources/maven-launcher/with-environment-variables/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>${env.SPOON_VERSION}</version>
+            <version>${SPOON_VERSION}</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/resources/maven-launcher/with-environment-variables/pom.xml
+++ b/src/test/resources/maven-launcher/with-environment-variables/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.foo.bar</groupId>
+    <artifactId>foobar</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>foobar</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>fr.inria.gforge.spoon</groupId>
+            <artifactId>spoon-core</artifactId>
+            <version>${spoonVersion}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/maven-launcher/with-environment-variables/pom.xml
+++ b/src/test/resources/maven-launcher/with-environment-variables/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
-            <version>${spoonVersion}</version>
+            <version>${env.spoonVersion}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Some maven builds might need environment variables to complete successfully and we should offer an API for this.

As the methods I overloaded are part of the public API, I enclosed the environment variables in an opaque settings object. This should allow us to add more options later without another overload layer per feature. I am not sure if this is a good idea, but it might ease the burden a bit.

Closes: #4817 