### PR TITLE
review: chore: replace deprecated set-output command in GHA

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Use Maven dependency cache
         uses: actions/cache@56461b9eb0f8438fd15c7a9968e3c9ebb18ceff1 # tag=v3.0.10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Use Maven dependency cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # tag=v3.0.11
@@ -87,7 +87,7 @@ jobs:
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Use Maven dependency cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # tag=v3.0.11
@@ -126,7 +126,7 @@ jobs:
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date
-        run: echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+        run: echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Use Maven dependency cache
         uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # tag=v3.0.11


### PR DESCRIPTION
We currently have warnings in our GH CI, caused by the changes described in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

Example: https://github.com/INRIA/spoon/actions/runs/3341083524 and https://github.com/INRIA/spoon/actions/runs/3341083525

I updated our scripts to use the replacement.

