### PR TITLE
Revert "chore(deps): update dependency org.apache.maven.plugins:maven-checkstyle-plugin to v3.2.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.1.2</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <consoleOutput>true</consoleOutput>

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-decompiler/pom.xml
+++ b/spoon-decompiler/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-		        <version>3.2.0</version>
+		        <version>3.1.2</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.1.2</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>


### PR DESCRIPTION
Reverts INRIA/spoon#4859

Apparently this did not play well with the javadoc style script.