### PR TITLE
[WIP] fix: Merge ambiguous packages instead of throwing an error 

### DIFF
--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -209,22 +209,22 @@ public class PackageFactory extends SubFactory {
 			if (pack == mergingPackage) continue;
 
 
-            Set<CtType<?>> oldTypes = pack.getTypes();
-            Set<CtPackage> oldPacks = pack.getPackages();
+			Set<CtType<?>> oldTypes = pack.getTypes();
+			Set<CtPackage> oldPacks = pack.getPackages();
 
-            for (CtType<?> type : oldTypes) {
+			for (CtType<?> type : oldTypes) {
 				// If we don't disconnect the type from its old package, spoon will get mad.
 				((CtPackage)type.getParent()).removeType(type);
 				type.setParent(null);
 			}
 			types.addAll(oldTypes);
 
-            for (CtPackage oldPack : oldPacks) {
+			for (CtPackage oldPack : oldPacks) {
 				// Applies to packagesToMerge too.
 				((CtPackage)oldPack.getParent()).removePackage(oldPack);
-                oldPack.setParent(null);
-            }
-            subpacks.addAll(oldPacks);
+				oldPack.setParent(null);
+			}
+			subpacks.addAll(oldPacks);
 			pack.delete();
 		}
 		mergingPackage.setTypes(types);

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -188,7 +188,9 @@ public class PackageFactory extends SubFactory {
 		CtPackage probablePackage = packageWithTypes != null ? packageWithTypes : lastNonNullPackage;
 
 		// We're going to have to return null, but quodana complains, so I hope this keeps it happy.
-		if (probablePackage == null) return probablePackage;
+		if (probablePackage == null) {
+			return probablePackage;
+		}
 
 		// Return a non synthetic package but if *no* package had any types we return the last one.
 		// This ensures that you can also retrieve empty packages with this API
@@ -206,22 +208,23 @@ public class PackageFactory extends SubFactory {
 		HashSet<CtPackage> subpacks = new HashSet<>(mergingPackage.getPackages());
 
 		for (CtPackage pack : packagesToMerge) {
-			if (pack == mergingPackage) continue;
-
+			if (pack == mergingPackage) {
+				continue;
+			}
 
 			Set<CtType<?>> oldTypes = pack.getTypes();
 			Set<CtPackage> oldPacks = pack.getPackages();
 
 			for (CtType<?> type : oldTypes) {
 				// If we don't disconnect the type from its old package, spoon will get mad.
-				((CtPackage)type.getParent()).removeType(type);
+				((CtPackage) type.getParent()).removeType(type);
 				type.setParent(null);
 			}
 			types.addAll(oldTypes);
 
 			for (CtPackage oldPack : oldPacks) {
 				// Applies to packages too.
-				((CtPackage)oldPack.getParent()).removePackage(oldPack);
+				((CtPackage) oldPack.getParent()).removePackage(oldPack);
 				oldPack.setParent(null);
 			}
 			subpacks.addAll(oldPacks);

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -187,6 +187,9 @@ public class PackageFactory extends SubFactory {
 
 		CtPackage probablePackage = packageWithTypes != null ? packageWithTypes : lastNonNullPackage;
 
+		// We're going to have to return null, but quodana complains, so I hope this keeps it happy.
+		if (probablePackage == null) return probablePackage;
+
 		// Return a non synthetic package but if *no* package had any types we return the last one.
 		// This ensures that you can also retrieve empty packages with this API
 		return mergeAmbiguousPackages(packages, probablePackage);
@@ -195,13 +198,10 @@ public class PackageFactory extends SubFactory {
 	/**
 	 * Merges ambiguous packagesToMerge together to fix inconsistent heirarchies.
 	 * @param packagesToMerge - The list of ambiguous packagesToMerge
-	 * @param mergingPackage - The package to merge everything into.
-	 * @return
+	 * @param mergingPackage - The package to merge everything into. Should not be null.
+	 * @return the merged package.
 	 */
 	private CtPackage mergeAmbiguousPackages(ArrayList<CtPackage> packagesToMerge, CtPackage mergingPackage) {
-
-		if (mergingPackage == null) return null;
-
 		HashSet<CtType<?>> types = new HashSet<>(mergingPackage.getTypes());
 		HashSet<CtPackage> subpacks = new HashSet<>(mergingPackage.getPackages());
 
@@ -220,7 +220,7 @@ public class PackageFactory extends SubFactory {
 			types.addAll(oldTypes);
 
 			for (CtPackage oldPack : oldPacks) {
-				// Applies to packagesToMerge too.
+				// Applies to packages too.
 				((CtPackage)oldPack.getParent()).removePackage(oldPack);
 				oldPack.setParent(null);
 			}

--- a/src/main/java/spoon/reflect/factory/PackageFactory.java
+++ b/src/main/java/spoon/reflect/factory/PackageFactory.java
@@ -8,18 +8,17 @@
 package spoon.reflect.factory;
 
 
-import spoon.reflect.declaration.CtModule;
-import spoon.reflect.declaration.CtPackage;
-import spoon.reflect.declaration.CtPackageDeclaration;
-import spoon.reflect.reference.CtPackageReference;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringTokenizer;
-
+import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtPackage;
+import spoon.reflect.declaration.CtPackageDeclaration;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtPackageReference;
 
 /**
  * The {@link CtPackage} sub-factory.

--- a/src/test/resources/package-src-roots/root1/src/main/java/com/example/Class1.java
+++ b/src/test/resources/package-src-roots/root1/src/main/java/com/example/Class1.java
@@ -1,0 +1,7 @@
+package com.example;
+
+public class Class1 {
+	Class2 doSomething() {
+		return new Class2(); // should be resolved if packages are correctly merged.
+	}
+}

--- a/src/test/resources/package-src-roots/root2/src/main/java/com/example/Class2.java
+++ b/src/test/resources/package-src-roots/root2/src/main/java/com/example/Class2.java
@@ -1,0 +1,5 @@
+package com.example;
+
+public class Class2 {
+	// ...
+}


### PR DESCRIPTION
(cherry picked from commit 1e62e4b99b286d6152ec786efcca4edbc2437501)

Spoon currently will raise an exception if there are multiple CtPackages with the same name as a CtPackageReference. This can occur when code in two different directories contains the same package name. 

Consider large projects such as maven which have a lot of such code; maven has several libraries which all contribute classes to the same package in many cases.


This change attempts to fix the ambiguous package problem by merging all such packages and deleting any leftovers. The first non-empty package is selected as the merge target. 

There are no tests; I'd like to be pointed in the right direction regarding this.

fixes: #5475

