### PR TITLE
fix: Add configuration for git user on GitHub Actions.

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
+      - name: Set git user
+        run: |
+          git config --global user.name "GitHub Actions Bot"
+          git config --global user.email "<>"
       - name: Set up JDK 11
         uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3
         with:
@@ -68,6 +72,9 @@ jobs:
         run: |
           git checkout -b ${{env.BRANCH_NAME}}
           git commit -am "release: Releasing version ${{ env.NEXT_VERSION }}"
+          git push --set-upstream origin ${{ env.BRANCH_NAME }}
+
+
 
 # Now we can run the release
       - name: Stage release
@@ -99,6 +106,7 @@ jobs:
       - name: Commit & Push changes
         run: |
           git commit -am "release: Setting SNAPSHOT version $NEXT_RELEASE_VERSION"
+          git push --set-upstream origin ${{ env.BRANCH_NAME }}
       - name: Merge Fast Forward
         run: |
           git checkout master


### PR DESCRIPTION
The `jreleaser.yml` file was updated to set up the git user before committing changes. The `user.name` was set as "GitHub Actions Bot" with a blank `user.email`. This config does the job and we need nothing fancy.