### PR TITLE
style: fix Bad Smells in spoon.support.util.ImmutableMapImpl

### DIFF
--- a/src/main/java/spoon/support/util/ImmutableMapImpl.java
+++ b/src/main/java/spoon/support/util/ImmutableMapImpl.java
@@ -88,7 +88,7 @@ public class ImmutableMapImpl implements ImmutableMap {
 		appendMap(sb, map);
 		if (parent != null) {
 			sb.append("\nparent:\n");
-			sb.append(parent.toString());
+			sb.append(parent);
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
## Changes: 
* Remove redudant `toString()` call in `parent.toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/spoon/support/util/ImmutableMapImpl.java"
position:
  startLine: 91
  endLine: 0
  startColumn: 21
  endColumn: 0
  charOffset: 2361
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\tif (parent != null) {\n\t\t\tsb.append(\"\\nparent:\\n\");\n\t\t\tsb.append(parent.toString());\n\
  \t\t}\n\t\treturn sb.toString();"
analyzer: "Qodana"
 -->
<!-- fingerprint:-1439614663 -->
