### PR TITLE
Revert "fix(deps): update dependency org.apache.maven:maven-model to v3.9.4"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 	<!-- We use this old version for maximum compatibility, as we use the system maven installation for all commands anyways. -->
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.9.4</version>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
             "digest",
             "pinDigest"
          ],
+         "ignoreDeps": ["org.apache.maven:maven-model"],
          "automerge":true
       }
    ]


### PR DESCRIPTION
Reverts INRIA/spoon#5376

The ignore feature somehow failed. After fixing this we can do a patch release to test the nix release workflow.