### PR TITLE
review: doc: add information about the compliance level to the launcher doc

### DIFF
--- a/doc/launcher.md
+++ b/doc/launcher.md
@@ -20,11 +20,16 @@ Launcher launcher = new Launcher();
 // path can be a folder or a file
 // addInputResource can be called several times
 launcher.addInputResource("<path_to_source>"); 
+// the compliance level should be set to the java version targeted by the input resources, e.g. Java 17
+launcher.getEnvironment().setComplianceLevel(17);
 
 launcher.buildModel();
 
 CtModel model = launcher.getModel();
 ```
+
+The current default value for the compliance level is 8.
+It might cause unexpected issues to have a compliance level lower than the Java version of the input resources. 
 
 ### Pretty-printing modes
 


### PR DESCRIPTION
Closes #4804.

As mentioned in the issue, it's not clear from the current examples that the user needs to configure the compliance level.
I think adding it to that copy-paste example is a good way to make users aware of it.