### PR TITLE
review: fix: Reject invalid float/double literals

### DIFF
--- a/src/main/java/spoon/reflect/visitor/LiteralHelper.java
+++ b/src/main/java/spoon/reflect/visitor/LiteralHelper.java
@@ -7,6 +7,7 @@
  */
 package spoon.reflect.visitor;
 
+import spoon.SpoonException;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtTextBlock;
 import spoon.reflect.code.LiteralBase;
@@ -43,13 +44,19 @@ abstract class LiteralHelper {
 	}
 
 	private static String getBasedString(Float value, LiteralBase base) {
+		if (value.isInfinite() || value.isNaN()) {
+			throw new SpoonException("Can not convert " + value + " to a float literal.");
+		}
 		if (base == LiteralBase.HEXADECIMAL) {
 			return Float.toHexString(value) + "F";
 		}
-		return Float.toString(value) + "F";
+		return value + "F";
 	}
 
 	private static String getBasedString(Double value, LiteralBase base) {
+		if (value.isInfinite() || value.isNaN()) {
+			throw new SpoonException("Can not convert " + value + " to a double literal.");
+		}
 		if (base == LiteralBase.HEXADECIMAL) {
 			return Double.toHexString(value);
 		}

--- a/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtLiteralImpl.java
@@ -38,8 +38,8 @@ public class CtLiteralImpl<T> extends CtExpressionImpl<T> implements CtLiteral<T
 
 	@Override
 	public <C extends CtLiteral<T>> C setValue(T value) {
-		if (this.value instanceof CtElement) {
-			((CtElement) this.value).setParent(this);
+		if (value instanceof CtElement) {
+			((CtElement) value).setParent(this);
 		}
 		getFactory().getEnvironment().getModelChangeListener().onObjectUpdate(this, EXPRESSION, value, this.value);
 		this.value = value;

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import spoon.Launcher;
+import spoon.SpoonException;
 import spoon.SpoonModelBuilder;
 import spoon.compiler.SpoonResourceHelper;
 import spoon.reflect.CtModel;
@@ -47,6 +48,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static spoon.test.SpoonTestHelpers.containsRegexMatch;
 
 public class DefaultJavaPrettyPrinterTest {
@@ -375,5 +377,19 @@ public class DefaultJavaPrettyPrinterTest {
 
         CtLocalVariable<Integer> localVariable = model.getElements(new TypeFilter<>(CtLocalVariable.class)).get(1);
         assertThat(localVariable.toString(), equalTo("int fieldReadOfA = ((A) c).a.i"));
+    }
+
+    @ParameterizedTest(name = "Printing literal ''{0}'' throws an error")
+    @ValueSource(doubles = {
+        Double.NEGATIVE_INFINITY,
+        Double.POSITIVE_INFINITY,
+        Double.NaN
+    })
+    void throwsExceptionWhenPrintingInvalidFloatingLiteral(double value) {
+        // contract: Printing invalid floating literals throws an exception
+        Factory factory = new Launcher().getFactory();
+
+        assertThrows(SpoonException.class, () -> factory.createLiteral(value).toString());
+        assertThrows(SpoonException.class, () -> factory.createLiteral((float) value).toString());
     }
 }


### PR DESCRIPTION
## About
`float` and `double` can represent ~~three~~ *many* values you can not write using a floating literal. Some examples are `Infinity`, `-Infinity` and then the whole family of `NaN` values.

As they can not be written down directly, the current printer creates invalid code for them. Forbidding such values in `CtLiteral` is not an option, as we can no longer represent `get(Double.class).getField("POSITIVE_INFINITY")`. 

Alternatively, we could also adjust the printer to *handle* (and not *reject*) such literals, by producing either reads of `Double.POSITIVE_INFINITY` or emitting `1d/0`.

## Further work and questions
I think we should probably offer a convenience method somewhere, which translates a `float` or `double` to a Literal or appropriate field read (`Double.POSITIVE_INFINITY`). Something to think about here is NaN-Boxing: Theoretically we need to use `Double.longBitsToDouble` or equivalent to preserve them. 