### PR TITLE
review: perf: override AbstractMap#get in ElementNameMap

### DIFF
--- a/src/main/java/spoon/support/util/internal/ElementNameMap.java
+++ b/src/main/java/spoon/support/util/internal/ElementNameMap.java
@@ -159,6 +159,15 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 		return map.containsKey(key);
 	}
 
+	@Override
+	public T get(Object key) {
+		InsertOrderWrapper<T> wrapper = map.get(key);
+		if (wrapper == null) {
+			return null;
+		}
+		return wrapper.value;
+	}
+
 	/**
 	 * Updates the mapping for a single key from {@code oldKey} to {@code newKey} if present.
 	 *


### PR DESCRIPTION
This was discovered after rebasing for #4848.

#4832 caused a severe regression due to the way `get` in `AbstractMap` works. Before, `AbstractMap#entrySet()` just delegated to the underlying map, but with the patch, it first has to build the map. For `get`, this isn't needed at all, therefore we should override the method.

This brings down this test https://github.com/INRIA/spoon/blob/0fcb28878671d90daede513326bff96274068b32/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java#L157

from ~1m 17s to ~52s. There might be more methods that should be overridden now, I'll investigate that. One that takes a lot of time is `values()` which is called heavily at the moment, but we can avoid many calls with #4848, so both PRs combined seem to achieve even better performance than before the regression.