### PR TITLE
review: chore: Fix javadoc regression script with newer checkstyle version

### DIFF
--- a/chore/check-javadoc-regressions.py
+++ b/chore/check-javadoc-regressions.py
@@ -58,6 +58,21 @@ def hl(text: str) -> str:
     return colored(text, _COLOR_HIGHLIGHT)
 
 
+def print_checkstyle_not_parseable_error():
+    """
+    If the user has a maven problem that prevents checkstyle from running they'd likely
+    appreciate *some* output. If we can't extract a violation count the checkstyle plugin
+    probably didn't run successfully. Let's warn them.
+    """
+    print()
+    print(warn("Checkstyle output doesn't contain a violation count. Maybe your setup has an error?"))
+    if len(sys.argv) > 1:
+        print(
+            f" {hl('Suggestion')}: Run this script without arguments and inspect the unfiltered "
+            "checkstyle output"
+        )
+
+
 def write_checkstyle_config(path: Path) -> None:
     """
     Saves the Javadoc checkstyle config in the given path.
@@ -197,9 +212,11 @@ def handle_compare_with_branch_output(target_branch: str, reference_output: str,
 
     if reference_violation_count is None:
         print(warn("The Checkstyle run for the reference branch did not yield any result."))
+        print_checkstyle_not_parseable_error()
         exit(1)
     if other_violation_count is None:
         print(warn("The Checkstyle run for your branch did not yield any result."))
+        print_checkstyle_not_parseable_error()
         exit(1)
 
     print_current_status(target_branch, reference_violation_count, other_violation_count)
@@ -244,17 +261,8 @@ def command_filtered_checkstyle_errors(regex_str: str) -> None:
             if regex.search(line):
                 print(line)
 
-        # If the user has a maven problem that prevents checkstyle from running they'd likely
-        # appreciate *some* output. If we can't extract a violation count the checkstyle plugin
-        # probably didn't successfully. Let's warn them.
         if extract_violation_count(checkstyle_output) is None:
-            print()
-            print(warn("Checkstyle output doesn't contain a violation count. Maybe your setup has an error?"))
-            if len(sys.argv) > 1:
-                print(
-                    f" {hl('Suggestion')}: Run this script without arguments and inspect the unfiltered "
-                    "checkstyle output"
-                )
+            print_checkstyle_not_parseable_error()
 
 
 def fix_colors_windows_cmd():

--- a/chore/check-javadoc-regressions.py
+++ b/chore/check-javadoc-regressions.py
@@ -68,7 +68,7 @@ def write_checkstyle_config(path: Path) -> None:
     <module name="Checker">
         <module name="TreeWalker">
             <module name="JavadocMethod">
-                <property name="scope" value="public"/>
+                <property name="accessModifiers" value="public"/>
             </module>
             <module name="MissingJavadocMethod">
                 <property name="scope" value="public"/>

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.0</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <consoleOutput>true</consoleOutput>

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-decompiler/pom.xml
+++ b/spoon-decompiler/pom.xml
@@ -83,7 +83,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-		        <version>3.1.2</version>
+		        <version>3.2.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>


### PR DESCRIPTION
It seems like I added a nicer error message (as you can see in the screenshot) but did not print it for comparison failures. Judging by slarse opening an issue, this indeed was the case and I still failed :P
```py
# If the user has a maven problem that prevents checkstyle from running they'd likely
# appreciate *some* output
```

Following that suggestion, the error message was
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.2.0:check (default-cli) on project spoon-core: Failed during checkstyle configuration: cannot initialize module TreeWalker - cannot initialize module JavadocMethod - Property 'scope' does not exist, please check the documentation -> [Help 1]
```

---

Note that the CI status will not be significant as it runs with the version on master. Also note that running `COMPARE_WITH_MASTER` will *fail* on this PR, as the master state was reverted and uses the older checkstyle version, breaking the check:
<img width="654" alt="grafik" src="https://user-images.githubusercontent.com/20284688/187080626-024a7a5e-5c5d-428c-9b0d-d922648b7fa3.png">

Closes #4869