### PR TITLE
style: fix Bad Smells in spoon.support.reflect.declaration.CtElementImpl

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -126,7 +126,7 @@ public abstract class CtElementImpl implements CtElement {
 		boolean ret = EqualsVisitor.equals(this, (CtElement) o);
 		// neat online testing of core Java contract
 		if (ret && !factory.getEnvironment().checksAreSkipped() && this.hashCode() != o.hashCode()) {
-			throw new IllegalStateException("violation of equal/hashcode contract between \n" + this.toString() + "\nand\n" + o.toString() + "\n");
+			throw new IllegalStateException("violation of equal/hashcode contract between \n" + this  + "\nand\n" + o  + "\n");
 		}
 		return ret;
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtElementImpl.java
@@ -126,7 +126,7 @@ public abstract class CtElementImpl implements CtElement {
 		boolean ret = EqualsVisitor.equals(this, (CtElement) o);
 		// neat online testing of core Java contract
 		if (ret && !factory.getEnvironment().checksAreSkipped() && this.hashCode() != o.hashCode()) {
-			throw new IllegalStateException("violation of equal/hashcode contract between \n" + this  + "\nand\n" + o  + "\n");
+			throw new IllegalStateException("violation of equal/hashcode contract between \n" + this + "\nand\n" + o + "\n");
 		}
 		return ret;
 	}


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
## Changes: 
* Remove redudant `toString()` call in `this.toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/spoon/support/reflect/declaration/CtElementImpl.java"
position:
  startLine: 129
  endLine: 0
  startColumn: 93
  endColumn: 0
  charOffset: 4817
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\t// neat online testing of core Java contract\n\t\tif (ret && !factory.getEnvironment().checksAreSkipped()\
  \ && this.hashCode() != o.hashCode()) {\n\t\t\tthrow new IllegalStateException(\"\
  violation of equal/hashcode contract between \\n\" + this.toString() + \"\\nand\\\
  n\" + o.toString() + \"\\n\");\n\t\t}\n\t\treturn ret;"
analyzer: "Qodana"
 -->
<!-- fingerprint:-914414042 -->
* Remove redudant `toString()` call in `o.toString()`
<!-- ruleID: "UnnecessaryToStringCall"
filePath: "src/main/java/spoon/support/reflect/declaration/CtElementImpl.java"
position:
  startLine: 129
  endLine: 0
  startColumn: 93
  endColumn: 0
  charOffset: 4817
  charLength: 8
message: "Unnecessary 'toString()' call"
messageMarkdown: "Unnecessary `toString()` call"
snippet: "\t\t// neat online testing of core Java contract\n\t\tif (ret && !factory.getEnvironment().checksAreSkipped()\
  \ && this.hashCode() != o.hashCode()) {\n\t\t\tthrow new IllegalStateException(\"\
  violation of equal/hashcode contract between \\n\" + this.toString() + \"\\nand\\\
  n\" + o.toString() + \"\\n\");\n\t\t}\n\t\treturn ret;"
analyzer: "Qodana"
 -->
<!-- fingerprint:-914414042 -->
