### PR TITLE
refactor: fix bad smell "Unnecessary Local Variable" (#4847)

### DIFF
--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -12,6 +12,8 @@ import spoon.reflect.code.CtTextBlock;
 import spoon.reflect.code.LiteralBase;
 import spoon.reflect.cu.SourcePosition;
 
+
+
 /**
  * Computes source code representation of the literal
  */
@@ -61,10 +63,7 @@ abstract class LiteralHelper {
 	 * @return source code representation of the literal
 	 */
 	public static String getTextBlockToken(CtTextBlock literal) {
-		String token = "\"\"\"\n"
-				+ literal.getValue().replace("\\", "\\\\")
-				+ "\"\"\"";
-		return token;
+		return "\"\"\"\n" + literal.getValue().replace("\\", "\\\\") + "\"\"\"";
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -12,8 +12,6 @@ import spoon.reflect.code.CtTextBlock;
 import spoon.reflect.code.LiteralBase;
 import spoon.reflect.cu.SourcePosition;
 
-
-
 /**
  * Computes source code representation of the literal
  */


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:

## UnnecessaryLocalVariable
A local variable is declared and in the next line returned. This can be replaced by an instant return.

## The following has changed in the code:
### UnnecessaryLocalVariable
- Inlined return statement return `("\"\"\"\n" + literal.getValue().replace("\\", "\\\\")) + "\"\"\""`
