### PR TITLE
review: chore: Add maven installed question

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -88,5 +88,5 @@ body:
       options:
         - label: "yes"
         - label: "no"
-  validations:
-    required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -85,6 +85,7 @@ body:
     id: maven_installed
     attributes:
       label: Do you have maven installed?
+       description: "Is maven installed in your environment and you can invoke maven commands?"
       options:
         - "yes"
         - "no"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -81,11 +81,12 @@ body:
       label: What operating system are you using?
     validations:
       required: true
-  - type: checkboxes
+  - type: dropdown
     id: maven_installed
     attributes:
       label: Do you have maven installed?
       options:
         - label: "yes"
         - label: "no"
-          required: true  
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -81,3 +81,11 @@ body:
       label: What operating system are you using?
     validations:
       required: true
+  - type: checkboxes
+    id: maven_installed
+    attributes:
+      label: Do you have maven installed?
+      options:
+        - label: yes
+        - label: no
+          required: true  

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -85,7 +85,7 @@ body:
     id: maven_installed
     attributes:
       label: Do you have maven installed?
-       description: "Is maven installed in your environment and you can invoke maven commands?"
+      description: "Is maven installed in your environment and you can invoke maven commands?"
       options:
         - "yes"
         - "no"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -86,7 +86,7 @@ body:
     attributes:
       label: Do you have maven installed?
       options:
-        - label: "yes"
-        - label: "no"
+        - "yes"
+        - "no"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -86,6 +86,6 @@ body:
     attributes:
       label: Do you have maven installed?
       options:
-        - label: yes
-        - label: no
+        - label: "yes"
+        - label: "no"
           required: true  


### PR DESCRIPTION
This PR simply adds the question if the maven has maven installed. This is for many failing tests a critical information.