### PR TITLE
review: fix: Synchronize reflection tree builder entrypoint method on factory

### DIFF
--- a/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
+++ b/src/main/java/spoon/support/visitor/java/JavaReflectionTreeBuilder.java
@@ -90,6 +90,9 @@ public class JavaReflectionTreeBuilder extends JavaReflectionVisitorImpl {
 	public <T, R extends CtType<T>> R scan(Class<T> clazz) {
 		// We modify and query our modified model in this part. If another thread were to do the same
 		// on the same model, things will explode (e.g. with a ParentNotInitialized exception).
+		// We only synchronize in the main entrypoint, as that should be enough for normal consumers.
+		// The shadow factory should not be modified in other places and nobody should be directly calling
+		// the visit methods.
 		synchronized (factory) {
 			CtPackage ctPackage;
 			CtType<?> ctEnclosingClass;


### PR DESCRIPTION
The normal spoon model is safe-ish under concurrent queries (*NOT* modifications), but as the shadow model is lazily build, querying *is* modification. Sadly, the tree builder even has internal side effects it relies on, making parallel use a game of chance. This PR proposes a pretty big, well worn duct-tape to paper over this by unquestionably serializing scans for one factory.

The performance impact should be okay (correct > fast) and each class is only looked up *once* before it is stored in the shadow cache.

----

This was debugged with the following JCStress test.
Before:
![grafik](https://github.com/INRIA/spoon/assets/20284688/4b561d88-0404-45b2-97d2-0592a6bc106a)

After:
![grafik](https://github.com/INRIA/spoon/assets/20284688/71ea6ec8-e70e-4943-ab21-25166bb6a624)


```java
package org.openjdk.jcstress.tests.spoon;

import static org.openjdk.jcstress.annotations.Expect.ACCEPTABLE;
import static org.openjdk.jcstress.annotations.Expect.FORBIDDEN;

import org.openjdk.jcstress.annotations.Actor;
import org.openjdk.jcstress.annotations.Description;
import org.openjdk.jcstress.annotations.JCStressTest;
import org.openjdk.jcstress.annotations.Outcome;
import org.openjdk.jcstress.annotations.State;
import org.openjdk.jcstress.infra.results.I_Result;
import spoon.Launcher;
import spoon.reflect.factory.Factory;

@Description("Spoon factory test")
@JCStressTest
@Outcome(id = "1", expect = ACCEPTABLE, desc = "Normal")
@Outcome(id = "0", expect = FORBIDDEN, desc = "NO!")
public class ReflectiveFactory {

  @State
  public static class SpoonState {

    public final Factory factory;

    public SpoonState() {
      Launcher launcher = new Launcher();
      launcher.getEnvironment().setComplianceLevel(11);
      factory = launcher.getFactory();
    }
  }

  @Actor
  public final void actor1(SpoonState s) {
    s.factory.Type().get(void.class);
  }

  @Actor
  public final void actor2(SpoonState s, I_Result r) {
    s.factory.Type().get(void.class);
    r.r1++;
  }
}
```