### PR TITLE
fix: Remove escaping of ' in a CtLiteral<String>

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Spoon
 
-Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. It parses source files to build a well-designed AST with powerful analysis and transformation API. It fully supports modern Java versions up to Java 16. Spoon is an official Inria open-source project, and member of the [OW2](https://www.ow2.org/) open-source consortium.
+Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. It parses source files to build a well-designed AST with powerful analysis and transformation API. It supports modern Java versions up to Java 20. Spoon is an official Inria open-source project, and member of the [OW2](https://www.ow2.org/) open-source consortium.
 
 ## Documentation
 

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -118,7 +118,7 @@ abstract class LiteralHelper {
 	 * This exists for backwards compatibility.
 	 * @param literal to be converted literal
 	 * @param sb the string builder to append the literal
-	 * @param c  the character to append 
+	 * @param c  the character to append
 	 * @param mayContainsSpecialCharacter  true if the string may contains special characters.
 	 */
 	static void appendCharLiteral(StringBuilder sb, Character c, boolean mayContainsSpecialCharacter) {

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -113,7 +113,18 @@ abstract class LiteralHelper {
 		}
 	}
 
+	/**
+	 * This methods only calls {@link #appendCharLiteral(StringBuilder, Character, boolean, boolean)} with {@code isInsideString = false}.
+	 * This exists for backwards compatibility.
+	 * @param literal to be converted literal
+	 * @param sb the string builder to append the literal
+	 * @param c  the character to append 
+	 * @param mayContainsSpecialCharacter  true if the string may contains special characters.
+	 */
 	static void appendCharLiteral(StringBuilder sb, Character c, boolean mayContainsSpecialCharacter) {
+		appendCharLiteral(sb, c, mayContainsSpecialCharacter, false);
+}
+	static void appendCharLiteral(StringBuilder sb, Character c, boolean mayContainsSpecialCharacter, boolean isInsideString) {
 		if (!mayContainsSpecialCharacter) {
 			sb.append(c);
 		} else {
@@ -137,7 +148,11 @@ abstract class LiteralHelper {
 					sb.append("\\\""); //$NON-NLS-1$
 					break;
 				case '\'':
-					sb.append("\\'"); //$NON-NLS-1$
+					if (isInsideString) {
+						sb.append("'"); //$NON-NLS-1$
+					} else {
+						sb.append("\\'"); //$NON-NLS-1$
+					}
 					break;
 				case '\\': // take care not to display the escape as a potential
 					// real char
@@ -155,7 +170,7 @@ abstract class LiteralHelper {
 		} else {
 			StringBuilder sb = new StringBuilder(value.length() * 2);
 			for (int i = 0; i < value.length(); i++) {
-				appendCharLiteral(sb, value.charAt(i), mayContainsSpecialCharacter);
+				appendCharLiteral(sb, value.charAt(i), mayContainsSpecialCharacter, true);
 			}
 			return sb.toString();
 		}

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -92,7 +92,7 @@ abstract class LiteralHelper {
 			}
 			StringBuilder sb = new StringBuilder(10);
 			sb.append('\'');
-			appendCharLiteral(sb, (Character) literal.getValue(), mayContainsSpecialCharacter);
+			appendCharLiteral(sb, (Character) literal.getValue(), mayContainsSpecialCharacter, false);
 			sb.append('\'');
 			return sb.toString();
 		} else if (literal.getValue() instanceof String) {
@@ -113,17 +113,7 @@ abstract class LiteralHelper {
 		}
 	}
 
-	/**
-	 * This methods only calls {@link #appendCharLiteral(StringBuilder, Character, boolean, boolean)} with {@code isInsideString = false}.
-	 * This exists for backwards compatibility.
-	 * @param literal to be converted literal
-	 * @param sb the string builder to append the literal
-	 * @param c  the character to append
-	 * @param mayContainsSpecialCharacter  true if the string may contains special characters.
-	 */
-	static void appendCharLiteral(StringBuilder sb, Character c, boolean mayContainsSpecialCharacter) {
-		appendCharLiteral(sb, c, mayContainsSpecialCharacter, false);
-}
+
 	static void appendCharLiteral(StringBuilder sb, Character c, boolean mayContainsSpecialCharacter, boolean isInsideString) {
 		if (!mayContainsSpecialCharacter) {
 			sb.append(c);

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -156,12 +156,11 @@ abstract class LiteralHelper {
 	static String getStringLiteral(String value, boolean mayContainsSpecialCharacter) {
 		if (!mayContainsSpecialCharacter) {
 			return value;
-		} else {
-			StringBuilder sb = new StringBuilder(value.length() * 2);
-			for (int i = 0; i < value.length(); i++) {
-				appendCharLiteral(sb, value.charAt(i), true, true);
-			}
-			return sb.toString();
 		}
+		StringBuilder sb = new StringBuilder(value.length() * 2);
+		for (int i = 0; i < value.length(); i++) {
+			appendCharLiteral(sb, value.charAt(i), true, true);
+		}
+		return sb.toString();
 	}
 }

--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -159,7 +159,7 @@ abstract class LiteralHelper {
 		} else {
 			StringBuilder sb = new StringBuilder(value.length() * 2);
 			for (int i = 0; i < value.length(); i++) {
-				appendCharLiteral(sb, value.charAt(i), mayContainsSpecialCharacter, true);
+				appendCharLiteral(sb, value.charAt(i), true, true);
 			}
 			return sb.toString();
 		}

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -22,6 +22,7 @@ import spoon.support.comparator.DeepRepresentationComparator;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.factory.CodeFactory;
+import spoon.test.GitHubIssue;
 import spoon.test.literal.testclasses.Tacos;
 import spoon.Launcher;
 import spoon.reflect.code.LiteralBase;
@@ -258,8 +259,8 @@ public class LiteralTest {
 		assertEquals("'c'", ctClass.getField("c1").getDefaultExpression().toString());
 		assertEquals("\"hello\"", ctClass.getField("s1").getDefaultExpression().toString());
 	}
-	//TODO: add issue number
-	@Test
+
+	@GitHubIssue(issueNumber = 5070, fixed = true)
 	void tooStrictEscaping() {
 		// contract: inside a string without a position ' are not escaped.
 		List<CtLiteral<?>> literals = Launcher.parseClass("class Foo { String s = \"'\"; }")

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -25,11 +25,12 @@ import spoon.reflect.factory.CodeFactory;
 import spoon.test.literal.testclasses.Tacos;
 import spoon.Launcher;
 import spoon.reflect.code.LiteralBase;
+import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.factory.TypeFactory;
 import spoon.reflect.declaration.CtClass;
 import org.junit.jupiter.api.Test;
 import spoon.testing.utils.ModelTest;
-
+import java.util.List;
 import java.util.TreeSet;
 
 import static spoon.testing.utils.ModelUtils.buildClass;
@@ -256,5 +257,17 @@ public class LiteralTest {
 
 		assertEquals("'c'", ctClass.getField("c1").getDefaultExpression().toString());
 		assertEquals("\"hello\"", ctClass.getField("s1").getDefaultExpression().toString());
+	}
+	//TODO: add issue number
+	@Test
+	void tooStrictEscaping() {
+		// contract: inside a string without a position ' are not escaped.
+		List<CtLiteral<?>> literals = Launcher.parseClass("class Foo { String s = \"'\"; }")
+				.getElements(new TypeFilter<>(CtLiteral.class));
+		CtLiteral<?> ctLiteral = literals.get(0);
+		ctLiteral.setPosition(SourcePosition.NOPOSITION);
+		String literal = (String) ctLiteral.getValue();
+		assertEquals("'", literal);
+		assertEquals("\"'\"", ctLiteral.toString());
 	}
 }

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -271,4 +271,15 @@ public class LiteralTest {
 		assertEquals("'", literal);
 		assertEquals("\"'\"", ctLiteral.toString());
 	}
+
+	@GitHubIssue(issueNumber = 5070, fixed = true)
+	void tooStrictEscapingCharTest() {
+		// contract: inside a string with a position ' are escaped.
+		List<CtLiteral<?>> literals = Launcher.parseClass("class Foo { char c = \'\\'\'; }")
+				.getElements(new TypeFilter<>(CtLiteral.class));
+		CtLiteral<?> ctLiteral = literals.get(0);
+		char literal = (char) ctLiteral.getValue();
+		assertEquals('\'', literal);
+		assertEquals("\'\\'\'", ctLiteral.toString());
+	}
 }


### PR DESCRIPTION
Currently, spoon escapes every `'` in a `CtLiteral<String>` without a source position. In a `string `escaping `'` is not necessary.