### PR TITLE
refactor: fix bad smell Non-Protected-Constructor-in-Abstract-Class

### DIFF
--- a/src/main/java/spoon/pattern/internal/ResultHolder.java
+++ b/src/main/java/spoon/pattern/internal/ResultHolder.java
@@ -21,7 +21,7 @@ import spoon.SpoonException;
 public abstract class ResultHolder<T> {
 	private final Class<T> requiredClass;
 
-	public ResultHolder(Class<T> requiredClass) {
+	protected ResultHolder(Class<T> requiredClass) {
 		this.requiredClass = requiredClass;
 	}
 
@@ -62,7 +62,7 @@ public abstract class ResultHolder<T> {
 
 		private T result;
 
-		public Single(Class<T> requiredClass) {
+		protected Single(Class<T> requiredClass) {
 			super(requiredClass);
 		}
 
@@ -103,7 +103,7 @@ public abstract class ResultHolder<T> {
 
 		List<T> result = new ArrayList<>();
 
-		public Multiple(Class<T> requiredClass) {
+		protected Multiple(Class<T> requiredClass) {
 			super(requiredClass);
 		}
 

--- a/src/main/java/spoon/pattern/internal/ResultHolder.java
+++ b/src/main/java/spoon/pattern/internal/ResultHolder.java
@@ -62,7 +62,7 @@ public abstract class ResultHolder<T> {
 
 		private T result;
 
-		protected Single(Class<T> requiredClass) {
+		public Single(Class<T> requiredClass) {
 			super(requiredClass);
 		}
 
@@ -103,7 +103,7 @@ public abstract class ResultHolder<T> {
 
 		List<T> result = new ArrayList<>();
 
-		protected Multiple(Class<T> requiredClass) {
+		public Multiple(Class<T> requiredClass) {
 			super(requiredClass);
 		}
 


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated

## The following has changed in the code:
### Non-Protected-Constructor-in-Abstract-Class
- Constructor `spoon.pattern.internal.ResultHolder(java.lang.Class)` is now protected instead of public
