### PR TITLE
feat: read parameter names from bytecode if possible

### DIFF
--- a/src/main/java/spoon/support/visitor/java/reflect/RtParameter.java
+++ b/src/main/java/spoon/support/visitor/java/reflect/RtParameter.java
@@ -11,6 +11,7 @@ import spoon.SpoonException;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 
 /**
@@ -143,7 +144,12 @@ public class RtParameter {
 	public static RtParameter[] parametersOf(RtMethod method) {
 		RtParameter[] parameters = new RtParameter[method.getParameterTypes().length];
 		for (int index = 0; index < method.getParameterTypes().length; index++) {
-			parameters[index] = new RtParameter(null, method.getParameterTypes()[index], method.getGenericParameterTypes()[index], method, null, index);
+			String name = null;
+			Parameter parameter = method.getMethod().getParameters()[index];
+			if (parameter.isNamePresent()) {
+				name = parameter.getName();
+			}
+			parameters[index] = new RtParameter(name, method.getParameterTypes()[index], method.getGenericParameterTypes()[index], method, null, index);
 		}
 		return parameters;
 	}
@@ -179,7 +185,12 @@ public class RtParameter {
 		}
 
 		for (int index = 0; index < constructor.getGenericParameterTypes().length; index++) {
-			parameters[index] = new RtParameter(null, constructor.getParameterTypes()[index + offset], constructor.getGenericParameterTypes()[index], null, constructor, index);
+			String name = null;
+			Parameter parameter = constructor.getParameters()[index + offset];
+			if (parameter.isNamePresent()) {
+				name = parameter.getName();
+			}
+			parameters[index] = new RtParameter(name, constructor.getParameterTypes()[index + offset], constructor.getGenericParameterTypes()[index], null, constructor, index);
 		}
 		return parameters;
 	}

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -847,7 +847,7 @@ public class JavaReflectionTreeBuilderTest {
 		assertThat(asClass.getConstructors().iterator().next().getParameters().size(), equalTo(inners.size()));
 	}
 
-	@GitHubIssue(issueNumber = 4972, fixed = false)
+	@GitHubIssue(issueNumber = 4972, fixed = true)
 	void parameterNamesAreParsedWhenCompilingWithParametersFlag() throws ClassNotFoundException {
 		ClassLoader loader = JavacFacade.compileFiles(
 			Map.of(


### PR DESCRIPTION
This feature allows Spoon to read the parameter name from Java 8 and later byte code that has been built with the "-parameters" flag such that CtParameter objects representing code from the class path contain the "real" parameter name instead of "argX".