### PR TITLE
refactor: adopt jspecify to `spoon.support.compiler`

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -20,6 +20,7 @@ import org.apache.maven.shared.invoker.Invoker;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import spoon.Launcher;
 import spoon.MavenLauncher;
@@ -332,7 +333,7 @@ public class SpoonPom implements SpoonResource {
 	 * @param key the key of the property
 	 * @return the property value if key exists or null
 	 */
-	private String getProperty(String key) {
+	private @Nullable String getProperty(String key) {
 		if ("project.version".equals(key) || "pom.version".equals(key) || "version".equals(key)) {
 			if (model.getVersion() != null) {
 				return model.getVersion();

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -11,6 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+import org.jspecify.annotations.Nullable;
+
 import spoon.SpoonException;
 import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtBinaryOperator;
@@ -572,7 +574,7 @@ public class JDTCommentBuilder {
 	 * @param e
 	 * @return body of element or null if this element has no body
 	 */
-	static CtElement getBody(CtElement e) {
+	static @Nullable CtElement getBody(CtElement e) {
 		if (e instanceof CtBodyHolder) {
 			return ((CtBodyHolder) e).getBody();
 		}

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.UnionTypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.jspecify.annotations.Nullable;
 
 import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
@@ -1041,7 +1042,7 @@ public class ParentExiter extends CtInheritanceScanner {
 	 * @param tryBlock
 	 * @return last CtCatch of `tryBlock` or null
 	 */
-	private CtCatch getLastCatcher(CtTry tryBlock) {
+	private @Nullable CtCatch getLastCatcher(CtTry tryBlock) {
 		List<CtCatch> catchers = tryBlock.getCatchers();
 		int nrCatchers = catchers.size();
 		if (nrCatchers > 0) {

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -309,7 +309,7 @@ public class ReferenceBuilder {
 	 * @param expectedName Name expected in imports.
 	 * @return CtReference which can be a CtTypeReference, a CtPackageReference or null.
 	 */
-	CtReference getDeclaringReferenceFromImports(char[] expectedName) {
+	@Nullable CtReference getDeclaringReferenceFromImports(char[] expectedName) {
 		CompilationUnitDeclaration cuDeclaration = this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration;
 		if (cuDeclaration == null) {
 			return null;
@@ -887,7 +887,7 @@ public class ReferenceBuilder {
 	 * @return a type reference or null if the binding has no closest match
 	 */
 	@SuppressWarnings("ReturnOfNull")
-	private CtTypeReference<?> getTypeReferenceFromUnresolvedReferenceBinding(UnresolvedReferenceBinding binding) {
+	private @Nullable CtTypeReference<?> getTypeReferenceFromUnresolvedReferenceBinding(UnresolvedReferenceBinding binding) {
 		TypeBinding closestMatch = binding.closestMatch();
 		if (closestMatch != null) {
 			CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();


### PR DESCRIPTION
This is a pull request for #5320 .
Applied `@Nullable` annotation to the classes of `spoon.support.compiler`.