### PR TITLE
style: fix Bad Smells in spoon.support.visitor.AbstractTypingContext

### DIFF
--- a/src/main/java/spoon/support/visitor/AbstractTypingContext.java
+++ b/src/main/java/spoon/support/visitor/AbstractTypingContext.java
@@ -45,7 +45,7 @@ abstract class AbstractTypingContext implements GenericTypeAdapter {
 		}
 		if (!result.getActualTypeArguments().isEmpty()) {
 			//we have to adapt actual type arguments recursive too
-			if (isCopy == false) {
+			if (!isCopy) {
 				CtElement parent = result.isParentInitialized() ? result.getParent() : null;
 				result = result.clone();
 				if (parent != null) {


### PR DESCRIPTION
# Repairing Code Style Issues
## PointlessBooleanExpression
Boolean expressions shouldn't be overcomplex. 
## Changes: 
* Replaced `isCopy == false` with `!isCopy`
<!-- ruleID: "PointlessBooleanExpression"
filePath: "src/main/java/spoon/support/visitor/AbstractTypingContext.java"
position:
  startLine: 48
  endLine: 0
  startColumn: 8
  endColumn: 0
  charOffset: 1662
  charLength: 15
message: "'isCopy == false' can be simplified to '!isCopy'"
messageMarkdown: "`isCopy == false` can be simplified to '!isCopy'"
snippet: "\t\tif (!result.getActualTypeArguments().isEmpty()) {\n\t\t\t//we have to\
  \ adapt actual type arguments recursive too\n\t\t\tif (isCopy == false) {\n\t\t\t\
  \tCtElement parent = result.isParentInitialized() ? result.getParent() : null;\n\
  \t\t\t\tresult = result.clone();"
analyzer: "Qodana"
 -->
<!-- fingerprint:942801096 -->
