### PR TITLE
review: chore: Remove .lift.toml configuration file

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,1 +1,0 @@
-disableTools=["refactor-first"]


### PR DESCRIPTION
Lift does not exist anymore, so we can delete this file.