### PR TITLE
review: fix: set declaring type for array field accesses

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -285,8 +285,9 @@ public class JDTTreeBuilderHelper {
 			sourceStart = (int) (positions[qualifiedNameReference.indexOfFirstFieldBinding - 1] >>> 32);
 			for (FieldBinding b : qualifiedNameReference.otherBindings) {
 				isOtherBinding = qualifiedNameReference.otherBindings.length == i + 1;
+				TypeBinding type = ((VariableBinding) qualifiedNameReference.binding).type;
 				CtFieldAccess<T> other = createFieldAccess(
-						jdtTreeBuilder.getReferencesBuilder().<T>getVariableReference(b, qualifiedNameReference.tokens[i + 1]), va, isOtherBinding && fromAssignment);
+						jdtTreeBuilder.getReferencesBuilder().getVariableReference(type, b, qualifiedNameReference.tokens[i + 1]), va, isOtherBinding && fromAssignment);
 				//set source position of fa
 				if (i + qualifiedNameReference.indexOfFirstFieldBinding >= qualifiedNameReference.otherBindings.length) {
 					sourceEnd = qualifiedNameReference.sourceEnd();
@@ -301,8 +302,9 @@ public class JDTTreeBuilderHelper {
 			sourceStart = (int) (positions[0] >>> 32);
 			for (int i = 1; i < qualifiedNameReference.tokens.length; i++) {
 				isOtherBinding = qualifiedNameReference.tokens.length == i + 1;
+				TypeBinding type = ((VariableBinding) qualifiedNameReference.binding).type;
 				CtFieldAccess<T> other = createFieldAccess(//
-						jdtTreeBuilder.getReferencesBuilder().<T>getVariableReference(null, qualifiedNameReference.tokens[i]), va, isOtherBinding && fromAssignment);
+						jdtTreeBuilder.getReferencesBuilder().getVariableReference(type, null, qualifiedNameReference.tokens[i]), va, isOtherBinding && fromAssignment);
 				//set source position of va;
 				sourceEnd = (int) (positions[i]);
 				va.setPosition(jdtTreeBuilder.getPositionBuilder().buildPosition(sourceStart, sourceEnd));
@@ -486,7 +488,7 @@ public class JDTTreeBuilderHelper {
 		} else {
 			fieldAccess = jdtTreeBuilder.getFactory().Core().createFieldRead();
 		}
-		fieldAccess.setVariable(jdtTreeBuilder.getReferencesBuilder().<T>getVariableReference(fieldReference.binding, fieldReference.token));
+		fieldAccess.setVariable(jdtTreeBuilder.getReferencesBuilder().getVariableReference(fieldReference.actualReceiverType, fieldReference.binding, fieldReference.token));
 		fieldAccess.setType(jdtTreeBuilder.getReferencesBuilder().<T>getTypeReference(fieldReference.resolvedType));
 		return fieldAccess;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1168,26 +1168,25 @@ public class ReferenceBuilder {
 		return bindingCache.get(b).clone();
 	}
 
-	<T> CtFieldReference<T> getVariableReference(FieldBinding varbin) {
+	<T> CtFieldReference<T> getVariableReference(TypeBinding type, FieldBinding varbin) {
 		CtFieldReference<T> ref = this.jdtTreeBuilder.getFactory().Core().createFieldReference();
 		if (varbin == null) {
 			return ref;
 		}
 		ref.setSimpleName(new String(varbin.name));
 		ref.setType(this.<T>getTypeReference(varbin.type));
-
-		if (varbin.declaringClass != null) {
-			ref.setDeclaringType(getTypeReference(varbin.declaringClass));
+		if (type != null && type.isArrayType()) {
+			ref.setDeclaringType(getTypeReference(type));
 		} else {
-			ref.setDeclaringType(ref.getType() == null ? null : ref.getType().clone());
+			ref.setDeclaringType(getTypeReference(varbin.declaringClass));
 		}
 		ref.setFinal(varbin.isFinal());
 		ref.setStatic((varbin.modifiers & ClassFileConstants.AccStatic) != 0);
 		return ref;
 	}
 
-	<T> CtFieldReference<T> getVariableReference(FieldBinding fieldBinding, char[] tokens) {
-		final CtFieldReference<T> ref = getVariableReference(fieldBinding);
+	<T> CtFieldReference<T> getVariableReference(TypeBinding type, FieldBinding fieldBinding, char[] tokens) {
+		final CtFieldReference<T> ref = getVariableReference(type, fieldBinding);
 		if (fieldBinding != null) {
 			return ref;
 		}
@@ -1199,7 +1198,7 @@ public class ReferenceBuilder {
 	<T> CtVariableReference<T> getVariableReference(VariableBinding varbin) {
 
 		if (varbin instanceof FieldBinding) {
-			return getVariableReference((FieldBinding) varbin);
+			return getVariableReference(((FieldBinding) varbin).declaringClass, (FieldBinding) varbin);
 		} else if (varbin instanceof LocalVariableBinding) {
 			final LocalVariableBinding localVariableBinding = (LocalVariableBinding) varbin;
 			if (localVariableBinding.declaration instanceof Argument && localVariableBinding.declaringScope instanceof MethodScope) {


### PR DESCRIPTION
Step 1 addressing #5199.

Previously, spoon set the declaring type to the type of the field if JDT didn't provide a declaring type. From running all tests, this seems to be only the case for access to the `length` field of arrays. Instead of setting the declaring type to `int` then, we now use the type binding provided by JDT that holds the actual declaring type.

Note that this does not fully fix the bug, but we get `The field java.lang.String[]#length not found` instead of `The field int#length not found`.