### PR TITLE
chore: Use Java 11 for extra CI checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,7 +118,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # v3.9.0
         with:
-          java-version: 17
+          java-version: 11
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - uses: actions/setup-python@5ccb29d8773c3f3f653e1705f474dfaa8a06a912 # v4.4.0
         with:


### PR DESCRIPTION
We should run our extra checks on the least supported version. It's significantly more likely to have breakage because of backwards-incompatible changes (e.g. Depclean moving to Java 17) than forwards-incompatible changes.