### PR TITLE
fix: Use a better heuristic for guessing type/field references in no classpath mode

### DIFF
--- a/spoon-smpl/src/test/java/spoon/smpl/C4JShouldVibrateTest.java
+++ b/spoon-smpl/src/test/java/spoon/smpl/C4JShouldVibrateTest.java
@@ -63,7 +63,7 @@ public class C4JShouldVibrateTest {
 				/* 22 */      "...\n" +
 				/* 23 */      "}\n";
 
-		ctx = new ZippedCodeBaseTestContext(smpl, "src/test/resources/C4JShouldVibrate.zip", false);
+		ctx = new ZippedCodeBaseTestContext(smpl, "src/test/resources/C4JShouldVibrate.zip", true);
 	}
 
 	@Test

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1525,11 +1525,11 @@ public class JDTTreeBuilder extends ASTVisitor {
 			context.enter(factory.Code().createTypeAccessWithoutCloningReference(typeRef), qualifiedNameRef);
 			return true;
 		} else if (qualifiedNameRef.binding instanceof ProblemBinding) {
-			if (context.stack.peek().element instanceof CtInvocation) {
+			if (helper.isProblemNameRefProbablyTypeRef(qualifiedNameRef)) {
 				context.enter(helper.createTypeAccessNoClasspath(qualifiedNameRef), qualifiedNameRef);
-				return true;
+			} else {
+				context.enter(helper.createFieldAccessNoClasspath(qualifiedNameRef), qualifiedNameRef);
 			}
-			context.enter(helper.createFieldAccessNoClasspath(qualifiedNameRef), qualifiedNameRef);
 			return true;
 		} else {
 			context.enter(

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -7,11 +7,13 @@
  */
 package spoon.support.compiler.jdt;
 
+import java.util.Arrays;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Argument;
 import org.eclipse.jdt.internal.compiler.ast.ExportsStatement;
 import org.eclipse.jdt.internal.compiler.ast.FieldReference;
+import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.ast.ModuleDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ModuleReference;
 import org.eclipse.jdt.internal.compiler.ast.OpensStatement;
@@ -390,6 +392,48 @@ public class JDTTreeBuilderHelper {
 			va.getVariable().setStatic(true);
 		}
 		return va;
+	}
+
+	boolean isProblemNameRefProbablyTypeRef(QualifiedNameReference qualifiedNameReference) {
+		ContextBuilder contextBuilder = jdtTreeBuilder.getContextBuilder();
+		if (contextBuilder.compilationunitdeclaration == null) {
+			return false;
+		}
+		if (contextBuilder.compilationunitdeclaration.imports == null) {
+			return false;
+		}
+		char[][] ourName = qualifiedNameReference.tokens;
+		for (ImportReference anImport : contextBuilder.compilationunitdeclaration.imports) {
+			char[][] importName = anImport.getImportName();
+			int i = indexOfSubList(importName, ourName);
+			if (i > 0) {
+				boolean extendsToEndOfImport = i + ourName.length == importName.length;
+				boolean isStaticImport = anImport.isStatic();
+				if (!isStaticImport) {
+					// import foo.bar.baz.A; => "A" is probably a type
+					// import foo.bar.baz.A; => "baz" is probably a type
+					return true;
+				}
+				// import static foo.Bar.bar; => bar is probably a method/field
+				// import static foo.Bar;     => Bar is probably a type
+				char[] simpleName = qualifiedNameReference.tokens[qualifiedNameReference.tokens.length - 1];
+				return !extendsToEndOfImport || !Character.isLowerCase(simpleName[0]);
+			}
+		}
+		return false;
+	}
+
+	private static int indexOfSubList(char[][] haystack, char[][] needle) {
+		outer:
+		for (int i = 0; i < haystack.length - needle.length; i++) {
+			for (int j = 0; j < needle.length; j++) {
+				if (!Arrays.equals(haystack[i + j], needle[j])) {
+					continue outer;
+				}
+			}
+			return i;
+		}
+		return -1;
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -423,6 +423,18 @@ public class JDTTreeBuilderHelper {
 		return false;
 	}
 
+	/**
+	 * Finds the lowest index where {@code needle} appears in {@code haystack}. This is akin to a
+	 * substring search, but JDT uses a String[] to omit separators and a char[] to represent strings.
+	 * If we want to find out where "String" appears in "java.lang.String", we would call
+	 * {@code indexOfSubList(["java", "lang", "String"], ["lang", "String"])} and receive {@code 1}.
+	 *
+	 * @param haystack the haystack to search in
+	 * @param needle the needle to search
+	 * @return the first index where needle appears in haystack
+	 * @see java.util.Collections#indexOfSubList(List, List) Collections#indexOfSubList for a more
+	 *     general version that does not correctly handle array equality
+	 */
 	private static int indexOfSubList(char[][] haystack, char[][] needle) {
 		outer:
 		for (int i = 0; i < haystack.length - needle.length; i++) {

--- a/src/test/java/spoon/reflect/visitor/CtScannerTest.java
+++ b/src/test/java/spoon/reflect/visitor/CtScannerTest.java
@@ -271,9 +271,9 @@ public class CtScannerTest {
 		// this is a coarse-grain check to see if the scanner changes
 		// no more exec ref in paramref
 		// also takes into account the comments
-		assertEquals(3631, counter.nElement + countOfCommentsInCompilationUnits);
-		assertEquals(2423, counter.nEnter + countOfCommentsInCompilationUnits);
-		assertEquals(2423, counter.nExit + countOfCommentsInCompilationUnits);
+		assertEquals(3667, counter.nElement + countOfCommentsInCompilationUnits);
+		assertEquals(2449, counter.nEnter + countOfCommentsInCompilationUnits);
+		assertEquals(2449, counter.nExit + countOfCommentsInCompilationUnits);
 
 		// contract: all AST nodes which are part of Collection or Map are visited first by method "scan(Collection|Map)" and then by method "scan(CtElement)"
 		Counter counter2 = new Counter();

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1529,10 +1529,10 @@ public class ImportTest {
 		List<CtStatement> statements = ctor.getBody().getStatements();
 
 		assertEquals("super(context, attributeSet)", statements.get(0).toString());
-		assertEquals("mButton = ((Button) (findViewById(page_button_button)))", statements.get(1).toString());
-		assertEquals("mCurrentActiveColor = getColor(c4_active_button_color)", statements.get(2).toString());
-		assertEquals("mCurrentActiveColor = getResources().getColor(c4_active_button_color)", statements.get(3).toString());
-		assertEquals("mCurrentActiveColor = getData().getResources().getColor(c4_active_button_color)", statements.get(4).toString());
+		assertEquals("mButton = ((Button) (findViewById(id.page_button_button)))", statements.get(1).toString());
+		assertEquals("mCurrentActiveColor = getColor(color.c4_active_button_color)", statements.get(2).toString());
+		assertEquals("mCurrentActiveColor = getResources().getColor(color.c4_active_button_color)", statements.get(3).toString());
+		assertEquals("mCurrentActiveColor = getData().getResources().getColor(color.c4_active_button_color)", statements.get(4).toString());
 	}
 
 	@Test


### PR DESCRIPTION
In no classpath mode, JDT only gives us a ProblemBinding with a QualifiedNameReference. We then have to figure out whether this is a type, field, inner class, package or anything else ourselves. Previously, every child of an invocation was treated as a type. This patch changes it to favor fields and only falls back to a type access, if it appeared somewhere in an import.

This is still far from perfect, but it at least produces better guesses.

Closes #5151