### PR TITLE
test: Introduce a custom temp dir to work around windows file locking

### DIFF
--- a/src/test/java/spoon/MavenLauncherTest.java
+++ b/src/test/java/spoon/MavenLauncherTest.java
@@ -30,7 +30,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import spoon.compiler.SpoonResource;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.reference.CtTypeReference;
@@ -43,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.test.TemporaryDirectoryExecutionListener.TEMPDIR;
 
 public class MavenLauncherTest {
 
@@ -70,8 +70,8 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void spoonMavenLauncherTest(@TempDir Path tempDir) throws IOException {
-		String targetPathString = copyResourceToFolder(tempDir, ".");
+	public void spoonMavenLauncherTest() throws IOException {
+		String targetPathString = copyResourceToFolder(TEMPDIR, ".");
 		Path targetPath = Path.of(targetPathString);
 
 		// without the tests
@@ -140,9 +140,9 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void multiModulesProjectTest(@TempDir Path tempDir) throws IOException {
+	public void multiModulesProjectTest() throws IOException {
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/pac4j"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/pac4j"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		assertEquals(8, launcher.getEnvironment().getComplianceLevel());
@@ -151,32 +151,32 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void mavenLauncherOnANotExistingFileTest(@TempDir Path tempDir) {
+	public void mavenLauncherOnANotExistingFileTest() {
 		assertThrows(
 			SpoonException.class,
 			() -> new MavenLauncher(
-				tempDir.resolve("pom.xml").toAbsolutePath().toString(),
+				TEMPDIR.resolve("pom.xml").toAbsolutePath().toString(),
 				MavenLauncher.SOURCE_TYPE.APP_SOURCE
 			)
 		);
 	}
 
 	@Test
-	public void mavenLauncherOnDirectoryWithoutPomTest(@TempDir Path tempDir) {
+	public void mavenLauncherOnDirectoryWithoutPomTest() {
 		assertThrows(
 			SpoonException.class,
 			() -> new MavenLauncher(
-				tempDir.toAbsolutePath().toString(),
+				TEMPDIR.toAbsolutePath().toString(),
 				MavenLauncher.SOURCE_TYPE.APP_SOURCE
 			)
 		);
 	}
 
 	@Test
-	public void testSystemDependency(@TempDir Path tempDir) throws IOException {
+	public void testSystemDependency() throws IOException {
 		//contract: scope dependencies are added to classpath
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/system-dependency"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		assertEquals(1, launcher.getEnvironment().getSourceClasspath().length);
@@ -184,8 +184,8 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void testForceRefresh(@TempDir Path tempDir) throws IOException {
-		String targetPath = copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency");
+	public void testForceRefresh() throws IOException {
+		String targetPath = copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/system-dependency");
 
 		// ensure classpath file exists so first constructor invocation won't build classpath
 		Files.writeString(Path.of(targetPath).resolve("spoon.classpath.tmp"), "");
@@ -207,8 +207,8 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void testRebuildClasspath(@TempDir Path tempDir) throws IOException {
-		String targetPath = copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/system-dependency");
+	public void testRebuildClasspath() throws IOException {
+		String targetPath = copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/system-dependency");
 
 		// ensure classpath file exists so first constructor invocation won't build classpath
 		Files.writeString(Path.of(targetPath).resolve("spoon.classpath.tmp"), "");
@@ -226,28 +226,28 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	public void mavenLauncherTestWithVerySimpleProject(@TempDir Path tempDir) throws IOException {
+	public void mavenLauncherTestWithVerySimpleProject() throws IOException {
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/very-simple"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/very-simple"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		assertEquals(1, launcher.getModelBuilder().getInputSources().size());
 	}
 
 	@Test
-	public void testPomSourceDirectory(@TempDir Path tempDir) throws IOException {
+	public void testPomSourceDirectory() throws IOException {
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/source-directory"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/source-directory"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		assertEquals(2, launcher.getModelBuilder().getInputSources().size());
 	}
 
 	@Test
-	public void mavenLauncherTestMultiModulesAndVariables(@TempDir Path tempDir) throws IOException {
+	public void mavenLauncherTestMultiModulesAndVariables() throws IOException {
 		// contract: variables coming from parent should be resolved
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/pac4j/pac4j-config"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/pac4j/pac4j-config"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		List<String> classpath = Arrays.asList(launcher.getEnvironment().getSourceClasspath());
@@ -275,9 +275,9 @@ public class MavenLauncherTest {
 	}
 
 	@Test
-	void mavenLauncherPassesEnvironmentVariables(@TempDir Path tempDir) throws IOException {
+	void mavenLauncherPassesEnvironmentVariables() throws IOException {
 		MavenLauncher launcher = new MavenLauncher(
-			copyResourceToFolder(tempDir, "./src/test/resources/maven-launcher/with-environment-variables"),
+			copyResourceToFolder(TEMPDIR, "./src/test/resources/maven-launcher/with-environment-variables"),
 			MavenLauncher.SOURCE_TYPE.ALL_SOURCE
 		);
 		launcher.setEnvironmentVariable("SPOON_VERSION", "10.1.0");

--- a/src/test/java/spoon/test/TemporaryDirectoryExecutionListener.java
+++ b/src/test/java/spoon/test/TemporaryDirectoryExecutionListener.java
@@ -19,6 +19,7 @@ package spoon.test;
 import org.apache.commons.io.FileUtils;
 import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
+import org.kohsuke.MetaInfServices;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,6 +30,7 @@ import java.nio.file.Path;
  * An execution listener maintaining a temporary directory tests can use. This is intended as an alternative to
  * Junit's {@link org.junit.jupiter.api.io.TempDir} but handles file locking a bit more leniently.
  */
+@MetaInfServices(TestExecutionListener.class)
 public class TemporaryDirectoryExecutionListener implements TestExecutionListener {
 
 	public static final Path TEMPDIR = Path.of("spooned");

--- a/src/test/java/spoon/test/TemporaryDirectoryExecutionListener.java
+++ b/src/test/java/spoon/test/TemporaryDirectoryExecutionListener.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2006-2018 INRIA and contributors
+ * Spoon - http://spoon.gforge.inria.fr/
+ *
+ * This software is governed by the CeCILL-C License under French law and
+ * abiding by the rules of distribution of free software. You can use, modify
+ * and/or redistribute the software under the terms of the CeCILL-C license as
+ * circulated by CEA, CNRS and INRIA at http://www.cecill.info.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the CeCILL-C License for more details.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+package spoon.test;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * An execution listener maintaining a temporary directory tests can use. This is intended as an alternative to
+ * Junit's {@link org.junit.jupiter.api.io.TempDir} but handles file locking a bit more leniently.
+ */
+public class TemporaryDirectoryExecutionListener implements TestExecutionListener {
+
+	public static final Path TEMPDIR = Path.of("spooned");
+
+	@Override
+	public void executionStarted(TestIdentifier testIdentifier) {
+		try {
+			if (Files.exists(TEMPDIR)) {
+				tryDelete(3);
+			}
+			Files.createDirectory(TEMPDIR);
+		} catch (IOException e) {
+			// Not much we can do. Let it bubble up and get logged.
+			throw new UncheckedIOException(e);
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Tries to delete a folder and retries after a delay on failure.
+	 * <p>
+	 * This might be needed on Windows, where recently exited processes might still hold file locks that prevent
+	 * deletion. See <a href="https://github.com/INRIA/spoon/issues/4877">#4877</a> for more information.
+	 *
+	 * @param allowedFailures the number of times deletion may fail before giving up
+	 * @throws IOException if deletion was not possible {@code allowedFailures} times in row
+	 * @throws InterruptedException if the current thread is interrupted while waiting between deletion retries
+	 */
+	private void tryDelete(int allowedFailures) throws IOException, InterruptedException {
+		try {
+			FileUtils.deleteDirectory(TEMPDIR.toFile());
+		} catch (IOException e) {
+			if (allowedFailures > 0) {
+				Thread.sleep(1000);
+				tryDelete(allowedFailures - 1);
+			} else {
+				throw e;
+			}
+		}
+	}
+
+}

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+spoon.test.TemporaryDirectoryExecutionListener

--- a/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,1 +1,0 @@
-spoon.test.TemporaryDirectoryExecutionListener


### PR DESCRIPTION
Adds a test execution listener that maintains a `spooned` temporary directory. This is intended as a replacement to the normal Junit `@TempDir`, which fails to clean up files due to file locking on Windows.

### Cons
- The temporary folder will be created before *every test*, which doesn't sound pleasant. Maybe we should only delete it if it actually contains files?

### Further steps
We need to update every test using `@TempDir` or `"spooned"` directly to use it. This could be directly done in this PR.

Closes #4877.