### PR TITLE
review: fix: fix releasing of spoon-core, parent and javadoc module

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -67,7 +67,10 @@ jobs:
       - name: set branchname to next version
         run: echo "BRANCH_NAME=release/$NEXT_VERSION" >> $GITHUB_ENV
       - name: Set release version
-        run: mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_VERSION -DprocessAllModules
+        run: |
+            mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_VERSION -DprocessAllModules
+            mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_VERSION -DprocessAllModules
+            mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_VERSION -DprocessAllModules
       - name: Commit & Push changes
         run: |
           git checkout -b ${{env.BRANCH_NAME}}
@@ -78,7 +81,7 @@ jobs:
 
 # Now we can run the release
       - name: Stage release
-        run:  mvn --no-transfer-progress --batch-mode -Pjreleaser clean deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy
+        run:  mvn -f spoon-pom --no-transfer-progress --batch-mode -Pjreleaser clean deploy -DaltDeploymentRepository=local::default::file:./target/staging-deploy
       - name: Print next version
         run: mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//'
       - name: Run JReleaser
@@ -101,7 +104,10 @@ jobs:
          echo "NEXT_RELEASE_VERSION=$(semver next patch $NEXT_VERSION)-SNAPSHOT" >> $GITHUB_ENV
          echo "NEXT_RELEASE_VERSION_WITHOUT_SNAPSHOT=$(semver next patch $NEXT_VERSION)" >> $GITHUB_ENV
       - name: Set release version
-        run: mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_RELEASE_VERSION -DprocessAllModules
+        run: |
+            mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_RELEASE_VERSION -DprocessAllModules
+            mvn --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_RELEASE_VERSION -DprocessAllModules
+            mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion=$NEXT_RELEASE_VERSION -DprocessAllModules
 # Commit and push changes
       - name: Commit & Push changes
         run: |

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,4 +1,5 @@
 project:
+  version: 10.4.0-SNAPSHOT
   name: spoon-core
   description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
   longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
@@ -24,6 +25,7 @@ release:
     owner: INRIA
     changelog:
       formatted: ALWAYS
+      preset: conventional-commits
       format: '- {{commitShortHash}} {{commitTitle}}'
       contributors:
         format: '- {{contributorName}} ({{contributorUsernameAsLink}})'
@@ -40,6 +42,7 @@ deploy:
       maven-central:
         active: ALWAYS
         url: https://s01.oss.sonatype.org/service/local
+        snapshotUrl: https://s01.oss.sonatype.org/content/repositories/snapshots
         closeRepository: true
         releaseRepository: true
         stagingRepositories:

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,5 +1,4 @@
 project:
-  version: 10.4.0-SNAPSHOT
   name: spoon-core
   description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
   longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
@@ -17,8 +16,8 @@ project:
     homepage: https://spoon.gforge.inria.fr/
   java:
     groupId: fr.inria.gforge.spoon
-    version: 11
-  inceptionYear: 2015
+    version: "11"
+  inceptionYear: "2015"
 
 release:
   github:
@@ -42,7 +41,6 @@ deploy:
       maven-central:
         active: ALWAYS
         url: https://s01.oss.sonatype.org/service/local
-        snapshotUrl: https://s01.oss.sonatype.org/content/repositories/snapshots
         closeRepository: true
         releaseRepository: true
         stagingRepositories:


### PR DESCRIPTION
This commit fixes the mvn commands to run for all modules.
Locally, I can produce snapshot releases with this config. The first changelog looks a bit doomed because JReleaser finds not matching git commit for the releases. Let's hope the GitHub API does not die. 