### PR TITLE
fix: records can have static initializers

### DIFF
--- a/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
@@ -118,7 +118,7 @@ public class CtRecordImpl extends CtClassImpl<Object> implements CtRecord {
 					member.getSimpleName()));
 		}
 		if (member instanceof CtAnonymousExecutable && !member.isStatic()) {
-			JLSViolation.throwIfSyntaxErrorsAreNotIgnored(this, "Instance initializer is not allowed in a record");
+			JLSViolation.throwIfSyntaxErrorsAreNotIgnored(this, "Instance initializer is not allowed in a record (JLS 17 $8.10.2)");
 		}
 		return super.addTypeMemberAt(position, member);
 	}

--- a/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
@@ -117,8 +117,8 @@ public class CtRecordImpl extends CtClassImpl<Object> implements CtRecord {
 			JLSViolation.throwIfSyntaxErrorsAreNotIgnored(this, String.format("%s method is native or abstract, both is not allowed",
 					member.getSimpleName()));
 		}
-		if (member instanceof CtAnonymousExecutable) {
-			JLSViolation.throwIfSyntaxErrorsAreNotIgnored(this, "Anonymous executable is not allowed in a record");
+		if (member instanceof CtAnonymousExecutable && !member.isStatic()) {
+			JLSViolation.throwIfSyntaxErrorsAreNotIgnored(this, "Instance initializer is not allowed in a record");
 		}
 		return super.addTypeMemberAt(position, member);
 	}

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -1,17 +1,22 @@
 package spoon.test.record;
 
 import static java.lang.System.lineSeparator;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
@@ -200,6 +205,15 @@ public class CtRecordTest {
 		Collection<CtRecord> records = model.getElements(new TypeFilter<>(CtRecord.class));
 		CtRecord record = head(records);
 		assertEquals("public record GenericRecord<T>(T a, T b) {}", record.toString());
+	}
+
+	@Test
+	void testBuildRecordModelWithStaticInitializer() {
+		// contract: a record can have static initializers
+		String code = "src/test/resources/records/WithStaticInitializer.java";
+		CtModel model = assertDoesNotThrow(() -> createModelFromPath(code));
+		List<CtAnonymousExecutable> execs = model.getElements(new TypeFilter<>(CtAnonymousExecutable.class));
+		assertThat(execs.size(), equalTo(2));
 	}
 
 	private <T> T head(Collection<T> collection) {

--- a/src/test/resources/records/WithStaticInitializer.java
+++ b/src/test/resources/records/WithStaticInitializer.java
@@ -1,0 +1,14 @@
+package records;
+
+public record WithStaticInitializer(int i, String s) {
+  static {
+    System.out.println("Hello World");
+  }
+  static {
+    if (Math.random() < 0.5) {
+      System.out.println("A");
+    } else {
+      System.out.println("B");
+    }
+  }
+}


### PR DESCRIPTION
Fixes #4961

While instance initializers are forbidden, static initializers are allowed.