### PR TITLE
review: refactor: SizeReplaceableByIsEmpty

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -43,7 +43,6 @@ import java.util.StringTokenizer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-
 /**
  * Represents a part of source code of an {@link CtElement}
  * It is connected into a tree of {@link ElementSourceFragment}s.

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -339,7 +339,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT;
+		OTHER_IS_PARENT
 	}
 
 	/**

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -7,7 +7,6 @@
  */
 package spoon.support.sniper.internal;
 
-
 import spoon.SpoonException;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLiteral;
@@ -42,6 +41,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
 
 /**
  * Represents a part of source code of an {@link CtElement}
@@ -339,7 +339,7 @@ public class ElementSourceFragment implements SourceFragment {
 		OTHER_IS_BEFORE,
 		OTHER_IS_AFTER,
 		OTHER_IS_CHILD,
-		OTHER_IS_PARENT
+		OTHER_IS_PARENT;
 	}
 
 	/**
@@ -666,7 +666,7 @@ public class ElementSourceFragment implements SourceFragment {
 			throw new SpoonException("Inconsistent start/end. Start=" + start + " is greater then End=" + end);
 		}
 		String sourceCode = getOriginalSourceCode();
-		if (sourceCode.length() == 0) {
+		if (sourceCode.isEmpty()) {
 			return;
 		}
 		StringBuilder buff = new StringBuilder();

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.sniper.internal;
 
+
 import spoon.SpoonException;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLiteral;


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:
## SizeReplaceableByIsEmpty
Checking if a string is empty should be done by `String#isEmpty` instead of `String.length==0`

## The following has changed in the code:
### SizeReplaceableByIsEmpty
- Replaced string.length empty check with string.isEmpty
