### PR TITLE
avoid version range: makes build is not stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>[3.6.0,)</version>
+      <version>3.9.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
unstable build is even worse than non-reproducible build

and FYI, Spoon 10.3.0 ingested Maven 4.0.0-alpha-4 components: did you really mean to inject alpha components?

see https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/fr/inria/gforge/spoon/spoon-core/README.md