### PR TITLE
perf: Don't clone method body when adapting it for isOverriding

### DIFF
--- a/src/main/java/spoon/support/adaption/TypeAdaptor.java
+++ b/src/main/java/spoon/support/adaption/TypeAdaptor.java
@@ -9,6 +9,7 @@ package spoon.support.adaption;
 
 import spoon.SpoonException;
 import spoon.processing.FactoryAccessor;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtExecutable;
@@ -403,8 +404,12 @@ public class TypeAdaptor {
 			return false;
 		}
 
+		// We don't need to clone the body here, so leave it out
+		CtBlock<?> superBody = superMethod.getBody();
+		superMethod.setBody(null);
 		CtMethod<?> adapted = new TypeAdaptor(subMethod.getDeclaringType())
 			.adaptMethod(superMethod);
+		superMethod.setBody(superBody);
 
 		for (int i = 0; i < subMethod.getParameters().size(); i++) {
 			CtParameter<?> subParam = subMethod.getParameters().get(i);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -45,6 +45,7 @@ import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.adaption.TypeAdaptor;
 import spoon.support.modelobs.ChangeCollector;
 import spoon.support.modelobs.SourceFragmentCreator;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
@@ -835,6 +836,25 @@ public class TestSniperPrinter {
 				assertThat(result, containsString("private static final java.lang.Integer x;"));
 
 		testSniper("sniperPrinter.SpaceAfterFinal", modifyField, assertContainsSpaceAfterFinal);
+	}
+
+	@Test
+	void typeAdaptionBodyResetDoesNotBreakSniper() {
+		// contract: Resetting the body in the type adaption does not impact the sniper printer.
+		testSniper(
+			"sniperPrinter.Overriding",
+			type -> {
+				CtType<?> top = type.getNestedType("Super");
+				CtType<?> bottom = type.getNestedType("Sub");
+
+				CtMethod<?> topFoo = top.getMethodsByName("foo").get(0);
+				CtMethod<?> bottomFoo = bottom.getMethodsByName("foo").get(0);
+
+				assertTrue(new TypeAdaptor(bottom).isOverriding(bottomFoo, topFoo));
+			},
+			// Did not reformat body
+			(type, result) -> assertThat(result, containsString("System. out. println(1+2\n"))
+		);
 	}
 
 	@Nested

--- a/src/test/resources/sniperPrinter/Overriding.java
+++ b/src/test/resources/sniperPrinter/Overriding.java
@@ -1,0 +1,16 @@
+package sniperPrinter;
+
+public class Overriding {
+	public static class Super {
+		void foo() {
+			System. out. println(1+2
+			);
+		}
+	}
+
+	public static class Sub extends Super {
+		@Override
+		void foo() {
+		}
+	}
+}


### PR DESCRIPTION
Cloning is quite slow and method bodies can be large - this results in the `isOverriding` check taking quite a bit longer than needed.

Removing the type adaption is not possible as the javadoc explains: If we do not adapt the method, we have no `CtTypeParameter` declaration lying around our references can attach to. This results in `getTypeErasure()` potentially entering an infinite recursion.

There are some more gains to be had if one really wants to, but I currently don't see the need. This one is quite unobtrusive and doesn't really make the code more confusing.

### Side effects
This creates an unnecessary change event for the Sniper printer (body changed), but it seems to ignore that and properly print it anyways.