### PR TITLE
fix: getActualClass() for multi-dimensional arrays

### DIFF
--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -290,6 +290,9 @@ public class TypeFactory extends SubFactory {
 	 */
 	public CtArrayTypeReference<?> createArrayReference(CtTypeReference<?> reference, int n) {
 		CtTypeReference<?> componentType;
+		if (n < 1) {
+			throw new SpoonException("Array dimension must be >= 1");
+		}
 		if (n == 1) {
 			return createArrayReference(reference);
 		}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
 import static spoon.reflect.ModelElementContainerDefaultCapacities.TYPE_TYPE_PARAMETERS_CONTAINER_DEFAULT_CAPACITY;
 import static spoon.reflect.path.CtRole.DECLARING_TYPE;
 import static spoon.reflect.path.CtRole.IS_SHADOW;
@@ -156,12 +157,14 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		if (isArray()) {
 			CtTypeReference<?> componentTypeReference = convertToComponentType();
 			if (componentTypeReference.isPrimitive()) {
-				return getPrimitiveType(componentTypeReference).map(this::arrayType).orElseThrow(() -> new SpoonException("Cant find primitive type: " + componentTypeReference));
+				return getPrimitiveType(componentTypeReference)
+					.map(this::asArrayTypeWithOurDimensions)
+					.orElseThrow(() -> new SpoonException("Cant find primitive type: " + componentTypeReference));
 			}
 			typeReference = componentTypeReference;
 		}
 		Class<T> actualClass = getClassFromThreadLocalCacheOrLoad(typeReference);
-		return isArray() ? arrayType(actualClass) : actualClass;
+		return isArray() ? asArrayTypeWithOurDimensions(actualClass) : actualClass;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -177,7 +180,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	 * @return  the component type of the type reference.
 	 */
 	private CtTypeReference<T> convertToComponentType() {
-		if (this.getQualifiedName().indexOf("[") == -1) {
+		if (!this.getQualifiedName().contains("[")) {
 			return this;
 		}
 		return getFactory().createReference(this.getQualifiedName().substring(0, this.getQualifiedName().indexOf("[")));
@@ -210,9 +213,13 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 	 * @return  the array type.
 	 */
 	@SuppressWarnings("unchecked")
-	private <R> Class<R> arrayType(Class<R> clazz) {
-			return (Class<R>) Array.newInstance(clazz, 0).getClass();
+	private <R> Class<R> asArrayTypeWithOurDimensions(Class<R> clazz) {
+		String simpleName = getSimpleName();
+		int dimensionCount = (simpleName.length() - simpleName.indexOf('[')) / 2;
+		int[] dimensions = new int[dimensionCount];
+		return (Class<R>) Array.newInstance(clazz, dimensions).getClass();
 	}
+
 	@Override
 	public List<CtTypeReference<?>> getActualTypeArguments() {
 		return actualTypeArguments;

--- a/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
+++ b/src/test/java/spoon/reflect/reference/CtTypeReferenceTest.java
@@ -3,10 +3,13 @@ package spoon.reflect.reference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
+import spoon.Launcher;
 import spoon.compiler.Environment;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.factory.TypeFactory;
@@ -32,9 +35,9 @@ public class CtTypeReferenceTest {
     @Mock private ClassLoader classLoader;
 
     @BeforeEach public void setUp() {
-        when(factory.Type()).thenReturn(typeFactory);
-        when(factory.getEnvironment()).thenReturn(environment);
-        when(environment.getModelChangeListener()).thenReturn(listener);
+        Mockito.lenient().when(factory.Type()).thenReturn(typeFactory);
+        Mockito.lenient().when(factory.getEnvironment()).thenReturn(environment);
+        Mockito.lenient().when(environment.getModelChangeListener()).thenReturn(listener);
         Mockito.lenient().when(environment.getInputClassLoader()).thenReturn(classLoader);
     }
 
@@ -90,4 +93,32 @@ public class CtTypeReferenceTest {
         //contract: box/unbox returns a reference toward the expected type
         assertEquals(expectedClass.getName(), result.getQualifiedName());
     }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "byte,              2, byte[][]",
+        "byte,              3, byte[][][]",
+        "java.lang.String,  3, String[][][]",
+        "char,              1, char[]",
+        "boolean,           1, boolean[]",
+        "byte,              1, byte[]",
+        "short,             1, short[]",
+        "int,               1, int[]",
+        "long,              1, long[]",
+        "float,             1, float[]",
+        "double,            1, double[]",
+    })
+    void testGetActualClassForArray(String className, int arrayDepth, String expected) {
+        // contract: "getActualClass" should return proper classes for multi-dimensional arrays
+        Factory factory = new Launcher().getFactory();
+        CtArrayTypeReference<?> reference = factory.createArrayReference(
+            factory.createReference(className),
+            arrayDepth
+        );
+        assertEquals(
+            expected,
+            reference.getActualClass().getSimpleName()
+        );
+    }
+
 }


### PR DESCRIPTION
The additional dimensions of multi-dimensional arrays were dropped by `getActualClass`.