### PR TITLE
style: fix Bad Smells in spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -104,7 +104,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 				//visit each CtField of `parent` CtType
 				CtQuery q = parent.map(new AllTypeMembersFunction(CtField.class));
 				q.forEach((CtField<?> field) -> {
-					if (isInStaticScope && !field.hasModifier(ModifierKind.STATIC) ) {
+					if (isInStaticScope && !field.hasModifier(ModifierKind.STATIC)) {
 						/*
 						 * the variable reference is used in static scope,
 						 * but the field is not static - ignore it

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -104,7 +104,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 				//visit each CtField of `parent` CtType
 				CtQuery q = parent.map(new AllTypeMembersFunction(CtField.class));
 				q.forEach((CtField<?> field) -> {
-					if (isInStaticScope && field.hasModifier(ModifierKind.STATIC) == false) {
+					if (isInStaticScope && !field.hasModifier(ModifierKind.STATIC) ) {
 						/*
 						 * the variable reference is used in static scope,
 						 * but the field is not static - ignore it


### PR DESCRIPTION
# Repairing Code Style Issues
## PointlessBooleanExpression
Boolean expressions shouldn't be overcomplex. 
## Changes: 
* Replaced `field.hasModifier(ModifierKind.STATIC) == false` with `!field.hasModifier(ModifierKind.STATIC)`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java"
position:
  startLine: 107
  endLine: 0
  startColumn: 29
  endColumn: 0
  charOffset: 4446
  charLength: 47
message: "'field.hasModifier(ModifierKind.STATIC) == false' can be simplified to '!field.hasModifier(ModifierKind.STATIC)'"
messageMarkdown: "`field.hasModifier(ModifierKind.STATIC) == false` can be simplified\
  \ to '!field.hasModifier(ModifierKind.STATIC)'"
snippet: "\t\t\t\tCtQuery q = parent.map(new AllTypeMembersFunction(CtField.class));\n\
  \t\t\t\tq.forEach((CtField<?> field) -> {\n\t\t\t\t\tif (isInStaticScope && field.hasModifier(ModifierKind.STATIC)\
  \ == false) {\n\t\t\t\t\t\t/*\n\t\t\t\t\t\t * the variable reference is used in\
  \ static scope,"
analyzer: "Qodana"
 -->
<!-- fingerprint:-388500741 -->
