### PR TITLE
review: test: add two test runs for newest and ea jdk

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,21 +193,33 @@ jobs:
     name: java 19
     steps:
     - uses: actions/checkout@v3
+    - name: Use Maven dependency cache
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # tag=v3.0.8
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '19'
-    - run: mvn test
+    - run: mvn test -Djacoco.skip=true
   early-access-jdk:
     runs-on: ubuntu-latest
     env:
       MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-    name: java 20-ea
+    name: java 20-ea (early access)
     steps:
     - uses: actions/checkout@v3
+    - name: Use Maven dependency cache
+      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # tag=v3.0.8
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
     - uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: '20-ea'
         check-latest: true
-    - run: mvn test
+    - run: mvn test -Djacoco.skip=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -185,3 +185,29 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Check status
         run: chore/check-reproducible-builds.sh
+
+  newest-general-availability-jdk:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+    name: java 19
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '19'
+    - run: mvn test
+  early-access-jdk:
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+    name: java 20-ea
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '20-ea'
+        check-latest: true
+    - run: mvn test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,11 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
-            java: 17,19,20-ea
+            java: 17
+          - os: windows-latest
+            java: 19
+          - os: windows-latest
+            java: 20-ea
 
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,11 +23,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17]
+        java: [11, 17, 19, 20-ea]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
-            java: 17
+            java: 17,19,20-ea
+
 
 
     env:
@@ -185,41 +186,3 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Check status
         run: chore/check-reproducible-builds.sh
-
-  newest-general-availability-jdk:
-    runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-    name: java 19
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Maven dependency cache
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # tag=v3.0.8
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-maven-
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '19'
-    - run: mvn test -Djacoco.skip=true
-  early-access-jdk:
-    runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
-    name: java 20-ea (early access)
-    steps:
-    - uses: actions/checkout@v3
-    - name: Use Maven dependency cache
-      uses: actions/cache@fd5de65bc895cf536527842281bea11763fefd77 # tag=v3.0.8
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-maven-
-    - uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '20-ea'
-        check-latest: true
-    - run: mvn test -Djacoco.skip=true

--- a/src/test/java/spoon/test/model/TypeTest.java
+++ b/src/test/java/spoon/test/model/TypeTest.java
@@ -7,6 +7,8 @@
  */
 package spoon.test.model;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import spoon.Launcher;
 import spoon.compiler.ModelBuildingException;
 import spoon.reflect.CtModel;
@@ -61,24 +63,23 @@ public class TypeTest {
 	}
 
 	@Test
+	@DisabledForJreRange(min = JRE.JAVA_14)
+	/*
+	* This annotation is needed because in java.lang.object the method registerNative was removed.
+	* See https://bugs.openjdk.java.net/browse/JDK-8232801 for details.
+	*/
 	public void testAllTypeMembersFunctionMode() throws Exception {
 		// contract: AllTypeMembersFunction can be configured to return all members or only internally visible members
 		CtClass<?> type = build("spoon.test.model", "Foo");
 		List<CtMethod<?>> internallyAccessibleMethods = type.map(new AllTypeMembersFunction(CtMethod.class).setMode(AllTypeMembersFunction.Mode.SKIP_PRIVATE)).list();
 		List<CtMethod<?>> allMethods = type.map(new AllTypeMembersFunction(CtMethod.class)).list();
-		assertAll(
-			() -> assertEquals(16, internallyAccessibleMethods.size()),
-			() -> assertTrue(17 == allMethods.size() || 16 == allMethods.size()));
+		assertEquals(16, internallyAccessibleMethods.size());
+		assertEquals(17, allMethods.size());
 
-		/*
-		This if-clause is needed because in java.lang.object the method registerNative was removed.
-		See https://bugs.openjdk.java.net/browse/JDK-8232801 for details.
-		*/
 		allMethods.removeAll(internallyAccessibleMethods);
-		if (allMethods.size() == 1) {
-			assertEquals(1, allMethods.size());
-			assertEquals("registerNatives()", allMethods.get(0).getSignature());
-		}
+		assertEquals(1, allMethods.size());
+		assertEquals("registerNatives()", allMethods.get(0).getSignature());
+
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds two new check runs in the CI. One for newest stable JDK(19) and early access JDK(20-ea). The goal is to know earlier if something will break in the future. Furthermore, a goal of this PR is to finally send a mail to [quality-outreach-programm](https://wiki.openjdk.org/display/quality/Quality+Outreach#QualityOutreach-HowtojointheQualityOutreachProgram) from openjdk. One test case was simply broken in future JDKs because we test against internal methods, and they got changed over the time.
I'm unsure if we should allow failure for these test runs. Allowing failure means we simply move the problem 6/12 months in the future.

1) Pinning of action hashes should be done by renovate after the merge, or shall I search for the hashes?
2) This checks need to be updated every 6 month to new versions, which shouldn't be too high an effort.

Edit: It seems like JDK-EA is around 50% slower than a released JDK 10 vs. 7 min runtime. This should still be fine.