### PR TITLE
fix: handle empty modifers in CodeFactory#createCatchVariable correctly

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -354,8 +354,13 @@ public class CodeFactory extends SubFactory {
 	 * 		Modifiers of the catch variable
 	 * @return a new catch variable declaration
 	 */
-	public <T> CtCatchVariable<T> createCatchVariable(CtTypeReference<T> type, String name, ModifierKind...modifierKinds) {
-		return factory.Core().<T>createCatchVariable().<CtCatchVariable<T>>setSimpleName(name).<CtCatchVariable<T>>setType(type).setModifiers(EnumSet.copyOf(Arrays.asList(modifierKinds)));
+	public <T> CtCatchVariable<T> createCatchVariable(CtTypeReference<T> type, String name, ModifierKind... modifierKinds) {
+		EnumSet<ModifierKind> modifiers = EnumSet.noneOf(ModifierKind.class);
+		modifiers.addAll(Arrays.asList(modifierKinds));
+		return factory.Core().<T>createCatchVariable()
+				.<CtCatchVariable<T>>setSimpleName(name)
+				.<CtCatchVariable<T>>setType(type)
+				.setModifiers(modifiers);
 	}
 
 	/**

--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -26,14 +26,14 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
-
+import spoon.test.GitHubIssue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static spoon.testing.utils.ModelUtils.createFactory;
 
 public class CodeFactoryTest {
-	int i;
 
 	@Test
 	public void testThisAccess() {
@@ -57,5 +57,13 @@ public class CodeFactoryTest {
 		//Variable assignment's assignee is a CtVariableWrite that point toward the right variable.
 		assertTrue(va.getAssigned() instanceof CtVariableWrite);
 		assertEquals(f.getReference(), ((CtVariableWrite) va.getAssigned()).getVariable());
+	}
+	
+	@GitHubIssue(issueNumber= 4956, fixed = true)
+	void createCtCatcVariablehWithoutModifiers() {
+		// contract: CtCatchVariable without modifiers is created. This a test for the regression of #4940
+		Factory factory = createFactory();
+		CtTypeReference<Exception> exceptionType = factory.Type().createReference(Exception.class);
+		assertDoesNotThrow(() -> factory.Code().createCatchVariable(exceptionType, "e"));
 	}
 }


### PR DESCRIPTION
This should fix the regression produced in #4940. I also applied at least some formatting to the long call chain and removed a random unused field in the test case.

Edit: I created this PR inside VSC, and the developer thought it would be nice to always create the branch in the main repo if possible. We should delete the branch afterwards.