### PR TITLE
review: build: Add nullaway from uber

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -138,6 +138,8 @@
                         <arg>-Xlint:deprecation,unchecked</arg>
                         <!-- always generate class files for package-info -->
                         <arg>-Xpkginfo:always</arg>
+                        <arg>-Xplugin:ErrorProne -Xep:NullAway:WARN -XepOpt:NullAway:AnnotatedPackages=spoon</arg>
+                        <arg>-XDcompilePolicy=simple</arg>
                     </compilerArgs>
                     <!-- incremental compilation is broken in maven, see https://issues.apache.org/jira/browse/MCOMPILER-205  -->
                     <!-- useIncrementalCompilation=false actually means that we won't recompile everything each time -->
@@ -148,6 +150,16 @@
                             <groupId>org.kohsuke.metainf-services</groupId>
                             <artifactId>metainf-services</artifactId>
                             <version>1.11</version>
+                        </annotationProcessorPath>
+                        <annotationProcessorPath>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.20.0</version>
+                        </annotationProcessorPath>
+                        <annotationProcessorPath>
+                            <groupId>com.uber.nullaway</groupId>
+                            <artifactId>nullaway</artifactId>
+                            <version>0.10.11</version>
                         </annotationProcessorPath>
                     </annotationProcessorPaths>
                 </configuration>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -138,7 +138,8 @@
                         <arg>-Xlint:deprecation,unchecked</arg>
                         <!-- always generate class files for package-info -->
                         <arg>-Xpkginfo:always</arg>
-                        <arg>-Xplugin:ErrorProne -Xep:NullAway:WARN -XepOpt:NullAway:AnnotatedPackages=spoon</arg>
+                        <arg>-Xplugin:ErrorProne -XepDisableAllChecks -Xep:NullAway:WARN
+                            -XepOpt:NullAway:AnnotatedPackages=spoon</arg>
                         <arg>-XDcompilePolicy=simple</arg>
                     </compilerArgs>
                     <!-- incremental compilation is broken in maven, see https://issues.apache.org/jira/browse/MCOMPILER-205  -->


### PR DESCRIPTION
Adds nullway from uber and set the logging leveling to warning. This currently assumes our packages are correct annotated, which they are not. I disabled all errorprone checks as we don't need two tools checking the same, we only want nullaway.