### PR TITLE
Revert "chore(deps): update dependency se.kth.castor:depclean-maven-plugin to v2.0.4"

### DIFF
--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -208,7 +208,7 @@
                     <!-- see https://github.com/castor-software/depclean -->
                     <groupId>se.kth.castor</groupId>
                     <artifactId>depclean-maven-plugin</artifactId>
-                    <version>2.0.4</version>
+                    <version>2.0.3</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
Reverts INRIA/spoon#5055

@MartinWitt @SirYwell @I-Al-Istannen Need to roll this back as depclean apparently moved to Java 17 causing our deploy job to fail. Unbeknownst to me, our extra CI checks here run on Java 17, I just assumed they would run on our lowest supported version. I'll try Java 11 for that to see if it works after this has been merged, anything that's running checks should either run on all supported versions or on the lowest supported version (the latter usually being sufficient when it comes to Java).