### PR TITLE
review: perf: avoid collection copy in CtPackageImpl

### DIFF
--- a/src/main/java/spoon/IncrementalLauncher.java
+++ b/src/main/java/spoon/IncrementalLauncher.java
@@ -223,7 +223,7 @@ public class IncrementalLauncher extends Launcher {
 
 			Collection<CtPackage> oldPackages = oldFactory.Package().getAll();
 			for (CtPackage pkg : oldPackages) {
-				if (pkg.getTypes().isEmpty() && pkg.getPackages().isEmpty() && !pkg.isUnnamedPackage()) {
+				if (pkg.isEmpty() && !pkg.isUnnamedPackage()) {
 					pkg.delete();
 				}
 			}

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -59,6 +59,8 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 
 	/**
 	 * Gets the set of included child packages.
+	 * This method might take linear time (regarding the amount of packages in this package).
+	 * For emptiness-checks, {@link #hasPackages()} should be preferred.
 	 */
 	@PropertyGetter(role = SUB_PACKAGE)
 	Set<CtPackage> getPackages();
@@ -91,6 +93,8 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 
 	/**
 	 * Returns the set of the top-level types in this package.
+	 * This method might take linear time (regarding the amount of types in this package).
+	 * For emptiness-checks, {@link #hasTypes()} should be preferred.
 	 */
 	@PropertyGetter(role = CONTAINED_TYPE)
 	Set<CtType<?>> getTypes();
@@ -163,6 +167,10 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	boolean isEmpty();
 
 	/**
+	 * Returns true if this package contains any types.
+	 * This method is expected to provide constant-time performance
+	 * and should be preferred over {@link #getTypes()}{@code .isEmpty()}.
+	 *
 	 * @return true if the package contains any types.
 	 * @see #getTypes()
 	 */

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -161,4 +161,9 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * @return true if the package contains no types nor any other packages
 	 */
 	boolean isEmpty();
+
+	/**
+	 * @return true if the package contains no types.
+	 */
+	boolean hasNoTypes();
 }

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -175,4 +175,14 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	 * @see #getTypes()
 	 */
 	boolean hasTypes();
+
+	/**
+	 * Returns true if this package contains any sub-packages.
+	 * This method is expected to provide constant-time performance
+	 * and should be preferred over {@link #getPackages()}{@code .isEmpty()}.
+	 *
+	 * @return true if the package contains any sub-packages
+	 * @see #getPackages()
+	 */
+	boolean hasPackages();
 }

--- a/src/main/java/spoon/reflect/declaration/CtPackage.java
+++ b/src/main/java/spoon/reflect/declaration/CtPackage.java
@@ -163,7 +163,8 @@ public interface CtPackage extends CtNamedElement, CtShadowable {
 	boolean isEmpty();
 
 	/**
-	 * @return true if the package contains no types.
+	 * @return true if the package contains any types.
+	 * @see #getTypes()
 	 */
-	boolean hasNoTypes();
+	boolean hasTypes();
 }

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -182,7 +182,7 @@ public class PackageFactory extends SubFactory {
 				continue;
 			}
 			lastNonNullPackage = aPackage;
-			if (!aPackage.hasNoTypes()) {
+			if (aPackage.hasTypes()) {
 				packageWithTypes = aPackage;
 				foundPackageCount++;
 			}

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -182,7 +182,7 @@ public class PackageFactory extends SubFactory {
 				continue;
 			}
 			lastNonNullPackage = aPackage;
-			if (!aPackage.getTypes().isEmpty()) {
+			if (!aPackage.hasNoTypes()) {
 				packageWithTypes = aPackage;
 				foundPackageCount++;
 			}

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -245,6 +245,11 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 		return getPackages().isEmpty() && getTypes().isEmpty();
 	}
 
+	@Override
+	public boolean hasNoTypes() {
+		return types.isEmpty();
+	}
+
 	void updateTypeName(CtType<?> newType, String oldName) {
 		types.updateKey(oldName, newType.getSimpleName());
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -242,7 +242,7 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public boolean isEmpty() {
-		return getPackages().isEmpty() && hasTypes();
+		return getPackages().isEmpty() && !hasTypes();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -242,12 +242,12 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public boolean isEmpty() {
-		return getPackages().isEmpty() && getTypes().isEmpty();
+		return getPackages().isEmpty() && hasTypes();
 	}
 
 	@Override
-	public boolean hasNoTypes() {
-		return types.isEmpty();
+	public boolean hasTypes() {
+		return !types.isEmpty();
 	}
 
 	void updateTypeName(CtType<?> newType, String oldName) {

--- a/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtPackageImpl.java
@@ -242,12 +242,17 @@ public class CtPackageImpl extends CtNamedElementImpl implements CtPackage {
 
 	@Override
 	public boolean isEmpty() {
-		return getPackages().isEmpty() && !hasTypes();
+		return !hasPackages() && !hasTypes();
 	}
 
 	@Override
 	public boolean hasTypes() {
 		return !types.isEmpty();
+	}
+
+	@Override
+	public boolean hasPackages() {
+		return !packs.isEmpty();
 	}
 
 	void updateTypeName(CtType<?> newType, String oldName) {

--- a/src/main/java/spoon/support/util/internal/ElementNameMap.java
+++ b/src/main/java/spoon/support/util/internal/ElementNameMap.java
@@ -11,7 +11,6 @@ import static spoon.support.util.internal.ModelCollectionUtils.linkToParent;
 
 import java.io.Serializable;
 import java.util.AbstractMap;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;

--- a/src/main/java/spoon/support/util/internal/ElementNameMap.java
+++ b/src/main/java/spoon/support/util/internal/ElementNameMap.java
@@ -11,6 +11,7 @@ import static spoon.support.util.internal.ModelCollectionUtils.linkToParent;
 
 import java.io.Serializable;
 import java.util.AbstractMap;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -82,6 +83,11 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 
 	protected abstract CtRole getRole();
 
+	@Override
+	public Collection<T> values() {
+		return map.values();
+	}
+
 	/**
 	 * {@inheritDoc }
 	 *
@@ -128,6 +134,11 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 		);
 
 		return removed;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return map.isEmpty();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/util/internal/ElementNameMap.java
+++ b/src/main/java/spoon/support/util/internal/ElementNameMap.java
@@ -83,11 +83,6 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 
 	protected abstract CtRole getRole();
 
-	@Override
-	public Collection<T> values() {
-		return map.values();
-	}
-
 	/**
 	 * {@inheritDoc }
 	 *


### PR DESCRIPTION
I saw that when running this test https://github.com/INRIA/spoon/blob/0fcb28878671d90daede513326bff96274068b32/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java#L157

most of the time is spent on `CtMethodImpl#getTopDefintions()`. I did some profiling and encountered this:
![lhs](https://user-images.githubusercontent.com/11150076/185568043-2e9526b3-dea6-45e5-98d7-2034d6fc5de4.png)

That's an immense amount of time of copying elements just to check if the set is empty. As a solution, I propose to introduce a `CtPackage#hasTypes()` method. This way, we can ask the ElementNameMap directly instead of doing costly copying.

In my first measurements, this reduced the runtime of the mentioned test from ~20s to ~16s.

(I rebased after that, and the runtime of the test on the current master takes >1m on my machine. With this patch, it is still faster, but I have a second PR ready to get back to the ~16s)