### PR TITLE
review: fix: Correctly adapt type parameters inherited from enclosing classes

### DIFF
--- a/doc/type_adaption.md
+++ b/doc/type_adaption.md
@@ -120,7 +120,7 @@ If we can not find any hierarchy we currently return the input type unchanged.
 Java allows classes to use generics of their enclosing class, e.g.
 ```java
 public class Outer<A> {
-  public static class Inner<B> {
+  public class Inner<B> {
     public void bar(A a, B b) {}
   }
 }
@@ -128,7 +128,7 @@ public class Outer<A> {
 If you now additionally introduce a dual inheritance relationship
 ```java
 public class OuterSub<A1> extends Outer<A1> {
-  public static class InnerSub<B1> extends Outer.Inner<B1> {
+  public class InnerSub<B1> extends Outer.Inner<B1> {
     public void bar(A1 a, B1 b) {}
   }
 }

--- a/doc/type_adaption.md
+++ b/doc/type_adaption.md
@@ -116,6 +116,43 @@ we need to go from any other node in the tree.
 #### Finding no hierarchy
 If we can not find any hierarchy we currently return the input type unchanged.
 
+#### Adapting generics of enclosing classes
+Java allows classes to use generics of their enclosing class, e.g.
+```java
+public class Outer<A> {
+  public static class Inner<B> {
+    public void bar(A a, B b) {}
+  }
+}
+```
+If you now additionally introduce a dual inheritance relationship
+```java
+public class OuterSub<A1> extends Outer<A1> {
+  public static class InnerSub<B1> extends Outer.Inner<B1> {
+    public void bar(A1 a, B1 b) {}
+  }
+}
+```
+Adapting the method from `Outer.Inner#bar` to `OuterSub.InnerSub#bar` involves
+building the hierarchy from `InnerSub` to `Outer.Inner` and then adapting `A1`
+and `B1`.
+While this hierarchy can be used to resolve `B` to `B1`, it will not be helpful
+for adapting `A` to `A1`: This generic type is passed down through a completely
+different inheritance chain.
+
+To solve this, we check whether a type parameter is declared by the class
+containing the type reference.
+For example, when translating `A1` we notice that even though the usage is in
+`InnerSub#bar`, the declaration of the type parameter was in `OuterSub`.
+Therefore, we adjust the end of our hierarchy to `Outer` instead of `Inner` and
+the start to the innermost enclosing class inheriting from that, which is
+`OuterSub` in our example.  
+Notice that there could be *multiple* matching enclosing classes, but we
+have no way to decide which one to use, and just arbitrarily resolve the
+ambiguity by picking the first one.
+
+After this adjustment of the start and end types, the rest of the translation
+continues normally.
 
 ## Adapting a method to a subclass
 Closely related to type adaption (but not exactly the same!) is translating

--- a/src/main/java/spoon/support/adaption/DeclarationNode.java
+++ b/src/main/java/spoon/support/adaption/DeclarationNode.java
@@ -69,12 +69,10 @@ class DeclarationNode {
 
 		// We try to find a glue node below us to delegate to. Glue nodes do the mapping so we can just
 		// pass it on unchanged.
-		Optional<GlueNode> glueNode = children.stream()
-			.filter(it -> it.isInducedBy(this.inducedBy))
-			.findFirst();
-
-		if (glueNode.isPresent()) {
-			return glueNode.get().resolveTypeParameter(reference);
+		if (!children.isEmpty()) {
+			// We pick a random child. Well-typed programs will converge to the same solution, no matter
+			// which path we pick.
+			return children.iterator().next().resolveTypeParameter(reference);
 		}
 
 		// If we have no glue node, we need to actually resolve the type parameter as we reached the

--- a/src/main/java/spoon/support/adaption/TypeAdaptor.java
+++ b/src/main/java/spoon/support/adaption/TypeAdaptor.java
@@ -559,6 +559,7 @@ public class TypeAdaptor {
 		return Optional.of((CtExecutable<?>) parent);
 	}
 
+	@SuppressWarnings("AssignmentToMethodParameter")
 	private DeclarationNode buildHierarchyFrom(CtTypeReference<?> startReference, CtType<?> startType,
 		CtTypeReference<?> end) {
 		CtType<?> endType = findDeclaringType(end);

--- a/src/main/java/spoon/support/adaption/TypeAdaptor.java
+++ b/src/main/java/spoon/support/adaption/TypeAdaptor.java
@@ -596,14 +596,7 @@ public class TypeAdaptor {
 		// Declaring type is not the same as the inner type (i.e. the type parameter was declared on an
 		// enclosing type)
 		CtType<?> parentType = end.getParent(CtType.class);
-		if (parentType instanceof CtTypeParameter) {
-			CtFormalTypeDeclarer declarer = ((CtTypeParameter) parentType).getTypeParameterDeclarer();
-			if (declarer instanceof CtType) {
-				parentType = (CtType<?>) declarer;
-			} else {
-				parentType = declarer.getDeclaringType();
-			}
-		}
+		parentType = resolveTypeParameterToDeclarer(parentType);
 
 		return !parentType.getQualifiedName().equals(endType.getQualifiedName());
 	}
@@ -648,14 +641,21 @@ public class TypeAdaptor {
 			type = reference.getTypeDeclaration();
 		}
 
-		if (type instanceof CtTypeParameter) {
-			CtFormalTypeDeclarer declarer = ((CtTypeParameter) type).getTypeParameterDeclarer();
+		return resolveTypeParameterToDeclarer(type);
+	}
+
+	private static CtType<?> resolveTypeParameterToDeclarer(CtType<?> parentType) {
+		if (parentType instanceof CtTypeParameter) {
+			CtFormalTypeDeclarer declarer = ((CtTypeParameter) parentType).getTypeParameterDeclarer();
 			if (declarer instanceof CtType) {
 				return (CtType<?>) declarer;
+			} else {
+				return declarer.getDeclaringType();
 			}
-			return declarer.getDeclaringType();
 		}
-		return type;
+		// Could not resolve type parameter declarer (no class path mode?).
+		// Type adaption results will not be accurate, this is just a wild (and probably wrong) guess.
+		return parentType;
 	}
 
 	private DeclarationNode buildDeclarationHierarchyFrom(

--- a/src/test/java/spoon/support/TypeAdaptorTest.java
+++ b/src/test/java/spoon/support/TypeAdaptorTest.java
@@ -1,5 +1,6 @@
 package spoon.support;
 
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -12,7 +13,9 @@ import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.adaption.TypeAdaptor;
+import spoon.test.GitHubIssue;
 import spoon.testing.utils.ModelTest;
 
 import java.util.List;
@@ -439,5 +442,54 @@ class TypeAdaptorTest {
 		public <T extends CharSequence> void overloaded(T t) {}
 
 		public <T extends String> void overriden(T t) {}
+	}
+
+	@GitHubIssue(issueNumber = 5226, fixed = true)
+	void testAdaptingTypeFromEnclosingClass() {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(11);
+		launcher.addInputResource("src/test/java/spoon/support/TypeAdaptorTest.java");
+		CtType<?> type = launcher.getFactory()
+				.Type()
+				.get(UseGenericFromEnclosingType.class);
+		@SuppressWarnings("rawtypes")
+		List<CtMethod> methods = type.getElements(new TypeFilter<>(CtMethod.class))
+				.stream()
+				.filter(it -> it.getSimpleName().equals("someMethod"))
+				.collect(Collectors.toList());
+		CtMethod<?> test1Method = methods.stream()
+				.filter(it -> !it.getDeclaringType().getSimpleName().startsWith("Extends"))
+				.findAny()
+				.orElseThrow();
+		CtMethod<?> test2Method = methods.stream()
+				.filter(it -> it.getDeclaringType().getSimpleName().startsWith("Extends"))
+				.findAny()
+				.orElseThrow();
+
+		assertTrue(test2Method.isOverriding(test1Method));
+		assertFalse(test1Method.isOverriding(test2Method));
+	}
+
+	public static class UseGenericFromEnclosingType {
+
+		public static class Enclosing<T> {
+
+			public class Enclosed<S> {
+
+				void someMethod(S s, T t) {
+				}
+			}
+		}
+
+		public static class ExtendsEnclosing extends Enclosing<String> {
+
+			public class ExtendsEnclosed extends Enclosed<Integer> {
+
+				@Override
+				void someMethod(Integer s, String t) {
+					throw new UnsupportedOperationException();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## description
Type adaption did not handle using generics inherited from enclosing classes. In these cases, a type hierarchy from the innermost class to its parent class was built, causing the generic resolution to fail.

This PR fixes this by adjusting building a hierarchy between the *declaring* types instead.

## todo
- [x] Implement the fix
- [x] Document the changes in `docs/type_adaption.md`
- [x] Maybe remove the code duplication in the type adaptor for resolving formal type declarers 

## closes
This closes #5226.