### PR TITLE
feat: Use inferred generic type in invocations

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -132,6 +132,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.INCLUDE_IF_IMPLICIT;
+import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.OMIT_IF_IMPLICIT;
+
 /**
  * A visitor for generating Java code from the program compile-time model.
  */
@@ -1356,7 +1359,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		enterCtExpression(invocation);
 		if (invocation.getExecutable().isConstructor()) {
 			// It's a constructor (super or this)
-			elementPrinterHelper.writeActualTypeArguments(invocation.getExecutable());
+			elementPrinterHelper.writeActualTypeArguments(invocation.getExecutable(), OMIT_IF_IMPLICIT);
 			CtType<?> parentType = invocation.getParent(CtType.class);
 			if (parentType == null || parentType.getQualifiedName() != null && parentType.getQualifiedName().equals(invocation.getExecutable().getDeclaringType().getQualifiedName())) {
 				printer.writeKeyword("this");
@@ -1381,7 +1384,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				}
 			}
 
-			elementPrinterHelper.writeActualTypeArguments(invocation);
+			elementPrinterHelper.writeActualTypeArguments(invocation, OMIT_IF_IMPLICIT);
 			if (env.isPreserveLineNumbers()) {
 				getPrinterHelper().adjustStartPosition(invocation);
 			}
@@ -1605,7 +1608,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeKeyword("new").writeSpace();
 
 			if (!ctConstructorCall.getActualTypeArguments().isEmpty()) {
-				elementPrinterHelper.writeActualTypeArguments(ctConstructorCall);
+				elementPrinterHelper.writeActualTypeArguments(ctConstructorCall, INCLUDE_IF_IMPLICIT);
 			}
 
 			scan(ctConstructorCall.getType());
@@ -1990,7 +1993,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 		if (withGenerics && !context.ignoreGenerics()) {
 			try (Writable _context = context.modify().ignoreEnclosingClass(false)) {
-				elementPrinterHelper.writeActualTypeArguments(ref);
+				elementPrinterHelper.writeActualTypeArguments(ref, INCLUDE_IF_IMPLICIT);
 			}
 		}
 	}

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -132,8 +132,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.INCLUDE_IF_IMPLICIT;
-import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.OMIT_IF_IMPLICIT;
+import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.ALSO_PRINT_DIAMOND_OPERATOR;
+import static spoon.reflect.visitor.ElementPrinterHelper.PrintTypeArguments.ONLY_PRINT_EXPLICIT_TYPES;
 
 /**
  * A visitor for generating Java code from the program compile-time model.
@@ -1359,7 +1359,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		enterCtExpression(invocation);
 		if (invocation.getExecutable().isConstructor()) {
 			// It's a constructor (super or this)
-			elementPrinterHelper.writeActualTypeArguments(invocation.getExecutable(), OMIT_IF_IMPLICIT);
+			elementPrinterHelper.writeActualTypeArguments(invocation.getExecutable(), ONLY_PRINT_EXPLICIT_TYPES);
 			CtType<?> parentType = invocation.getParent(CtType.class);
 			if (parentType == null || parentType.getQualifiedName() != null && parentType.getQualifiedName().equals(invocation.getExecutable().getDeclaringType().getQualifiedName())) {
 				printer.writeKeyword("this");
@@ -1384,7 +1384,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				}
 			}
 
-			elementPrinterHelper.writeActualTypeArguments(invocation, OMIT_IF_IMPLICIT);
+			elementPrinterHelper.writeActualTypeArguments(invocation, ONLY_PRINT_EXPLICIT_TYPES);
 			if (env.isPreserveLineNumbers()) {
 				getPrinterHelper().adjustStartPosition(invocation);
 			}
@@ -1608,7 +1608,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			printer.writeKeyword("new").writeSpace();
 
 			if (!ctConstructorCall.getActualTypeArguments().isEmpty()) {
-				elementPrinterHelper.writeActualTypeArguments(ctConstructorCall, INCLUDE_IF_IMPLICIT);
+				elementPrinterHelper.writeActualTypeArguments(ctConstructorCall, ALSO_PRINT_DIAMOND_OPERATOR);
 			}
 
 			scan(ctConstructorCall.getType());
@@ -1993,7 +1993,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		}
 		if (withGenerics && !context.ignoreGenerics()) {
 			try (Writable _context = context.modify().ignoreEnclosingClass(false)) {
-				elementPrinterHelper.writeActualTypeArguments(ref, INCLUDE_IF_IMPLICIT);
+				elementPrinterHelper.writeActualTypeArguments(ref, ALSO_PRINT_DIAMOND_OPERATOR);
 			}
 		}
 	}

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1607,9 +1607,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 
 			printer.writeKeyword("new").writeSpace();
 
-			if (!ctConstructorCall.getActualTypeArguments().isEmpty()) {
-				elementPrinterHelper.writeActualTypeArguments(ctConstructorCall, ALSO_PRINT_DIAMOND_OPERATOR);
-			}
+			elementPrinterHelper.writeActualTypeArguments(ctConstructorCall, ALSO_PRINT_DIAMOND_OPERATOR);
 
 			scan(ctConstructorCall.getType());
 		}

--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -240,6 +240,20 @@ public class ElementPrinterHelper {
 
 	/**
 	 * Writes actual type arguments in a {@link CtActualTypeContainer} element.
+	 * Passes {@link PrintTypeArguments#ONLY_PRINT_EXPLICIT_TYPES}.
+	 *
+	 * @param ctGenericElementReference Reference with actual type arguments.
+	 * @see #writeActualTypeArguments(CtActualTypeContainer, PrintTypeArguments)
+	 * @deprecated use {@link #writeActualTypeArguments(CtActualTypeContainer, PrintTypeArguments)}. This method is
+	 * only kept for backwards compatibility.
+	 */
+	@Deprecated
+	public void writeActualTypeArguments(CtActualTypeContainer ctGenericElementReference) {
+		writeActualTypeArguments(ctGenericElementReference, PrintTypeArguments.ONLY_PRINT_EXPLICIT_TYPES);
+	}
+
+	/**
+	 * Writes actual type arguments in a {@link CtActualTypeContainer} element.
 	 *
 	 * @param ctGenericElementReference Reference with actual type arguments.
 	 * @param handleImplicit Whether to print type arguments if they are all implicit
@@ -254,7 +268,7 @@ public class ElementPrinterHelper {
 		}
 
 		boolean allImplicit = arguments.stream().allMatch(CtElement::isImplicit);
-		if (allImplicit && handleImplicit == PrintTypeArguments.OMIT_IF_IMPLICIT) {
+		if (allImplicit && handleImplicit == PrintTypeArguments.ONLY_PRINT_EXPLICIT_TYPES) {
 			return;
 		}
 
@@ -576,8 +590,22 @@ public class ElementPrinterHelper {
 		printer.decTab();
 	}
 
+	/**
+	 * Whether to print generic types for references. This affects e.g. explicit type arguments for constructor
+	 * or method calls.
+	 *
+	 * A diamond operator is only valid in some places. This enum controls whether they can and should be printed at
+	 * a given location.
+	 */
 	public enum PrintTypeArguments {
-		OMIT_IF_IMPLICIT,
-		INCLUDE_IF_IMPLICIT
+		/**
+		 * Only print explicit type argument. Implicit (i.e. inferred types) are not printed. Consequently, this will
+		 * also not print a diamond operator.
+		 */
+		ONLY_PRINT_EXPLICIT_TYPES,
+		/**
+		 * Print explicit type arguments, but also print a diamond operator if implicit type arguments were used.
+		 */
+		ALSO_PRINT_DIAMOND_OPERATOR
 	}
 }


### PR DESCRIPTION
If no explicit type arguments are given, the type arguments JDT inferred are now used for getActualTypeArguments.

This addresses #4834, but I am not sure we actually want to use the inferred information. It seems quite useful, but it may also be incomplete if JDT is not able to infer things correctly.