### PR TITLE
refactor: fix bad smell "Non-Protected-Constructor-in-Abstract-Class"

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -81,7 +81,7 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 	@MetamodelPropertyField(role = {CtRole.TYPE_MEMBER, CtRole.FIELD, CtRole.CONSTRUCTOR, CtRole.ANNONYMOUS_EXECUTABLE, CtRole.METHOD, CtRole.NESTED_TYPE})
 	List<CtTypeMember> typeMembers = emptyList();
 
-	public CtTypeImpl() {
+	protected CtTypeImpl() {
 	}
 
 	@Override


### PR DESCRIPTION
# Changelog
The following bad smells are refactored:
## Non-Protected-Constructor-in-Abstract-Class
A non-protected constructor in an abstract class is not needed because only subclasses can be instantiated

## The following has changed in the code:
### Non-Protected-Constructor-in-Abstract-Class
- Constructor `spoon.support.reflect.declaration.CtTypeImpl()` is now protected instead of public
