### PR TITLE
chore: convert qodana config to new format

### DIFF
--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -4,7 +4,7 @@
 # risk of someone injecting malicious code into a release and then simply
 # changing a tag.
 
-name: Qodana
+name: Qodana-Cloud-Scan
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -27,5 +27,5 @@ jobs:
             post-pr-comment: "false"
             pr-mode: "false"
             push-fixes: pull-request
-            args: "--apply-fixes"
+            # args: "--apply-fixes"
 

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -15,10 +15,6 @@ on:
 jobs:
   qodana:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      checks: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -30,4 +26,6 @@ jobs:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:
             post-pr-comment: "false"
+            push-fixes: pull-request
+            args: "--apply-fixes"
 

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -1,0 +1,33 @@
+# Workflow for testing spoon code quality.
+#
+# Note that actions are specified by commit hash. This is to avoid the security
+# risk of someone injecting malicious code into a release and then simply
+# changing a tag.
+
+name: Qodana
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
+          fetch-depth: 0  # a full history is required for pull request analysis
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2023.2
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+        with:
+            post-pr-comment: "false"
+

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2023.2

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -25,6 +25,7 @@ jobs:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         with:
             post-pr-comment: "false"
+            pr-mode: "false"
             push-fixes: pull-request
             args: "--apply-fixes"
 

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -12,20 +12,24 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
 jobs:
   qodana:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
-          fetch-depth: 0  # a full history is required for pull request analysis
+          fetch-depth: 0
       - name: 'Qodana Scan'
-        uses: JetBrains/qodana-action@v2023.2
+        uses: JetBrains/qodana-action@77f0ff0c702065648df9fd0340a48919dca5a1ff # v2023.2.1
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+      - uses: github/codeql-action/upload-sarif@a09933a12a80f87b87005513f0abb1494c27a716 # v2
         with:
-            post-pr-comment: "false"
-            pr-mode: "false"
-            # push-fixes: pull-request
-            # args: "--apply-fixes"
+          sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
 

--- a/.github/workflows/qodana-cloud.yaml
+++ b/.github/workflows/qodana-cloud.yaml
@@ -26,6 +26,6 @@ jobs:
         with:
             post-pr-comment: "false"
             pr-mode: "false"
-            push-fixes: pull-request
+            # push-fixes: pull-request
             # args: "--apply-fixes"
 

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -37,6 +37,8 @@ jobs:
           with:
             args: --source-directory,./spoon-javadoc/src/main/java , --fail-threshold, 0
             post-pr-comment: "false"
+          env:
+            QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }
         - uses: github/codeql-action/upload-sarif@a09933a12a80f87b87005513f0abb1494c27a716 # v2
           with:
             sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -22,6 +22,8 @@ jobs:
           with:
             args: --source-directory,./src/main/java , --fail-threshold, 0
             post-pr-comment: "false"
+          env:
+              QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         - uses: github/codeql-action/upload-sarif@a09933a12a80f87b87005513f0abb1494c27a716 # v2
           with:
             sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
@@ -38,7 +40,7 @@ jobs:
             args: --source-directory,./spoon-javadoc/src/main/java , --fail-threshold, 0
             post-pr-comment: "false"
           env:
-            QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }
+            QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
         - uses: github/codeql-action/upload-sarif@a09933a12a80f87b87005513f0abb1494c27a716 # v2
           with:
             sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,7 +1,7 @@
 profile:
   name: qodana.recommended
 version: "1.0"
-linter: jetbrains/qodana-jvm:2023.2.6
+linter: jetbrains/qodana-jvm:2023.2
 groups:
   - groupId: IncludedPaths
     groups:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,30 +1,38 @@
 profile:
   name: qodana.recommended
 version: "1.0"
-include:
-  - name: Anonymous2MethodRef
-  - name: AssignmentToCatchBlockParameter
-  - name: AssignmentToLambdaParameter
-  - name: AssignmentToMethodParameter
-  - name: AssignmentToNull
-  - name: Convert2Lambda
-  - name: DoubleBraceInitialization
-  - name: EqualsAndHashcode
-  - name: JavaLangImport
-  # Disabled for annotations applied to type
-  #- name: MissortedModifiers
-  - name: NestedAssignment
-  - name: NonShortCircuitBoolean
-  - name: RedundantFieldInitialization
-  - name: RedundantSuppression
-  - name: Reformat
-  - name: ReturnNull
-  - name: SamePackageImport
-  - name: StringEquality
-  - name: UnnecessaryBoxing
-  - name: UnnecessaryLocalVariable
-  - name: UnnecessaryUnboxing
-  - name: UNUSED_IMPORT
-  - name: PointlessBooleanExpression 
-exclude:
-  - name: UseOfClone
+groups:
+  - groupId: IncludedPaths
+    groups:
+          - "category:Java"
+          - "GLOBAL"
+  - groupId: ExcludedInspections # list of inspections disabled by specific reason
+    inspections:
+      - "!IncludedPaths"
+      - Annotator # substituted by JavaAnnotator in sanity
+      - JavaAnnotator # works in "sanity" inspections
+      - SyntaxError # should work on sanity level
+      - Since15 #Detects wrong language level. Should work on sanity.
+      - JavadocBlankLines # Questionable. Spam on mockito, RxJava and other projects.
+      - UseOfClone # We use clone correct implemented often as deep copy. It's not a problem.
+      - UnstableApiUsage  
+      - MissortedModifiers   # Disabled for annotations applied to type
+inspections:
+  - group: ExcludedInspections
+    enabled: false
+  - group: IncludedPaths
+    ignore:
+      - "vendor/**"
+      - "build/**"
+      - "buildSrc/**"
+      - "builds/**"
+      - "dist/**"
+      - "tests/**"
+      - "tools/**"
+      - "vendor/**"
+      - "**.test.ts"
+      - "scope#$gitignore" # $gitignore scope available only in qodana execution
+      - "scope#test:*..*"
+      - "scope#file:buildSrc/*"
+  - inspection: JavadocReference
+    severity: WARNING # It has default ERROR severity. It's understandable for unresolved references in javadocs for editor but not on CI.

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -14,7 +14,7 @@ groups:
       - SyntaxError # should work on sanity level
       - Since15 #Detects wrong language level. Should work on sanity.
       - JavadocBlankLines # Questionable. Spam on mockito, RxJava and other projects.
-      - UseOfClone # We use clone correct implemented often as deep copy. It's not a problem.
+      - UseOfClone # We often use clone (correctly implemented as a deep copy). It's not a problem.
       - UnstableApiUsage  
       - MissortedModifiers   # Disabled for annotations applied to type
 inspections:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -12,7 +12,7 @@ groups:
       - Annotator # substituted by JavaAnnotator in sanity
       - JavaAnnotator # works in "sanity" inspections
       - SyntaxError # should work on sanity level
-      - Since15 #Detects wrong language level. Should work on sanity.
+      - Since15 # Detects wrong language level. Should work on sanity.
       - JavadocBlankLines # Questionable. Spam on mockito, RxJava and other projects.
       - UseOfClone # We often use clone (correctly implemented as a deep copy). It's not a problem.
       - UnstableApiUsage  

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,7 @@
 profile:
   name: qodana.recommended
 version: "1.0"
+linter: jetbrains/qodana-jvm:2023.2.6
 groups:
   - groupId: IncludedPaths
     groups:

--- a/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java
@@ -207,4 +207,14 @@ public class CtInvocationImpl<T> extends CtTargetedExpressionImpl<T, CtExpressio
 	public CtInvocation<T> clone() {
 		return (CtInvocation<T>) super.clone();
 	}
+
+
+	// just to test if qodana works
+	public void qodanaTest(String a) {
+		Integer[] arr = null;
+		arr.toString();
+		arr.hashCode();
+		a.equals(arr);
+		System.out.println(a);
+	}
 }


### PR DESCRIPTION
This PR enables more or less all java rules. We could cut them down a bit if we see some we really hate. But as they are adding more and more nice rules, it is real hard to keep the file up-to-date otherwise.