### PR TITLE
review: chore:  Remove Java 11 from tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17, 20, 21-ea]
+        java: [17, 20, 21-ea]
         os: [ubuntu-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -116,7 +116,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
         with:
-          java-version: 11
+          java-version: 17
           distribution: ${{ env.JAVA_DISTRIBUTION }}
       - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4.6.1
         with:
@@ -156,10 +156,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
         # the pom checker needs maven 3.9.0
       - name: Set up Maven


### PR DESCRIPTION
This commit removes `java` version 11 in the matrix of os and java versions in the tests.yml file. It sets the `java-version` to 17 in the `Set up JDK` step in both the `build` and `tests` jobs.