### PR TITLE
chore: Use native transport configuration for Maven in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
 
     env:
-      MAVEN_OPTS: -Djava.src.version=${{ matrix.java }} -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+      MAVEN_OPTS: -Djava.src.version=${{ matrix.java }}
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
@@ -79,8 +79,6 @@ jobs:
         run: cat testResults.spoon
   coverage:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     name: Test with coverage
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -113,8 +111,6 @@ jobs:
 
   extra:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     name: Extra checks
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -147,8 +143,6 @@ jobs:
         run: ./chore/check-javadoc-regressions.py COMPARE_WITH_MASTER
   reproducible-builds:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     name: reproducible-builds
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -162,8 +156,6 @@ jobs:
         run: chore/check-reproducible-builds.sh
   maven-central-requirements:
     runs-on: ubuntu-latest
-    env:
-      MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ on:
 
 env:
   JAVA_DISTRIBUTION: temurin
+  MAVEN_OPTS: >-
+    -Dmaven.resolver.transport=native
+    -Daether.connector.connectTimeout=300000
+    -Daether.connector.requestTimeout=300000
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,8 +39,6 @@ jobs:
 
 
 
-    env:
-      MAVEN_OPTS: -Djava.src.version=${{ matrix.java }}
 
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:


### PR DESCRIPTION
replaces #5189 Somehow the GitHub API allows creating branches which destroy GitHub. Having a `/` leading your branch name is not the best idea.


Had a lengthy discussion with @I-Al-Istannen and @SirYwell about our failing master and how to fix this. We concluded to switch to mavens new http transport and increase the timeout. This should reduce/remove the failing of mavens dependency resolution on master. The timeout is still set to a reasonable number, but we will monitor it closely and increase if we see we still need a large.

Add system properties to Maven options to set the native dependency transport for Aether connector. This will improve the speed of dependency resolution by using the native transport layer over HTTP. Also, the request timeout and connection timeout are increased to 300,000 milliseconds in order to allow for slower networks.