### PR TITLE
fix: print square brackets for manually created array references

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java
@@ -25,6 +25,7 @@ public class CtArrayTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> implemen
 	CtTypeReference<?> componentType;
 
 	public CtArrayTypeReferenceImpl() {
+		setDeclarationKind(DeclarationKind.TYPE);
 	}
 
 	@Override

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -260,7 +260,7 @@ public class DefaultJavaPrettyPrinterTest {
 
     @Nested
     class SquareBracketsForArrayInitialization_ArrayIsBuiltUsingFactoryMethods {
-        @GitHubIssue(issueNumber = 4887, fixed = false)
+        @GitHubIssue(issueNumber = 4887, fixed = true)
         @Test
         void bracketsShouldBeAttachedToTypeByDefault() {
             // contract: the square brackets should be attached to type by default when array is built using factory methods

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -261,7 +261,6 @@ public class DefaultJavaPrettyPrinterTest {
     @Nested
     class SquareBracketsForArrayInitialization_ArrayIsBuiltUsingFactoryMethods {
         @GitHubIssue(issueNumber = 4887, fixed = true)
-        @Test
         void bracketsShouldBeAttachedToTypeByDefault() {
             // contract: the square brackets should be attached to type by default when array is built using factory methods
             // arrange


### PR DESCRIPTION
Fixes #4887 

The changes modify the constructor of `CtArrayTypeReferenceImpl` to set the declaration style as [`TYPE`](https://github.com/INRIA/spoon/blob/43a5b9a6983a808948ae490dceb02fbe83c3b505/src/main/java/spoon/support/reflect/reference/CtArrayTypeReferenceImpl.java#L135) by default.