### PR TITLE
doc: fix typos "is is..."

### DIFF
--- a/src/main/java/spoon/FluentLauncher.java
+++ b/src/main/java/spoon/FluentLauncher.java
@@ -173,7 +173,7 @@ public class FluentLauncher {
 	 * are handled with the reference mechanism. The "simplename" of the reference
 	 * object refers to the unbound identifier.
 	 *
-	 * This option facilitates the use of Spoon when is is hard to have the complete
+	 * This option facilitates the use of Spoon when it is hard to have the complete
 	 * and correct classpath, for example for mining software repositories.
 	 *
 	 * For writing analyses, this option works well if you don't cross the reference

--- a/src/main/java/spoon/compiler/Environment.java
+++ b/src/main/java/spoon/compiler/Environment.java
@@ -314,7 +314,7 @@ public interface Environment {
 	 * classpath are handled with the reference mechanism. The "simplename" of
 	 * the reference object refers to the unbound identifier.
 	 *
-	 * This option facilitates the use of Spoon when is is hard to have the
+	 * This option facilitates the use of Spoon when it is hard to have the
 	 * complete and correct classpath, for example for mining software
 	 * repositories.
 	 *


### PR DESCRIPTION
There are typos "when *is* is hard..." in several classes, fixed them to "it is".