### PR TITLE
review: feat: support to parse `CtType`, `CtClass` and `CtField` from JDK element CtPath.toString()

### DIFF
--- a/doc/path.md
+++ b/doc/path.md
@@ -13,11 +13,20 @@ For instance, a "then" branch in an if/then/else is a role (and not a node). All
 
 ### Evaluating AST paths
 
-Paths are used to find code elements, from a given root element.
+Paths are used to find code elements, from a given root element(e.g. `model.getRootPackage()`).
 
 ```java
 path = new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.foo#body#statement[index=0]");
 List<CtElement> l = path.evaluateOn(root)
+```
+
+If the root parameter is not given, spoon will try to find shadow elements(e.g. jdk classes).
+
+> If so, it can only supperts `CtType`, `CtMethod` and `CtField` for now.
+
+```java
+path = new CtPathStringBuilder().fromString("#subPackage[name=java]#subPackage[name=util]#containedType[name=HashSet]");
+List<CtElement> l = path.evaluateOn()
 ```
 
 ### Creating AST paths

--- a/src/main/java/spoon/reflect/declaration/CtClass.java
+++ b/src/main/java/spoon/reflect/declaration/CtClass.java
@@ -50,6 +50,18 @@ public interface CtClass<T> extends CtType<T>, CtStatement, CtSealable {
 	CtConstructor<T> getConstructor(CtTypeReference<?>... parameterTypes);
 
 	/**
+	 * Returns the constructor of the class that takes the given signature.
+	 * e.g. java.util.HashSet has constructor with no parameters `()`
+	 * e.g. java.util.HashSet has constructor with a int and a float parameters `(int,float)`
+	 * e.g. java.util.HashSet has constructor with a java.util.Collection parameter `(java.util.Collection)`
+	 *
+	 * Derived from {@link #getTypeMembers()}
+	 */
+	@DerivedProperty
+	@PropertyGetter(role = CONSTRUCTOR)
+	CtConstructor<T> getConstructorBySignature(String signature);
+
+	/**
 	 * Returns the constructors of this class. This includes the default
 	 * constructor if this class has no constructors explicitly declared.
 	 *

--- a/src/main/java/spoon/reflect/declaration/CtType.java
+++ b/src/main/java/spoon/reflect/declaration/CtType.java
@@ -235,6 +235,14 @@ public interface CtType<T> extends CtNamedElement, CtTypeInformation, CtTypeMemb
 	<R> CtMethod<R> getMethod(String name, CtTypeReference<?>... parameterTypes);
 
 	/**
+	 * Gets a method from its signature.
+	 *
+	 * @return null if does not exit
+	 */
+	@PropertyGetter(role = METHOD)
+	<R> CtMethod<R> getMethodBySignature(String signature);
+
+	/**
 	 * Returns the methods that are directly declared by this class or
 	 * interface.
 	 *

--- a/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
+++ b/src/main/java/spoon/reflect/path/CtPathStringBuilder.java
@@ -145,7 +145,8 @@ public class CtPathStringBuilder {
 				}
 			} else if ("]".equals(token) || ";".equals(token)) {
 				//finished reading of argument value
-				pathElement.addArgument(argName, argValue.toString());
+				//[fix bug]:AbstractPathElement.getArguments([constructor with no parameters])
+				pathElement.addArgument(argName, argValue.toString().replace("())","()"));
 				return token;
 			}
 			argValue.append(token);

--- a/src/main/java/spoon/reflect/path/impl/CtPathImpl.java
+++ b/src/main/java/spoon/reflect/path/impl/CtPathImpl.java
@@ -36,6 +36,32 @@ public class CtPathImpl implements CtPath {
 		return (List<T>) filtered;
 	}
 
+	private Class<?> getJdkClass(String name) {
+		name = name.replaceAll("[\\[\\]]", "");
+		switch (name) {
+			case "byte":
+				return byte.class;
+			case "int":
+				return int.class;
+			case "long":
+				return long.class;
+			case "float":
+				return float.class;
+			case "double":
+				return double.class;
+			case "char":
+				return char.class;
+			case "boolean":
+				return boolean.class;
+			default:
+				try {
+					return Class.forName(name);
+				} catch (ClassNotFoundException e) {
+				}
+		}
+		return null;
+	}
+
 	@Override
 	public CtPath relativePath(CtElement parent) {
 		List<CtElement> roots = new ArrayList<>();

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -89,6 +89,20 @@ public class CtClassImpl<T> extends CtTypeImpl<T> implements CtClass<T> {
 	}
 
 	@Override
+	public CtConstructor<T> getConstructorBySignature(String signature) {
+		for (CtTypeMember typeMember : getTypeMembers()) {
+			if (!(typeMember instanceof CtConstructor)) {
+				continue;
+			}
+			CtConstructor<T> c = (CtConstructor<T>) typeMember;
+			if (c.getSignature().replaceAll(c.getDeclaringType().getQualifiedName(), "").equals(signature)) {
+				return c;
+			}
+		}
+		return null;
+	}
+
+	@Override
 	public Set<CtConstructor<T>> getConstructors() {
 		Set<CtConstructor<T>> constructors = new SignatureBasedSortedSet<>();
 		for (CtTypeMember typeMember : typeMembers) {

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeImpl.java
@@ -723,6 +723,21 @@ public abstract class CtTypeImpl<T> extends CtNamedElementImpl implements CtType
 		return null;
 	}
 
+	@Override
+	@SuppressWarnings("unchecked")
+	public <R> CtMethod<R> getMethodBySignature(String signature) {
+		if (signature == null) {
+			return null;
+		}
+		String name = signature.substring(0, signature.indexOf('('));
+		for (CtMethod<?> candidate : getMethodsByName(name)) {
+			if (candidate.getSignature().equals(signature)) {
+				return (CtMethod<R>) candidate;
+			}
+		}
+		return null;
+	}
+
 	protected boolean hasSameParameters(CtExecutable<?> candidate, CtTypeReference<?>... parameterTypes) {
 		if (candidate.getParameters().size() != parameterTypes.length) {
 			return false;


### PR DESCRIPTION
fix #4984 
* feat(CtType,CtTypeImpl): add method `getMethodBySignature(String signature)`.
* feat(CtClass,CtClassImpl): add method `getConstructorBySignature(String signature)`.
* fix(CtPathStringBuilder): delete redundant ')' when get arguments for default constructor.
* feat(CtPathImpl): add method `getJdkClass`.
* feat(CtPathImpl): rewrite method `evaluateOn`, search for jdk elements when no root parameter is given.
* docs(path.md): update doc