### PR TITLE
chore: Add PointlessBooleanExpression rule to qodana checks

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -24,5 +24,6 @@ include:
   - name: UnnecessaryLocalVariable
   - name: UnnecessaryUnboxing
   - name: UNUSED_IMPORT
+  - name: PointlessBooleanExpression 
 exclude:
   - name: UseOfClone


### PR DESCRIPTION
All violations of this rule are fixed in #4903. I see zero cases where we want code like `.. == true` or `... == false`, so we should stop such code in the quality check. As a reminder, we only run the checks on `src/main/java`.