### PR TITLE
review: fix: Subtyping relationships for arrays

### DIFF
--- a/src/test/java/spoon/support/TypeAdaptorTest.java
+++ b/src/test/java/spoon/support/TypeAdaptorTest.java
@@ -513,6 +513,8 @@ class TypeAdaptorTest {
 		CtArrayTypeReference<?> numArr = factory.createArrayReference(numType, 1);
 		CtArrayTypeReference<?> numArr2 = factory.createArrayReference(numType, 2);
 
+		CtArrayTypeReference<?> objArr = factory.createArrayReference(factory.Type().objectType(), 1);
+
 		verifySubtype(intArr, numArr, true);
 		verifySubtype(intArr2, numArr2, true);
 
@@ -525,6 +527,10 @@ class TypeAdaptorTest {
 		verifySubtype(intArr2, intType, false);
 		verifySubtype(numArr2, numType, false);
 		verifySubtype(numArr2, intType, false);
+
+		// int[][] < Object[], as int[] < Object
+		verifySubtype(intArr2, objArr, true);
+		verifySubtype(numArr2, objArr, true);
 	}
 
 	@Test

--- a/src/test/java/spoon/support/TypeAdaptorTest.java
+++ b/src/test/java/spoon/support/TypeAdaptorTest.java
@@ -1,6 +1,5 @@
 package spoon.support;
 
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -12,13 +11,17 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.adaption.TypeAdaptor;
+import spoon.support.compiler.VirtualFile;
 import spoon.testing.utils.GitHubIssue;
 import spoon.testing.utils.ModelTest;
 
+import java.io.Serializable;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -428,7 +431,8 @@ class TypeAdaptorTest {
 	private static abstract class GenericThrowsParent {
 		public abstract <E extends Throwable> void orElseThrow(E throwable) throws E;
 
-		public <T extends String> void overloaded(T t) {}
+		public <T extends String> void overloaded(T t) {
+		}
 
 		public abstract <T extends String> void overriden(T t);
 	}
@@ -439,9 +443,11 @@ class TypeAdaptorTest {
 			throw throwable;
 		}
 
-		public <T extends CharSequence> void overloaded(T t) {}
+		public <T extends CharSequence> void overloaded(T t) {
+		}
 
-		public <T extends String> void overriden(T t) {}
+		public <T extends String> void overriden(T t) {
+		}
 	}
 
 	@Test
@@ -451,21 +457,21 @@ class TypeAdaptorTest {
 		launcher.getEnvironment().setComplianceLevel(11);
 		launcher.addInputResource("src/test/java/spoon/support/TypeAdaptorTest.java");
 		CtType<?> type = launcher.getFactory()
-				.Type()
-				.get(UseGenericFromEnclosingType.class);
+			.Type()
+			.get(UseGenericFromEnclosingType.class);
 		@SuppressWarnings("rawtypes")
 		List<CtMethod> methods = type.getElements(new TypeFilter<>(CtMethod.class))
-				.stream()
-				.filter(it -> it.getSimpleName().equals("someMethod"))
-				.collect(Collectors.toList());
+			.stream()
+			.filter(it -> it.getSimpleName().equals("someMethod"))
+			.collect(Collectors.toList());
 		CtMethod<?> test1Method = methods.stream()
-				.filter(it -> !it.getDeclaringType().getSimpleName().startsWith("Extends"))
-				.findAny()
-				.orElseThrow();
+			.filter(it -> !it.getDeclaringType().getSimpleName().startsWith("Extends"))
+			.findAny()
+			.orElseThrow();
 		CtMethod<?> test2Method = methods.stream()
-				.filter(it -> it.getDeclaringType().getSimpleName().startsWith("Extends"))
-				.findAny()
-				.orElseThrow();
+			.filter(it -> it.getDeclaringType().getSimpleName().startsWith("Extends"))
+			.findAny()
+			.orElseThrow();
 
 		assertTrue(test2Method.isOverriding(test1Method));
 		assertFalse(test1Method.isOverriding(test2Method));
@@ -492,5 +498,112 @@ class TypeAdaptorTest {
 				}
 			}
 		}
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 5462, fixed = true)
+	void testArraySubtypingShadow() {
+		// contract: Array subtyping should hold for shadow types
+		Factory factory = new Launcher().getFactory();
+		CtTypeReference<Integer> intType = factory.Type().INTEGER;
+		CtArrayTypeReference<?> intArr = factory.createArrayReference(intType, 1);
+		CtArrayTypeReference<?> intArr2 = factory.createArrayReference(intType, 2);
+
+		CtTypeReference<Number> numType = factory.createCtTypeReference(Number.class);
+		CtArrayTypeReference<?> numArr = factory.createArrayReference(numType, 1);
+		CtArrayTypeReference<?> numArr2 = factory.createArrayReference(numType, 2);
+
+		verifySubtype(intArr, numArr, true);
+		verifySubtype(intArr2, numArr2, true);
+
+		verifySubtype(intArr, numArr2, false);
+		verifySubtype(intArr, numType, false);
+		verifySubtype(intArr, intType, false);
+		verifySubtype(numArr, numType, false);
+		verifySubtype(numArr, intType, false);
+		verifySubtype(intArr2, numType, false);
+		verifySubtype(intArr2, intType, false);
+		verifySubtype(numArr2, numType, false);
+		verifySubtype(numArr2, intType, false);
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 5462, fixed = true)
+	void testArraySubtypingNoShadow() {
+		// contract: Array subtyping should hold for non-shadow types
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(false);
+		launcher.getEnvironment().setShouldCompile(true);
+		launcher.addInputResource(new VirtualFile(
+			"public class Foo {}",
+			"Foo.java"
+		));
+		launcher.addInputResource(new VirtualFile(
+			"public class Bar extends Foo {}",
+			"Bar.java"
+		));
+		launcher.buildModel();
+		Factory factory = launcher.getFactory();
+
+		CtTypeReference<?> barType = factory.Type().get("Bar").getReference();
+		CtArrayTypeReference<?> barArr = factory.createArrayReference(barType, 1);
+		CtArrayTypeReference<?> barArr2 = factory.createArrayReference(barType, 2);
+
+		CtTypeReference<?> fooType = factory.Type().get("Foo").getReference();
+		CtArrayTypeReference<?> fooArr = factory.createArrayReference(fooType, 1);
+		CtArrayTypeReference<?> fooArr2 = factory.createArrayReference(fooType, 2);
+
+		verifySubtype(barArr, fooArr, true);
+		verifySubtype(barArr2, fooArr2, true);
+
+		verifySubtype(barArr, fooArr2, false);
+		verifySubtype(barArr, fooType, false);
+		verifySubtype(barArr, barType, false);
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 5462, fixed = true)
+	void testArraySubtypingInbuiltTypes() {
+		// contract: Array subtyping should hold for inbuilt types (Cloneable, Serializable, Object)
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(false);
+		launcher.getEnvironment().setShouldCompile(true);
+		launcher.addInputResource(new VirtualFile(
+			"public class Foo {}",
+			"Foo.java"
+		));
+		CtTypeReference<?> fooType = launcher.buildModel().getAllTypes().iterator().next().getReference();
+		Factory factory = launcher.getFactory();
+
+		CtArrayTypeReference<?> fooArray = factory.createArrayReference(fooType, 1);
+		CtArrayTypeReference<?> intArray = factory.createArrayReference(factory.Type().INTEGER_PRIMITIVE, 1);
+		CtArrayTypeReference<?> objArray = factory.createArrayReference(factory.Type().objectType(), 1);
+
+		verifySubtype(fooArray, factory.createCtTypeReference(Object.class), true);
+		verifySubtype(fooArray, factory.createCtTypeReference(Cloneable.class), true);
+		verifySubtype(fooArray, factory.createCtTypeReference(Serializable.class), true);
+
+		verifySubtype(intArray, factory.createCtTypeReference(Object.class), true);
+		verifySubtype(intArray, factory.createCtTypeReference(Cloneable.class), true);
+		verifySubtype(intArray, factory.createCtTypeReference(Serializable.class), true);
+
+		verifySubtype(objArray, factory.createCtTypeReference(Object.class), true);
+		verifySubtype(objArray, factory.createCtTypeReference(Cloneable.class), true);
+		verifySubtype(objArray, factory.createCtTypeReference(Serializable.class), true);
+	}
+
+	private static void verifySubtype(CtTypeReference<?> bottom, CtTypeReference<?> top, boolean shouldSubtype) {
+		String message = bottom + (shouldSubtype ? " < " : " !< ") + top;
+		boolean resultReference = bottom.isSubtypeOf(top);
+		boolean resultAdaptor = new TypeAdaptor(bottom).isSubtypeOf(top);
+		assertEquals(shouldSubtype, resultReference, message);
+		assertEquals(shouldSubtype, resultAdaptor, message);
+
+		// There are no type declarations for source level arrays
+		if (bottom.getTypeDeclaration() != null) {
+			boolean resultAdaptorTwo = TypeAdaptor.isSubtype(bottom.getTypeDeclaration(), top);
+			assertEquals(shouldSubtype, resultAdaptorTwo, message);
+		}
+
 	}
 }


### PR DESCRIPTION
This one was a bit of a doozy.

Array subtyping needs to be special cased, as Spoon is not able to build a `CtType` for source-level arrays. Similarly, once we are given a shadow `CtType` that refers to an array type, we need to unpack to find the real type to build our hierarchy for. We can not just fall back to the java `Class#isAssignableFrom`, as the super type reference might not be shadowable.

Closes #5462.