### PR TITLE
review: chore: Switch to oracle JDK 21 in CI until nixpkgs catches up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17, 20, 21-ea]
+        java: [11, 17, 20, 21]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17, 20, 21]
+        java: [11, 17, 21, 22-ea]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop .#jdk${{ matrix.java }} --command true
+        run: nix develop .#jdk${{ matrix.java }} --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
       - name: Test
-        run: nix develop .#jdk${{ matrix.java }} --command test
+        run: nix develop .#jdk${{ matrix.java }} --ignore-environment --keep MAVEN_OPTS --keep PATH --command test
 
   test-windows:
     runs-on: windows-latest
@@ -77,9 +77,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --command true
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
       - name: Run tests with coverage
-        run: nix develop --command coverage
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --keep PR_NUMBER --keep GITHUB_TOKEN --command coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
@@ -96,14 +96,14 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop .#extraChecks --command true
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command true
       - name: Run extra checks
-        run: nix develop .#extraChecks --command extra
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command extra
       - name: Trigger extra remote tasks
         if: github.repository == 'INRIA/spoon' && github.event_name == 'pull_request'
-        run: nix develop .#extraChecks --command extra-remote
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command extra-remote
       - name: Run Javadoc quality check
-        run: nix develop .#extraChecks --command javadoc-quality
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command javadoc-quality
 
   reproducible-builds:
     runs-on: ubuntu-latest
@@ -117,9 +117,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --command true
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
       - name: Check status
-        run: nix develop --command reproducible-builds
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command reproducible-builds
 
   maven-central-requirements:
     runs-on: ubuntu-latest
@@ -132,6 +132,6 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --command true
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
       - name: Check maven pom quality
-        run: nix develop --command maven-pom-quality
+        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command maven-pom-quality

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     name: Tests with Java ${{ matrix.java }} on ${{ matrix.os }}
     strategy:
       matrix:
-        java: [11, 17, 21, 22-ea]
+        java: [11, 17, 21]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,9 @@ env:
     -Dmaven.resolver.transport=native
     -Daether.connector.connectTimeout=300000
     -Daether.connector.requestTimeout=300000
+  NIX_OPTIONS: >-
+    --ignore-environment
+    --keep MAVEN_OPTS --keep PATH --keep LANG
 
 jobs:
   test-linux:
@@ -39,9 +42,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop .#jdk${{ matrix.java }} --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
+        run: nix develop .#jdk${{ matrix.java }} ${{ env.NIX_OPTIONS }} --command true
       - name: Test
-        run: nix develop .#jdk${{ matrix.java }} --ignore-environment --keep MAVEN_OPTS --keep PATH --command test
+        run: nix develop .#jdk${{ matrix.java }} ${{ env.NIX_OPTIONS }} --command test
 
   test-windows:
     runs-on: windows-latest
@@ -77,9 +80,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
+        run: nix develop ${{ env.NIX_OPTIONS }} --command true
       - name: Run tests with coverage
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --keep PR_NUMBER --keep GITHUB_TOKEN --command coverage
+        run: nix develop ${{ env.NIX_OPTIONS }} --keep PR_NUMBER --keep GITHUB_TOKEN --command coverage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
@@ -96,14 +99,14 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command true
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command true
       - name: Run extra checks
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command extra
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command extra
       - name: Trigger extra remote tasks
         if: github.repository == 'INRIA/spoon' && github.event_name == 'pull_request'
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command extra-remote
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command extra-remote
       - name: Run Javadoc quality check
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH .#extraChecks --command javadoc-quality
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command javadoc-quality
 
   reproducible-builds:
     runs-on: ubuntu-latest
@@ -117,9 +120,9 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
+        run: nix develop ${{ env.NIX_OPTIONS }} --command true
       - name: Check status
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command reproducible-builds
+        run: nix develop ${{ env.NIX_OPTIONS }} --command reproducible-builds
 
   maven-central-requirements:
     runs-on: ubuntu-latest
@@ -132,6 +135,6 @@ jobs:
         uses: ./.github/actions/setup-tests
 
       - name: Time nix setup
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command true
+        run: nix develop ${{ env.NIX_OPTIONS }} --command true
       - name: Check maven pom quality
-        run: nix develop --ignore-environment --keep MAVEN_OPTS --keep PATH --command maven-pom-quality
+        run: nix develop ${{ env.NIX_OPTIONS }} --command maven-pom-quality

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
               (final: prev:
                 let
                   base = rec {
-                    jdk = if javaVersion < 21 then prev."jdk${toString javaVersion}" else jdk21-ea;
+                    jdk = if javaVersion < 21 then prev."jdk${toString javaVersion}" else jdk21;
                     maven = prev.maven.override { inherit jdk; };
                   };
                   extra = with base; {
@@ -29,12 +29,12 @@
                 (if extraChecks then base // extra else base))
             ];
           };
-          jdk21-ea = pkgs.stdenv.mkDerivation rec {
+          jdk21 = pkgs.stdenv.mkDerivation rec {
             name = "jdk21-oracle";
             version = "21+35";
             src = builtins.fetchTarball {
-              url = "https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz";
-              sha256 = "sha256:0g3vf0kcpciixfv1kvgbk685h6cfn1s0cx2di4rhl3r7xlal217w";
+              url = "https://download.oracle.com/java/21/archive/jdk-21_linux-x64_bin.tar.gz";
+              sha256 = "sha256:1snj1jxa5175r17nb6l2ldgkcvjbp5mbfflwcc923svgf0604ps4";
             };
             installPhase = ''
               cd ..
@@ -188,7 +188,7 @@
         let
           # We have additional options (currently EA jdks) on 64 bit linux systems
           blessedSystem = "x86_64-linux";
-          blessed = { jdk21-ea = mkShell blessedSystem { javaVersion = 21; }; };
+          blessed = { jdk21 = mkShell blessedSystem { javaVersion = 21; }; };
           common = forAllSystems
             (system:
               rec {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,10 @@
               (final: prev:
                 let
                   base = rec {
-                    jdk = if javaVersion < 21 then prev."jdk${toString javaVersion}" else jdk21;
+                    jdk =
+                      if javaVersion < 21 then prev."jdk${toString javaVersion}"
+                      else if javaVersion == 22 then jdk22-ea
+                      else jdk21;
                     maven = prev.maven.override { inherit jdk; };
                   };
                   extra = with base; {
@@ -35,6 +38,18 @@
             src = builtins.fetchTarball {
               url = "https://download.oracle.com/java/21/archive/jdk-21_linux-x64_bin.tar.gz";
               sha256 = "sha256:1snj1jxa5175r17nb6l2ldgkcvjbp5mbfflwcc923svgf0604ps4";
+            };
+            installPhase = ''
+              cd ..
+              mv $sourceRoot $out
+            '';
+          };
+          jdk22-ea = pkgs.stdenv.mkDerivation rec {
+            name = "jdk22-ea";
+            version = "22+16";
+            src = builtins.fetchTarball {
+              url = "https://download.java.net/java/early_access/jdk22/16/GPL/openjdk-22-ea+16_linux-x64_bin.tar.gz";
+              sha256 = "sha256:17fckjdr1gadm41ih2nxi8c7zdimk4s9p12d8jcr0paic74mqinj";
             };
             installPhase = ''
               cd ..
@@ -188,12 +203,15 @@
         let
           # We have additional options (currently EA jdks) on 64 bit linux systems
           blessedSystem = "x86_64-linux";
-          blessed = { jdk21 = mkShell blessedSystem { javaVersion = 21; }; };
+          blessed = rec {
+            jdk21 = mkShell blessedSystem { javaVersion = 21; };
+            jdk22-ea = mkShell blessedSystem { javaVersion = 22; };
+            default = jdk21;
+          };
           common = forAllSystems
             (system:
               rec {
-                default = jdk20;
-                jdk20 = mkShell system { javaVersion = 20; };
+                default = jdk11;
                 jdk17 = mkShell system { javaVersion = 17; };
                 jdk11 = mkShell system { javaVersion = 11; };
                 extraChecks = mkShell system { extraChecks = true; javaVersion = 11; };

--- a/pom.xml
+++ b/pom.xml
@@ -168,54 +168,6 @@
   <build>
     <plugins>
         <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <executions>
-                <execution>
-                    <goals>
-                        <goal>prepare-agent</goal>
-                    </goals>
-                </execution>
-                <execution>
-                    <id>report</id>
-                    <phase>prepare-package</phase>
-                    <goals>
-                        <goal>report</goal>
-                    </goals>
-                </execution>
-                <execution>
-                  <!-- reference:
-                  * https://www.jacoco.org/jacoco/trunk/doc/check-mojo.html
-                  * https://stackoverflow.com/questions/41891739/how-to-fail-a-maven-build-if-junit-coverage-falls-below-certain-threshold
-                  -->
-                  <id>check-coverage</id>
-                  <goals>
-                    <goal>check</goal>
-                  </goals>
-                  <configuration>
-                    <rules>
-                    <rule implementation="org.jacoco.maven.RuleConfiguration">
-                      <element>CLASS</element>
-                      <excludes>
-                        <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI -->
-                        <exclude>spoon.support.gui.*</exclude>
-                        <!-- we exclude the generated inner classes of ReplacementVisitor -->
-                        <exclude>spoon.support.visitor.replace.ReplacementVisitor.*</exclude>
-                      </excludes>
-                      <limits>
-                        <limit implementation="org.jacoco.report.check.Limit">
-                          <counter>LINE</counter>
-                          <value>COVEREDRATIO</value>
-                          <minimum>0.1</minimum>
-                        </limit>
-                      </limits>
-                    </rule>
-                  </rules>
-                  </configuration>
-                </execution>
-          </executions>
-      </plugin>
-        <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <configuration>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -343,6 +343,54 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <!-- reference:
+                                * https://www.jacoco.org/jacoco/trunk/doc/check-mojo.html
+                                * https://stackoverflow.com/questions/41891739/how-to-fail-a-maven-build-if-junit-coverage-falls-below-certain-threshold
+                                -->
+                                <id>check-coverage</id>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                            <element>CLASS</element>
+                                            <excludes>
+                                                <!-- we exclude the GUI classes, because we don't have Swing GUI tests in CI -->
+                                                <exclude>spoon.support.gui.*</exclude>
+                                                <!-- we exclude the generated inner classes of ReplacementVisitor -->
+                                                <exclude>spoon.support.visitor.replace.ReplacementVisitor.*</exclude>
+                                            </excludes>
+                                            <limits>
+                                                <limit implementation="org.jacoco.report.check.Limit">
+                                                    <counter>LINE</counter>
+                                                    <value>COVEREDRATIO</value>
+                                                    <minimum>0.1</minimum>
+                                                </limit>
+                                            </limits>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.eluder.coveralls</groupId>
                         <artifactId>coveralls-maven-plugin</artifactId>
                         <version>4.3.0</version>


### PR DESCRIPTION
We can now update the CI to use the (oracle) JDK 21 GA build.