### PR TITLE
fix: attach comment to `CtLiteral` nodes

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -22,6 +22,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtLambda;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
@@ -432,6 +433,11 @@ public class JDTCommentBuilder {
 				} catch (ParentNotInitializedException ex) {
 					e.addComment(comment);
 				}
+			}
+
+			@Override
+			public <T> void visitCtLiteral(CtLiteral<T> e) {
+				e.addComment(comment);
 			}
 
 			@Override

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -44,6 +44,7 @@ import spoon.support.UnsettableProperty;
 import spoon.support.comparator.CtLineElementComparator;
 import spoon.support.util.internal.ElementNameMap;
 import spoon.support.util.ModelList;
+import spoon.testing.utils.ModelTest;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -59,15 +60,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AstCheckerTest {
 
-	@Test
-	void ctLiteralsInCtCaseExpressionShouldHaveCommentsAttached() {
+	@ModelTest("src/test/resources/comment/CommentsOnCaseExpression.java")
+	void ctLiteralsInCtCaseExpressionShouldHaveCommentsAttached(CtModel model) {
 		// contract: literal nodes should have comments attached to them.
-		// arrange
-		Launcher launcher = new Launcher();
-		launcher.addInputResource("src/test/resources/comment/CommentsOnCaseExpression.java");
-		launcher.getEnvironment().setCommentEnabled(true);
-		CtModel model = launcher.buildModel();
-
 		// act
 		List<CtComment> comments = model.getElements(new TypeFilter<>(CtComment.class));
 

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -22,8 +22,10 @@ import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.support.modelobs.FineModelChangeListener;
+import spoon.reflect.CtModel;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtIf;
@@ -56,6 +58,22 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AstCheckerTest {
+
+	@Test
+	void ctLiteralsInCtCaseExpressionShouldHaveCommentsAttached() {
+		// contract: literal nodes should have comments attached to them.
+		// arrange
+		Launcher launcher = new Launcher();
+		launcher.addInputResource("src/test/resources/comment/CommentsOnCaseExpression.java");
+		launcher.getEnvironment().setCommentEnabled(true);
+		CtModel model = launcher.buildModel();
+
+		// act
+		List<CtComment> comments = model.getElements(new TypeFilter<>(CtComment.class));
+
+		// assert
+		assertThat(comments.size(), equalTo(3));
+	}
 
 	@Test
 	void leftOperandShouldBeGivenPriorityForStoringTheNestedOperator_stringLiteralConcatenation() {

--- a/src/test/java/spoon/reflect/ast/AstCheckerTest.java
+++ b/src/test/java/spoon/reflect/ast/AstCheckerTest.java
@@ -72,7 +72,7 @@ public class AstCheckerTest {
 		List<CtComment> comments = model.getElements(new TypeFilter<>(CtComment.class));
 
 		// assert
-		assertThat(comments.size(), equalTo(3));
+		assertThat(comments.size(), equalTo(4));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -36,7 +36,6 @@ import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
-import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtClass;
@@ -416,7 +415,7 @@ public class FieldAccessTest {
 			@Override
 			public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
 				visited++;
-				assertEquals("a", ((CtVariableRead<?>) fieldWrite.getTarget()).getVariable().getSimpleName());
+				assertEquals("a", ((CtVariableWrite) fieldWrite.getTarget()).getVariable().getSimpleName());
 				assertEquals("l", fieldWrite.getVariable().getSimpleName());
 			}
 		}

--- a/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
+++ b/src/test/java/spoon/test/fieldaccesses/FieldAccessTest.java
@@ -36,6 +36,7 @@ import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.CtVariableRead;
 import spoon.reflect.code.CtVariableWrite;
 import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtClass;
@@ -415,7 +416,7 @@ public class FieldAccessTest {
 			@Override
 			public <T> void visitCtFieldWrite(CtFieldWrite<T> fieldWrite) {
 				visited++;
-				assertEquals("a", ((CtVariableWrite) fieldWrite.getTarget()).getVariable().getSimpleName());
+				assertEquals("a", ((CtVariableRead<?>) fieldWrite.getTarget()).getVariable().getSimpleName());
 				assertEquals("l", fieldWrite.getVariable().getSimpleName());
 			}
 		}

--- a/src/test/resources/comment/CommentsOnCaseExpression.java
+++ b/src/test/resources/comment/CommentsOnCaseExpression.java
@@ -3,6 +3,7 @@ public class CommentsOnCaseExpression {
         String stageStr;
         boolean fullStatus;
         switch (stage) {
+            // Inline comments are also a part now
             case (1/*org.apache.coyote.Constants.STAGE_PARSE*/):
                 stageStr = "P";
                 fullStatus = false;

--- a/src/test/resources/comment/CommentsOnCaseExpression.java
+++ b/src/test/resources/comment/CommentsOnCaseExpression.java
@@ -1,0 +1,19 @@
+public class CommentsOnCaseExpression {
+    public void commentsShouldBeAttachedToCtLiteral(int stage) {
+        String stageStr;
+        boolean fullStatus;
+        switch (stage) {
+            case (1/*org.apache.coyote.Constants.STAGE_PARSE*/):
+                stageStr = "P";
+                fullStatus = false;
+                break;
+            case (2/*org.apache.coyote.Constants.STAGE_PREPARE*/):
+                stageStr = "P";
+                fullStatus = false;
+                break;
+            case (3/*org.apache.coyote.Constants.STAGE_SERVICE*/):
+                stageStr = "S";
+                break;
+        }
+    }
+}


### PR DESCRIPTION
I was trying to reproduce https://github.com/INRIA/spoon/issues/4727 and I came across another possible bug in the Spoon model builder. It seems that when comments  are added to `CtCaseExpression`s, they are not parsed and stored in the model. Is this a bug or does Spoon has some configuration that I need to enable to include comments in the model? Note that I already set one in my knowledge - `launcher.getEnvironment().setCommentEnabled(true);`.