### PR TITLE
fix: Do not visit package for nested classes

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -39,7 +39,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	@Override
 	public <T> void visitClass(Class<T> clazz) {
-		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
+		if (isTopLevelType(clazz)) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -125,7 +125,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T> void visitInterface(Class<T> clazz) {
 		assert clazz.isInterface();
-		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
+		if (isTopLevelType(clazz)) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -183,7 +183,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T> void visitEnum(Class<T> clazz) {
 		assert clazz.isEnum();
-		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
+		if (isTopLevelType(clazz)) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -257,7 +257,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T extends Annotation> void visitAnnotationClass(Class<T> clazz) {
 		assert clazz.isAnnotation();
-		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
+		if (isTopLevelType(clazz)) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -499,7 +499,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	@Override
 	public <T> void visitTypeReference(CtRole role, Class<T> clazz) {
-		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
+		if (isTopLevelType(clazz)) {
 			visitPackage(clazz.getPackage());
 		}
 		if (clazz.getEnclosingClass() != null) {
@@ -599,6 +599,9 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	}
 
+	private static boolean isTopLevelType(Class<?> clazz) {
+		return clazz.getEnclosingClass() == null && clazz.getPackage() != null;
+	}
 
 	private static Class<?> getRecordClass() {
 		try {

--- a/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionVisitorImpl.java
@@ -39,7 +39,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	@Override
 	public <T> void visitClass(Class<T> clazz) {
-		if (clazz.getPackage() != null) {
+		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -125,7 +125,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T> void visitInterface(Class<T> clazz) {
 		assert clazz.isInterface();
-		if (clazz.getPackage() != null) {
+		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -183,7 +183,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T> void visitEnum(Class<T> clazz) {
 		assert clazz.isEnum();
-		if (clazz.getPackage() != null) {
+		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -257,7 +257,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 	@Override
 	public <T extends Annotation> void visitAnnotationClass(Class<T> clazz) {
 		assert clazz.isAnnotation();
-		if (clazz.getPackage() != null) {
+		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
 			visitPackage(clazz.getPackage());
 		}
 		try {
@@ -499,7 +499,7 @@ class JavaReflectionVisitorImpl implements JavaReflectionVisitor {
 
 	@Override
 	public <T> void visitTypeReference(CtRole role, Class<T> clazz) {
-		if (clazz.getPackage() != null && clazz.getEnclosingClass() == null) {
+		if (clazz.getEnclosingClass() == null && clazz.getPackage() != null) {
 			visitPackage(clazz.getPackage());
 		}
 		if (clazz.getEnclosingClass() != null) {

--- a/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
+++ b/src/test/java/spoon/support/visitor/java/JavaReflectionTreeBuilderTest.java
@@ -949,7 +949,7 @@ public class JavaReflectionTreeBuilderTest {
 		factory.Type().get(loader.loadClass("First"));
 
 		// This will throw if the replacement was successful
-		CtType<?> victim = factory.Type().get(loader.loadClass("Victim$Inner"));
+		CtType<?> victim = assertDoesNotThrow(() -> factory.Type().get(loader.loadClass("Victim$Inner")));
 
 		// Make sure we got the right class, but this should be fine now in any case
 		assertNotNull(victim.getField("bar"));


### PR DESCRIPTION
If we did, we would overwrite potential top-level classes in the package. This happened with `java.util.ArrayList` and `java.util.Arrays$ArrayList` in a project of mine. As a consequence, lookups for `java.util.ArrayList$ListIter` fail: The now-overwritten `ArrayList` has no member classes and the lookup returns null.

The problem cost me a few hours to find and fix, but I hope the fix seems reasonable enough.