### PR TITLE
test: Add javac facade to test reflection tree builder

### DIFF
--- a/src/test/java/spoon/support/util/compilation/ClassFileManager.java
+++ b/src/test/java/spoon/support/util/compilation/ClassFileManager.java
@@ -1,0 +1,33 @@
+package spoon.support.util.compilation;
+
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import java.util.HashMap;
+import java.util.Map;
+
+class ClassFileManager extends ForwardingJavaFileManager<StandardJavaFileManager> {
+
+	private final Map<String, InMemoryOutputObject> outputFileMap;
+
+	public ClassFileManager(StandardJavaFileManager fileManager) {
+		super(fileManager);
+
+		this.outputFileMap = new HashMap<>();
+	}
+
+	@Override
+	public JavaFileObject getJavaFileForOutput(Location location, String className, JavaFileObject.Kind kind,
+		FileObject sibling) {
+		InMemoryOutputObject outputObject = new InMemoryOutputObject(className);
+
+		outputFileMap.put(className, outputObject);
+
+		return outputObject;
+	}
+
+	Map<String, InMemoryOutputObject> getAll() {
+		return outputFileMap;
+	}
+}

--- a/src/test/java/spoon/support/util/compilation/InMemoryClassLoader.java
+++ b/src/test/java/spoon/support/util/compilation/InMemoryClassLoader.java
@@ -1,0 +1,24 @@
+package spoon.support.util.compilation;
+
+import java.util.Map;
+
+class InMemoryClassLoader extends ClassLoader {
+
+	private final Map<String, byte[]> compiledClasses;
+
+	public InMemoryClassLoader(Map<String, byte[]> compiledClasses) {
+		// Allow class requests to bubble up
+		super(InMemoryClassLoader.class.getClassLoader());
+
+		this.compiledClasses = compiledClasses;
+	}
+
+	@Override
+	protected Class<?> findClass(String name) throws ClassNotFoundException {
+		if (compiledClasses.containsKey(name)) {
+			byte[] bytes = compiledClasses.get(name);
+			return defineClass(name, bytes, 0, bytes.length);
+		}
+		return super.findClass(name);
+	}
+}

--- a/src/test/java/spoon/support/util/compilation/InMemoryInputObject.java
+++ b/src/test/java/spoon/support/util/compilation/InMemoryInputObject.java
@@ -1,0 +1,27 @@
+package spoon.support.util.compilation;
+
+import javax.tools.SimpleJavaFileObject;
+import java.nio.file.Paths;
+
+class InMemoryInputObject extends SimpleJavaFileObject {
+
+	private final String name;
+	private final String content;
+
+	public InMemoryInputObject(String fullyQualifiedName, String content) {
+		super(Paths.get(fullyQualifiedName).toUri(), Kind.SOURCE);
+		this.name = fullyQualifiedName;
+
+		this.content = content;
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+		return content;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+}

--- a/src/test/java/spoon/support/util/compilation/InMemoryOutputObject.java
+++ b/src/test/java/spoon/support/util/compilation/InMemoryOutputObject.java
@@ -1,0 +1,34 @@
+package spoon.support.util.compilation;
+
+import javax.tools.SimpleJavaFileObject;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+
+class InMemoryOutputObject extends SimpleJavaFileObject {
+
+	private final ByteArrayOutputStream outputStream;
+	private final String name;
+
+	InMemoryOutputObject(String fullyQualifiedName) {
+		// A path does necessarily exist
+		super(Paths.get(fullyQualifiedName).toUri(), Kind.CLASS);
+
+		this.name = fullyQualifiedName;
+		this.outputStream = new ByteArrayOutputStream();
+	}
+
+	@Override
+	public OutputStream openOutputStream() {
+		return outputStream;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	byte[] getContent() {
+		return outputStream.toByteArray();
+	}
+}

--- a/src/test/java/spoon/support/util/compilation/JavacFacade.java
+++ b/src/test/java/spoon/support/util/compilation/JavacFacade.java
@@ -1,0 +1,73 @@
+package spoon.support.util.compilation;
+
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JavacFacade {
+
+	/**
+	 * Compiles a list of files and returns a classloader containing them.
+	 *
+	 * @param files the java files (unique name -> content) to compile
+	 * @param parameters the parameters to pass to javac
+	 * @return a classloader with the compiled classes loaded
+	 * @throws AssertionError if anything goes wrong during compilation
+	 * @throws IllegalArgumentException if the parameters are invalid
+	 */
+	public static ClassLoader compileFiles(Map<String, String> files, List<String> parameters) {
+		JavaCompiler javaCompiler = ToolProvider.getSystemJavaCompiler();
+		StringWriter output = new StringWriter();
+
+		List<InMemoryInputObject> compilationUnits = files.entrySet()
+			.stream()
+			.map(entry -> new InMemoryInputObject(entry.getKey(), entry.getValue()))
+			.collect(Collectors.toList());
+
+		ClassFileManager manager = new ClassFileManager(
+			javaCompiler.getStandardFileManager(null, null, StandardCharsets.UTF_8)
+		);
+
+		Map<String, List<String>> diagnostics = new HashMap<>();
+
+		Boolean successful = javaCompiler.getTask(
+				output,
+				manager,
+				diagnostic -> {
+					// Skip general information not related to the classes
+					// Like "Note: Some messages have been simplified;"
+					if (diagnostic.getSource() == null) {
+						return;
+					}
+					List<String> diagnosticMessages = diagnostics
+						.getOrDefault(diagnostic.getSource().getName(), new ArrayList<>());
+
+					diagnosticMessages.add(diagnostic.toString());
+
+					diagnostics.put(diagnostic.getSource().getName(), diagnosticMessages);
+				},
+				parameters,
+				null,
+				compilationUnits
+			)
+			.call();
+
+		assertTrue(successful, "Compilation failed: " + diagnostics);
+
+		Map<String, byte[]> compiledFiles = manager.getAll().entrySet().stream()
+			.collect(Collectors.toMap(
+				Map.Entry::getKey,
+				it -> it.getValue().getContent()
+			));
+
+		return new InMemoryClassLoader(compiledFiles);
+	}
+}

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -99,6 +100,7 @@ import spoon.support.reflect.code.CtAssignmentImpl;
 import spoon.support.reflect.code.CtConditionalImpl;
 import spoon.support.reflect.declaration.CtEnumValueImpl;
 import spoon.support.reflect.declaration.CtFieldImpl;
+import spoon.support.util.compilation.JavacFacade;
 import spoon.support.visitor.equals.EqualsChecker;
 import spoon.support.visitor.equals.EqualsVisitor;
 import spoon.test.generics.testclasses3.ComparableComparatorBug;
@@ -840,4 +842,23 @@ public class JavaReflectionTreeBuilderTest {
 		assertThat(asClass.getConstructors().size(), equalTo(1));
 		assertThat(asClass.getConstructors().iterator().next().getParameters().size(), equalTo(inners.size()));
 	}
+
+	@Test
+	void parameterNamesAreParsedWhenCompilingWithParametersFlag() throws ClassNotFoundException {
+		ClassLoader loader = JavacFacade.compileFiles(
+			Map.of(
+				"Test",
+				"class Test {\n"
+					+ "  public void foo(String bar) {}\n" +
+					"}\n"
+			),
+			List.of("-parameters")
+		);
+		CtType<?> test = new JavaReflectionTreeBuilder(createFactory()).scan(loader.loadClass("Test"));
+		CtMethod<?> method = test.getMethodsByName("foo").get(0);
+		CtParameter<?> parameter = method.getParameters().get(0);
+
+		assertThat(parameter.getSimpleName(), is("bar"));
+	}
+
 }

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -103,6 +103,7 @@ import spoon.support.reflect.declaration.CtFieldImpl;
 import spoon.support.util.compilation.JavacFacade;
 import spoon.support.visitor.equals.EqualsChecker;
 import spoon.support.visitor.equals.EqualsVisitor;
+import spoon.test.GitHubIssue;
 import spoon.test.generics.testclasses3.ComparableComparatorBug;
 import spoon.test.innerclasses.InnerClasses;
 import spoon.test.pkg.PackageTest;
@@ -843,7 +844,7 @@ public class JavaReflectionTreeBuilderTest {
 		assertThat(asClass.getConstructors().iterator().next().getParameters().size(), equalTo(inners.size()));
 	}
 
-	@Test
+	@GitHubIssue(issueNumber = 4972, fixed = false)
 	void parameterNamesAreParsedWhenCompilingWithParametersFlag() throws ClassNotFoundException {
 		ClassLoader loader = JavacFacade.compileFiles(
 			Map.of(

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -101,7 +101,7 @@ public class MainTest {
 		for (CtType t : launcher.getFactory().getModel().getAllTypes()) {
 			if ("spoon.metamodel".equals(t.getPackage().getQualifiedName())
 					|| t.getPackage().getQualifiedName().startsWith("spoon.generating")
-					|| t.getPackage().getQualifiedName().startsWith("spoon.support.compilation")) {
+					|| t.getPackage().getQualifiedName().startsWith("spoon.support.util.compilation")) {
 				//Meta model classes doesn't have to follow test class naming conventions
 				continue;
 			}

--- a/src/test/java/spoon/test/main/MainTest.java
+++ b/src/test/java/spoon/test/main/MainTest.java
@@ -100,7 +100,8 @@ public class MainTest {
 		// this helps a lot to easily automatically differentiate app classes and test classes
 		for (CtType t : launcher.getFactory().getModel().getAllTypes()) {
 			if ("spoon.metamodel".equals(t.getPackage().getQualifiedName())
-					|| t.getPackage().getQualifiedName().startsWith("spoon.generating")) {
+					|| t.getPackage().getQualifiedName().startsWith("spoon.generating")
+					|| t.getPackage().getQualifiedName().startsWith("spoon.support.compilation")) {
 				//Meta model classes doesn't have to follow test class naming conventions
 				continue;
 			}


### PR DESCRIPTION
This PR adds a — deliberately simple(istic) — facade to the system Javac compiler. This allows us to compile certain classes using Javac and ensure our reflection tree builder handles it correctly.

### Considerations
We could also use JDT (probably) to compile the files instead. I opted to use Javac as it is a lot more widely used and should also use different java versions in our CI.