### PR TITLE
test: clean up MainTest#testGenericContract

### DIFF
--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -38,62 +38,27 @@ public class MainTest {
 		Launcher launcher;
 		CtPackage rootPackage;
 
-		// we have to remove the test-classes folder
-		// so that the precondition of --source-classpath is not violated
-		// (target/test-classes contains src/test/resources which itself contains Java files)
-		StringBuilder classpath = new StringBuilder();
-		for (String classpathEntry : System.getProperty("java.class.path").split(File.pathSeparator)) {
-			if (!classpathEntry.contains("test-classes")) {
-				classpath.append(classpathEntry);
-				classpath.append(File.pathSeparator);
-			}
-		}
-		String systemClassPath = classpath.substring(0, classpath.length() - 1);
-
 		launcher = new Launcher();
-
-		launcher.setArgs(new String[] {
-				"-o", "target/spooned",
-				"--destination","target/spooned-build",
-				"--source-classpath", systemClassPath,
-				"--compile", // compiling Spoon code itself on the fly
-				"--compliance", "8",
-				"--level", "OFF",
-		});
+		launcher.getEnvironment().setComplianceLevel(11);
 
 		// there are still some bugs with comments
 		launcher.getEnvironment().setCommentEnabled(false);
 
-		int n = 0;
 		Files.walk(Paths.get("src/test/java"))
-				.filter(path -> path.toFile().getAbsolutePath().contains("testclasses")
-						&& path.toFile().isFile() // only Java files, not directory
+				.filter(path -> path.toAbsolutePath().toString().contains("testclasses")
+						&& Files.isRegularFile(path) // only Java files, not directory
 				)
 
 				// by using testclasses, we find a lot of bugs
 				// I propose to put them under the carpet first (aka carpet debugging)
 				// in order to make progress on this important blocking first refactoring
 
-				// bug 1: those three classes together trigger a bug somewhere in inner class
+				// bug 1: those two classes together trigger a bug somewhere in inner class
 				.filter(path -> !filePathContains(path, "fieldaccesses/testclasses/Tacos")) // carpet debugging
-				.filter(path -> !filePathContains(path, "fieldaccesses/testclasses/internal/Bar"))
-				.filter(path -> !filePathContains(path, "fieldaccesses/testclasses/internal/Foo"))
 				.filter(path -> !filePathContains(path, "reference/testclasses/Stream"))
 
 				// bug 2: remove the filter to trigger it
-				.filter(path -> !filePathContains(path, "AccessibleClassFromNonAccessibleInterf"))
-
-				// bug 3: remove the filter to trigger it
 				.filter(path -> !filePathContains(path, "MethodeWithNonAccessibleTypeArgument"))
-
-				// bug 4: remove the filter to trigger it
-				.filter(path -> !filePathContains(path, "lambda/testclasses/Bar"))
-
-				// bug 5: remove the filter to trigger it
-				.filter(path -> !filePathContains(path, "LambdaRxJava"))
-
-				// bug 6: remove the filter to trigger it
-				.filter(path -> !filePathContains(path, "Tapas"))
 
 				.forEach(x -> {
 					launcher.addInputResource(x.toString());


### PR DESCRIPTION
This test seems to be outdated. It used compliance level 8 on spoon.
Additionally, there are files which are filtered as they caused bugs before, but it seems like that's not the case for most of them anymore.
I also removed the manual launcher args as it's cleaner to do that in code directly (and most options are not needed).