### PR TITLE
wip: feat: implement the null object for CtPackage

### DIFF
--- a/src/main/java/spoon/support/reflect/NoPackage.java
+++ b/src/main/java/spoon/support/reflect/NoPackage.java
@@ -1,4 +1,4 @@
-package spoon.support.reflect.declaration;
+package spoon.support.reflect;
 
 import java.lang.annotation.Annotation;
 import java.util.Collection;
@@ -35,7 +35,7 @@ import spoon.support.sniper.internal.ElementSourceFragment;
  */
 public class NoPackage implements CtPackage {
 	private static final long serialVersionUID = 1L;
-	private String NO_PACKAGE_NAME = "<no package>";
+	private static final String NO_PACKAGE_NAME = "<no package>";
 
 	@Override
 	public void accept(CtVisitor visitor) {

--- a/src/main/java/spoon/support/reflect/declaration/NoPackage.java
+++ b/src/main/java/spoon/support/reflect/declaration/NoPackage.java
@@ -1,0 +1,451 @@
+package spoon.support.reflect.declaration;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import spoon.reflect.code.CtComment;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtShadowable;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.ParentNotInitializedException;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtPath;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtPackageReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.Filter;
+import spoon.reflect.visitor.chain.CtConsumableFunction;
+import spoon.reflect.visitor.chain.CtFunction;
+import spoon.reflect.visitor.chain.CtQuery;
+import spoon.support.sniper.internal.ElementSourceFragment;
+
+/**
+ * The null object implementation for {@link spoon.reflect.declaration.CtPackage}.
+ */
+public class NoPackage implements CtPackage {
+	private static final long serialVersionUID = 1L;
+	private String NO_PACKAGE_NAME = "<no package>";
+
+	@Override
+	public void accept(CtVisitor visitor) {
+		// do nothing
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtPackage> T addPackage(CtPackage pack) {
+		return (T) this;
+	}
+
+	@Override
+	public boolean removePackage(CtPackage pack) {
+		return false;
+	}
+
+	@Override
+	public CtModule getDeclaringModule() {
+		return null;
+	}
+
+	@Override
+	public CtPackage getDeclaringPackage() {
+		return this;
+	}
+
+	@Override
+	public CtPackage getPackage(String name) {
+		return this;
+	}
+
+	@Override
+	public Set<CtPackage> getPackages() {
+		return Collections.singleton(this);
+	}
+
+	@Override
+	public String getQualifiedName() {
+		return getSimpleName();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtType<?>> T getType(String simpleName) {
+		return (T) this;
+	}
+
+	@Override
+	public Set<CtType<?>> getTypes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtPackage> T setPackages(Set<CtPackage> pack) {
+		return (T) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtPackage> T setTypes(Set<CtType<?>> types) {
+		return (T) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtPackage> T addType(CtType<?> type) {
+		return (T) this;
+	}
+
+	@Override
+	public void removeType(CtType<?> type) {
+		// do nothing
+	}
+
+	@Override
+	public CtPackageReference getReference() {
+		return null;
+	}
+
+	@Override
+	public String getSimpleName() {
+		return NO_PACKAGE_NAME;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <T extends CtNamedElement> T setSimpleName(String simpleName) {
+		return (T) this;
+	}
+
+	@Override
+	public String getShortRepresentation() {
+		return super.toString();
+	}
+
+	@Override
+	public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+		return null;
+	}
+
+	@Override
+	public <A extends Annotation> boolean hasAnnotation(Class<A> annotationType) {
+		return false;
+	}
+
+	@Override
+	public <A extends Annotation> CtAnnotation<A> getAnnotation(CtTypeReference<A> annotationType) {
+		return null;
+	}
+
+	@Override
+	public List<CtAnnotation<? extends Annotation>> getAnnotations() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public String getDocComment() {
+		return "";
+	}
+
+	@Override
+	public SourcePosition getPosition() {
+		return SourcePosition.NOPOSITION;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setAnnotations(List<CtAnnotation<? extends Annotation>> annotation) {
+		return (E) this;
+	}
+
+	@Override
+	public void delete() {
+		// do nothing
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E addAnnotation(CtAnnotation<? extends Annotation> annotation) {
+		return (E) this;
+	}
+
+	@Override
+	public boolean removeAnnotation(CtAnnotation<? extends Annotation> annotation) {
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setDocComment(String docComment) {
+		return (E) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setPosition(SourcePosition position) {
+		return (E) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setPositions(SourcePosition position) {
+		return (E) this;
+	}
+
+	@Override
+	public String prettyprint() {
+		return "";
+	}
+
+	@Override
+	public <E extends CtElement> List<E> getAnnotatedChildren(Class<? extends Annotation> annotationType) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public boolean isImplicit() {
+		return true;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setImplicit(boolean b) {
+		return (E) this;
+	}
+
+	@Override
+	public Set<CtTypeReference<?>> getReferencedTypes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public <E extends CtElement> List<E> getElements(Filter<E> filter) {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public <I> CtQuery map(CtConsumableFunction<I> queryStep) {
+		return null;
+	}
+
+	@Override
+	public <I, R> CtQuery map(CtFunction<I, R> function) {
+		return null;
+	}
+
+	@Override
+	public <R extends CtElement> CtQuery filterChildren(Filter<R> filter) {
+		return null;
+	}
+
+	@Override
+	public CtElement getParent() throws ParentNotInitializedException {
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setParent(CtElement parent) {
+		return (E) this;
+	}
+
+	@Override
+	public boolean isParentInitialized() {
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <P extends CtElement> P getParent(Class<P> parentType) {
+		return (P) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E getParent(Filter<E> filter) {
+		return (E) this;
+	}
+
+	@Override
+	public boolean hasParent(CtElement candidate) {
+		return false;
+	}
+
+	@Override
+	public CtRole getRoleInParent() {
+		return null;
+	}
+
+	@Override
+	public void updateAllParentsBelow() {
+		// do nothing
+	}
+
+	@Override
+	public Factory getFactory() {
+		return null;
+	}
+
+	@Override
+	public void setFactory(Factory factory) {
+		// do nothing
+	}
+
+	@Override
+	public void replace(CtElement element) {
+		// do nothing
+	}
+
+	@Override
+	public <E extends CtElement> void replace(Collection<E> elements) {
+		// do nothing
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setAllMetadata(Map<String, Object> metadata) {
+		return (E) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E putMetadata(String key, Object val) {
+		return (E) this;
+	}
+
+	@Override
+	public Object getMetadata(String key) {
+		return null;
+	}
+
+	@Override
+	public Map<String, Object> getAllMetadata() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public Set<String> getMetadataKeys() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public List<CtComment> getComments() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E addComment(CtComment comment) {
+		return (E) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E removeComment(CtComment comment) {
+		return (E) this;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement> E setComments(List<CtComment> comments) {
+		return (E) this;
+	}
+
+	@Override
+	public <T> T getValueByRole(CtRole role) {
+		return null;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtElement, T> E setValueByRole(CtRole role, T value) {
+		return (E) this;
+	}
+
+	@Override
+	public CtPath getPath() {
+		return null;
+	}
+
+	@Override
+	public Iterator<CtElement> descendantIterator() {
+		return Collections.emptyIterator();
+	}
+
+	@Override
+	public Iterable<CtElement> asIterable() {
+		return this::descendantIterator;
+	}
+
+	@Override
+	public List<CtElement> getDirectChildren() {
+		return Collections.emptyList();
+	}
+
+	@Override
+	public ElementSourceFragment getOriginalSourceFragment() {
+		return ElementSourceFragment.NO_SOURCE_FRAGMENT;
+	}
+
+	@Override
+	public String toString() {
+		return getQualifiedName();
+	}
+
+	@Override
+	public String toStringDebug() {
+		return toString();
+	}
+
+	@Override
+	public boolean isShadow() {
+		return false;
+	}
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <E extends CtShadowable> E setShadow(boolean isShadow) {
+		return (E) this;
+	}
+
+	@Override
+	public CtPackage clone() {
+		throw new UnsupportedOperationException("can't clone NoPackage");
+	}
+
+	@Override
+	public boolean isUnnamedPackage() {
+		return false;
+	}
+
+	@Override
+	public boolean hasPackageInfo() {
+		return false;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return true;
+	}
+
+	@Override
+	public boolean hasTypes() {
+		return false;
+	}
+
+	@Override
+	public boolean hasPackages() {
+		return false;
+	}
+}

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -51,7 +51,7 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.support.JavaOutputProcessor;
-import spoon.support.reflect.declaration.NoPackage;
+import spoon.support.reflect.NoPackage;
 import spoon.test.annotation.testclasses.GlobalAnnotation;
 import spoon.test.pkg.name.PackageTestClass;
 import spoon.test.pkg.processors.ElementProcessor;

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -51,6 +51,7 @@ import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.filter.NamedElementFilter;
 import spoon.support.JavaOutputProcessor;
+import spoon.support.reflect.declaration.NoPackage;
 import spoon.test.annotation.testclasses.GlobalAnnotation;
 import spoon.test.pkg.name.PackageTestClass;
 import spoon.test.pkg.processors.ElementProcessor;
@@ -451,5 +452,19 @@ public class PackageTest {
 
 		var typeNames = types.stream().map(CtType::getSimpleName).collect(Collectors.toList());
 		assertEquals(typeNames, List.of("A", "D", "C", "B"));
+	}
+
+	@Test
+	public void testNoPackage() {
+		Launcher launcher = new Launcher();
+		Factory factory = launcher.getFactory();
+
+		CtClass<?> fooClass = factory.Class().create("test.Foo");
+		// Set the package to the null object
+		CtClass<?> noPackageClass = fooClass.clone().setParent(new NoPackage());
+
+		assertNotNull(noPackageClass.getPackage());
+
+		assertEquals(fooClass.toString(), noPackageClass.toString());
 	}
 }


### PR DESCRIPTION
Implemented the null object for CtPackage, issue #3705.

This null object is designed to "do nothing" as much as possible.
The return value of each method is as follows, depending on its return value type:

1. void
do nothing.

2. boolean
basically return false.  `isEmpty()` and `isImplicit()` return true.

3. Some collection
return an empty collection.

4. String
return an appropriate result, especially `getSimpleName()` returns `"<no package>"`.

5. CtPackage or its super classes
return `this`.

6. Other referenced types
return `null`.

Since this is my first feature pull request, I would greatly appreciate any suggestions or feedback.