### PR TITLE
Use prebuilt z3 package/binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,6 @@
                   };
                   extra = with base; {
                     gradle = prev.gradle.override { java = jdk; };
-                    z3 = prev.z3.override { inherit jdk; javaBindings = true; };
                   };
                 in
                 (if extraChecks then base // extra else base))
@@ -149,11 +148,6 @@
             mvn -q checkstyle:checkstyle license:check
             popd || exit 1
 
-            # Requires z3
-            pushd spoon-dataflow || exit 1
-            env LD_LIBRARY_PATH="${pkgs.z3.lib}/lib:${pkgs.z3.java}/lib" ./gradlew build
-            popd || exit 1
-
             pushd spoon-visualisation || exit 1
             mvn -q versions:use-latest-versions -DallowSnapshots=true -Dincludes=fr.inria.gforge.spoon
             mvn -q versions:update-parent -DallowSnapshots=true
@@ -194,7 +188,7 @@
             else [ ];
           packages = with pkgs;
             [ jdk maven test coverage mavenPomQuality javadocQuality reproducibleBuilds ]
-            ++ (if extraChecks then [ gradle pythonEnv z3.java z3.lib extra extraRemote ] else [ ])
+            ++ (if extraChecks then [ gradle pythonEnv extra extraRemote ] else [ ])
             ++ (if release then [ semver jreleaser ] else [ ]);
         };
     in

--- a/spoon-dataflow/README.md
+++ b/spoon-dataflow/README.md
@@ -32,7 +32,8 @@ Check out test directory for more examples.
 In general, spoon-dataflow is capable to evaluate expressions statically, perform symbolic execution, handle control flow of a program, and so on. It also features a proper memory model, so it nicely deals with reference aliasing.
 
 ## Build and run
-In order to build spoon-dataflow you need JDK 8 or newer.
+In order to build spoon-dataflow, you will need to have JDK 11 or later, as
+this is required by the latest versions of spoon-core.
 
 Now you can go to the build directory and run the resulting jar:    
 `java -jar spoon-dataflow.jar -sources <arg...> [-classpath <arg...>]`

--- a/spoon-dataflow/README.md
+++ b/spoon-dataflow/README.md
@@ -32,26 +32,7 @@ Check out test directory for more examples.
 In general, spoon-dataflow is capable to evaluate expressions statically, perform symbolic execution, handle control flow of a program, and so on. It also features a proper memory model, so it nicely deals with reference aliasing.
 
 ## Build and run
-In order to build spoon-dataflow you need JDK 8 or newer. Also, you have to download and install Z3.
-
-### Windows:
-1. Download z3-4.8.4 here: https://github.com/Z3Prover/z3/releases
-2. Add bin directory to your PATH environment variable
-3. Run `gradlew build`
-
-Note: Visual C++ 2015 Redistributable may be required.
-
-### Linux:
-1. Download z3-4.8.4 here https://github.com/Z3Prover/z3/releases
-2. Add bin directory to your LD_LIBRARY_PATH: `export LD_LIBRARY_PATH=/path/to/z3/bin`
-3. Run `./gradlew build`
-
-### macOS:
-1. Download z3-4.8.4 here https://github.com/Z3Prover/z3/releases
-2. Add bin directory to your DYLD_LIBRARY_PATH: `export DYLD_LIBRARY_PATH=/path/to/z3/bin`
-3. Run `./gradlew build`
-
-Note that you may still need to set up environment variables or java.lang.path in your IDE.
+In order to build spoon-dataflow you need JDK 8 or newer.
 
 Now you can go to the build directory and run the resulting jar:    
 `java -jar spoon-dataflow.jar -sources <arg...> [-classpath <arg...>]`

--- a/spoon-dataflow/build.gradle
+++ b/spoon-dataflow/build.gradle
@@ -23,7 +23,7 @@ repositories {
 dependencies {
     implementation group: 'fr.inria.gforge.spoon', name: 'spoon-core', version: '+'
     implementation group: 'commons-cli', name: 'commons-cli', version: '1.5.0'
-    implementation group: 'com.microsoft', name: 'z3', version: '4.8.4'
+    implementation group: 'tools.aqua', name: 'z3-turnkey', version: '4.11.2'
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
 }
 


### PR DESCRIPTION
Use z3-turnkey which extracts the native z3 libraries and loads them. This releases the user from compiling and installing the z3 binaries. We use 4.11.2 because it still supports glibc-2.31.

This should allow @I-Al-Istannen to remove z3 specific config from the nix packages which in turn should shorten CI duration on a cache miss.