### PR TITLE
review: chore: update jdt to 3.36.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,8 @@
                 let
                   base = rec {
                     jdk =
-                      if javaVersion < 21 then prev."jdk${toString javaVersion}"
-                      else if javaVersion == 22 then jdk22-ea
-                      else jdk21;
+                      if javaVersion <= 21 then prev."jdk${toString javaVersion}"
+                      else jdk22-ea;
                     maven = prev.maven.override { inherit jdk; };
                   };
                   extra = with base; {
@@ -30,18 +29,6 @@
                 in
                 (if extraChecks then base // extra else base))
             ];
-          };
-          jdk21 = pkgs.stdenv.mkDerivation rec {
-            name = "jdk21-oracle";
-            version = "21+35";
-            src = builtins.fetchTarball {
-              url = "https://download.oracle.com/java/21/archive/jdk-21_linux-x64_bin.tar.gz";
-              sha256 = "sha256:1snj1jxa5175r17nb6l2ldgkcvjbp5mbfflwcc923svgf0604ps4";
-            };
-            installPhase = ''
-              cd ..
-              mv $sourceRoot $out
-            '';
           };
           jdk22-ea = pkgs.stdenv.mkDerivation rec {
             name = "jdk22-ea";
@@ -198,18 +185,16 @@
           # We have additional options (currently EA jdks) on 64 bit linux systems
           blessedSystem = "x86_64-linux";
           blessed = rec {
-            jdk21 = mkShell blessedSystem { javaVersion = 21; };
             jdk22-ea = mkShell blessedSystem { javaVersion = 22; };
-            default = jdk21;
           };
           common = forAllSystems
             (system:
               rec {
-                default = jdk11;
+                default = jdk17;
                 jdk17 = mkShell system { javaVersion = 17; };
-                jdk11 = mkShell system { javaVersion = 11; };
-                extraChecks = mkShell system { extraChecks = true; javaVersion = 11; };
-                jReleaser = mkShell system { release = true; javaVersion = 11; };
+                jdk21 = mkShell system { javaVersion = 21; };
+                extraChecks = mkShell system { extraChecks = true; javaVersion = 21; };
+                jReleaser = mkShell system { release = true; javaVersion = 21; };
               });
         in
         common // { "${blessedSystem}" = common."${blessedSystem}" // blessed; };

--- a/flake.nix
+++ b/flake.nix
@@ -147,7 +147,7 @@
             mvn -q versions:use-latest-versions -DallowSnapshots=true -Dincludes=fr.inria.gforge.spoon
             mvn -q versions:update-parent -DallowSnapshots=true
             git diff
-            mvn -q -Djava.src.version=11 test
+            mvn -q -Djava.src.version=17 test
             mvn -q checkstyle:checkstyle license:check
             mvn -q depclean:depclean
             popd || exit 1

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.33.0</version>
+      <version>3.36.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -25,7 +25,7 @@
     </modules>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <runtime.log>target/velocity.log</runtime.log>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>1696689792</project.build.outputTimestamp>

--- a/spoon-smpl/src/test/java/spoon/smpl/ZippedCodeBaseTestContext.java
+++ b/spoon-smpl/src/test/java/spoon/smpl/ZippedCodeBaseTestContext.java
@@ -47,6 +47,7 @@ public class ZippedCodeBaseTestContext {
 	public static CtModel buildModel(String pathToZipFile, boolean useAutoImports) {
 		Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(useAutoImports);
+		launcher.getEnvironment().setIgnoreSyntaxErrors(true);
 
 		try {
 			launcher.addInputResource(new ZipFolder(new File(pathToZipFile)));

--- a/src/test/java/spoon/FluentLauncherTest.java
+++ b/src/test/java/spoon/FluentLauncherTest.java
@@ -96,7 +96,7 @@ public class FluentLauncherTest {
 	@Test
 	public void testMavenLauncher(@TempDir Path tempDir) throws IOException {
 		CtModel model = new FluentLauncher(new MavenLauncher("./pom.xml", MavenLauncher.SOURCE_TYPE.ALL_SOURCE))
-				.complianceLevel(11)
+				.complianceLevel(17)
 				.outputDirectory(tempDir.toString())
 				.buildModel();
 		assertNotNull(model);

--- a/src/test/resources/records/MultipleConstructors.java
+++ b/src/test/resources/records/MultipleConstructors.java
@@ -1,0 +1,8 @@
+package records;
+
+public record MultipleConstructors(int i) {
+
+	public MultipleConstructors(String s) {
+		this(Integer.parseInt(s));
+	}
+}

--- a/src/test/resources/records/NonCompactCanonicalConstructor.java
+++ b/src/test/resources/records/NonCompactCanonicalConstructor.java
@@ -1,0 +1,9 @@
+package records;
+
+public record NonCompactCanonicalConstructor(int i) {
+
+	public NonCompactCanonicalConstructor(int x) {
+		this.i = x;
+	}
+
+}


### PR DESCRIPTION
Supersedes #5570.

We require Java 17 to run this jdt version, and this jdt version is required for Java 21 feature support.

Note these changes contain bugfixes for issues due to changes in JDT.