### PR TITLE
fix: enclosing class parameters being ignored for static inner classes

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -339,7 +339,13 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 		if (parameter.isImplicit()) {
 			return true;
 		}
-		// best effort fallback
+		// best effort fallback for the implicit enclosing class parameter in non-static inner class constructors
+
+		// static inner classes have no implicit parameter
+		if (Modifier.isStatic(constructor.getDeclaringClass().getModifiers())) {
+			return false;
+		}
+
 		return isFirstParameter && parameter.getType() == constructor.getDeclaringClass().getEnclosingClass();
 	}
 


### PR DESCRIPTION
While constructors of non-static inner classes have an *implicit* parameter of the enclosing class's type, static classes *do not*. This should be reflected in the model.