### PR TITLE
style: fix Bad Smells in spoon.support.visitor.MethodTypingContext

### DIFF
--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -61,7 +61,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 			}
 			if (classTypingContext.getAdaptationScope() != declType) {
 				//the method is declared in different type. We have to adapt it to required classTypingContext
-				if (classTypingContext.isSubtypeOf(declType.getReference()) == false) {
+				if (!classTypingContext.isSubtypeOf(declType.getReference())) {
 					throw new SpoonException("Cannot create MethodTypingContext for method declared in different ClassTypingContext");
 				}
 				/*
@@ -180,11 +180,11 @@ public class MethodTypingContext extends AbstractTypingContext {
 		}
 		//only method to method or constructor to constructor can be adapted
 		if (typeParamDeclarer instanceof CtMethod<?>) {
-			if ((scopeMethod instanceof CtMethod<?>) == false) {
+			if (!(scopeMethod instanceof CtMethod)) {
 				return null;
 			}
 		} else if (typeParamDeclarer instanceof CtConstructor<?>) {
-			if ((scopeMethod instanceof CtConstructor<?>) == false) {
+			if (!(scopeMethod instanceof CtConstructor)) {
 				return null;
 			}
 		} else {
@@ -198,7 +198,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 		 * 2) Where A1, ..., An are the type parameters of M and B1, ..., Bn are the type parameters of N, let T=[B1:=A1, ..., Bn:=An].
 		 * Then, for all i (1 ≤ i ≤ n), the bound of Ai is the same type as T applied to the bound of Bi.
 		 */
-		if (hasSameMethodFormalTypeParameters(typeParamDeclarer) == false) {
+		if (!hasSameMethodFormalTypeParameters(typeParamDeclarer)) {
 			//the methods formal type parameters are different. We cannot adapt such parameters
 			return null;
 		}
@@ -232,7 +232,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 			//the methods has same count of formal parameters
 			//check that bounds of formal type parameters are same after adapting
 			for (int i = 0; i < thisTypeParameters.size(); i++) {
-				if (isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i)) == false) {
+				if (!isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i))) {
 					return false;
 				}
 			}


### PR DESCRIPTION
# Repairing Code Style Issues
## PointlessBooleanExpression
Boolean expressions shouldn't be overcomplex. 
## Changes: 
* Replaced `isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i)) == false` with `!isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i))`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/MethodTypingContext.java"
position:
  startLine: 235
  endLine: 0
  startColumn: 9
  endColumn: 0
  charOffset: 9794
  charLength: 94
message: "'isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i))\
  \ == false' can be simplified to '!isSameMethodFormalTypeParameter(thisTypeParameters.get(i),\
  \ thatTypeParameters.get(i))'"
messageMarkdown: "`isSameMethodFormalTypeParameter(thisTypeParameters.get(i), thatTypeParameters.get(i))\
  \ == false` can be simplified to '!isSameMethodFormalTypeParameter(thisTypeParameters.get(i),\
  \ thatTypeParameters.get(i))'"
snippet: "\t\t\t//check that bounds of formal type parameters are same after adapting\n\
  \t\t\tfor (int i = 0; i < thisTypeParameters.size(); i++) {\n\t\t\t\tif (isSameMethodFormalTypeParameter(thisTypeParameters.get(i),\
  \ thatTypeParameters.get(i)) == false) {\n\t\t\t\t\treturn false;\n\t\t\t\t}"
analyzer: "Qodana"
 -->
<!-- fingerprint:-241422812 -->
* Replaced `classTypingContext.isSubtypeOf(declType.getReference()) == false` with `!classTypingContext.isSubtypeOf(declType.getReference())`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/MethodTypingContext.java"
position:
  startLine: 64
  endLine: 0
  startColumn: 9
  endColumn: 0
  charOffset: 2501
  charLength: 64
message: "'classTypingContext.isSubtypeOf(declType.getReference()) == false' can be\
  \ simplified to '!classTypingContext.isSubtypeOf(declType.getReference())'"
messageMarkdown: "`classTypingContext.isSubtypeOf(declType.getReference()) == false`\
  \ can be simplified to '!classTypingContext.isSubtypeOf(declType.getReference())'"
snippet: "\t\t\tif (classTypingContext.getAdaptationScope() != declType) {\n\t\t\t\
  \t//the method is declared in different type. We have to adapt it to required classTypingContext\n\
  \t\t\t\tif (classTypingContext.isSubtypeOf(declType.getReference()) == false) {\n\
  \t\t\t\t\tthrow new SpoonException(\"Cannot create MethodTypingContext for method\
  \ declared in different ClassTypingContext\");\n\t\t\t\t}"
analyzer: "Qodana"
 -->
<!-- fingerprint:-1676633637 -->
* Replaced `(scopeMethod instanceof CtMethod) == false` with `!(scopeMethod instanceof CtMethod)`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/MethodTypingContext.java"
position:
  startLine: 183
  endLine: 0
  startColumn: 8
  endColumn: 0
  charOffset: 7488
  charLength: 45
message: "'(scopeMethod instanceof CtMethod) == false' can be simplified to '!(scopeMethod\
  \ instanceof CtMethod)'"
messageMarkdown: "`(scopeMethod instanceof CtMethod``) == false` can be simplified\
  \ to '!(scopeMethod instanceof CtMethod)'"
snippet: "\t\t//only method to method or constructor to constructor can be adapted\n\
  \t\tif (typeParamDeclarer instanceof CtMethod<?>) {\n\t\t\tif ((scopeMethod instanceof\
  \ CtMethod<?>) == false) {\n\t\t\t\treturn null;\n\t\t\t}"
analyzer: "Qodana"
 -->
<!-- fingerprint:-412720121 -->
* Replaced `(scopeMethod instanceof CtConstructor) == false` with `!(scopeMethod instanceof CtConstructor)`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/MethodTypingContext.java"
position:
  startLine: 187
  endLine: 0
  startColumn: 8
  endColumn: 0
  charOffset: 7628
  charLength: 50
message: "'(scopeMethod instanceof CtConstructor) == false' can be simplified to '!(scopeMethod\
  \ instanceof CtConstructor)'"
messageMarkdown: "`(scopeMethod instanceof CtConstructor``) == false` can be simplified\
  \ to '!(scopeMethod instanceof CtConstructor)'"
snippet: "\t\t\t}\n\t\t} else if (typeParamDeclarer instanceof CtConstructor<?>) {\n\
  \t\t\tif ((scopeMethod instanceof CtConstructor<?>) == false) {\n\t\t\t\treturn\
  \ null;\n\t\t\t}"
analyzer: "Qodana"
 -->
<!-- fingerprint:676655935 -->
* Replaced `hasSameMethodFormalTypeParameters(typeParamDeclarer) == false` with `!hasSameMethodFormalTypeParameters(typeParamDeclarer)`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/MethodTypingContext.java"
position:
  startLine: 201
  endLine: 0
  startColumn: 7
  endColumn: 0
  charOffset: 8264
  charLength: 61
message: "'hasSameMethodFormalTypeParameters(typeParamDeclarer) == false' can be simplified\
  \ to '!hasSameMethodFormalTypeParameters(typeParamDeclarer)'"
messageMarkdown: "`hasSameMethodFormalTypeParameters(typeParamDeclarer) == false`\
  \ can be simplified to '!hasSameMethodFormalTypeParameters(typeParamDeclarer)'"
snippet: "\t\t * Then, for all i (1 ≤ i ≤ n), the bound of Ai is the same type as\
  \ T applied to the bound of Bi.\n\t\t */\n\t\tif (hasSameMethodFormalTypeParameters(typeParamDeclarer)\
  \ == false) {\n\t\t\t//the methods formal type parameters are different. We cannot\
  \ adapt such parameters\n\t\t\treturn null;"
analyzer: "Qodana"
 -->
<!-- fingerprint:434030851 -->
