### PR TITLE
fix: fix top definitions filtering

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The implementation for {@link spoon.reflect.declaration.CtMethod}.
@@ -223,20 +224,18 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		});
 
 		// now removing the intermediate methods for which there exists a definition upper in the hierarchy
-		List<CtMethod<?>> finalMeths = new ArrayList<>();
-		for (CtMethod<?> method : s) {
-			boolean methodIsTop = true;
-			for (CtMethod<?> probablyTop : s) {
-				if (method != probablyTop && context.isOverriding(method, probablyTop)) {
-					methodIsTop = false;
-					break;
-				}
-			}
-			if (methodIsTop) {
-				finalMeths.add(method);
-			}
-		}
-		return finalMeths;
+		return s.stream()
+				.filter(ctMethod ->  isTopDefinition(ctMethod, s, context))
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Returns {@code true} if the {@code method} parameter is a top definition,
+	 * i.e. no other candidate is overridden by it.
+	 */
+	private boolean isTopDefinition(CtMethod<?> method, Collection<CtMethod<?>> allCandidates, TypeAdaptor context) {
+		return allCandidates.stream()
+				.noneMatch(candidate -> candidate != method && context.isOverriding(method, candidate));
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -231,7 +231,7 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 
 	/**
 	 * Returns {@code true} if the {@code method} parameter is a top definition,
-	 * i.e. no other candidate is overridden by it.
+	 * i.e. no other candidate overrides it.
 	 */
 	private boolean isTopDefinition(CtMethod<?> method, Collection<CtMethod<?>> allCandidates, TypeAdaptor context) {
 		return allCandidates.stream()

--- a/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtMethodImpl.java
@@ -223,16 +223,17 @@ public class CtMethodImpl<T> extends CtExecutableImpl<T> implements CtMethod<T> 
 		});
 
 		// now removing the intermediate methods for which there exists a definition upper in the hierarchy
-		List<CtMethod<?>> finalMeths = new ArrayList<>(s);
-		for (CtMethod m1 : s) {
-			boolean m1IsIntermediate = false;
-			for (CtMethod m2 : s) {
-				if (context.isOverriding(m1, m2)) {
-					m1IsIntermediate = true;
+		List<CtMethod<?>> finalMeths = new ArrayList<>();
+		for (CtMethod<?> method : s) {
+			boolean methodIsTop = true;
+			for (CtMethod<?> probablyTop : s) {
+				if (method != probablyTop && context.isOverriding(method, probablyTop)) {
+					methodIsTop = false;
+					break;
 				}
 			}
-			if (!m1IsIntermediate) {
-				finalMeths.add(m1);
+			if (methodIsTop) {
+				finalMeths.add(method);
 			}
 		}
 		return finalMeths;

--- a/src/test/java/spoon/test/filters/FilterTest.java
+++ b/src/test/java/spoon/test/filters/FilterTest.java
@@ -459,9 +459,8 @@ public class FilterTest {
 		List<CtMethod<?>> methods;
 
 		methods = orderByName(aTostada.getMethodsByName("make").get(0).getTopDefinitions());
-		assertEquals(2, methods.size());
-		assertEquals("AbstractTostada", methods.get(0).getDeclaringType().getSimpleName());
-		assertEquals("ITostada", methods.get(1).getDeclaringType().getSimpleName());
+		assertEquals(1, methods.size());
+		assertEquals("ITostada", methods.get(0).getDeclaringType().getSimpleName());
 
 		methods = orderByName(aTostada.getMethodsByName("prepare").get(0).getTopDefinitions());
 		assertEquals(1, methods.size());

--- a/src/test/java/spoon/test/method/testclasses/Hierarchy.java
+++ b/src/test/java/spoon/test/method/testclasses/Hierarchy.java
@@ -1,0 +1,19 @@
+package spoon.test.method.testclasses;
+
+public class Hierarchy {
+	interface A1 {
+		void m();
+	}
+	interface A2 {
+		void m();
+	}
+	interface B extends A1 {
+		void m();
+	}
+	interface C extends B, A1 {
+		void m();
+	}
+	public interface D extends C, A2 {
+		void m();
+	}
+}


### PR DESCRIPTION
With multiple independent interfaces declaring the same method, `getTopDefinitions()` returned wrong results.

The filtering was broken due to `TypeAdaptor#isOverriding(m, m) == true` *and* the wrong initialization of the method (as all methods were already added to the result).