### PR TITLE
fix: use old sonatype url

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -40,6 +40,8 @@ deploy:
     nexus2:
       maven-central:
         active: ALWAYS
+        # Spoon is hosted on the legacy sonatype instance, see
+        # https://central.sonatype.org/publish/publish-guide/#releasing-to-central
         url: https://oss.sonatype.org/service/local
         closeRepository: true
         releaseRepository: true

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -41,7 +41,7 @@ deploy:
       maven-central:
         active: ALWAYS
         url: https://oss.sonatype.org/service/local
-        closeRepository: false
+        closeRepository: true
         releaseRepository: true
         stagingRepositories:
           - target/staging-deploy

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,5 +1,5 @@
 project:
-  name: spoon-core
+  name: spoon
   description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
   longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
                    It parses source files to build a well-designed AST with powerful analysis and transformation API. 
@@ -40,8 +40,8 @@ deploy:
     nexus2:
       maven-central:
         active: ALWAYS
-        url: https://s01.oss.sonatype.org/service/local
-        closeRepository: true
+        url: https://oss.sonatype.org/service/local
+        closeRepository: false
         releaseRepository: true
         stagingRepositories:
           - target/staging-deploy


### PR DESCRIPTION
Spoon has a pre2021 URL. Also the project name should be `spoon` instead of ´spoon-core´