### PR TITLE
doc: change "upcall" to "call"

### DIFF
--- a/src/main/java/spoon/processing/Processor.java
+++ b/src/main/java/spoon/processing/Processor.java
@@ -45,12 +45,12 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	boolean isToBeProcessed(E candidate);
 
 	/**
-	 * A callback method upcalled by the meta-model scanner to perform a
-	 * dedicated job on the currently scanned element. The way Spoon upcalls
+	 * A callback method called by the meta-model scanner to perform a
+	 * dedicated job on the currently scanned element. The way Spoon calls
 	 * this method depends on the processed element types (
 	 * {@link #getProcessedElementTypes()}), the traversal strategy (
 	 * {@link #getTraversalStrategy()}), and the used processing manager (
-	 * {@link Environment#getManager()}. Also, this method is upcalled only if
+	 * {@link Environment#getManager()}. Also, this method is called only if
 	 * the method {@link #isToBeProcessed(CtElement)} returns true for a given
 	 * scanned element. In order to manually scan the meta-model, one can define
 	 * the {@link #process()} method instead.
@@ -61,20 +61,20 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	void process(E element);
 
 	/**
-	 * A callback method upcalled by the manager so that this processor can
+	 * A callback method called by the manager so that this processor can
 	 * manually implement a processing job. On contrary to
 	 * {@link #process(CtElement)}, this method does not rely on a built-in
 	 * meta-model scanner and has to implement its own traversal strategy on the
 	 * meta-model, which is stored in the factory (
 	 * {@link FactoryAccessor#getFactory}). Note that if a processor implements
-	 * both process methods, this one is upcalled first. This method does
+	 * both process methods, this one is called first. This method does
 	 * nothing in default implementations (
 	 * {@link spoon.processing.AbstractProcessor}).
 	 */
 	void process();
 
 	/**
-	 * Do the processing job for a given element. This method is upcalled on an
+	 * Do the processing job for a given element. This method is called on an
 	 * element if the method {@link #isToBeProcessed(CtElement)} returns true.
 	 *
 	 * @param element
@@ -87,7 +87,7 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	Set<Class<? extends CtElement>> getProcessedElementTypes();
 
 	/**
-	 * This method is upcalled by the {@link ProcessingManager} when this
+	 * This method is called by the {@link ProcessingManager} when this
 	 * processor has finished a full processing round on the program's model. It
 	 * is convenient to override this method to tune the application's strategy
 	 * of a set of processors, for instance by dynamically adding processors to
@@ -97,7 +97,7 @@ public interface Processor<E extends CtElement> extends FactoryAccessor {
 	void processingDone();
 
 	/**
-	 * This method is upcalled to initialize the processor before each
+	 * This method is called to initialize the processor before each
 	 * processing round. It is convenient to override this method rather than
 	 * using a default constructor to initialize the processor, since the
 	 * factory is not initialized at construction time. When overriding, do not

--- a/src/main/java/spoon/reflect/visitor/CtScanner.java
+++ b/src/main/java/spoon/reflect/visitor/CtScanner.java
@@ -122,14 +122,14 @@ public abstract class CtScanner implements CtVisitor {
 	}
 
 	/**
-	 * This method is upcalled by the scanner when entering a scanned element.
+	 * This method is called by the scanner when entering a scanned element.
 	 * To be overridden to implement specific scanners.
 	 */
 	protected void enter(CtElement e) {
 	}
 
 	/**
-	 * This method is upcalled by the scanner when exiting a scanned element. To
+	 * This method is called by the scanner when exiting a scanned element. To
 	 * be overridden to implement specific scanners.
 	 */
 	protected void exit(CtElement e) {

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -48,7 +48,7 @@ public class ProcessingVisitor extends CtScanner {
 
 	/**
 	 * Applies the processing to the given element. To apply the processing,
-	 * this method upcalls, for all the registered processor in, the
+	 * this method calls, for all the registered processor in, the
 	 * {@link Processor#process(CtElement)} method if
 	 * {@link Processor#isToBeProcessed(CtElement)} returns true.
 	 */


### PR DESCRIPTION
Just fixing a small typo in a couple of Javadoc comments. Methods just _call_ each other 😉 