### PR TITLE
review: fix: Update spoon-javadoc installation instructions

### DIFF
--- a/doc/_data/sidebar_doc.yml
+++ b/doc/_data/sidebar_doc.yml
@@ -53,6 +53,13 @@ entries:
           product: all
           version: all
 
+        - title: Javadoc Analysis
+          url: /spoon_javadoc.html
+          audience: writers, designers
+          platform: all
+          product: all
+          version: all
+
         - title: FAQ
           url: /faq.html
           audience: writers, designers

--- a/doc/spoon_javadoc.md
+++ b/doc/spoon_javadoc.md
@@ -15,13 +15,13 @@ converting them into your own format.
 
 ### Installation
 
-On a Unix-like system, the following set of commands should be sufficient for
-getting spoon-javadoc up and running from scratch.
-
-```
-$ git clone https://github.com/INRIA/spoon.git
-$ cd spoon/spoon-pom
-$ mvn install
+To use spoon-javadoc, add the following dependency to your `pom.xml`:
+```xml
+<dependency>
+    <groupId>fr.inria.gforge.spoon</groupId>
+    <artifactId>spoon-javadoc</artifactId>
+    <version>$currentVersion</version>
+</dependency>
 ```
 
 ### Basic usage


### PR DESCRIPTION
Separated this part of the #5609 and switched target branch. We could also include gradle instructions.