### PR TITLE
fix: Fix getOriginalSourceFragment and getRawJavadoc for zip file inputs

### DIFF
--- a/src/main/java/spoon/support/Internal.java
+++ b/src/main/java/spoon/support/Internal.java
@@ -13,10 +13,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Tells that a class or method is not in the public API (even if it has Java visibility "public")
+ * Tells that an element is not in the public API (even if it has Java visibility "public")
  * Required because package-visibility is too coarse-grained.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.TYPE })
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE })
 public @interface Internal {
 }

--- a/src/main/java/spoon/support/compiler/ZipFile.java
+++ b/src/main/java/spoon/support/compiler/ZipFile.java
@@ -29,7 +29,7 @@ public class ZipFile implements SpoonFile {
 	private final byte[] content;
 
 	/**
-	 * Creates a new zip file. Should never be called manually.#
+	 * Creates a new zip file. Should never be called manually.
 	 *
 	 * @param parent the parent folder
 	 * @param name the name of the file

--- a/src/main/java/spoon/support/compiler/ZipFile.java
+++ b/src/main/java/spoon/support/compiler/ZipFile.java
@@ -7,32 +7,68 @@
  */
 package spoon.support.compiler;
 
+import spoon.SpoonException;
+import spoon.compiler.SpoonFile;
+import spoon.compiler.SpoonFolder;
+import spoon.support.Internal;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Objects;
 
-import spoon.compiler.SpoonFile;
-import spoon.compiler.SpoonFolder;
-
 public class ZipFile implements SpoonFile {
 
-	byte[] content;
+	private final String name;
+	private final ZipFolder parent;
+	private final Path tempFile;
+	private final byte[] content;
 
-	String name;
-
-	ZipFolder parent;
-
+	/**
+	 * Creates a new zip file. Should never be called manually.#
+	 *
+	 * @param parent the parent folder
+	 * @param name the name of the file
+	 * @param content the content of the file
+	 * @deprecated use {@link ZipFile#ZipFile(ZipFolder, String, Path)}
+	 */
+	@Deprecated
 	public ZipFile(ZipFolder parent, String name, byte[] content) {
 		this.content = content;
 		this.name = name;
 		this.parent = parent;
+		this.tempFile = null;
+	}
+
+	/**
+	 * Creates a new zip file. Should never be called manually.
+	 *
+	 * @param parent the parent folder
+	 * @param name the name of the file
+	 * @param tempFile the temporary file it was cached to
+	 */
+	@Internal
+	public ZipFile(ZipFolder parent, String name, Path tempFile) {
+		this.parent = parent;
+		this.name = name;
+		this.tempFile = tempFile;
+		this.content = null;
 	}
 
 	@Override
 	public InputStream getContent() {
-		return new ByteArrayInputStream(content);
+		if (content != null) {
+			return new ByteArrayInputStream(content);
+		}
+		try {
+			return Files.newInputStream(Objects.requireNonNull(tempFile));
+		} catch (IOException e) {
+			throw new SpoonException(e);
+		}
 	}
 
 	@Override
@@ -62,6 +98,9 @@ public class ZipFile implements SpoonFile {
 
 	@Override
 	public String getPath() {
+		if (tempFile != null) {
+			return tempFile.toAbsolutePath().toString();
+		}
 		return toString();
 	}
 
@@ -82,15 +121,13 @@ public class ZipFile implements SpoonFile {
 
 	@Override
 	public boolean isActualFile() {
-		return false;
+		return tempFile != null;
 	}
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + Arrays.hashCode(content);
-		result = prime * result + Objects.hash(name, parent);
+		int result = Objects.hash(name, parent, tempFile);
+		result = 31 * result + Arrays.hashCode(content);
 		return result;
 	}
 
@@ -102,11 +139,11 @@ public class ZipFile implements SpoonFile {
 		if (!(obj instanceof ZipFile)) {
 			return false;
 		}
-		ZipFile other = (ZipFile) obj;
-		return Arrays.equals(content, other.content) && Objects.equals(name, other.name)
-				&& Objects.equals(parent, other.parent);
+		ZipFile zipFile = (ZipFile) obj;
+		return Objects.equals(name, zipFile.name)
+			&& Objects.equals(parent, zipFile.parent)
+			&& Objects.equals(tempFile, zipFile.tempFile)
+			&& Arrays.equals(content, zipFile.content);
 	}
-
-
 
 }

--- a/src/main/java/spoon/support/compiler/ZipFolder.java
+++ b/src/main/java/spoon/support/compiler/ZipFolder.java
@@ -7,27 +7,35 @@
  */
 package spoon.support.compiler;
 
+import org.apache.commons.io.FileUtils;
+import spoon.Launcher;
+import spoon.SpoonException;
+import spoon.compiler.SpoonFile;
+import spoon.compiler.SpoonFolder;
+import spoon.compiler.SpoonResourceHelper;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-
-import spoon.Launcher;
-import spoon.SpoonException;
-import spoon.compiler.SpoonFile;
-import spoon.compiler.SpoonFolder;
-import spoon.compiler.SpoonResourceHelper;
 
 public class ZipFolder implements SpoonFolder {
 
@@ -57,20 +65,45 @@ public class ZipFolder implements SpoonFolder {
 		// Indexing content
 		if (files == null) {
 			files = new ArrayList<>();
-			try (ZipInputStream zipInput = new ZipInputStream(new BufferedInputStream(new FileInputStream(file)));
-				ByteArrayOutputStream output = new ByteArrayOutputStream(2048)) {
+			try (FileSystem zip = FileSystems.newFileSystem(URI.create("jar:" + file.toURI()), Map.of())) {
+				Path tempFolder = Files.createTempDirectory("spoon-zip-file-proxy");
+				// Try to clean up - not guaranteed to work!
+				Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+					try {
+						FileUtils.deleteDirectory(tempFolder.toFile());
+					} catch (IOException e) {
+						throw new UncheckedIOException(e);
+					}
+				}));
 
-				ZipEntry entry;
-				while ((entry = zipInput.getNextEntry()) != null) {
-					zipInput.transferTo(output);
-					files.add(new ZipFile(this, entry.getName(), output.toByteArray()));
-					output.reset();
+
+				for (Path directory : zip.getRootDirectories()) {
+					copyFolder(directory, tempFolder);
 				}
 			} catch (Exception e) {
-				Launcher.LOGGER.error(e.getMessage(), e);
+				Launcher.LOGGER.error("Error copying zip file contents", e);
 			}
 		}
 		return files;
+	}
+
+	private void copyFolder(Path source, Path target) throws IOException {
+		try (Stream<Path> stream = Files.walk(source)) {
+			for (Path path : (Iterable<Path>) stream::iterator) {
+				// This little dance is needed, as resolve with the Path fails: The two paths are in different and
+				// incompatible file systems!
+				String relativePath = source.relativize(path).toString();
+				Path targetFile = target.resolve(relativePath);
+
+				if (Files.isDirectory(path)) {
+					Files.createDirectories(targetFile);
+				} else {
+					// walked in depth-first order, so we can just copy it and expect the parent to exist
+					Files.copy(path, targetFile);
+					files.add(new ZipFile(this, relativePath, targetFile));
+				}
+			}
+		}
 	}
 
 	@Override
@@ -127,8 +160,6 @@ public class ZipFolder implements SpoonFolder {
 	public File toFile() {
 		return file;
 	}
-
-
 
 	@Override
 	public int hashCode() {

--- a/src/test/java/spoon/support/compiler/ZipFileTest.java
+++ b/src/test/java/spoon/support/compiler/ZipFileTest.java
@@ -1,0 +1,67 @@
+package spoon.support.compiler;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import spoon.Launcher;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ZipFileTest {
+
+	@Test
+	void fetchingSourceFragmentWorks(@TempDir Path tempDir) throws IOException {
+		// contract: Fetching an original source code fragment from a zip folder input works
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new ZipFolder(createZip(tempDir).toFile()));
+		launcher.buildModel();
+
+		CtType<?> type = launcher.getFactory().Type().get("a.Test");
+		CtMethod<?> method = type.getMethod("foo");
+		assertNotNull(method.getOriginalSourceFragment().getSourceCode());
+		assertTrue(method.getOriginalSourceFragment().getSourceCode().contains("/**"));
+		assertTrue(method.getOriginalSourceFragment().getSourceCode().contains("foo()"));
+	}
+
+	private Path createZip(Path tempDir) throws IOException {
+		Files.createDirectories(tempDir.resolve("a"));
+
+		Path testFile = tempDir.resolve("a").resolve("Test.java");
+		Files.writeString(
+			testFile,
+			"package a;\n" +
+				"class Test {\n" +
+				"  /**\n" +
+				"   * A foo method.\n" +
+				"   *\n" +
+				"   * @return some int\n" +
+				"   */\n" +
+				"  public int foo() {\n" +
+				"    return 1 + 1;\n" +
+				"  }" +
+				"}"
+		);
+
+		Path zipPath = tempDir.resolve("test.zip");
+		try (FileSystem zip = FileSystems.newFileSystem(
+			URI.create("jar:" + zipPath.toUri()),
+			Map.of("create", true)
+		)) {
+			Files.createDirectories(zip.getPath("a"));
+			Files.copy(testFile, zip.getPath("a/Test.java"));
+		}
+
+		return zipPath;
+	}
+}

--- a/src/test/java/spoon/support/compiler/ZipFileTest.java
+++ b/src/test/java/spoon/support/compiler/ZipFileTest.java
@@ -1,6 +1,5 @@
 package spoon.support.compiler;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
@@ -15,8 +14,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ZipFileTest {
 
@@ -30,8 +30,8 @@ class ZipFileTest {
 		CtType<?> type = launcher.getFactory().Type().get("a.Test");
 		CtMethod<?> method = type.getMethod("foo");
 		assertNotNull(method.getOriginalSourceFragment().getSourceCode());
-		assertTrue(method.getOriginalSourceFragment().getSourceCode().contains("/**"));
-		assertTrue(method.getOriginalSourceFragment().getSourceCode().contains("foo()"));
+		assertThat(method.getOriginalSourceFragment().getSourceCode(), containsString("/**"));
+		assertThat(method.getOriginalSourceFragment().getSourceCode(), containsString("foo()"));
 	}
 
 	private Path createZip(Path tempDir) throws IOException {


### PR DESCRIPTION
## Description of the problem
Previously, zip files were flattened and stored as `<name><random number>.java`. This caused all methods that retrieve code
at runtime, such as `getOriginalSourceFragment` or `getRawJavadoc,` to fail.

## Chosen solution
This patch keeps the structure of the zip file intact while extracting it into a temporary folder. Consequently, the aforementioned methods are now able to find the source files.

There were multiple ways to proceed here. As JDT needs a copy anyways, I chose to proactively copy the files to disk instead of storing them in memory and copying them when the sources are prepared. Then I set `isActualFile` to true, tricking the relevant parts of spoon into treating the zip file as a regular file (which it mostly is by now, as it has an on-disk representation). The old constructor is kept in place (but will cause problems) as the class is public. Nobody should have used it in the first place, so maybe we could also delete it?

Instead of changing the folder structure we could change the compilation unit name named passed to JDT, This sounds a bit deadly and is also absolutely not compatible with existing code looking at the compilation unit layer. Every compilation unit would be named `/tmp/MyClass381891.java` or similiar, which is not that helpful.

## Further possible features
Allow the user to specify where the temporary files should be stored when creating a `ZipFolder`. This can be easily retrofitted in the future though.