### PR TITLE
fix: creation of CtTypeReferences from java classes

### DIFF
--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -17,6 +17,8 @@
 package spoon.test.factory;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.code.CtTypeAccess;
@@ -66,4 +68,54 @@ public class CodeFactoryTest {
 		CtTypeReference<Exception> exceptionType = factory.Type().createReference(Exception.class);
 		assertDoesNotThrow(() -> factory.Code().createCatchVariable(exceptionType, "e"));
 	}
+
+	@ParameterizedTest
+	@ValueSource(classes = {
+		byte[].class,
+		byte[][].class,
+		String[][].class,
+	})
+	void testCreateCtReferenceOfArray(Class<?> clazz) {
+		// contract: References for arrays are created
+		Factory factory = createFactory();
+		assertEquals(
+			clazz.getSimpleName(),
+			factory.createCtTypeReference(clazz).getSimpleName()
+		);
+	}
+
+	@Test
+	void testCreateCtReferenceOfInnerClass() {
+		// contract: References for inner classes are created
+		Factory factory = createFactory();
+		assertEquals(
+			TestClassInnerClass.class.getSimpleName(),
+			factory.createCtTypeReference(TestClassInnerClass.class).getSimpleName()
+		);
+	}
+
+	@Test
+	void testCreateCtReferenceOfLocalClass() {
+		class LocalClass {}
+		// contract: References for local classes are created
+		Factory factory = createFactory();
+		assertEquals(
+			LocalClass.class.getSimpleName(),
+			factory.createCtTypeReference(LocalClass.class).getSimpleName()
+		);
+	}
+
+	@Test
+	void testCreateCtReferenceOfAnonymousClass() {
+		// contract: References for anonymous classes are created
+		Class<?> clazz = (new Object() {
+		}.getClass());
+		Factory factory = createFactory();
+		assertEquals(
+			clazz.getName(),
+			factory.createCtTypeReference(clazz).getQualifiedName()
+		);
+	}
+
+	private static class TestClassInnerClass {}
 }

--- a/src/test/java/spoon/test/factory/CodeFactoryTest.java
+++ b/src/test/java/spoon/test/factory/CodeFactoryTest.java
@@ -28,7 +28,12 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.support.util.compilation.JavacFacade;
 import spoon.test.GitHubIssue;
+
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -85,19 +90,29 @@ public class CodeFactoryTest {
 	}
 
 	@Test
-	void testCreateCtReferenceOfInnerClass() {
+	void testCreateCtReferenceOfInnerClass() throws ClassNotFoundException {
 		// contract: References for inner classes are created
 		Factory factory = createFactory();
+		Class<?> innerClass = JavacFacade.compileFiles(
+				Map.of(
+					"Test.java",
+					"class Test {" +
+						"  class TestClassInner {}" +
+						"}"
+				),
+				List.of()
+			)
+			.loadClass("Test$TestClassInner");
 		assertEquals(
-			TestClassInnerClass.class.getSimpleName(),
-			factory.createCtTypeReference(TestClassInnerClass.class).getSimpleName()
+			innerClass.getSimpleName(),
+			factory.createCtTypeReference(innerClass).getSimpleName()
 		);
 	}
 
 	@Test
 	void testCreateCtReferenceOfLocalClass() {
-		class LocalClass {}
 		// contract: References for local classes are created
+		class LocalClass {}
 		Factory factory = createFactory();
 		assertEquals(
 			LocalClass.class.getSimpleName(),
@@ -117,5 +132,4 @@ public class CodeFactoryTest {
 		);
 	}
 
-	private static class TestClassInnerClass {}
 }


### PR DESCRIPTION
Creating `CtTypeReference`s from java classes was a bit too ad-hoc for my usecase. This PR adds support for array types and anonymous classes. Anonymous classes do not appear in the shadow model but can still be useful when dealing with arbitrary objects. They are also supported by the source model.

Notable changes: This PR switches from `CLass#getDeclaringClass` to `Class#getEnclosingClass` to properly work with anonymous classes. This seems to be closer to what the source model uses as well.