### PR TITLE
refactor: fix bad smell "Non-Strict-Comparison-Can-Be-Equality"

### DIFF
--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -28,7 +28,7 @@ public class DeepRepresentationComparator implements Comparator<CtElement>, Seri
 		}
 		String current = getDeepRepresentation(o1);
 		String other = getDeepRepresentation(o2);
-		if (current.length() == 0 || other.length() == 0) {
+		if (current.isEmpty() || other.isEmpty()) {
 			throw new ClassCastException("Unable to compare elements");
 		}
 		return current.compareTo(other);

--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -12,6 +12,7 @@ import spoon.reflect.declaration.CtElement;
 import java.io.Serializable;
 import java.util.Comparator;
 
+
 /**
  * Compares based on a toString representation.
  */
@@ -28,7 +29,7 @@ public class DeepRepresentationComparator implements Comparator<CtElement>, Seri
 		}
 		String current = getDeepRepresentation(o1);
 		String other = getDeepRepresentation(o2);
-		if (current.length() <= 0 || other.length() <= 0) {
+		if (current.length() == 0 || other.length() == 0) {
 			throw new ClassCastException("Unable to compare elements");
 		}
 		return current.compareTo(other);

--- a/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
+++ b/src/main/java/spoon/support/comparator/DeepRepresentationComparator.java
@@ -12,7 +12,6 @@ import spoon.reflect.declaration.CtElement;
 import java.io.Serializable;
 import java.util.Comparator;
 
-
 /**
  * Compares based on a toString representation.
  */


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:
## Non-Strict-Comparison-Can-Be-Equality
Inequality conditions that, according to data flow analysis, can be satisfied only for a single operand value. Such conditions could be replaced with equality conditions to make the code clearer.

## The following has changed in the code:
### Non-Strict-Comparison-Can-Be-Equality
- Replaced inequality with simpler equality
