### PR TITLE
chore: Update CI python version from 3.6 to 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,7 +122,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # tag=v4.3.0
         with:
-          python-version: 3.6
+          python-version: 3.11
 
       - name: Get date for cache # see https://github.com/actions/cache README
         id: get-date

--- a/chore/check-links-in-doc.py
+++ b/chore/check-links-in-doc.py
@@ -2,7 +2,7 @@
 # checks the links of the Spoon documentation
 # a problem is reported as an exception, hence as a Unic return code != -1, hence as a build failure
 
-import CommonMark
+import commonmark
 import glob
 import os
 import codecs
@@ -23,7 +23,7 @@ def check_external_url(url):
 
 
 def main(where):
-  parser = CommonMark.Parser()
+  parser = commonmark.Parser()
 
   for root, subdirs, files in os.walk(where):
     for i in files:
@@ -44,6 +44,6 @@ def main(where):
             if not os.path.exists(linked_page): raise Exception("no such page "+linked_page)
     
 def debug(filename):
-  print("\n".join(str(x) for x in list(CommonMark.Parser().parse(codecs.open(filename, encoding="utf8").read()).walker())))
+  print("\n".join(str(x) for x in list(commonmark.Parser().parse(codecs.open(filename, encoding="utf8").read()).walker())))
 
 main("./doc")

--- a/chore/ci-extra.sh
+++ b/chore/ci-extra.sh
@@ -9,7 +9,7 @@
 # fails if anything fails
 set -e
 
-pip install --user CommonMark==0.7.5 requests pygithub
+pip install --user CommonMark==0.9.1 requests pygithub
 
 mvn -version
 


### PR DESCRIPTION
Github recently updated their `ubuntu-latest` image to 22.04. This broke setup-python as it no python 3.6 tarball is provided (https://github.com/actions/setup-python/issues/544). 

This PR fixes the issue by just updating the CI to use python 3.9. It does not adjust the ci scripts to take advantage of possible new python features introduced since then.

This breakage is responsible for the current red master (as the PR run was executed *before* the Github runner change but the master action ran *after* it) and unblocks some PRs.

----

I also needed to update commonmark. Note that commonmark is **deprecated** for **over a year** now: https://github.com/readthedocs/commonmark.py/issues/308. We might to want migrate away from it in a future PR, though we don't really *need* to. The source code we analyze is benign so security isn't really an issue and the featureset is enough for us.