### PR TITLE
doc: remove spoon-user-manual.pdf link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Spoon is an open-source library to analyze, rewrite, transform, transpile Java s
 
 ## Documentation
 
-The latest official documentation is available at <http://spoon.gforge.inria.fr/> and a regularly updated PDF version is as <https://projects.ow2.org/download/spoon/WebHome/spoon-user-manual.pdf>.
+The latest official documentation is available at <http://spoon.gforge.inria.fr/>.
 
 ### Academic usage
 


### PR DESCRIPTION
spoon-user-manual.pdf is not regularly updated, it was more an experiment.

this (+deleting the file) will avoid confusion due to outdated doc.