### PR TITLE
review: feat: configurable encoding of processed source code

### DIFF
--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -77,10 +77,18 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 		return this.getEnvironment().getSourceOutputDirectory();
 	}
 
+	/**
+	 * Gets the charset.
+	 * @return the charset used for processed source code.
+	 */
 	public Charset getCharset() {
 		return this.charset;
 	}
 
+	/**
+	 * Sets the charset.
+	 * @param charset the charset used for processed source code.
+	 */
 	public void setCharset(Charset charset) {
 		this.charset = charset;
 	}

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -22,9 +22,9 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.support.compiler.SpoonProgress;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +38,8 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 	PrettyPrinter printer;
 
 	List<File> printedFiles = new ArrayList<>();
+
+	Charset charset = Charset.defaultCharset();
 
 	/**
 	 * @param printer  the PrettyPrinter to use for written the files
@@ -123,7 +125,7 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 				printedFiles.add(file);
 			}
 			// print type
-			try (PrintStream stream = new PrintStream(file)) {
+			try (PrintStream stream = new PrintStream(file, charset)) {
 				stream.print(printer.getResult());
 				for (CtType<?> t : toBePrinted) {
 					lineNumberMappings.put(t.getQualifiedName(), printer.getLineNumberMapping());
@@ -161,9 +163,9 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 		if (!printedFiles.contains(packageAnnot)) {
 			printedFiles.add(packageAnnot);
 		}
-		try (PrintStream stream = new PrintStream(packageAnnot)) {
+		try (PrintStream stream = new PrintStream(packageAnnot, charset)) {
 			stream.println(getPrinter().printPackageInfo(pack));
-		} catch (FileNotFoundException e) {
+		} catch (IOException e) {
 			Launcher.LOGGER.error(e.getMessage(), e);
 		}
 	}
@@ -174,9 +176,9 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 			if (!printedFiles.contains(moduleFile)) {
 				printedFiles.add(moduleFile);
 			}
-			try (PrintStream stream = new PrintStream(moduleFile)) {
+			try (PrintStream stream = new PrintStream(moduleFile, charset)) {
 				stream.println(getPrinter().printModuleInfo(module));
-			} catch (FileNotFoundException e) {
+			} catch (IOException e) {
 				Launcher.LOGGER.error(e.getMessage(), e);
 			}
 		}

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -77,6 +77,14 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 		return this.getEnvironment().getSourceOutputDirectory();
 	}
 
+	public Charset getCharset() {
+		return this.charset;
+	}
+
+	public void setCharset(Charset charset) {
+		this.charset = charset;
+	}
+
 	@Override
 	public void init() {
 		// Skip loading properties

--- a/src/main/java/spoon/support/JavaOutputProcessor.java
+++ b/src/main/java/spoon/support/JavaOutputProcessor.java
@@ -39,7 +39,7 @@ public class JavaOutputProcessor extends AbstractProcessor<CtNamedElement> imple
 
 	List<File> printedFiles = new ArrayList<>();
 
-	Charset charset = Charset.defaultCharset();
+	private Charset charset = Charset.defaultCharset();
 
 	/**
 	 * @param printer  the PrettyPrinter to use for written the files

--- a/src/test/java/spoon/support/JavaOutputProcessorTest.java
+++ b/src/test/java/spoon/support/JavaOutputProcessorTest.java
@@ -7,12 +7,63 @@ import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JavaOutputProcessorTest {
 
+	@Test
+	void testCreateJavaFileAssertFileCreated(@TempDir File tempDir) {
+		// contract : createJavaFile creates a Java file and prints it
+
+		// arrange
+		Launcher launcher = new Launcher();
+		launcher.setSourceOutputDirectory(tempDir.getAbsolutePath());
+		launcher.getEnvironment().setComplianceLevel(9);
+		Factory factory = launcher.getFactory();
+
+		CtClass<?> ctClass = factory.Class().create("spoon.support.EmptyClass");
+		JavaOutputProcessor javaOutputProcessor = new JavaOutputProcessor();
+		javaOutputProcessor.setFactory(factory);
+
+		// act
+		javaOutputProcessor.process(ctClass);
+
+		// assert
+		File expectedFile = tempDir.toPath().resolve("spoon/support/EmptyClass.java").toFile();
+		assertTrue(expectedFile.exists());
+		assertEquals(1, javaOutputProcessor.printedFiles.size());
+	}
+
+	@Test
+	void testCreateJavaFileAssertFileEncodingChanged(@TempDir File tempDir) throws Exception {
+
+		// arrange
+		Launcher launcher = new Launcher();
+		launcher.setSourceOutputDirectory(tempDir.getAbsolutePath());
+		launcher.getEnvironment().setComplianceLevel(9);
+		Factory factory = launcher.getFactory();
+
+		// use characters encoded differently in ISO-8859-01 and UTFs
+		String code = "class ÈmptyÇlàss {}";
+		CtClass<?> ctClass =  Launcher.parseClass(code);
+
+		JavaOutputProcessor javaOutputProcessor = new JavaOutputProcessor();
+		javaOutputProcessor.setCharset(StandardCharsets.ISO_8859_1);
+		javaOutputProcessor.setFactory(factory);
+
+		// act
+		javaOutputProcessor.process(ctClass);
+
+		// assert
+		File expectedFile = tempDir.toPath().resolve("ÈmptyÇlàss.java").toFile();
+
+		byte[] bytes = Files.readAllBytes(expectedFile.toPath());
+		assertEquals(code, new String(bytes, StandardCharsets.ISO_8859_1));
+	}
 
     @Test
     void testCreateModuleFileAssertAnnotationFileCreated(@TempDir File tempDir) {


### PR DESCRIPTION
This pull request is related to #5343.

With this commit, `JavaOutputProcessor` now uses `PrintStream​(File file, Charset charset)` instead of `PrintStream​(File file)`.
By default, `Charset.defaultCharset()`  is assigned to `charset`. So the default behavior remains the same.