### PR TITLE
fix: Support back-to-back properties and file.separator in SpoonPom

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -310,7 +310,7 @@ public class SpoonPom implements SpoonResource {
 	}
 
 	// Pattern corresponding to maven properties ${propertyName}
-	private static Pattern mavenProperty = Pattern.compile("\\$\\{.*?\\}");
+	private static final Pattern MAVEN_PROPERTY = Pattern.compile("\\$\\{.*?}");
 
 	/**
 	 * Extract the variable from a string
@@ -318,7 +318,7 @@ public class SpoonPom implements SpoonResource {
 	private String extractVariable(String value) {
 		String val = value;
 		if (value != null && value.contains("$")) {
-			Matcher matcher = mavenProperty.matcher(value);
+			Matcher matcher = MAVEN_PROPERTY.matcher(value);
 			while (matcher.find()) {
 				String var = matcher.group();
 				val = val.replace(var, getProperty(var.substring(2, var.length() - 1)));

--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -310,7 +310,7 @@ public class SpoonPom implements SpoonResource {
 	}
 
 	// Pattern corresponding to maven properties ${propertyName}
-	private static Pattern mavenProperty = Pattern.compile("\\$\\{.*\\}");
+	private static Pattern mavenProperty = Pattern.compile("\\$\\{.*?\\}");
 
 	/**
 	 * Extract the variable from a string
@@ -353,6 +353,8 @@ public class SpoonPom implements SpoonResource {
 			}
 		} else if ("project.basedir".equals(key) || "pom.basedir".equals(key) || "basedir".equals(key)) {
 			return pomFile.getParent();
+		} else if ("file.separator".equals(key)) {
+			return File.separator;
 		}
 		String value = extractVariable(model.getProperties().getProperty(key));
 		if (value == null) {


### PR DESCRIPTION
This fixes property extraction for poms with `<something>${first}${second}</something>`.