### PR TITLE
chore: Update `jdt` to 3.34.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.33.0</version>
+      <version>3.34.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>


### PR DESCRIPTION
This update includes a fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/966.