### PR TITLE
review: fix: Fixing regression in CtQueryImpl caused by lambda names in Java 21

### DIFF
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -377,7 +377,7 @@ public class CtQueryImpl implements CtQuery {
 		protected void onCallbackSet(String stackClass, String stackMethodName, Class<?> callbackClass, String callbackMethod, int nrOfParams, int idxOfInputParam) {
 			this.cceStacktraceClass = stackClass;
 			this.cceStacktraceMethodName = stackMethodName;
-			if (callbackClass.getName().contains("$$Lambda$")) {
+			if (callbackClass.getName().contains("$$Lambda")) {
 				//lambda expressions does not provide runtime information about type of input parameter
 				//clear it now. We can detect input type from first ClassCastException
 				this.expectedClass = null;


### PR DESCRIPTION
## Pull request title
`@clyde` Can you write a pull request description for this patch fixing a java 21 regression?
```patch
diff --git a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
index a7fd868a3..a995111df 100644
--- a/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
+++ b/src/main/java/spoon/reflect/visitor/chain/CtQueryImpl.java
@@ -377,7 +377,7 @@ public class CtQueryImpl implements CtQuery {
                protected void onCallbackSet(String stackClass, String stackMethodName, Class<?> callbackClass, String callbackMethod, int nrOfParams, int idxOfInputParam) {
                        this.cceStacktraceClass = stackClass;
                        this.cceStacktraceMethodName = stackMethodName;
-                       if (callbackClass.getName().contains("$$Lambda$")) {
+                       if (callbackClass.getName().contains("$$Lambda")) {
                                //lambda expressions does not provide runtime information about type of input parameter
                                //clear it now. We can detect input type from first ClassCastException
                                this.expectedClass = null;
```

----

Fixes a regression in Java 21 by updating the CtQueryImpl class. The patch corrects a condition that checks for lambda expressions, ensuring that the runtime information about the type of input parameter is accurately detected. This resolves issues caused by the lack of type information in lambda expressions.
