### PR TITLE
chore: disable comments from sonarlift and refactor-first

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,1 @@
+disableTools=['refactor-first']

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,1 +1,1 @@
-disableTools=['refactor-first']
+disableTools=["refactor-first"]


### PR DESCRIPTION
we want to suppress the useless warnings.

We need a `.lift.toml` for this. Looking at the doc at https://help.sonatype.com/lift/configuring-lift/build-and-.toml-details, the godclass warning is due to`refactor-first`

> The refactor-first tool is an implementation of an open source project created and maintained by Jim Bethancourt. The fundamentals of the tool are based on the paper [Prioritizing Design Debt Investment Opportunities](https://dl.acm.org/doi/10.1145/1985362.1985372) by Nico Zazworka, Carolyn Seaman and Forrest Shull.



