### PR TITLE
review: refactor: replace direct access to ContextBuilder#stack with methods

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -75,7 +75,7 @@ public class ContextBuilder {
 	/**
 	 * Stack of all parents elements
 	 */
-	Deque<ASTPair> stack = new ArrayDeque<>();
+	private Deque<ASTPair> stack = new ArrayDeque<>();
 
 	private final JDTTreeBuilder jdtTreeBuilder;
 
@@ -130,6 +130,37 @@ public class ContextBuilder {
 		}
 	}
 
+	/**
+	 * @return all {@link ASTPair}s currently on the stack
+	 */
+	Iterable<ASTPair> getAllContexts() {
+		return stack;
+	}
+
+	/**
+	 * @return {@code true} if there are any elements on the stack
+	 */
+	boolean hasCurrentContext() {
+		return !stack.isEmpty();
+	}
+
+	/**
+	 *
+	 * @return the {@link CtElement} on the top of the stack
+	 * @throws NullPointerException if the stack is empty
+	 */
+	CtElement getCurrentElement() {
+		return stack.peek().element;
+	}
+
+	/**
+	 * @return the {@link ASTNode} on the top of the stack
+	 * @throws NullPointerException if the stack is empty
+	 */
+	ASTNode getCurrentNode() {
+		return stack.peek().node;
+	}
+
 	CtElement getContextElementOnLevel(int level) {
 		for (ASTPair pair : stack) {
 			if (level == 0) {
@@ -168,7 +199,7 @@ public class ContextBuilder {
 			// note: this happens when using the new try(vardelc) structure
 			this.jdtTreeBuilder.getLogger().error(
 					format("Could not find declaration for local variable %s at %s",
-							name, stack.peek().element.getPosition()));
+							name, getCurrentElement().getPosition()));
 		}
 		return localVariable;
 	}
@@ -183,7 +214,7 @@ public class ContextBuilder {
 			// note: this happens when using the new try(vardelc) structure
 			this.jdtTreeBuilder.getLogger().error(
 					format("Could not find declaration for catch variable %s at %s",
-							name, stack.peek().element.getPosition()));
+							name, getCurrentElement().getPosition()));
 		}
 		return catchVariable;
 	}
@@ -195,7 +226,7 @@ public class ContextBuilder {
 			// note: this can happen when identifier is not a variable name but e.g. a Type name.
 			this.jdtTreeBuilder.getLogger().debug(
 					format("Could not find declaration for variable %s at %s.",
-							name, stack.peek().element.getPosition()));
+							name, getCurrentElement().getPosition()));
 		}
 		return variable;
 	}

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -75,7 +75,7 @@ public class ContextBuilder {
 	/**
 	 * Stack of all parents elements
 	 */
-	private Deque<ASTPair> stack = new ArrayDeque<>();
+	private final Deque<ASTPair> stack = new ArrayDeque<>();
 
 	private final JDTTreeBuilder jdtTreeBuilder;
 

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -126,7 +126,7 @@ public class JDTTreeBuilderHelper {
 	 * @return a catch variable.
 	 */
 	CtCatchVariable<Throwable> createCatchVariable(TypeReference typeReference, Scope scope) {
-		final Argument jdtCatch = (Argument) jdtTreeBuilder.getContextBuilder().stack.peekFirst().node;
+		final Argument jdtCatch = (Argument) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		final Set<CtExtendedModifier> modifiers = getModifiers(jdtCatch.modifiers, false, ModifierTarget.LOCAL_VARIABLE);
 
 		CtCatchVariable<Throwable> result = jdtTreeBuilder.getFactory().Core().createCatchVariable();
@@ -215,7 +215,7 @@ public class JDTTreeBuilderHelper {
 
 				// find executable's corresponding jdt element
 				AbstractMethodDeclaration executableJDT = null;
-				for (final ASTPair astPair : contextBuilder.stack) {
+				for (final ASTPair astPair : contextBuilder.getAllContexts()) {
 					if (astPair.element == executable) {
 						executableJDT = (AbstractMethodDeclaration) astPair.node;
 					}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -239,7 +239,7 @@ class JDTTreeBuilderQuery {
 	 * @return true if the lhs is equals to the given expression.
 	 */
 	static boolean isLhsAssignment(ContextBuilder context, Expression lhs) {
-		return context.stack.peek().node instanceof Assignment && ((Assignment) context.stack.peek().node).lhs.equals(lhs);
+		return context.getCurrentNode() instanceof Assignment && ((Assignment) context.getCurrentNode()).lhs.equals(lhs);
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -274,14 +274,14 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToDefaultValue(CtVariable<T> ctVariable) {
-		if (jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof AnnotationMethodDeclaration) {
-			final AnnotationMethodDeclaration parent = (AnnotationMethodDeclaration) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		if (jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof AnnotationMethodDeclaration) {
+			final AnnotationMethodDeclaration parent = (AnnotationMethodDeclaration) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 			// Default value is equals to the jdt child.
 			return parent.defaultValue != null && getFinalExpressionFromCast(parent.defaultValue).equals(childJDT)
 					// Return type not yet initialized.
 					&& !child.equals(ctVariable.getDefaultExpression());
 		}
-		final AbstractVariableDeclaration parent = (AbstractVariableDeclaration) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final AbstractVariableDeclaration parent = (AbstractVariableDeclaration) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Default value is equals to the jdt child.
 		return parent.initialization != null && getFinalExpressionFromCast(parent.initialization).equals(childJDT)
 				// Return type not yet initialized.
@@ -325,7 +325,7 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToType(CtMethod<T> ctMethod) {
-		final MethodDeclaration parent = (MethodDeclaration) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final MethodDeclaration parent = (MethodDeclaration) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Return type is equals to the jdt child.
 		return parent.returnType != null && parent.returnType.equals(childJDT)
 				// Return type not yet initialized.
@@ -342,7 +342,7 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToDefaultValue(CtAnnotationMethod<T> ctAnnotationMethod) {
-		final AnnotationMethodDeclaration parent = (AnnotationMethodDeclaration) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final AnnotationMethodDeclaration parent = (AnnotationMethodDeclaration) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Default value is equals to the jdt child.
 		return parent.defaultValue != null && parent.defaultValue.equals(childJDT)
 				// Default value not yet initialized.
@@ -444,7 +444,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				}
 				operator.setRightHandOperand((CtExpression<?>) child);
 				return;
-			} else if (jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof StringLiteralConcatenation) {
+			} else if (jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof StringLiteralConcatenation) {
 				CtBinaryOperator<?> op = operator.getFactory().Core().createBinaryOperator();
 				op.setKind(BinaryOperatorKind.PLUS);
 				op.setLeftHandOperand(operator.getLeftHandOperand());
@@ -478,7 +478,7 @@ public class ParentExiter extends CtInheritanceScanner {
 
 	@Override
 	public <E> void visitCtCase(CtCase<E> caseStatement) {
-		final ASTNode node = jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ASTNode node = jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		if (node instanceof CaseStatement) {
 			caseStatement.setCaseKind(((CaseStatement) node).isExpr ? CaseKind.ARROW : CaseKind.COLON);
 		}
@@ -511,7 +511,7 @@ public class ParentExiter extends CtInheritanceScanner {
 
 	@Override
 	public <T> void visitCtCatchVariable(CtCatchVariable<T> e) {
-		if (jdtTreeBuilder.getContextBuilder().stack.peekFirst().node instanceof UnionTypeReference) {
+		if (jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof UnionTypeReference) {
 			e.addMultiType((CtTypeReference<?>) child);
 			return;
 		}
@@ -613,10 +613,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private boolean isContainedInForInit() {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ForStatement)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ForStatement)) {
 			return false;
 		}
-		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		if (parent.initializations == null) {
 			return false;
 		}
@@ -629,10 +629,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private boolean isContainedInForUpdate() {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ForStatement)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ForStatement)) {
 			return false;
 		}
-		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		if (parent.increments == null) {
 			return false;
 		}
@@ -645,10 +645,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private boolean isContainedInForCondition() {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ForStatement)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ForStatement)) {
 			return false;
 		}
-		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ForStatement parent = (ForStatement) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		return parent.condition != null && parent.condition.equals(childJDT);
 	}
 
@@ -785,10 +785,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToQualification(CtInvocation<T> ctInvocation) {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ExplicitConstructorCall)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ExplicitConstructorCall)) {
 			return false;
 		}
-		final ExplicitConstructorCall parent = (ExplicitConstructorCall) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ExplicitConstructorCall parent = (ExplicitConstructorCall) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// qualification is equals to the jdt child.
 		return parent.qualification != null && getFinalExpressionFromCast(parent.qualification).equals(childJDT)
 				// qualification not yet initialized.
@@ -796,10 +796,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToReceiver(CtInvocation<T> ctInvocation) {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof MessageSend)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof MessageSend)) {
 			return false;
 		}
-		final MessageSend parent = (MessageSend) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final MessageSend parent = (MessageSend) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Receiver is equals to the jdt child.
 		return parent.receiver != null && getFinalExpressionFromCast(parent.receiver).equals(childJDT)
 				// Receiver not yet initialized.
@@ -816,12 +816,12 @@ public class ParentExiter extends CtInheritanceScanner {
 	@Override
 	public <T> void visitCtNewArray(CtNewArray<T> newArray) {
 		if (childJDT instanceof TypeReference && child instanceof CtTypeAccess) {
-			final ArrayAllocationExpression arrayAlloc = (ArrayAllocationExpression) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+			final ArrayAllocationExpression arrayAlloc = (ArrayAllocationExpression) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 			newArray.setType((CtArrayTypeReference) jdtTreeBuilder.getFactory().Type().createArrayReference(((CtTypeAccess) child).getAccessedType(), arrayAlloc.dimensions.length));
 		} else if (child instanceof CtExpression) {
 			if (isContainedInDimensionExpression()) {
 				newArray.addDimensionExpression((CtExpression<Integer>) child);
-			} else if (child instanceof CtNewArray && childJDT instanceof ArrayInitializer && jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ArrayAllocationExpression) {
+			} else if (child instanceof CtNewArray && childJDT instanceof ArrayInitializer && jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ArrayAllocationExpression) {
 				newArray.setElements(((CtNewArray) child).getElements());
 			} else {
 				newArray.addElement((CtExpression) child);
@@ -830,10 +830,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private boolean isContainedInDimensionExpression() {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof ArrayAllocationExpression)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof ArrayAllocationExpression)) {
 			return false;
 		}
-		final ArrayAllocationExpression parent = (ArrayAllocationExpression) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final ArrayAllocationExpression parent = (ArrayAllocationExpression) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		if (parent.dimensions == null) {
 			return false;
 		}
@@ -866,10 +866,10 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToEnclosingInstance(CtConstructorCall<T> ctConstructorCall) {
-		if (!(jdtTreeBuilder.getContextBuilder().stack.peek().node instanceof QualifiedAllocationExpression)) {
+		if (!(jdtTreeBuilder.getContextBuilder().getCurrentNode() instanceof QualifiedAllocationExpression)) {
 			return false;
 		}
-		final QualifiedAllocationExpression parent = (QualifiedAllocationExpression) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final QualifiedAllocationExpression parent = (QualifiedAllocationExpression) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Enclosing instance is equals to the jdt child.
 		return parent.enclosingInstance != null && getFinalExpressionFromCast(parent.enclosingInstance).equals(childJDT)
 				// Enclosing instance not yet initialized.
@@ -877,7 +877,7 @@ public class ParentExiter extends CtInheritanceScanner {
 	}
 
 	private <T> boolean hasChildEqualsToType(CtConstructorCall<T> ctConstructorCall) {
-		final AllocationExpression parent = (AllocationExpression) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+		final AllocationExpression parent = (AllocationExpression) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 		// Type is equals to the jdt child.
 		return parent.type != null && parent.type.equals(childJDT);
 	}
@@ -887,7 +887,7 @@ public class ParentExiter extends CtInheritanceScanner {
 	public <T> void visitCtNewClass(CtNewClass<T> newClass) {
 		if (child instanceof CtClass) {
 			newClass.setAnonymousClass((CtClass<?>) child);
-			final QualifiedAllocationExpression node = (QualifiedAllocationExpression) jdtTreeBuilder.getContextBuilder().stack.peek().node;
+			final QualifiedAllocationExpression node = (QualifiedAllocationExpression) jdtTreeBuilder.getContextBuilder().getCurrentNode();
 			final ReferenceBinding[] referenceBindings = node.resolvedType == null ? null : node.resolvedType.superInterfaces();
 			if (referenceBindings != null && referenceBindings.length > 0) {
 				//the interface of anonymous class is not printed so it must have no position
@@ -1064,7 +1064,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				tryWithResource.addResource((CtResource<?>) variableRef.getDeclaration().clone().setImplicit(true));
 			} else {
 				// we have to find it manually
-				for (ASTPair pair: this.jdtTreeBuilder.getContextBuilder().stack) {
+				for (ASTPair pair: this.jdtTreeBuilder.getContextBuilder().getAllContexts()) {
 					final List<CtLocalVariable> variables = pair.element.getElements(new TypeFilter<>(CtLocalVariable.class));
 					for (CtLocalVariable v: variables) {
 						if (v.getSimpleName().equals(variableRef.getSimpleName())) {

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -465,7 +465,7 @@ public class PositionBuilder {
 	}
 
 	private int getParentsSourceStart() {
-		Iterator<ASTPair> iter = this.jdtTreeBuilder.getContextBuilder().stack.iterator();
+		Iterator<ASTPair> iter = this.jdtTreeBuilder.getContextBuilder().getAllContexts().iterator();
 		if (iter.hasNext()) {
 			iter.next();
 			if (iter.hasNext()) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -673,14 +673,14 @@ public class ReferenceBuilder {
 	 * See #3360 for details.
 	 */
 	private void tryRecoverTypeArguments(CtTypeReference<?> type) {
-		final Deque<ASTPair> stack = jdtTreeBuilder.getContextBuilder().stack;
-		if (stack.peek() == null || !(stack.peek().node instanceof AllocationExpression)) {
+		ContextBuilder contextBuilder = jdtTreeBuilder.getContextBuilder();
+		if (!contextBuilder.hasCurrentContext() || !(contextBuilder.getCurrentNode() instanceof AllocationExpression)) {
 			// have thus far only ended up here with a generic array type,
 			// don't know if we want or need to deal with those
 			return;
 		}
 
-		AllocationExpression alloc = (AllocationExpression) stack.peek().node;
+		AllocationExpression alloc = (AllocationExpression) contextBuilder.getCurrentNode();
 		if (alloc.expectedType() instanceof ParameterizedTypeBinding) {
 			ParameterizedTypeBinding expectedType = (ParameterizedTypeBinding) alloc.expectedType();
 			if (expectedType.typeArguments() != null) {
@@ -1313,7 +1313,7 @@ public class ReferenceBuilder {
 	 */
 	public CtExecutableReference<?> getLambdaExecutableReference(SingleNameReference singleNameReference) {
 		ASTPair potentialLambda = null;
-		for (ASTPair astPair : jdtTreeBuilder.getContextBuilder().stack) {
+		for (ASTPair astPair : jdtTreeBuilder.getContextBuilder().getAllContexts()) {
 			if (astPair.node instanceof LambdaExpression) {
 				potentialLambda = astPair;
 				// stop at innermost lambda, fixes #1100

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -90,7 +90,6 @@ import spoon.support.reflect.CtExtendedModifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Replaces repetitive code with methods that simplify the code. This also helps to get rid of NPE warnings.