### PR TITLE
review: chore: enable nix renovate correctly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,5 +18,8 @@
    ],
    "nix": {
       "enabled": true
+   },
+   "lockFileMaintenance": {
+      "enabled": true
    }
 }


### PR DESCRIPTION
According to this comment we also need the lockFileMaintenance https://github.com/renovatebot/renovate/issues/8000#issuecomment-1312289641