### PR TITLE
checkstyle: add a whitespace after varargs

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -176,7 +176,7 @@ public class CodeFactory extends SubFactory {
 	 * @param <T> the actual type of the decelerating type of the constructor if available
 	 * @return the constructor call
 	 */
-	public <T> CtConstructorCall<T> createConstructorCall(CtTypeReference<T> type, CtExpression<?>...parameters) {
+	public <T> CtConstructorCall<T> createConstructorCall(CtTypeReference<T> type, CtExpression<?>... parameters) {
 		CtConstructorCall<T> constructorCall = factory.Core()
 				.createConstructorCall();
 		CtExecutableReference<T> executableReference = factory.Core()
@@ -197,7 +197,7 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a new anonymous class.
 	 */
-	public <T> CtNewClass<T> createNewClass(CtType<T> superClass, CtExpression<?>...parameters) {
+	public <T> CtNewClass<T> createNewClass(CtType<T> superClass, CtExpression<?>... parameters) {
 		CtNewClass<T> ctNewClass = factory.Core().createNewClass();
 		CtConstructor<T> constructor = ((CtClass) superClass).getConstructor(Arrays.stream(parameters).map(x -> x.getType()).toArray(CtTypeReference[]::new));
 		if (constructor == null) {

--- a/src/main/java/spoon/reflect/factory/ConstructorFactory.java
+++ b/src/main/java/spoon/reflect/factory/ConstructorFactory.java
@@ -154,7 +154,7 @@ public class ConstructorFactory extends ExecutableFactory {
 	 * @param <T> Infered type of the constructor.
 	 * @return CtExecutablereference if a constructor.
 	 */
-	public <T> CtExecutableReference<T> createReference(CtTypeReference<T> type, CtExpression<?>...parameters) {
+	public <T> CtExecutableReference<T> createReference(CtTypeReference<T> type, CtExpression<?>... parameters) {
 		final CtExecutableReference<T> executableReference = factory.Core().createExecutableReference();
 		executableReference.setType(type);
 		executableReference.setDeclaringType(type == null ? null : type.clone());

--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -220,7 +220,7 @@ public class SourcePositionImpl implements SourcePosition {
 	 * fails when `values` are not sorted ascending
 	 * It is used to check whether start/end values of SourcePosition are consistent
 	 */
-	protected static void checkArgsAreAscending(int...values) {
+	protected static void checkArgsAreAscending(int... values) {
 		int last = -1;
 		for (int value : values) {
 			if (value < 0) {


### PR DESCRIPTION
Add a space after varargs(...) to follow the checkstyle rule.