### PR TITLE
feat: Add `CtTry.addCatcherAt`

### DIFF
--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -48,6 +48,12 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	<T extends CtTry> T addCatcher(CtCatch catcher);
 
 	/**
+	 * Adds a catch block at the specified position in the <code>try</code> statement.
+	 */
+	@PropertySetter(role = CATCH)
+	<T extends CtTry> T addCatcherAt(int index, CtCatch catcher);
+
+	/**
 	 * Removes a catch block.
 	 */
 	@PropertySetter(role = CATCH)

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -49,9 +49,14 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 
 	/**
 	 * Adds a catch block at the specified position in the <code>try</code> statement.
+	 *
+	 * @param <T> the type of the try statement
+	 * @param position the position at which the <code>catcher</code> is to be inserted
+	 * @param catcher the catch statement to be inserted
+	 * @return this try statement
 	 */
 	@PropertySetter(role = CATCH)
-	<T extends CtTry> T addCatcherAt(int index, CtCatch catcher);
+	<T extends CtTry> T addCatcherAt(int position, CtCatch catcher);
 
 	/**
 	 * Removes a catch block.

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -51,14 +51,13 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 	 * Adds a catch block at the specified position in the <code>try</code> statement.
 	 * Behaves similarly to {@link java.util.List#add(int, Object)}.
 	 *
-	 * @param <T> the type of the try statement
 	 * @param position the position at which the <code>catcher</code> is to be inserted
 	 * @param catcher the catch statement to be inserted
 	 * @return this try statement
 	 * @throws IndexOutOfBoundsException if the position is out of range (position < 0 || position > number of catchers)
 	 */
 	@PropertySetter(role = CATCH)
-	<T extends CtTry> T addCatcherAt(int position, CtCatch catcher);
+	CtTry addCatcherAt(int position, CtCatch catcher);
 
 	/**
 	 * Removes a catch block.

--- a/src/main/java/spoon/reflect/code/CtTry.java
+++ b/src/main/java/spoon/reflect/code/CtTry.java
@@ -49,11 +49,13 @@ public interface CtTry extends CtStatement, TemplateParameter<Void>, CtBodyHolde
 
 	/**
 	 * Adds a catch block at the specified position in the <code>try</code> statement.
+	 * Behaves similarly to {@link java.util.List#add(int, Object)}.
 	 *
 	 * @param <T> the type of the try statement
 	 * @param position the position at which the <code>catcher</code> is to be inserted
 	 * @param catcher the catch statement to be inserted
 	 * @return this try statement
+	 * @throws IndexOutOfBoundsException if the position is out of range (position < 0 || position > number of catchers)
 	 */
 	@PropertySetter(role = CATCH)
 	<T extends CtTry> T addCatcherAt(int position, CtCatch catcher);

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -69,9 +69,9 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 	}
 
 	@Override
-	public <T extends CtTry> T addCatcherAt(int position, CtCatch catcher) {
+	public CtTry addCatcherAt(int position, CtCatch catcher) {
 		if (catcher == null) {
-			return (T) this;
+			return this;
 		}
 		if (catchers == CtElementImpl.<CtCatch>emptyList()) {
 			catchers = new ArrayList<>(CATCH_CASES_CONTAINER_DEFAULT_CAPACITY);
@@ -79,7 +79,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 		catcher.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CATCH, this.catchers, catcher);
 		catchers.add(position, catcher);
-		return (T) this;
+		return this;
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTryImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTryImpl.java
@@ -64,6 +64,12 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 
 	@Override
 	public <T extends CtTry> T addCatcher(CtCatch catcher) {
+		addCatcherAt(catchers.size(), catcher);
+		return (T) this;
+	}
+
+	@Override
+	public <T extends CtTry> T addCatcherAt(int position, CtCatch catcher) {
 		if (catcher == null) {
 			return (T) this;
 		}
@@ -72,7 +78,7 @@ public class CtTryImpl extends CtStatementImpl implements CtTry {
 		}
 		catcher.setParent(this);
 		getFactory().getEnvironment().getModelChangeListener().onListAdd(this, CATCH, this.catchers, catcher);
-		catchers.add(catcher);
+		catchers.add(position, catcher);
 		return (T) this;
 	}
 

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -498,7 +498,7 @@ public class TryCatchTest {
 
 			// act & assert
 			assertThrows(IndexOutOfBoundsException.class,
-					() -> tryStatement.addCatcherAt(2, catcherAtWrongPosition));
+					() -> tryStatement.addCatcherAt(1, catcherAtWrongPosition));
 		}
 	}
 }

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -473,9 +473,10 @@ public class TryCatchTest {
 					.setType(factory.Type().createReference(NoSuchMethodException.class)));
 
 			// act
-			tryStatement.addCatcherAt(0, third);
-			tryStatement.addCatcherAt(0, first);
-			tryStatement.addCatcherAt(1, second);
+			tryStatement
+				.addCatcherAt(0, third)
+				.addCatcherAt(0, first)
+				.addCatcherAt(1, second);
 
 			// assert
 			assertThat(tryStatement.getCatchers(), contains(first, second, third));

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -455,22 +455,9 @@ public class TryCatchTest {
 
 			CtTry tryStatement = factory.createTry();
 
-			CtCatch first = factory.createCatch();
-			first.setParameter(factory
-					.createCatchVariable()
-					.setType(factory.Type().createReference(IOException.class)));
-
-			CtCatch second = factory.createCatch();
-			second.setParameter(factory
-					.createCatchVariable()
-					.setMultiTypes(List.of(
-							factory.Type().createReference(ExceptionInInitializerError.class),
-							factory.Type().createReference(NoSuchFieldException.class))));
-
-			CtCatch third = factory.createCatch();
-			third.setParameter(factory
-					.createCatchVariable()
-					.setType(factory.Type().createReference(NoSuchMethodException.class)));
+			CtCatch first = createCatch(factory, IOException.class);
+			CtCatch second = createCatch(factory, ExceptionInInitializerError.class);
+			CtCatch third = createCatch(factory, NoSuchMethodException.class);
 
 			// act
 			tryStatement
@@ -491,14 +478,18 @@ public class TryCatchTest {
 			Factory factory = createFactory();
 
 			CtTry tryStatement = factory.createTry();
-			CtCatch catcherAtWrongPosition = factory.createCatch();
-			catcherAtWrongPosition.setParameter(factory
-					.createCatchVariable()
-					.setType(factory.Type().createReference(Exception.class)));
+			CtCatch catcherAtWrongPosition = createCatch(factory, Exception.class);
 
 			// act & assert
 			assertThrows(IndexOutOfBoundsException.class,
 					() -> tryStatement.addCatcherAt(1, catcherAtWrongPosition));
+		}
+
+		private <T extends Throwable> CtCatch createCatch(Factory factory, Class<T> typeToCatch) {
+			CtTypeReference<T> typeReference = factory.Type().createReference(typeToCatch);
+			return factory.createCatch().setParameter(
+					factory.createCatchVariable().setType(typeReference)
+			);
 		}
 	}
 }


### PR DESCRIPTION
Reference: #3884 

The order of catchers is important because the thrown exception is matched with the parameters of the catchers in the order they appear, hence it is semantically important.

