### PR TITLE
chore(deps): update dependency org.jacoco:jacoco-maven-plugin to version 0.8.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <plugin>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
-            <version>0.8.8</version>
+            <version>0.8.9</version>
             <executions>
                 <execution>
                     <goals>


### PR DESCRIPTION
*Beep boop, this action was performed manually.*

 I guess I am cosplaying as renovate now… The release was 3 days ago, maybe renovate would have come around in the future. But this fails the 20-ea CI on other PRs, so we should fix it.