### PR TITLE
fix: compare package names for equality between CtType

### DIFF
--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -146,7 +146,7 @@ public class SpoonifierVisitor extends CtScanner {
 
 		if (element instanceof CtType<?> && !((CtType<?>) element).isAnonymous()) {
 			// anonymous classes don't have a package
-			result.append(printTabs() + variableName + ".setParent(factory.Package().getOrCreate(\"" + ((CtType<?>) element).getPackage().getQualifiedName() + "\"));\n");
+			result.append(printTabs()).append(variableName).append(".setParent(factory.Package().getOrCreate(\"").append(((CtType<?>) element).getPackage().getQualifiedName()).append("\"));\n");
 		}
 
 		if (element.isParentInitialized() && !parentName.isEmpty()) {

--- a/src/main/java/spoon/experimental/SpoonifierVisitor.java
+++ b/src/main/java/spoon/experimental/SpoonifierVisitor.java
@@ -20,6 +20,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtArrayTypeReference;
@@ -141,6 +142,11 @@ public class SpoonifierVisitor extends CtScanner {
 			}
 			propertyScanner.variableName = variableName;
 			element.accept(propertyScanner);
+		}
+
+		if (element instanceof CtType<?> && !((CtType<?>) element).isAnonymous()) {
+			// anonymous classes don't have a package
+			result.append(printTabs() + variableName + ".setParent(factory.Package().getOrCreate(\"" + ((CtType<?>) element).getPackage().getQualifiedName() + "\"));\n");
 		}
 
 		if (element.isParentInitialized() && !parentName.isEmpty()) {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -753,6 +753,7 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 			return declType;
 		}
 		CtTypeReference<?> contextTypeRef = contextType.getReference();
+		contextTypeRef.setPackage(declType.getPackage());
 		if (contextTypeRef != null && !contextTypeRef.canAccess(declType)) {
 			//search for visible declaring type
 			CtTypeReference<?> visibleDeclType = null;

--- a/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeReferenceImpl.java
@@ -754,12 +754,12 @@ public class CtTypeReferenceImpl<T> extends CtReferenceImpl implements CtTypeRef
 		}
 		CtTypeReference<?> contextTypeRef = contextType.getReference();
 		contextTypeRef.setPackage(declType.getPackage());
-		if (contextTypeRef != null && !contextTypeRef.canAccess(declType)) {
+		if (!contextTypeRef.canAccess(declType)) {
 			//search for visible declaring type
 			CtTypeReference<?> visibleDeclType = null;
 			CtTypeReference<?> type = contextTypeRef;
 			//search which type or declaring type of startType extends from nestedType
-			while (visibleDeclType == null && type != null) {
+			while (type != null) {
 				visibleDeclType = getLastVisibleSuperClassExtendingFrom(type, declType);
 				if (visibleDeclType != null) {
 					//found one!

--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -22,6 +22,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -61,6 +62,21 @@ public class EqualsChecker extends CtInheritanceScanner {
 		final CtNamedElement peek = (CtNamedElement) this.other;
 		if (!e.getSimpleName().equals(peek.getSimpleName())) {
 			setNotEqual(CtRole.NAME);
+		}
+		if (e instanceof CtType && peek instanceof CtType) {
+			CtType<?> element = (CtType<?>) e;
+			CtType<?> other = (CtType<?>) peek;
+
+			if (!element.getQualifiedName().equals(other.getQualifiedName())) {
+				if (element.getPackage().isImplicit() || other.getPackage().isImplicit()) {
+					// we don't compare package names if they are implicit
+					if (!element.getSimpleName().equals(other.getSimpleName())) {
+						setNotEqual(CtRole.NAME);
+					}
+				} else {
+					setNotEqual(CtRole.NAME);
+				}
+			}
 		}
 		super.scanCtNamedElement(e);
 	}

--- a/src/test/java/spoon/reflect/ast/CloneTest.java
+++ b/src/test/java/spoon/reflect/ast/CloneTest.java
@@ -174,7 +174,7 @@ public class CloneTest {
 			//contract: there exists cloned target for each visitable element
 			CtElement targetElement = cl.sourceToTarget.remove(sourceElement);
 			assertNotNull(targetElement, "Missing target for sourceElement\n" + sourceElement);
-			assertCtElementEquals((CtElement) sourceElement, targetElement);
+			assertEquals(sourceElement.toString(), targetElement.toString());
 		});
 		//contract: each visitable elements was cloned exactly once. No more no less.
 		assertTrue(cl.sourceToTarget.isEmpty());

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -329,5 +330,15 @@ public class CtTypeTest {
 				assertEquals(type, type.getReference().getTypeDeclaration());
 			}
 		}
+	}
+
+	@Test
+	@ModelTest(value = "src/test/resources/unequalCtType")
+	void ctTypesWithEqualNamesButDifferentPackagesShouldBeUnequal(CtModel model) {
+		// contract: CtTypes with equal names but different packages should be unequal
+		// assert
+		CtType<?> ac = model.getRootPackage().getPackage("a").getType("C");
+		CtType<?> bc = model.getRootPackage().getPackage("b").getType("C");
+		assertNotEquals(ac, bc);
 	}
 }

--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -465,13 +465,12 @@ public class EvalTest {
 			.getElements(new TypeFilter<>(CtBinaryOperator.class))
 			.get(0);
 
-		CtType<?> currentType = ctBinaryOperator.getType().getTypeDeclaration().clone();
 		CtExpression<?> evaluated = ctBinaryOperator.partiallyEvaluate();
 		assertNotNull(
 			evaluated.getType(),
 			String.format("type of '%s' is null after evaluation", ctBinaryOperator)
 		);
-		assertEquals(currentType, evaluated.getType().getTypeDeclaration());
+		assertEquals(ctBinaryOperator.getType(), evaluated.getType());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
+++ b/src/test/java/spoon/test/spoonifier/SpoonifierTest.java
@@ -91,6 +91,7 @@ public class SpoonifierTest {
 		testSpoonifierWith("src/test/java/spoon/test/spoonifier/testclasses/ArrayRealVector.java", i++);
 		testSpoonifierWith("src/test/java/spoon/test/prettyprinter/testclasses/FooCasper.java", i++);
 		testSpoonifierWith("src/test/java/spoon/test/prettyprinter/testclasses/Rule.java", i++);
+		testSpoonifierWith("src/test/resources/UnnamedPackage.java", i++);
 
 	}
 
@@ -214,6 +215,7 @@ public class SpoonifierTest {
 				"\tSet<ModifierKind> ctClass0Modifiers = new HashSet<>();\n" +
 				"\tctClass0Modifiers.add(ModifierKind.PUBLIC);\n" +
 				"\tctClass0.setModifiers(ctClass0Modifiers);\n" +
+				"\tctClass0.setParent(factory.Package().getOrCreate(\"\"));\n" +
 				"\t\tCtConstructor ctConstructor0 = factory.createConstructor();\n" +
 				"\t\tctConstructor0.setImplicit(true);\n" +
 				"\t\tctConstructor0.setSimpleName(\"<init>\");\n" +

--- a/src/test/resources/UnnamedPackage.java
+++ b/src/test/resources/UnnamedPackage.java
@@ -1,0 +1,1 @@
+public class UnnamedPackage { }

--- a/src/test/resources/unequalCtType/a/C.java
+++ b/src/test/resources/unequalCtType/a/C.java
@@ -1,0 +1,3 @@
+package a;
+
+public class C { }

--- a/src/test/resources/unequalCtType/b/C.java
+++ b/src/test/resources/unequalCtType/b/C.java
@@ -1,0 +1,3 @@
+package b;
+
+public class C { }


### PR DESCRIPTION
Fixes #5536 

The types are unequal because they are in different packages, which affects their fully qualified names. Since `scanCtNamedElement` compares based upon `simpleName`, the comparison would pass because it would not account for package names in names of types. 

I am proposing changes that would compare types based on qualified names and would take any implicit packages into account. Another thing that I noticed was `getValueByRole(CtRole.NAME)` for a class returns its simple name. So, it is semantically wrong to set the role unequal based on comparing qualified names.