### PR TITLE
refactor: Apply the `@Nullable` annotation to `spoon.support`

### DIFF
--- a/src/main/java/spoon/support/modelobs/ChangeCollector.java
+++ b/src/main/java/spoon/support/modelobs/ChangeCollector.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import spoon.compiler.Environment;
 import spoon.reflect.CtModel;
 import spoon.reflect.declaration.CtElement;
@@ -35,7 +36,7 @@ public class ChangeCollector {
 	 * @param env to be checked {@link Environment}
 	 * @return {@link ChangeCollector} attached to the `env` or null if there is none
 	 */
-	public static ChangeCollector getChangeCollector(Environment env) {
+	public static @Nullable ChangeCollector getChangeCollector(Environment env) {
 		FineModelChangeListener mcl = env.getModelChangeListener();
 		if (mcl instanceof ChangeListener) {
 			return ((ChangeListener) mcl).getChangeCollector();

--- a/src/main/java/spoon/support/sniper/internal/ElementPrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementPrinterEvent.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.sniper.internal;
 
+import org.jspecify.annotations.Nullable;
 import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
@@ -29,7 +30,7 @@ public abstract class ElementPrinterEvent implements PrinterEvent {
 	}
 
 	@Override
-	public SourcePositionHolder getElement() {
+	public @Nullable SourcePositionHolder getElement() {
 		return element;
 	}
 

--- a/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
+++ b/src/main/java/spoon/support/sniper/internal/ElementSourceFragment.java
@@ -8,6 +8,7 @@
 package spoon.support.sniper.internal;
 
 
+import org.jspecify.annotations.Nullable;
 import spoon.SpoonException;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtLiteral;
@@ -235,7 +236,7 @@ public class ElementSourceFragment implements SourceFragment {
 	 * @param otherElement {@link SourcePositionHolder} whose {@link ElementSourceFragment} has to be added to `parentFragment`
 	 * @return new {@link ElementSourceFragment} created for `otherElement` or null if `otherElement` cannot be included
 	 */
-	private ElementSourceFragment addChild(CtRole roleInParent, SourcePositionHolder otherElement) {
+	private @Nullable ElementSourceFragment addChild(CtRole roleInParent, SourcePositionHolder otherElement) {
 		SourcePosition otherSourcePosition = otherElement.getPosition();
 		if (otherSourcePosition instanceof SourcePositionImpl && !(otherSourcePosition.getCompilationUnit() instanceof NoSourcePosition.NullCompilationUnit)
 				// method imports have child type references from other files, see https://github.com/INRIA/spoon/issues/3743

--- a/src/main/java/spoon/support/sniper/internal/PrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/PrinterEvent.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.sniper.internal;
 
+import org.jspecify.annotations.Nullable;
 import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.path.CtRole;
 
@@ -31,6 +32,6 @@ public interface PrinterEvent  {
 	/**
 	 * @return printed element or null if printing a primitive token
 	 */
-	SourcePositionHolder getElement();
+	@Nullable SourcePositionHolder getElement();
 
 }

--- a/src/main/java/spoon/support/sniper/internal/TokenPrinterEvent.java
+++ b/src/main/java/spoon/support/sniper/internal/TokenPrinterEvent.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.path.CtRole;
@@ -41,12 +42,12 @@ public abstract class TokenPrinterEvent implements PrinterEvent {
 	}
 
 	@Override
-	public SourcePositionHolder getElement() {
+	public @Nullable SourcePositionHolder getElement() {
 		return comment;
 	}
 
 	/** @return printed token or null if printing complex element or comment */
-	public String getToken() {
+	public @Nullable String getToken() {
 		return token;
 	}
 


### PR DESCRIPTION
See #5320.
Apply the `@Nullable` annotation to classes in `spoon.support`.
Specifically, for the following packages:

- `spoon.support.modelobs`
- `spoon.support.sniper.internal`