### PR TITLE
review: fix: Refactor code to fix runtime exception caused by package name with CtType.INNERTTYPE_SEPARATOR

### DIFF
--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -155,9 +155,6 @@ public class PackageFactory extends SubFactory {
 	 * @return a found package or null
 	 */
 	public CtPackage get(String qualifiedName) {
-		if (qualifiedName.contains(CtType.INNERTTYPE_SEPARATOR)) {
-			throw new RuntimeException("Invalid package name " + qualifiedName);
-		}
 
 		// Find package with the most contained types. If a module exports package "foo.bar" and the
 		// other "foo.bar.baz", *both modules* will contain a "foo.bar" package in spoon. As

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -16,7 +16,6 @@ import spoon.SpoonException;
 import spoon.reflect.declaration.CtModule;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtPackageDeclaration;
-import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtPackageReference;
 
 

--- a/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
+++ b/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
@@ -27,8 +27,7 @@ class PackageFactoryTest {
 		assertThat(topLevelPackage.getQualifiedName(), equalTo(topLevelPackageName));
 		assertThat(packageWithDuplicatedSimpleNames.getQualifiedName(), equalTo(nestedPackageName));
 
-		assertThat(topLevelPackage.getPackage(topLevelPackageName),
-				sameInstance(packageWithDuplicatedSimpleNames));
+		assertThat(topLevelPackage.getPackage(topLevelPackageName), sameInstance(packageWithDuplicatedSimpleNames));
 		assertThat(packageWithDuplicatedSimpleNames.getParent(), sameInstance(topLevelPackage));
 	}
 	

--- a/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
+++ b/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
@@ -32,20 +32,19 @@ class PackageFactoryTest {
 		assertThat(packageWithDuplicatedSimpleNames.getParent(), sameInstance(topLevelPackage));
 	}
 	
-		@Test
-		@GitHubIssue(issueNumber = 5140, fixed = true)
-    void testGetPackageWithNameContainingDollarSign() {
-			// contract: A package with a name containing a dollar sign can be retrieved using the PackageFactory
+	@Test
+	@GitHubIssue(issueNumber = 5140, fixed = true)
+	void testGetPackageWithNameContainingDollarSign() {
+		// contract: A package with a name containing a dollar sign can be retrieved using the PackageFactory
+		// Create a package with a name containing a dollar sign
+		String packageName = "com.example.package$with$dollar$sign";
+		CtClass<?> clazz = Launcher.parseClass("package " + packageName + ";" + "\n" + "enum Foo { }");
 
-        // Create a package with a name containing a dollar sign
-				String packageName = "com.example.package$with$dollar$sign";
-				CtClass<?> clazz = Launcher.parseClass("package " + packageName + ";" + "\n" + "enum Foo { }");
+		// Get the package using the PackageFactory
+		CtPackage ctPackage = clazz.getFactory().Package().get(packageName);
 
-				// Get the package using the PackageFactory
-        CtPackage ctPackage = clazz.getFactory().Package().get(packageName);
-
-        // Verify that the package was found
-        assertNotNull(ctPackage);
-        assertEquals(packageName, ctPackage.getQualifiedName());
-    }
+		// Verify that the package was found
+		assertNotNull(ctPackage);
+		assertEquals(packageName, ctPackage.getQualifiedName());
+	}
 }

--- a/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
+++ b/src/test/java/spoon/reflect/factory/PackageFactoryTest.java
@@ -3,8 +3,10 @@ package spoon.reflect.factory;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
-
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import spoon.Launcher;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtPackage;
 import spoon.test.GitHubIssue;
 
@@ -25,7 +27,25 @@ class PackageFactoryTest {
 		assertThat(topLevelPackage.getQualifiedName(), equalTo(topLevelPackageName));
 		assertThat(packageWithDuplicatedSimpleNames.getQualifiedName(), equalTo(nestedPackageName));
 
-		assertThat(topLevelPackage.getPackage(topLevelPackageName), sameInstance(packageWithDuplicatedSimpleNames));
+		assertThat(topLevelPackage.getPackage(topLevelPackageName),
+				sameInstance(packageWithDuplicatedSimpleNames));
 		assertThat(packageWithDuplicatedSimpleNames.getParent(), sameInstance(topLevelPackage));
 	}
+	
+		@Test
+		@GitHubIssue(issueNumber = 5140, fixed = true)
+    void testGetPackageWithNameContainingDollarSign() {
+			// contract: A package with a name containing a dollar sign can be retrieved using the PackageFactory
+
+        // Create a package with a name containing a dollar sign
+				String packageName = "com.example.package$with$dollar$sign";
+				CtClass<?> clazz = Launcher.parseClass("package " + packageName + ";" + "\n" + "enum Foo { }");
+
+				// Get the package using the PackageFactory
+        CtPackage ctPackage = clazz.getFactory().Package().get(packageName);
+
+        // Verify that the package was found
+        assertNotNull(ctPackage);
+        assertEquals(packageName, ctPackage.getQualifiedName());
+    }
 }


### PR DESCRIPTION
The check is 17 years old and $ is allowed in packages. Interesting that we had no bug reports earlier.

The check for the `CtType.INNERTTYPE_SEPARATOR` that caused runtime exceptions has been removed so that valid packages with `CtType.INNERTTYPE_SEPARATOR` can be found.

A new test has been added to verify that a package with a name containing a dollar sign can be successfully retrieved using the `PackageFactory`.

Fixes #5140 