### PR TITLE
fix: properly print type parameter reference in instanceof

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -537,7 +537,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace();
 		try (Writable _context = context.modify()) {
 			if (operator.getKind() == BinaryOperatorKind.INSTANCEOF) {
-				_context.forceWildcardGenerics(true);
+				_context.forceWildcardGenerics(env.getComplianceLevel() < 16);
 			}
 			scan(operator.getRightHandOperand());
 		}

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -537,11 +537,21 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		printer.writeSpace();
 		try (Writable _context = context.modify()) {
 			if (operator.getKind() == BinaryOperatorKind.INSTANCEOF) {
-				_context.forceWildcardGenerics(env.getComplianceLevel() < 16);
+				_context.forceWildcardGenerics(canForceWildcardInInstanceof());
 			}
 			scan(operator.getRightHandOperand());
 		}
 		exitCtExpression(operator);
+	}
+
+	/**
+	 * Since Java 16, it is allowed to have type parameters other than {@code <?>} in instanceof checks.
+	 * This is allowed in cases where the generic type can be carried over from the type on the left side.
+	 * In previous Java versions, only {@code <?>} is allowed, and to keep the original behavior for such
+	 * versions, this method returns {@code true} if the compliance level is below 16.
+	 */
+	private boolean canForceWildcardInInstanceof() {
+		return env.getComplianceLevel() < 16;
 	}
 
 	@Override

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -30,6 +30,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 import spoon.test.GitHubIssue;
 import spoon.test.SpoonTestHelpers;
+import spoon.testing.utils.ModelTest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -307,5 +308,15 @@ public class DefaultJavaPrettyPrinterTest {
             assertThat(actualStringRepresentation,
                     equalTo("spoon.reflect.declaration.CtElement spoonElements[] = new spoon.reflect.declaration.CtElement[]{ 1.0F }"));
         }
+    }
+
+    @ModelTest(value = "src/test/resources/patternmatching/InstanceofGenerics.java", complianceLevel = 16)
+    void testKeepGenericType(Factory factory) {
+        // contract: generic type parameters can appear in instanceof expressions if they are only carried over
+        CtType<?> x = factory.Type().get("InstanceofGenerics");
+        String printed = x.toString();
+        assertThat(printed, containsString("Set<T>"));
+        assertThat(printed, containsString("List<T> list"));
+        assertThat(printed, containsRegexMatch("Collection<.*String>"));
     }
 }

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -318,5 +318,8 @@ public class DefaultJavaPrettyPrinterTest {
         assertThat(printed, containsString("Set<T>"));
         assertThat(printed, containsString("List<T> list"));
         assertThat(printed, containsRegexMatch("Collection<.*String>"));
+        assertThat(printed, containsRegexMatch("List<.*List<T>>"));
+        assertThat(printed, containsRegexMatch("List<.*List<\\? extends T>>"));
+        assertThat(printed, containsRegexMatch("List<.*List<\\? super T>>"));
     }
 }

--- a/src/test/resources/patternmatching/InstanceofGenerics.java
+++ b/src/test/resources/patternmatching/InstanceofGenerics.java
@@ -1,0 +1,22 @@
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+class InstanceofGenerics {
+	<T> boolean check(Iterable<T> iterable) {
+		return iterable instanceof Set<T>;
+	}
+
+	<T> T first(Iterable<T> iterable) {
+		if (iterable instanceof List<T> list) {
+			return list.get(0);
+		}
+		return iterable.iterator().next();
+	}
+
+	boolean alwaysTrue(StringCollection collection) {
+		return collection instanceof Collection<String>;
+	}
+
+	interface StringCollection extends Collection<String> {}
+}

--- a/src/test/resources/patternmatching/InstanceofGenerics.java
+++ b/src/test/resources/patternmatching/InstanceofGenerics.java
@@ -14,9 +14,21 @@ class InstanceofGenerics {
 		return iterable.iterator().next();
 	}
 
-	boolean alwaysTrue(StringCollection collection) {
+	interface StringCollection extends Collection<String> {}
+
+	boolean alwaysTrue0(StringCollection collection) {
 		return collection instanceof Collection<String>;
 	}
 
-	interface StringCollection extends Collection<String> {}
+	<T> boolean alwaysTrue1(Iterable<List<T>> iterable) {
+		return iterable instanceof List<List<T>>;
+	}
+
+	<T> boolean alwaysTrue2(Iterable<List<? extends T>> iterable) {
+		return iterable instanceof List<List<? extends T>>;
+	}
+
+	<T> boolean alwaysTrue3(Iterable<List<? super T>> iterable) {
+		return iterable instanceof List<List<? super T>>;
+	}
 }


### PR DESCRIPTION
Since Java 16, it is allowed to have type parameters other than `<?>` in instanceof checks. This is allowed in cases where the generic type can be carried over from the type on the left side.

I added a test with three such examples, one with pattern matching (the main reason this feature was added), one normal instanceof check with a type parameter as type argument and one with String as type argument.

The current solution is to not enforce wildcard in the printer for compliance mode >= 16. I would personally prefer to not change the printing output there at all, but there are tests relying on it - namely this one:
https://github.com/INRIA/spoon/blob/59990fe39101fdb7fcb13d4ad6bbaf0085cb8509/src/test/java/spoon/test/template/TemplateTest.java#L1096
And it also might break existing code.

I'm not sure if that's the best solution. If you have any better ideas, please let me know.