### PR TITLE
review: test: Remove last traces of JUnit4 [cont]

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -59,13 +59,10 @@
             <version>4.6.1</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
-            <!-- must come after junit5 deps, otherwise it overrides the junit version -->
-            <!-- must be here in the parent POM, because the parent always comes last, see https://stackoverflow.com/questions/28999057/order-of-inherited-dependencies-in-maven-3 -->
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/spoon/support/compiler/jdt/JDTBatchCompilerTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/JDTBatchCompilerTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import java.io.File;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JDTBatchCompilerTest {
 

--- a/src/test/java/spoon/test/SpoonTestHelpers.java
+++ b/src/test/java/spoon/test/SpoonTestHelpers.java
@@ -40,7 +40,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static org.junit.Assume.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 public class SpoonTestHelpers {
 	// only static methods

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -16,9 +16,7 @@
  */
 package spoon.test.field;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static spoon.testing.utils.ModelUtils.buildClass;
 import static spoon.testing.utils.ModelUtils.createFactory;
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1095,7 +1095,7 @@ public class ImportTest {
 		String output = prettyPrinter.getResult();
 
 		assertThat("The file should contain a static import ", output, containsString("import static spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite;"));
-		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.addTest(suite());"));
+		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.add(suite());"));
 
 		canBeBuilt(outputDir, 7);
 	}
@@ -1124,7 +1124,7 @@ public class ImportTest {
 		String output = prettyPrinter.getResult();
 
 		assertThat("The file should not contain a static import ", output, not(containsString("import static")));
-		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.addTest(spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite());"));
+		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.add(spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite());"));
 
 		canBeBuilt(outputDir, 3);
 	}
@@ -1153,7 +1153,7 @@ public class ImportTest {
 		String output = prettyPrinter.getResult();
 
 		assertThat("The file should not contain a static import ", output, not(containsString("import static spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite.suite;")));
-		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.addTest(spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite.suite());"));
+		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.add(spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite.suite());"));
 
 		canBeBuilt(outputDir, 3);
 	}

--- a/src/test/java/spoon/test/model/IncrementalLauncherTest.java
+++ b/src/test/java/spoon/test/model/IncrementalLauncherTest.java
@@ -16,11 +16,7 @@
  */
 package spoon.test.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -263,7 +263,7 @@ public class DefaultPrettyPrinterTest {
 			+ "}";
 
 		String computed = aClass.getMethodsByName("setFieldUsingExternallyDefinedEnumWithSameNameAsLocal").get(0).toString();
-		assertEquals("We use FQN for E1", expected, computed);
+		assertEquals(expected, computed, "We use FQN for E1");
 
 		expected =
 			"public void setFieldUsingLocallyDefinedEnum() {" + nl
@@ -279,7 +279,7 @@ public class DefaultPrettyPrinterTest {
 			+ "}";
 
 		computed = aClass.getMethodsByName("setFieldOfClassWithSameNameAsTheCompilationUnitClass").get(0).toString();
-		assertEquals("The static field of an external type with the same identifier as the compilation unit is printed with FQN", expected, computed);
+		assertEquals(expected, computed, "The static field of an external type with the same identifier as the compilation unit is printed with FQN");
 
 		expected =
 			"public void referToTwoInnerClassesWithTheSameName() {" + nl
@@ -290,7 +290,7 @@ public class DefaultPrettyPrinterTest {
 		//Ensure the ClassA of Class0 takes precedence over an import statement for ClassA in Class1, and its identifier can be the short version.
 
 		computed = aClass.getMethodsByName("referToTwoInnerClassesWithTheSameName").get(0).prettyprint();
-		assertEquals("where inner types have the same identifier only one may be shortened and the other should be fully qualified", expected, computed);
+		assertEquals(expected, computed, "where inner types have the same identifier only one may be shortened and the other should be fully qualified");
 
 		expected =
 			"public enum ENUM {" + nl + nl
@@ -318,7 +318,7 @@ public class DefaultPrettyPrinterTest {
 			"public java.util.List<?> aMethod() {" + nl
 			+ "    return new java.util.ArrayList<>();" + nl
 			+ "}";
-		assertEquals("the toString method of CtElementImpl should not shorten type names as it has no context or import statements", expected, computed);
+		assertEquals(expected, computed, "the toString method of CtElementImpl should not shorten type names as it has no context or import statements");
 	}
 
 	@Test

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -79,10 +79,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static spoon.testing.utils.ModelUtils.build;
 
 public class DefaultPrettyPrinterTest {

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -132,7 +132,7 @@ public class PrinterTest {
 
 		assertTrue(!result.contains("import static spoon.test.prettyprinter.testclasses.sub.Constants.READY"), "The result should not contain import static: ");
 		assertTrue(result.contains("import spoon.test.prettyprinter.testclasses.sub.Constants"), "The result should contain import type: ");
-		assertTrue(result.contains("import static org.junit.Assert.assertTrue;"), "The result should contain import static assertTrue: ");
+		assertTrue(result.contains("import static org.junit.jupiter.api.Assertions.assertTrue;"), "The result should contain import static assertTrue: ");
 		assertTrue(result.contains("assertTrue(\"blabla\".equals(\"toto\"));"), "The result should contain assertTrue(...): ");
 		assertTrue(result.contains("System.out.println(Constants.READY);"), "The result should use System.out.println(Constants.READY): " + result);
 	}

--- a/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/ImportStatic.java
@@ -2,7 +2,7 @@ package spoon.test.prettyprinter.testclasses;
 
 import spoon.test.prettyprinter.testclasses.sub.Constants;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import static java.lang.System.out;
 

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -370,7 +370,7 @@ public class VariableReferencesTest {
 		CtClass<?> clazz = factory.Class().get(VariableReferencesFromStaticMethod.class);
 		CtMethod staticMethod = clazz.getMethodsByName("staticMethod").get(0);
 		CtStatement stmt = staticMethod.getBody().getStatements().get(1);
-		assertEquals("org.junit.Assert.assertTrue(field == 2)", stmt.toString());
+		assertEquals("org.junit.jupiter.api.Assertions.assertTrue(field == 2)", stmt.toString());
 		CtLocalVariableReference varRef = stmt.filterChildren(new TypeFilter<>(CtLocalVariableReference.class)).first();
 		List<CtVariable> vars = varRef.map(new PotentialVariableDeclarationFunction()).list();
 		assertEquals(1, vars.size(), "Found unexpected variable declaration.");

--- a/src/test/java/spoon/test/query_function/testclasses/VariableReferencesFromStaticMethod.java
+++ b/src/test/java/spoon/test/query_function/testclasses/VariableReferencesFromStaticMethod.java
@@ -1,6 +1,6 @@
 package spoon.test.query_function.testclasses;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VariableReferencesFromStaticMethod {
 	int field = 1;

--- a/src/test/java/spoon/test/refactoring/testclasses/CtRenameLocalVariableRefactoringTestSubject.java
+++ b/src/test/java/spoon/test/refactoring/testclasses/CtRenameLocalVariableRefactoringTestSubject.java
@@ -6,7 +6,7 @@ import java.lang.reflect.Modifier;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CtRenameLocalVariableRefactoringTestSubject
 {

--- a/src/test/java/spoon/test/statementComment/StatementCommentTest.java
+++ b/src/test/java/spoon/test/statementComment/StatementCommentTest.java
@@ -39,9 +39,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.support.reflect.code.CtCatchImpl;
 import spoon.testing.utils.LineSeperatorExtension;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class StatementCommentTest {
 	String EOL = "\n";

--- a/src/test/java/spoon/test/variable/VariableTest.java
+++ b/src/test/java/spoon/test/variable/VariableTest.java
@@ -33,9 +33,7 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VariableTest {
 

--- a/src/test/resources/imports/StaticNoOrdered.java
+++ b/src/test/resources/imports/StaticNoOrdered.java
@@ -3,8 +3,7 @@ package spoon.test.imports.testclasses;
 import java.lang.annotation.Annotation;
 import java.nio.charset.Charset;
 
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 import static java.nio.charset.Charset.forName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -18,22 +17,7 @@ public class StaticNoOrdered {
         assertEquals("bla","truc");
         assertEquals(7,12);
         assertEquals(new String[0],new String[0]);
-        Test test = new Test() {
-            @Override
-            public Class<? extends Annotation> annotationType() {
-                return null;
-            }
-
-            @Override
-            public Class<? extends Throwable> expected() {
-                return null;
-            }
-
-            @Override
-            public long timeout() {
-                return 0;
-            }
-        };
+        Annotation test = (Test) null;
     }
 
     public void anotherStaticImoport() {

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/LangTestSuite.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/LangTestSuite.java
@@ -1,13 +1,10 @@
 package spoon.test.imports.testclasses2.apachetestsuite;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-
 /**
  * Created by urli on 22/06/2017.
  */
-public class LangTestSuite extends TestCase {
-    public static Test suite() {
+public class LangTestSuite {
+    public static Object suite() {
         return null;
     }
 }

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/enum2/EnumTestSuite.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/enum2/EnumTestSuite.java
@@ -1,13 +1,10 @@
 package spoon.test.imports.testclasses2.apachetestsuite.enum2;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-
 /**
  * Created by urli on 22/06/2017.
  */
-public class EnumTestSuite extends TestCase {
-    public static Test suite() {
+public class EnumTestSuite {
+    public static Object suite() {
         return null;
     }
 }

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/enums/EnumTestSuite.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/enums/EnumTestSuite.java
@@ -1,13 +1,10 @@
 package spoon.test.imports.testclasses2.apachetestsuite.enums;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-
 /**
  * Created by urli on 22/06/2017.
  */
-public class EnumTestSuite extends TestCase {
-    public static Test suite() {
+public class EnumTestSuite {
+    public static Object suite() {
         return null;
     }
 }

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticcollision/AllLangTestSuite.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticcollision/AllLangTestSuite.java
@@ -20,10 +20,8 @@ package spoon.test.imports.testclasses2.apachetestsuite.staticcollision;
  * limitations under the License.
  */
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.textui.TestRunner;
+import java.util.ArrayList;
+import java.util.List;
 
 import spoon.test.imports.testclasses2.apachetestsuite.LangTestSuite;
 import spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite;
@@ -34,31 +32,28 @@ import spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite;
  * @author Stephen Colebourne
  * @version $Id$
  */
-public class AllLangTestSuite extends TestCase {
+public class AllLangTestSuite {
 
     /**
      * Construct a new instance.
      */
     public AllLangTestSuite(String name) {
-        super(name);
     }
 
     /**
      * Command-line interface.
      */
     public static void main(String[] args) {
-        TestRunner.run(suite());
     }
 
     /**
      * Get the suite of tests
      */
-    public static Test suite() {
-        TestSuite suite = new TestSuite();
-        suite.setName("Commons-Lang (all) Tests");
-        suite.addTest(LangTestSuite.suite());
-        suite.addTest(EnumTestSuite.suite());
-        suite.addTest(spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite.suite());
+    public static Object suite() {
+        List suite = new ArrayList();
+        suite.add(LangTestSuite.suite());
+        suite.add(EnumTestSuite.suite());
+        suite.add(spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite.suite());
         return suite;
     }
 }

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticjava3/AllLangTestJava3.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticjava3/AllLangTestJava3.java
@@ -20,10 +20,9 @@ package spoon.test.imports.testclasses2.apachetestsuite.staticjava3;
  * limitations under the License.
  */
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.textui.TestRunner;
+import java.util.List;
+import java.util.ArrayList;
+
 import spoon.test.imports.testclasses2.apachetestsuite.LangTestSuite;
 import spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite;
 
@@ -33,31 +32,28 @@ import spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite;
  * @author Stephen Colebourne
  * @version $Id$
  */
-public class AllLangTestJava3 extends TestCase {
+public class AllLangTestJava3 {
 
     /**
      * Construct a new instance.
      */
     public AllLangTestJava3(String name) {
-        super(name);
     }
 
     /**
      * Command-line interface.
      */
     public static void main(String[] args) {
-        TestRunner.run(truc());
     }
 
     /**
      * Get the suite of tests
      */
-    public static Test truc() {
-        TestSuite suite = new TestSuite();
-        suite.setName("Commons-Lang (all) Tests");
-        suite.addTest(LangTestSuite.suite());
-        suite.addTest(EnumTestSuite.suite());
-        suite.addTest(spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite());
+    public static List truc() {
+        List suite = new ArrayList();
+        suite.add(LangTestSuite.suite());
+        suite.add(EnumTestSuite.suite());
+        suite.add(spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite());
         return suite;
     }
 }

--- a/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticmethod/AllLangTestSuiteStaticMethod.java
+++ b/src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/staticmethod/AllLangTestSuiteStaticMethod.java
@@ -20,12 +20,11 @@ package spoon.test.imports.testclasses2.apachetestsuite.staticmethod;
  * limitations under the License.
  */
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
-import junit.textui.TestRunner;
 import spoon.test.imports.testclasses2.apachetestsuite.LangTestSuite;
 import spoon.test.imports.testclasses2.apachetestsuite.enum2.EnumTestSuite;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite;
 /**
@@ -34,31 +33,28 @@ import static spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuit
  * @author Stephen Colebourne
  * @version $Id$
  */
-public class AllLangTestSuiteStaticMethod extends TestCase {
+public class AllLangTestSuiteStaticMethod {
 
     /**
      * Construct a new instance.
      */
     public AllLangTestSuiteStaticMethod(String name) {
-        super(name);
     }
 
     /**
      * Command-line interface.
      */
     public static void main(String[] args) {
-        TestRunner.run(truc());
     }
 
     /**
      * Get the suite of tests
      */
-    public static Test truc() {
-        TestSuite suite = new TestSuite();
-        suite.setName("Commons-Lang (all) Tests");
-        suite.addTest(LangTestSuite.suite());
-        suite.addTest(EnumTestSuite.suite());
-        suite.addTest(suite());
+    public static List truc() {
+        List suite = new ArrayList();
+        suite.add(LangTestSuite.suite());
+        suite.add(EnumTestSuite.suite());
+        suite.add(suite());
         return suite;
     }
 }


### PR DESCRIPTION
You can go ahead and absorb the patches into #4792 and close this, if you want @slarse.

I believe they do not change semantics, but that is honestly a bit hard to tell. I built spoon 5.7.0 in a docker container (*roughly*)
```Dockerfile
FROM openjdk:8
RUN apt update && apt install maven vim -y

RUN git clone https://github.com/surli/spoon.git
WORKDIR /spoon
RUN git checkout 9b38f48bf72c4a911029985c012f9b067c40a649

RUN sed -i 's/<version>1.4/2.0/' pom.xml # replace commons-io with 2.0 which is java 7 compatible
                                         # system-rules pulls in [2.0;, causing problems

RUN mvn test
```

to understand the intent of the tests and I *believe* it is okay, but I am not fully certain.