### PR TITLE
refactor: remove cast by narrowing type

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -819,7 +819,7 @@ public class Launcher implements SpoonAPI {
 						final Path relativePath = dirInputSourceAsPath.relativize(resourcePath);
 						final Path targetPath = outputPath.resolve(relativePath).getParent();
 						try {
-							FileUtils.copyFileToDirectory((File) resource, targetPath.toFile());
+							FileUtils.copyFileToDirectory(resource, targetPath.toFile());
 						} catch (IOException e) {
 							throw new SpoonException(e);
 						}

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -813,9 +813,9 @@ public class Launcher implements SpoonAPI {
 			for (File dirInputSource : modelBuilder.getInputSources()) {
 				if (dirInputSource.isDirectory()) {
 					final Path dirInputSourceAsPath = dirInputSource.toPath();
-					final Collection<?> resources = FileUtils.listFiles(dirInputSource, RESOURCES_FILE_FILTER, ALL_DIR_FILTER);
-					for (Object resource : resources) {
-						final Path resourcePath = ((File) resource).toPath();
+					final Collection<File> resources = FileUtils.listFiles(dirInputSource, RESOURCES_FILE_FILTER, ALL_DIR_FILTER);
+					for (File resource : resources) {
+						final Path resourcePath = resource.toPath();
 						final Path relativePath = dirInputSourceAsPath.relativize(resourcePath);
 						final Path targetPath = outputPath.resolve(relativePath).getParent();
 						try {


### PR DESCRIPTION
Simplify file iteration loop in `Launcher.java` by changing the `resources` collection to be a `Collection<File>`, and using `File` instead of `Object` in the loop, which removes the requirement of casting it before converting it to a `Path`.