### PR TITLE
review: chore: Added GPG private key & passphrase secrets to JReleaser workflow.

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -29,6 +29,8 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: maven
+          gpg-private-key: ${{ secrets.JRELEASER_GPG_SECRET_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: ${{ secrets.JRELEASER_GPG_PASSPHRASE }} # env variable for GPG private key passphrase
           
       - name: install go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4


### PR DESCRIPTION
This commit adds GPG private key and passphrase secrets to the workflow by setting `gpg-private-key` and `gpg-passphrase` fields respectively, enabling secure and automated signing of the release artifacts with JReleaser.

This should fix this error https://github.com/INRIA/spoon/actions/runs/5224090878/jobs/9431846062, see https://github.com/actions/setup-java#maven-options for the options.