### PR TITLE
feat: Set source position for executable references

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -508,6 +508,11 @@ public class ReferenceBuilder {
 		CtExecutableReference<T> ref = jdtTreeBuilder.getFactory().Core().createExecutableReference();
 		ref.setSimpleName(CharOperation.charToString(messageSend.selector));
 		ref.setType(this.<T>getTypeReference(messageSend.expectedType(), true));
+		ref.setPosition(jdtTreeBuilder.getPositionBuilder().buildPosition(
+			// (start << 32) + end
+			(int) (messageSend.nameSourcePosition >>> 32),
+			(int) messageSend.nameSourcePosition
+		));
 		if (messageSend.receiver.resolvedType == null) {
 			// It is crisis dude! static context, we don't have much more information.
 			ref.setStatic(true);


### PR DESCRIPTION
Currently spoon seems to do the following:
```java
foo.bar(0, 20)
^^^            target     position
        ^  ^^  literal    positions
^^^^^^^^^^^^^^ invocation position
```

This PR changes it to:
```java
foo.bar(0, 20)
^^^            target         position
        ^  ^^  literal        positions
    ^^^        executable ref position   (*)
^^^^^^^^^^^^^^ invocation     position
```

Using only the name should be fine as the executable reference has no children with positions. The only children are the parameter *types* (not the *arguments* of the call!).

Helps with: #5008