### PR TITLE
review: fix: special-case getModifiers for array.length accesses

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -172,6 +172,12 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 
 	@Override
 	public Set<ModifierKind> getModifiers() {
+		// special-case the length field of array, as it doesn't have a declaration
+		// as arrays only have one field, we do not need to check the name additionally
+		CtTypeReference<?> declaringType = getDeclaringType();
+		if (declaringType != null && declaringType.isArray()) {
+			return Set.of(ModifierKind.PUBLIC, ModifierKind.FINAL);
+		}
 		CtVariable<?> v = getDeclaration();
 		if (v != null) {
 			return v.getModifiers();

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -28,9 +28,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import spoon.Launcher;
+import spoon.processing.AbstractProcessor;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtReturn;
+import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtMethod;
@@ -240,6 +242,20 @@ public class FieldTest {
 
 		assertEquals(arrayType, elements.get(0).getDeclaringType());
 		assertEquals(arrayType, elements.get(1).getDeclaringType());
+
+
+		ctModel.processWith(new AbstractProcessor<CtVariableAccess<?>>() {
+			@Override
+			public void process(CtVariableAccess<?> element) {
+				if (!(element.getVariable() instanceof CtFieldReference<?>)) {
+					return;
+				}
+				CtFieldReference<?> ctFieldReference = (CtFieldReference<?>) element.getVariable();
+
+				ctFieldReference.getModifiers();
+				ctFieldReference.getActualField(); // <- this crashes
+			}
+		});
 	}
 
 


### PR DESCRIPTION
Fixes the use case described in #5199, `getModifiers()` now works for the `length` field in arrays.

`getActualField()` still throws the exception, but this modelling is just similar to the reflection api.

I also added a contract and renamed the test method from my previous work on this... 