### PR TITLE
style: fix bad smells in spoon.reflect.factory.PackageFactory

### DIFF
--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -102,7 +102,7 @@ public class PackageFactory extends SubFactory {
 		if (parent == null) {
 			return getOrCreate(simpleName);
 		} else {
-			return getOrCreate(parent.toString() + CtPackage.PACKAGE_SEPARATOR + simpleName);
+			return getOrCreate(parent + CtPackage.PACKAGE_SEPARATOR + simpleName);
 		}
 	}
 


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion.
## Changes: 
Unnecessary `toString()` call
in `spoon.reflect.factory.PackageFactory`