### PR TITLE
refactor: fix bad smell "Unnecessary Local Variable"

### DIFF
--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -7,7 +7,6 @@
  */
 package spoon.support;
 
-
 import org.slf4j.Logger;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -52,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
+
 
 
 /**
@@ -692,8 +692,7 @@ private transient  ClassLoader inputClassloader;
 
 
 			if (PRETTY_PRINTING_MODE.DEBUG.equals(prettyPrintingMode)) {
-				DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(this);
-				return printer;
+				return new DefaultJavaPrettyPrinter(this);
 			}
 
 			if (PRETTY_PRINTING_MODE.FULLYQUALIFIED.equals(prettyPrintingMode)) {

--- a/src/main/java/spoon/support/StandardEnvironment.java
+++ b/src/main/java/spoon/support/StandardEnvironment.java
@@ -7,6 +7,7 @@
  */
 package spoon.support;
 
+
 import org.slf4j.Logger;
 import spoon.Launcher;
 import spoon.OutputType;
@@ -51,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-
 
 
 /**


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:

## UnnecessaryLocalVariable
A local variable is declared and in the next line returned. This can be replaced by an instant return.

## The following has changed in the code:
### UnnecessaryLocalVariable
- Inlined return statement return new spoon.reflect.visitor.DefaultJavaPrettyPrinter(this)