### PR TITLE
chore: Enable renovate automerge for non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,7 @@
             "minor",
             "patch",
             "pin",
-            "digest",
-            "fix"
+            "digest"
          ],
          "automerge":true,
          "semanticCommitType":":arrow_up:"

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
             "digest"
          ],
          "automerge":true,
-         "semanticCommitType":":arrow_up:"
       }
    ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,19 @@
 {
-  "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests"
-  ],
-  "packageRules": [
-    {
-      "packageNames": ["org.mockito:mockito-core"],
-      "schedule": ["on monday"]
-    }
-  ]
+   "extends":[
+      "config:base",
+      "helpers:pinGitHubActionDigests"
+   ],
+   "packageRules":[
+      {
+         "matchUpdateTypes":[
+            "minor",
+            "patch",
+            "pin",
+            "digest",
+            "fix"
+         ],
+         "automerge":true,
+         "semanticCommitType":":arrow_up:"
+      }
+   ]
 }


### PR DESCRIPTION
After discussion with @monperrus this renovate config enables automerge of green PR updates from renovate. I have changed the master protection rules to let renovate bypass them. I removed some old mockito rule which seems useless.