### PR TITLE
chore: Run tests for java17 branch

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - java17
 jobs:
     code-quality:
       runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - master
+      - java17
   push:
     branches:
       - master


### PR DESCRIPTION
This commit updates the Github workflows configuration files to include the Java 17 branch in pull requests and push events.