### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -88,7 +88,7 @@ public class SnippetCompilationHelper {
 			pkg = "package " + pkg + ";";
 		}
 		try {
-			build(f, pkg + clonedInitialClass );
+			build(f, pkg + clonedInitialClass);
 		} finally {
 			// restore modifiers
 			initialClass.setModifiers(backup);

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -88,7 +88,7 @@ public class SnippetCompilationHelper {
 			pkg = "package " + pkg + ";";
 		}
 		try {
-			build(f, pkg + clonedInitialClass.toString());
+			build(f, pkg + clonedInitialClass );
 		} finally {
 			// restore modifiers
 			initialClass.setModifiers(backup);


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:613497432 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (1)
