### PR TITLE
feat: Add native transport configuration to Maven 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ on:
 
 env:
   JAVA_DISTRIBUTION: temurin
+  MAVEN_OPTS: >-
+    -Dmaven.resolver.transport=native
+    -Daether.connector.connectTimeout=300000
+    -Daether.connector.requestTimeout=300000
 
 jobs:
   build:


### PR DESCRIPTION
Add system properties to Maven options to set the native dependency transport for Aether connector. This will improve the speed of dependency resolution by using the native transport layer over HTTP. Also, the request timeout and connection timeout are increased to 300,000 milliseconds in order to allow for slower networks.