### PR TITLE
fix: Do not import two types with the same simple name

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
+++ b/src/main/java/spoon/reflect/visitor/ImportConflictDetector.java
@@ -26,6 +26,7 @@ import spoon.reflect.reference.CtPackageReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.support.Experimental;
 
+import java.util.Map;
 
 /**
  * Detects conflicts needed to be required be a fully-qualified name.
@@ -196,6 +197,16 @@ public class ImportConflictDetector extends ImportAnalyzer<LexicalScope> {
 				ref.setSimplyQualified(false);
 				return false;
 			});
+
+			if (!ref.isImplicit() && ref.isSimplyQualified()) {
+				Map<String, String> encounteredNames = ((LexicalScopeScanner) scanner).getEncounteredImportedQualifiedNames();
+				encounteredNames.putIfAbsent(ref.getSimpleName(), ref.getQualifiedName());
+				if (!encounteredNames.get(ref.getSimpleName()).equals(ref.getQualifiedName())) {
+					// We have found a different type with the same simple name, do not import this one
+					ref.setImplicit(false);
+					ref.setSimplyQualified(false);
+				}
+			}
 		} //else it is already fully qualified
 		checkConflictOfTypeReference(nameScope, ref);
 	}

--- a/src/main/java/spoon/reflect/visitor/LexicalScopeScanner.java
+++ b/src/main/java/spoon/reflect/visitor/LexicalScopeScanner.java
@@ -23,6 +23,8 @@ import spoon.reflect.declaration.CtMethod;
 import java.lang.annotation.Annotation;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * A {@link CtScanner} which provides current lexical scope
@@ -30,6 +32,8 @@ import java.util.Deque;
  */
 public class LexicalScopeScanner extends EarlyTerminatingScanner<Object> {
 	private final Deque<LexicalScope> scopes = new ArrayDeque<>();
+	private final Map<String, String> encounteredImportedQualifiedNames = new HashMap<>();
+
 	protected void enter(spoon.reflect.declaration.CtElement e) {
 		LexicalScope newFinder = onElement(scopes.peek(), e);
 		if (newFinder != null) {
@@ -51,6 +55,10 @@ public class LexicalScopeScanner extends EarlyTerminatingScanner<Object> {
 	public LexicalScope getCurrentLexicalScope() {
 		LexicalScope ns = scopes.peek();
 		return ns == null ? EMPTY : ns;
+	}
+
+	Map<String, String> getEncounteredImportedQualifiedNames() {
+		return encounteredImportedQualifiedNames;
 	}
 
 	/**

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -259,7 +259,7 @@ public class DefaultPrettyPrinterTest {
 
 		String expected =
 			"public void setFieldUsingExternallyDefinedEnumWithSameNameAsLocal() {" + nl
-			+ "    localField = TypeIdentifierCollision.ENUM.E1.ordinal();" + nl
+			+ "    localField = spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1.ordinal();" + nl
 			+ "}";
 
 		String computed = aClass.getMethodsByName("setFieldUsingExternallyDefinedEnumWithSameNameAsLocal").get(0).toString();
@@ -294,7 +294,7 @@ public class DefaultPrettyPrinterTest {
 
 		expected =
 			"public enum ENUM {" + nl + nl
-			+ "    E1(TypeIdentifierCollision.globalField, TypeIdentifierCollision.ENUM.E1);" + nl
+			+ "    E1(spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField, spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1);" + nl
 			+ "    final int NUM;" + nl + nl
 			+ "    final Enum<?> e;" + nl + nl
 			+ "    private ENUM(int num, Enum<?> e) {" + nl


### PR DESCRIPTION
Previously, spoon would turn
```java
package bar;
public class User {
  public static void foo() {
    System.out.println(foo.bar.baz.Locale.HELLO);
    System.out.println(java.util.Locale.GERMANY);
  }
}
```
into
```java
package bar;
import foo.bar.baz.Locale;
import java.util.Locale;
public class User {
    public static void foo() {
        System.out.println(Locale.HELLO);
        System.out.println(Locale.GERMANY);
    }
}
```

which is *not ideal*. There was a test case verifying this does not happen, but as far as I can see the assertions in the test are wrong. I also have no idea what code was supposed to implement it.