### PR TITLE
refactor: Apply `@Nullable` annotation to `spoon.support.util`

### DIFF
--- a/src/main/java/spoon/support/util/RtHelper.java
+++ b/src/main/java/spoon/support/util/RtHelper.java
@@ -7,6 +7,7 @@
  */
 package spoon.support.util;
 
+import org.jspecify.annotations.Nullable;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLiteral;
@@ -179,7 +180,7 @@ public abstract class RtHelper {
 	 * @param numParams
 	 * @return the found method or null
 	 */
-	public static Method getMethod(Class<?> clazz, String methodName, int numParams) {
+	public static @Nullable Method getMethod(Class<?> clazz, String methodName, int numParams) {
 		Method[] methods = clazz.getMethods();
 		for (Method method : methods) {
 			if (!method.isSynthetic() && method.getName().equals(methodName)) {

--- a/src/main/java/spoon/support/util/internal/ElementNameMap.java
+++ b/src/main/java/spoon/support/util/internal/ElementNameMap.java
@@ -23,6 +23,7 @@ import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.support.modelobs.FineModelChangeListener;
@@ -91,7 +92,7 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 	 *     if the element is actually replaced.
 	 */
 	@Override
-	public T put(String key, T e) {
+	public @Nullable T put(String key, T e) {
 		if (e == null) {
 			return null;
 		}
@@ -107,12 +108,12 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 		return valueOrNull(map.put(key, wrapper));
 	}
 
-	private T valueOrNull(InsertOrderWrapper<T> wrapper) {
+	private @Nullable T valueOrNull(InsertOrderWrapper<T> wrapper) {
 		return wrapper != null ? wrapper.value : null;
 	}
 
 	@Override
-	public T remove(Object key) {
+	public @Nullable T remove(Object key) {
 		T removed = valueOrNull(map.remove(key));
 
 		if (removed == null) {
@@ -165,7 +166,7 @@ public abstract class ElementNameMap<T extends CtElement> extends AbstractMap<St
 	}
 
 	@Override
-	public T get(Object key) {
+	public @Nullable T get(Object key) {
 		InsertOrderWrapper<T> wrapper = map.get(key);
 		if (wrapper == null) {
 			return null;


### PR DESCRIPTION
See #5320 .
Apply `@Nullable` annotation to classes in `spoon.support.util`.