### PR TITLE
fix: isOverriding check with generic throws clause

### DIFF
--- a/src/main/java/spoon/support/adaption/TypeAdaptor.java
+++ b/src/main/java/spoon/support/adaption/TypeAdaptor.java
@@ -239,7 +239,7 @@ public class TypeAdaptor {
 			newParameter.setType(adaptType(inputMethod.getParameters().get(i).getType()));
 		}
 
-		Set<CtTypeReference<? extends Throwable>> newThrownTypes = clonedMethod.getThrownTypes()
+		Set<CtTypeReference<? extends Throwable>> newThrownTypes = inputMethod.getThrownTypes()
 			.stream()
 			.map(this::adaptType)
 			.map(it -> (CtTypeReference<? extends Throwable>) it)


### PR DESCRIPTION
This fixes a small oversight where the cloned throws clause was adapted instead of the original. As the cloned method does not have a parent, lookup of the enclosing type failed and an exception was thrown.

It would likely also be possible to use a method context for the adaption and then try to adapt formal type parameters to the submethod, but that does not make a difference for the overriding check as far as I can see. It would complicate the implementation and be slower though, so I did not do this here.

Closes #5115.