### PR TITLE
wip: fix: make getActualField respect static fields in annotations

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtFieldReferenceImpl.java
@@ -69,13 +69,13 @@ public class CtFieldReferenceImpl<T> extends CtVariableReferenceImpl<T> implemen
 			throw e;
 		}
 		try {
-			if (clazz.isAnnotation()) {
+			if (clazz.isAnnotation() && !isStatic()) {
 				return clazz.getDeclaredMethod(getSimpleName());
 			} else {
 				return clazz.getDeclaredField(getSimpleName());
 			}
 		} catch (NoSuchMethodException | NoSuchFieldException e) {
-			throw new SpoonException("The field " + getQualifiedName() + " not found", e);
+			throw new SpoonException("The field " + getQualifiedName() + " was not found", e);
 		}
 	}
 

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -218,6 +218,19 @@ public class FieldTest {
 
 	}
 
+	@ModelTest(
+					"./src/test/java/spoon/test/field/testclasses/AnnoWithConst.java"
+	)
+	void testGetActualFieldForConstantInAnnotation(CtModel ctModel) {
+		// contract: CtFieldReference#getActualField() returns the field for constants in annotations
+		CtFieldReference<?> access = ctModel.getElements(new TypeFilter<CtFieldReference<?>>(CtFieldReference.class))
+						.stream()
+						.filter(field -> field.getSimpleName().equals("VALUE"))
+						.findFirst()
+						.orElseGet(() -> fail("No reference to VALUE found"));
+		assertNotNull(assertDoesNotThrow(access::getActualField));
+	}
+
 	@Test
 	void test() {
 		Launcher launcher = new Launcher();

--- a/src/test/java/spoon/test/field/testclasses/AnnoWithConst.java
+++ b/src/test/java/spoon/test/field/testclasses/AnnoWithConst.java
@@ -1,0 +1,8 @@
+package spoon.test.field.testclasses;
+
+public @interface AnnoWithConst {
+		int VALUE = 42;
+	}
+class User {
+	int i = AnnoWithConst.VALUE;
+}


### PR DESCRIPTION
Annotations can have static fields, so looking up a method for them fails. The fix is rather simple: If the referenced field is static, it must be an actual field in the annotation.