### PR TITLE
doc: undeprecate method getActualClass

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -59,11 +59,10 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 
 	/**
 	 *
-	 * NEVER USE THIS.
+	 * This is a low-level feature, it should never been used by non advanced users.
 	 *
 	 * See {@link CtTypeReference#getActualClass()}.
 	 *
-	 * @deprecated (since Spoon 7.0.0) this will be removed from the public API
 	 */
 	@DerivedProperty
 	Class<T> getActualClass();

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -61,7 +61,7 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	 *
 	 * This is a low-level feature, it should never been used by non advanced users.
 	 *
-	 * See {@link CtTypeReference#getActualClass()}.
+	 * See full documentation at {@link CtTypeReference#getActualClass()}.
 	 *
 	 */
 	@DerivedProperty

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -52,6 +52,10 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 *
 	 * This is a low-level feature, it should never been used, use {@link #getTypeDeclaration()} instead
 	 * in order to only stay in the Spoon world and manipulate CtType instead of java.lang.Class.
+	 * Note:
+	 * - it will return null if the class is not the classpath
+	 * - it will fail if the static initializers of the class fail
+	 * - the Class object may not reflect the CtType if case you made recent changes to it, only the version from the classpath is taken into account
 	 *
 	 * @return the Java class or throws a {@link SpoonClassNotFoundException} if the class is not found.
 	 * @throws SpoonClassNotFoundException if the class is not in the classpath

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -50,13 +50,11 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	/**
 	 * Gets the Java runtime class of the referenced type.
 	 *
-	 * This is a low-level feature, it should never been used.
-	 * For CtTypeReference, use {@link #getTypeDeclaration()} instead,
+	 * This is a low-level feature, it should never been used, use {@link #getTypeDeclaration()} instead
 	 * in order to only stay in the Spoon world and manipulate CtType instead of java.lang.Class.
 	 *
 	 * @return the Java class or throws a {@link SpoonClassNotFoundException} if the class is not found.
 	 * @throws SpoonClassNotFoundException if the class is not in the classpath
-	 * @deprecated (Since Spoon 7.0.0) use {@link #getTypeDeclaration()} instead
 	 */
 	Class<T> getActualClass();
 

--- a/src/main/java/spoon/reflect/reference/CtTypeReference.java
+++ b/src/main/java/spoon/reflect/reference/CtTypeReference.java
@@ -52,10 +52,21 @@ public interface CtTypeReference<T> extends CtReference, CtActualTypeContainer, 
 	 *
 	 * This is a low-level feature, it should never been used, use {@link #getTypeDeclaration()} instead
 	 * in order to only stay in the Spoon world and manipulate CtType instead of java.lang.Class.
-	 * Note:
-	 * - it will return null if the class is not the classpath
-	 * - it will fail if the static initializers of the class fail
-	 * - the Class object may not reflect the CtType if case you made recent changes to it, only the version from the classpath is taken into account
+	 * <br/>
+	 * <br/>
+	 * Note (these are artifacts of the <em>current implementation</em> and might change at any time):
+	 * <ol>
+	 *     <li>
+	 *         it will return the version of the class your {@link spoon.compiler.Environment#getInputClassLoader()}
+	 *         loads. This might be a version spoon compiled
+	 *         (manually using {@link spoon.SpoonModelBuilder#compile(spoon.SpoonModelBuilder.InputType...)}
+	 *     	   or implicitly using {@link spoon.compiler.Environment#shouldCompile})
+	 *     	   or from your classpath (which might be null)
+	 *     </li>
+	 *     <li>it will run static initializers (executing arbitrary code from the analyzed project in the process)</li>
+	 *     <li>it will fail if the static initializers of the class fail</li>
+	 *     <li>the Class object may not reflect the CtType in case you made recent changes to it based on point 1</li>
+	 * </ol>
 	 *
 	 * @return the Java class or throws a {@link SpoonClassNotFoundException} if the class is not found.
 	 * @throws SpoonClassNotFoundException if the class is not in the classpath


### PR DESCRIPTION
`getActualClass` was deprecated (I may even be the author of the deprecation).

But:
1. we use it all over the place
2. I used it myself naturally in a transformation I recently wrote.

So it is indeed very useful, and we should undeprecate it.