### PR TITLE
review: chore: deprecate public CtTypeReference fields in TypeFactory

### DIFF
--- a/src/main/java/spoon/metamodel/MetamodelProperty.java
+++ b/src/main/java/spoon/metamodel/MetamodelProperty.java
@@ -203,7 +203,7 @@ public class MetamodelProperty {
 		if (valueType instanceof CtTypeParameterReference) {
 			valueType = ((CtTypeParameterReference) valueType).getBoundingType();
 			if (valueType == null) {
-				valueType = f.Type().OBJECT;
+				valueType = f.Type().objectType();
 			}
 		}
 		if (valueType.isImplicit()) {
@@ -338,8 +338,9 @@ public class MetamodelProperty {
 		CtTypeReference<?> returnType1 = methods.get(0).getActualCtMethod().getType();
 		CtTypeReference<?> returnType2 = methods.get(1).getActualCtMethod().getType();
 		Factory f = returnType1.getFactory();
-		boolean is1Iterable = returnType1.isSubtypeOf(f.Type().ITERABLE);
-		boolean is2Iterable = returnType2.isSubtypeOf(f.Type().ITERABLE);
+		CtTypeReference<?> iterableRef = f.Type().createReference(Iterable.class);
+		boolean is1Iterable = returnType1.isSubtypeOf(iterableRef);
+		boolean is2Iterable = returnType2.isSubtypeOf(iterableRef);
 		if (is1Iterable != is2Iterable) {
 			// they are not some. Only one of them is iterable
 			if (is1Iterable) {
@@ -419,7 +420,7 @@ public class MetamodelProperty {
 		if (itemValueType instanceof CtTypeParameterReference) {
 			itemValueType = ((CtTypeParameterReference) itemValueType).getBoundingType();
 			if (itemValueType == null) {
-				itemValueType = valueType.getFactory().Type().OBJECT;
+				itemValueType = valueType.getFactory().Type().objectType();
 			}
 		}
 		return itemValueType;

--- a/src/main/java/spoon/pattern/PatternParameterConfigurator.java
+++ b/src/main/java/spoon/pattern/PatternParameterConfigurator.java
@@ -409,7 +409,7 @@ public class PatternParameterConfigurator {
 
 				CtTypeReference<?> paramType = paramField.getType();
 
-				if (paramType.isSubtypeOf(f.Type().ITERABLE) || paramType instanceof CtArrayTypeReference<?>) {
+				if (paramType.isSubtypeOf(f.Type().createReference(Iterable.class)) || paramType instanceof CtArrayTypeReference<?>) {
 					//parameter is a multivalue
 					// here we need to replace all named element and all references whose simpleName == stringMarker
 					parameter(parameterName).setContainerKind(ContainerKind.LIST).byNamedElement(stringMarker).byReferenceName(stringMarker);

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -278,7 +278,7 @@ public class CodeFactory extends SubFactory {
 	public CtTextBlock createTextBlock(String value) {
 		CtTextBlock textblock = factory.Core().createTextBlock();
 		textblock.setValue(value);
-		textblock.setType((CtTypeReference<String>) factory.Type().STRING);
+		textblock.setType(factory.Type().stringType());
 		return textblock;
 	}
 

--- a/src/main/java/spoon/reflect/factory/ExecutableFactory.java
+++ b/src/main/java/spoon/reflect/factory/ExecutableFactory.java
@@ -133,7 +133,7 @@ public class ExecutableFactory extends SubFactory {
 			}
 		}
 		if (paramType == null) {
-			paramType = factory.Type().OBJECT;
+			return factory.Type().objectType();
 		}
 		return paramType.clone();
 	}

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -216,154 +216,154 @@ public class TypeFactory extends SubFactory {
 	 * Returns a reference on the null type (type of null).
 	 */
 	public CtTypeReference<?> nullType() {
-		return NULL_TYPE.clone();
+		return ((CtTypeReference<?>) createReference(CtTypeReference.NULL_TYPE_NAME)).clone();
 	}
 
 	/**
 	 * Returns a reference on the void type.
 	 */
 	public CtTypeReference<Void> voidType() {
-		return VOID.clone();
+		return createReference(Void.class);
 	}
 
 	/**
 	 * Returns a reference on the void primitive type.
 	 */
 	public CtTypeReference<Void> voidPrimitiveType() {
-		return VOID_PRIMITIVE.clone();
+		return createReference(void.class);
 	}
 
 	/**
 	 * Returns a reference on the string type.
 	 */
 	public CtTypeReference<String> stringType() {
-		return STRING.clone();
+		return createReference(String.class);
 	}
 
 	/**
 	 * Returns a reference on the boolean type.
 	 */
 	public CtTypeReference<Boolean> booleanType() {
-		return BOOLEAN.clone();
+		return createReference(Boolean.class);
 	}
 
 	/**
 	 * Returns a reference on the boolean primitive type.
 	 */
 	public CtTypeReference<Boolean> booleanPrimitiveType() {
-		return BOOLEAN_PRIMITIVE.clone();
+		return createReference(boolean.class);
 	}
 
 	/**
 	 * Returns a reference on the byte type.
 	 */
 	public CtTypeReference<Byte> byteType() {
-		return BYTE.clone();
+		return createReference(Byte.class);
 	}
 
 	/**
 	 * Returns a reference on the byte primitive type.
 	 */
 	public CtTypeReference<Byte> bytePrimitiveType() {
-		return BYTE_PRIMITIVE.clone();
+		return createReference(byte.class);
 	}
 
 	/**
 	 * Returns a reference on the character type.
 	 */
 	public CtTypeReference<Character> characterType() {
-		return CHARACTER.clone();
+		return createReference(Character.class);
 	}
 
 	/**
 	 * Returns a reference on the character primitive type.
 	 */
 	public CtTypeReference<Character> characterPrimitiveType() {
-		return CHARACTER_PRIMITIVE.clone();
+		return createReference(char.class);
 	}
 
 	/**
 	 * Returns a reference on the integer type.
 	 */
 	public CtTypeReference<Integer> integerType() {
-		return INTEGER.clone();
+		return createReference(Integer.class);
 	}
 
 	/**
 	 * Returns a reference on the integer primitive type.
 	 */
 	public CtTypeReference<Integer> integerPrimitiveType() {
-		return INTEGER_PRIMITIVE.clone();
+		return createReference(int.class);
 	}
 
 	/**
 	 * Returns a reference on the long type.
 	 */
 	public CtTypeReference<Long> longType() {
-		return LONG.clone();
+		return createReference(Long.class);
 	}
 
 	/**
 	 * Returns a reference on the long primitive type.
 	 */
 	public CtTypeReference<Long> longPrimitiveType() {
-		return LONG_PRIMITIVE.clone();
+		return createReference(long.class);
 	}
 
 	/**
 	 * Returns a reference on the float type.
 	 */
 	public CtTypeReference<Float> floatType() {
-		return FLOAT.clone();
+		return createReference(Float.class);
 	}
 
 	/**
 	 * Returns a reference on the float primitive type.
 	 */
 	public CtTypeReference<Float> floatPrimitiveType() {
-		return FLOAT_PRIMITIVE.clone();
+		return createReference(float.class);
 	}
 
 	/**
 	 * Returns a reference on the double type.
 	 */
 	public CtTypeReference<Double> doubleType() {
-		return DOUBLE.clone();
+		return createReference(Double.class);
 	}
 
 	/**
 	 * Returns a reference on the double primitive type.
 	 */
 	public CtTypeReference<Double> doublePrimitiveType() {
-		return DOUBLE_PRIMITIVE.clone();
+		return createReference(double.class);
 	}
 
 	/**
 	 * Returns a reference on the short type.
 	 */
 	public CtTypeReference<Short> shortType() {
-		return SHORT.clone();
+		return createReference(Short.class);
 	}
 
 	/**
 	 * Returns a reference on the short primitive type.
 	 */
 	public CtTypeReference<Short> shortPrimitiveType() {
-		return SHORT_PRIMITIVE.clone();
+		return createReference(short.class);
 	}
 
 	/**
 	 * Returns a reference on the date type.
 	 */
 	public CtTypeReference<Date> dateType() {
-		return DATE.clone();
+		return createReference(Date.class);
 	}
 
 	/**
 	 * Returns a reference on the object type.
 	 */
 	public CtTypeReference<Object> objectType() {
-		return OBJECT.clone();
+		return createReference(Object.class);
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/factory/TypeFactory.java
+++ b/src/main/java/spoon/reflect/factory/TypeFactory.java
@@ -62,34 +62,150 @@ public class TypeFactory extends SubFactory {
 			// TODO (leventov) it is questionable to me that nulltype should also be here
 			CtTypeReference.NULL_TYPE_NAME);
 
+	/**
+	 * @deprecated Use {@link #nullType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<?> NULL_TYPE = createReference(CtTypeReference.NULL_TYPE_NAME);
+	/**
+	 * @deprecated Use {@link #voidType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Void> VOID = createReference(Void.class);
+	/**
+	 * @deprecated Use {@link #stringType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<String> STRING = createReference(String.class);
+	/**
+	 * @deprecated Use {@link #booleanType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Boolean> BOOLEAN = createReference(Boolean.class);
+	/**
+	 * @deprecated Use {@link #byteType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Byte> BYTE = createReference(Byte.class);
+	/**
+	 * @deprecated Use {@link #characterType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Character> CHARACTER = createReference(Character.class);
+	/**
+	 * @deprecated Use {@link #integerType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Integer> INTEGER = createReference(Integer.class);
+	/**
+	 * @deprecated Use {@link #longType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Long> LONG = createReference(Long.class);
+	/**
+	 * @deprecated Use {@link #floatType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Float> FLOAT = createReference(Float.class);
+	/**
+	 * @deprecated Use {@link #doubleType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Double> DOUBLE = createReference(Double.class);
+	/**
+	 * @deprecated Use {@link #voidPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Void> VOID_PRIMITIVE = createReference(void.class);
+	/**
+	 * @deprecated Use {@link #booleanPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Boolean> BOOLEAN_PRIMITIVE = createReference(boolean.class);
+	/**
+	 * @deprecated Use {@link #bytePrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Byte> BYTE_PRIMITIVE = createReference(byte.class);
+	/**
+	 * @deprecated Use {@link #characterPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Character> CHARACTER_PRIMITIVE = createReference(char.class);
+	/**
+	 * @deprecated Use {@link #integerPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Integer> INTEGER_PRIMITIVE = createReference(int.class);
+	/**
+	 * @deprecated Use {@link #longPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Long> LONG_PRIMITIVE = createReference(long.class);
+	/**
+	 * @deprecated Use {@link #floatPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Float> FLOAT_PRIMITIVE = createReference(float.class);
+	/**
+	 * @deprecated Use {@link #doublePrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Double> DOUBLE_PRIMITIVE = createReference(double.class);
+	/**
+	 * @deprecated Use {@link #shortType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Short> SHORT = createReference(Short.class);
+	/**
+	 * @deprecated Use {@link #shortPrimitiveType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Short> SHORT_PRIMITIVE = createReference(short.class);
+	/**
+	 * @deprecated Use {@link #dateType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Date> DATE = createReference(Date.class);
+	/**
+	 * @deprecated Use {@link #objectType()} instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Object> OBJECT = createReference(Object.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(Iterable.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Iterable> ITERABLE = createReference(Iterable.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(Collection.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Collection> COLLECTION = createReference(Collection.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(List.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<List> LIST = createReference(List.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(Set.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Set> SET = createReference(Set.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(Map.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Map> MAP = createReference(Map.class);
+	/**
+	 * @deprecated Use {@link #createReference(Class) TypeFactory#createReference(Enum.class)}  instead.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<Enum> ENUM = createReference(Enum.class);
+	/**
+	 * @deprecated Deprecated for removal without replacement.
+	 */
+	@Deprecated(since = "11.0.0", forRemoval = true)
 	public final CtTypeReference<?> OMITTED_TYPE_ARG_TYPE = createReference(CtTypeReference.OMITTED_TYPE_ARG_NAME);
 
 	// This map MUST provide a useful computeIfAbsent method in the face of concurrency.
@@ -728,7 +844,7 @@ public class TypeFactory extends SubFactory {
 	 * Returns the default bounding type value
 	 */
 	public CtTypeReference getDefaultBoundingType() {
-		return OBJECT;
+		return objectType();
 	}
 
 	/**

--- a/src/main/java/spoon/reflect/visitor/OperatorHelper.java
+++ b/src/main/java/spoon/reflect/visitor/OperatorHelper.java
@@ -288,7 +288,7 @@ public final class OperatorHelper {
 		// if the operand is of type byte, short, or char, it is promoted to a value of type int by a widening
 		// primitive conversion (§5.1.2).
 		if (NUMBERS_PROMOTED_TO_INT.contains(operandType.getActualClass())) {
-			return Optional.of(operandType.getFactory().Type().INTEGER_PRIMITIVE);
+			return Optional.of(operandType.getFactory().Type().integerPrimitiveType());
 		}
 
 		// otherwise, the operand is not converted at all.
@@ -309,26 +309,26 @@ public final class OperatorHelper {
 			return Optional.empty();
 		}
 
-		CtTypeReference<?> doubleType = typeFactory.DOUBLE_PRIMITIVE;
+		CtTypeReference<?> doubleType = typeFactory.doublePrimitiveType();
 		// If either operand is of type double, the other is converted to double.
 		if (leftType.equals(doubleType) || rightType.equals(doubleType)) {
 			return Optional.of(doubleType);
 		}
 
 		// Otherwise, if either operand is of type float, the other is converted to float.
-		CtTypeReference<?> floatType = typeFactory.FLOAT_PRIMITIVE;
+		CtTypeReference<?> floatType = typeFactory.floatPrimitiveType();
 		if (leftType.equals(floatType) || rightType.equals(floatType)) {
 			return Optional.of(floatType);
 		}
 
 		// Otherwise, if either operand is of type long, the other is converted to long.
-		CtTypeReference<?> longType = typeFactory.LONG_PRIMITIVE;
+		CtTypeReference<?> longType = typeFactory.longPrimitiveType();
 		if (leftType.equals(longType) || rightType.equals(longType)) {
 			return Optional.of(longType);
 		}
 
 		// Otherwise, both operands are converted to type int.
-		return Optional.of(typeFactory.INTEGER_PRIMITIVE);
+		return Optional.of(typeFactory.integerPrimitiveType());
 	}
 
 	/**
@@ -359,7 +359,7 @@ public final class OperatorHelper {
 			// logical operators
 			case AND:
 			case OR: {
-				CtTypeReference<?> booleanType = typeFactory.BOOLEAN_PRIMITIVE;
+				CtTypeReference<?> booleanType = typeFactory.booleanPrimitiveType();
 				if (!left.getType().equals(booleanType) || !right.getType().equals(booleanType)) {
 					return Optional.empty();
 				}
@@ -401,7 +401,7 @@ public final class OperatorHelper {
 				// The equality operators may be used to compare two operands that are convertible (§5.1.8)
 				// to numeric type, or two operands of type boolean or Boolean, or two operands that are each
 				// of either reference type or the null type. All other cases result in a compile-time error.
-				CtTypeReference<?> booleanType = typeFactory.BOOLEAN_PRIMITIVE;
+				CtTypeReference<?> booleanType = typeFactory.booleanPrimitiveType();
 				return binaryNumericPromotion(left, right).or(() -> {
 					// check if both operands are of type boolean or Boolean
 					// if so they will be promoted to the primitive type boolean
@@ -415,7 +415,7 @@ public final class OperatorHelper {
 						// either operand to the type of the other by a casting conversion (§5.5).
 						// The run-time values of the two operands would necessarily be unequal
 						// (ignoring the case where both values are null).
-						CtTypeReference<?> nullType = typeFactory.NULL_TYPE;
+						CtTypeReference<?> nullType = typeFactory.nullType();
 						if (leftType.equals(nullType)) {
 							return Optional.of(rightType);
 						}
@@ -454,7 +454,7 @@ public final class OperatorHelper {
 					//
 					// If the type of either operand of a + operator is String, then the operation is
 					// string concatenation.
-					CtTypeReference<?> stringType = typeFactory.STRING;
+					CtTypeReference<?> stringType = typeFactory.stringType();
 					if (left.getType().equals(stringType) || right.getType().equals(stringType)) {
 						return Optional.of(stringType);
 					}
@@ -469,14 +469,14 @@ public final class OperatorHelper {
 				CtTypeReference<?> rightType = right.getType().unbox();
 
 				Set<CtTypeReference<?>> floatingPointNumbers = Set.of(
-					typeFactory.FLOAT_PRIMITIVE,
-					typeFactory.DOUBLE_PRIMITIVE
+					typeFactory.floatPrimitiveType(),
+					typeFactory.doublePrimitiveType()
 				);
 				if (floatingPointNumbers.contains(leftType) || floatingPointNumbers.contains(rightType)) {
 					return Optional.empty();
 				}
 
-				if (leftType.equals(rightType) && leftType.equals(typeFactory.BOOLEAN_PRIMITIVE)) {
+				if (leftType.equals(rightType) && leftType.equals(typeFactory.booleanPrimitiveType())) {
 					return Optional.of(leftType);
 				}
 
@@ -522,8 +522,8 @@ public final class OperatorHelper {
 				// See: https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.15.3
 				return unaryNumericPromotion(operand);
 			case NOT:
-				if (operand.getType().unbox().equals(typeFactory.BOOLEAN_PRIMITIVE)) {
-					return Optional.of(typeFactory.BOOLEAN_PRIMITIVE);
+				if (operand.getType().unbox().equals(typeFactory.booleanPrimitiveType())) {
+					return Optional.of(typeFactory.booleanPrimitiveType());
 				}
 
 				return Optional.empty();

--- a/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SuperInheritanceHierarchyFunction.java
@@ -245,7 +245,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 				visitSuperInterfaces(typeRef, outputConsumer);
 				if (interfacesExtendObject) {
 					//last visit Object.class, because interface inherits all public type members of Object.class
-					sendResultWithListener(typeRef.getFactory().Type().OBJECT, isClass, outputConsumer, (ref) -> { });
+					sendResultWithListener(typeRef.getFactory().Type().objectType(), isClass, outputConsumer, (ref) -> { });
 				}
 			} else {
 				//call visitSuperClasses only for input of type class. The contract of visitSuperClasses requires that
@@ -276,7 +276,7 @@ public class SuperInheritanceHierarchyFunction implements CtConsumableFunction<C
 		if (superClassRef == null) {
 			//only CtClasses extend object,
 			//this method is called only for classes (not for interfaces) so we know we can visit java.lang.Object now too
-			superClassRef = superTypeRef.getFactory().Type().OBJECT;
+			superClassRef = superTypeRef.getFactory().Type().objectType();
 		}
 		sendResultWithListener(superClassRef, true,
 				outputConsumer, (classRef) -> visitSuperClasses(classRef, outputConsumer, includingInterfaces));

--- a/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
+++ b/src/main/java/spoon/support/compiler/SnippetCompilationHelper.java
@@ -175,7 +175,7 @@ public class SnippetCompilationHelper {
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st)
 			throws SnippetCompilationError {
-		return internalCompileStatement(st, st.getFactory().Type().VOID_PRIMITIVE);
+		return internalCompileStatement(st, st.getFactory().Type().voidPrimitiveType());
 	}
 
 	public static CtStatement compileStatement(CtCodeSnippetStatement st, CtTypeReference returnType)
@@ -218,7 +218,7 @@ public class SnippetCompilationHelper {
 	public static <T> CtExpression<T> compileExpression(
 			CtCodeSnippetExpression<T> expr) throws SnippetCompilationError {
 
-		CtReturn<T> ret = (CtReturn<T>) internalCompileStatement(expr, expr.getFactory().Type().OBJECT);
+		CtReturn<T> ret = (CtReturn<T>) internalCompileStatement(expr, expr.getFactory().Type().objectType());
 
 		CtExpression<T> returnedExpression = ret.getReturnedExpression();
 

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -446,7 +446,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				op.setKind(BinaryOperatorKind.PLUS);
 				op.setLeftHandOperand(operator.getLeftHandOperand());
 				op.setRightHandOperand(operator.getRightHandOperand());
-				op.setType((CtTypeReference) operator.getFactory().Type().STRING.clone());
+				op.setType(operator.getFactory().Type().stringType());
 				operator.setLeftHandOperand(op);
 				operator.setRightHandOperand(((CtExpression<?>) child));
 				int[] lineSeparatorPositions = jdtTreeBuilder.getContextBuilder().getCompilationUnitLineSeparatorPositions();

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -707,7 +707,7 @@ public class ReferenceBuilder {
 
 		// the expected type is not available/parameterized if the constructor call occurred in e.g. an unresolved
 		// method, or in a method that did not expect a parameterized argument
-		type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().OMITTED_TYPE_ARG_TYPE.clone());
+		type.addActualTypeArgument(jdtTreeBuilder.getFactory().Type().createReference(CtTypeReference.OMITTED_TYPE_ARG_NAME));
 	}
 
 	/**
@@ -1380,7 +1380,7 @@ public class ReferenceBuilder {
 			paramType = ((CtTypeParameterReference) paramType).getBoundingType();
 		}
 		if (paramType == null) {
-			paramType = param.getFactory().Type().OBJECT;
+			return param.getFactory().Type().objectType();
 		}
 		return paramType.clone();
 	}

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	public CtTypeReference<Void> getType() {
-		return (CtTypeReference<Void>) getFactory().Type().voidPrimitiveType().<CtTypeAccess>setParent(this);
+		return getFactory().Type().voidPrimitiveType().setParent(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
+++ b/src/main/java/spoon/support/reflect/code/CtTypeAccessImpl.java
@@ -45,7 +45,7 @@ public class CtTypeAccessImpl<A> extends CtExpressionImpl<Void> implements CtTyp
 
 	@Override
 	public CtTypeReference<Void> getType() {
-		return (CtTypeReference<Void>) getFactory().Type().VOID_PRIMITIVE.clone().<CtTypeAccess>setParent(this);
+		return (CtTypeReference<Void>) getFactory().Type().voidPrimitiveType().<CtTypeAccess>setParent(this);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtAnonymousExecutableImpl.java
@@ -171,7 +171,7 @@ public class CtAnonymousExecutableImpl extends CtExecutableImpl<Void> implements
 	@Override
 	@DerivedProperty
 	public CtTypeReference<Void> getType() {
-		return factory.Type().VOID_PRIMITIVE;
+		return factory.Type().voidPrimitiveType();
 	}
 
 	@Override

--- a/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtEnumImpl.java
@@ -212,7 +212,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 			valueOfMethod.addThrownType(
 				getFactory().Type().createReference(IllegalArgumentException.class));
 			valueOfMethod.setType(getReference());
-			factory.Method().createParameter(valueOfMethod, factory.Type().STRING, "name");
+			factory.Method().createParameter(valueOfMethod, factory.Type().stringType(), "name");
 		}
 		return valueOfMethod;
 	}
@@ -221,7 +221,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 	public <R> CtMethod<R> getMethod(String name, CtTypeReference<?>... parameterTypes) {
 		if ("values".equals(name) && parameterTypes.length == 0) {
 			return valuesMethod();
-		} else if ("valueOf".equals(name) && parameterTypes.length == 1 && parameterTypes[0].equals(factory.Type().STRING)) {
+		} else if ("valueOf".equals(name) && parameterTypes.length == 1 && parameterTypes[0].equals(factory.Type().stringType())) {
 			return valueOfMethod();
 		} else {
 			return super.getMethod(name, parameterTypes);
@@ -236,7 +236,7 @@ public class CtEnumImpl<T extends Enum<?>> extends CtClassImpl<T> implements CtE
 			return valuesMethod();
 		} else if ("valueOf".equals(name)
 			&& parameterTypes.length == 1
-			&& parameterTypes[0].equals(factory.Type().STRING)
+			&& parameterTypes[0].equals(factory.Type().stringType())
 			&& returnType.equals(factory.Type().createArrayReference(getReference()))) {
 			return valueOfMethod();
 		} else {

--- a/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtTypeParameterImpl.java
@@ -305,7 +305,7 @@ public class CtTypeParameterImpl extends CtTypeImpl<Object> implements CtTypePar
 	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
 		CtTypeReference<?> bound = typeParam.getSuperclass();
 		if (bound == null) {
-			bound = typeParam.getFactory().Type().OBJECT;
+			bound = typeParam.getFactory().Type().objectType();
 		}
 		return bound;
 	}

--- a/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
+++ b/src/main/java/spoon/support/reflect/eval/VisitorPartialEvaluator.java
@@ -436,7 +436,7 @@ public class VisitorPartialEvaluator extends CtScanner implements PartialEvaluat
 
 		if ((f != null) && f.getModifiers().contains(ModifierKind.FINAL)
 				// enum values have no meaningful default expression to be evaluated
-				&& !fieldAccess.getVariable().getDeclaringType().isSubtypeOf(fieldAccess.getFactory().Type().ENUM)
+				&& !fieldAccess.getVariable().getDeclaringType().isSubtypeOf(fieldAccess.getFactory().Type().createReference(Enum.class))
 				) {
 			setResult(evaluate(f.getDefaultExpression()));
 			return;

--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -383,7 +383,7 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 
 	@Override
 	public CtExecutableReference<?> getOverridingExecutable() {
-		CtTypeReference<Object> objectType = getFactory().Type().OBJECT;
+		CtTypeReference<Object> objectType = getFactory().Type().objectType();
 		CtTypeReference<?> declaringType = getDeclaringType();
 		if (declaringType == null) {
 			return getOverloadedExecutable(objectType, objectType);

--- a/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtIntersectionTypeReferenceImpl.java
@@ -76,7 +76,7 @@ public class CtIntersectionTypeReferenceImpl<T> extends CtTypeReferenceImpl<T> i
 	@Override
 	public CtTypeReference<?> getTypeErasure() {
 		if (bounds == null || bounds.isEmpty()) {
-			return getFactory().Type().OBJECT;
+			return getFactory().Type().objectType();
 		}
 		return bounds.get(0).getTypeErasure();
 	}

--- a/src/main/java/spoon/support/visitor/ClassTypingContext.java
+++ b/src/main/java/spoon/support/visitor/ClassTypingContext.java
@@ -591,14 +591,14 @@ public class ClassTypingContext extends AbstractTypingContext {
 		if (superArg instanceof CtWildcardReference) {
 			CtWildcardReference wr = (CtWildcardReference) superArg;
 			CtTypeReference<?> superBound = wr.getBoundingType();
-			if (superBound.equals(wr.getFactory().Type().OBJECT)) {
+			if (superBound.equals(wr.getFactory().Type().objectType())) {
 				//everything extends from object, nothing is super of Object
 				return wr.isUpper();
 			}
 			if (subArg instanceof CtWildcardReference) {
 				CtWildcardReference subWr = (CtWildcardReference) subArg;
 				CtTypeReference<?> subBound = subWr.getBoundingType();
-				if (subBound.equals(wr.getFactory().Type().OBJECT)) {
+				if (subBound.equals(wr.getFactory().Type().objectType())) {
 					//nothing is super of object
 					return false;
 				}

--- a/src/main/java/spoon/support/visitor/MethodTypingContext.java
+++ b/src/main/java/spoon/support/visitor/MethodTypingContext.java
@@ -261,7 +261,7 @@ public class MethodTypingContext extends AbstractTypingContext {
 	private static CtTypeReference<?> getBound(CtTypeParameter typeParam) {
 		CtTypeReference<?> bound = typeParam.getSuperclass();
 		if (bound == null) {
-			bound = typeParam.getFactory().Type().OBJECT;
+			bound = typeParam.getFactory().Type().objectType();
 		}
 		return bound;
 	}

--- a/src/test/java/spoon/generating/CloneVisitorGenerator.java
+++ b/src/test/java/spoon/generating/CloneVisitorGenerator.java
@@ -566,7 +566,7 @@ public class CloneVisitorGenerator extends AbstractManualProcessor {
 			 * Check if the type is a subtype of CtElement.
 			 */
 			private boolean isSubTypeOfCtElement(CtTypeReference<?> type) {
-				if (!type.isPrimitive() && !type.equals(factory.Type().STRING)) {
+				if (!type.isPrimitive() && !type.equals(factory.Type().stringType())) {
 					if (type.isSubtypeOf(factory.Type().createReference(CtElement.class))) {
 						return true;
 					}

--- a/src/test/java/spoon/generating/RoleHandlersGenerator.java
+++ b/src/test/java/spoon/generating/RoleHandlersGenerator.java
@@ -133,7 +133,7 @@ public class RoleHandlersGenerator extends AbstractManualProcessor {
 	private CtTypeReference<?> fixMainValueType(CtTypeReference<?> valueType) {
 		valueType = fixValueType(valueType);
 		if (valueType instanceof CtWildcardReference) {
-			return getFactory().Type().OBJECT;
+			return getFactory().Type().objectType();
 		}
 		return valueType;
 	}

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -285,7 +285,7 @@ public class DefaultJavaPrettyPrinterTest {
             Factory factory = launcher.getFactory();
 
             CtArrayTypeReference<Integer> arrayTypeReference = factory.createArrayTypeReference();
-            arrayTypeReference.setComponentType(factory.Type().INTEGER_PRIMITIVE);
+            arrayTypeReference.setComponentType(factory.Type().integerPrimitiveType());
             CtNewArray<Integer> newArray = factory.createNewArray();
             newArray.setValueByRole(CtRole.TYPE, arrayTypeReference);
             List<CtLiteral<Integer>> elements = new ArrayList<>(List.of(factory.createLiteral(3)));

--- a/src/test/java/spoon/support/TypeAdaptorTest.java
+++ b/src/test/java/spoon/support/TypeAdaptorTest.java
@@ -505,7 +505,7 @@ class TypeAdaptorTest {
 	void testArraySubtypingShadow() {
 		// contract: Array subtyping should hold for shadow types
 		Factory factory = new Launcher().getFactory();
-		CtTypeReference<Integer> intType = factory.Type().INTEGER;
+		CtTypeReference<Integer> intType = factory.Type().integerType();
 		CtArrayTypeReference<?> intArr = factory.createArrayReference(intType, 1);
 		CtArrayTypeReference<?> intArr2 = factory.createArrayReference(intType, 2);
 
@@ -582,7 +582,7 @@ class TypeAdaptorTest {
 		Factory factory = launcher.getFactory();
 
 		CtArrayTypeReference<?> fooArray = factory.createArrayReference(fooType, 1);
-		CtArrayTypeReference<?> intArray = factory.createArrayReference(factory.Type().INTEGER_PRIMITIVE, 1);
+		CtArrayTypeReference<?> intArray = factory.createArrayReference(factory.Type().integerPrimitiveType(), 1);
 		CtArrayTypeReference<?> objArray = factory.createArrayReference(factory.Type().objectType(), 1);
 
 		verifySubtype(fooArray, factory.createCtTypeReference(Object.class), true);

--- a/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationLoopTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.test.annotation.testclasses.Pozole;
 import spoon.testing.utils.ModelUtils;
@@ -43,9 +44,10 @@ public class AnnotationLoopTest {
 		assertEquals("p", ((CtLocalVariable) aLoop.getForInit().get(1)).getSimpleName());
 		assertEquals("e", ((CtLocalVariable) aLoop.getForInit().get(2)).getSimpleName());
 
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(0)).getType());
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(1)).getType());
-		assertEquals(aPozole.getFactory().Type().STRING, ((CtLocalVariable) aLoop.getForInit().get(2)).getType());
+		CtTypeReference<?> stringRef = aPozole.getFactory().Type().stringType();
+		assertEquals(stringRef, ((CtLocalVariable) aLoop.getForInit().get(0)).getType());
+		assertEquals(stringRef, ((CtLocalVariable) aLoop.getForInit().get(1)).getType());
+		assertEquals(stringRef, ((CtLocalVariable) aLoop.getForInit().get(2)).getType());
 
 		final String nl = System.lineSeparator();
 		final String expected = "for (@java.lang.SuppressWarnings(\"rawtypes\")" + nl + "java.lang.String u = \"\", p = \"\", e = \"\"; u != e; u = p , p = \"\") {" + nl + "}";

--- a/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
+++ b/src/test/java/spoon/test/annotation/AnnotationValuesTest.java
@@ -130,7 +130,7 @@ public class AnnotationValuesTest {
 	public void testAnnotateWithEnum() {
 		final Factory factory = createFactory();
 		final CtClass<Object> target = factory.Class().create("org.example.Tacos");
-		final CtField<String> field = factory.Field().create(target, new HashSet<>(), factory.Type().STRING, "field");
+		final CtField<String> field = factory.Field().create(target, new HashSet<>(), factory.Type().stringType(), "field");
 		target.addField(field);
 
 		final CtAnnotation<BoundNumber> byteOrder = factory.Annotation().annotate(field, BoundNumber.class, "byteOrder", BoundNumber.ByteOrder.LittleEndian);

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -298,7 +298,7 @@ public class APITest {
 
 		final CtMethod aMethod = spoon.getFactory().Core().createMethod();
 		aMethod.setSimpleName("foo");
-		aMethod.setType(spoon.getFactory().Type().BOOLEAN_PRIMITIVE);
+		aMethod.setType(spoon.getFactory().Type().booleanPrimitiveType());
 		aMethod.setBody(spoon.getFactory().Core().createBlock());
 		aClass.addMethod(aMethod);
 

--- a/src/test/java/spoon/test/api/processors/AwesomeProcessor.java
+++ b/src/test/java/spoon/test/api/processors/AwesomeProcessor.java
@@ -18,7 +18,7 @@ public class AwesomeProcessor extends AbstractProcessor<CtClass<Bar>> {
 		// Creates new elements.
 		final CtMethod prepareMojito = element.getMethodsByName("doSomething").get(0);
 		prepareMojito.setSimpleName("prepareMojito");
-		prepareMojito.setType(getFactory().Type().VOID_PRIMITIVE);
+		prepareMojito.setType(getFactory().Type().voidPrimitiveType());
 		final CtBlock<Object> block = getFactory().Core().createBlock();
 		block.addStatement(
 				getFactory().Code()

--- a/src/test/java/spoon/test/casts/CastTest.java
+++ b/src/test/java/spoon/test/casts/CastTest.java
@@ -105,7 +105,7 @@ public class CastTest {
 		assertEquals("T", getValueMethod.getType().getSimpleName());
 		assertEquals("T", getValueMethod.getParameters().get(0).getType().getActualTypeArguments().get(0).toString());
 
-		assertEquals(type.getFactory().Class().INTEGER, getValueInvocation.getType());
+		assertEquals(type.getFactory().Class().integerType(), getValueInvocation.getType());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -696,7 +696,7 @@ public class CommentTest {
 		CtMethod method = f.Core().createMethod();
 		method.setSimpleName("newMethod");
 		method.setBody(f.Core().createBlock());
-		method.setType(f.Type().VOID_PRIMITIVE);
+		method.setType(f.Type().voidPrimitiveType());
 
 		type.addMethod(method);
 
@@ -710,7 +710,7 @@ public class CommentTest {
 
 		method.getBody().removeStatement(method.getBody().getStatement(0));
 
-		CtLocalVariable<Integer> i = f.Code().createLocalVariable(f.Type().INTEGER_PRIMITIVE, "i", null);
+		CtLocalVariable<Integer> i = f.Code().createLocalVariable(f.Type().integerPrimitiveType(), "i", null);
 		i.addComment(createFakeComment(f, "comment local variable"));
 		method.getBody().addStatement(i);
 

--- a/src/test/java/spoon/test/constructor/ConstructorTest.java
+++ b/src/test/java/spoon/test/constructor/ConstructorTest.java
@@ -123,7 +123,7 @@ public class ConstructorTest {
 
 	@Test
 	public void testTypeAnnotationOnExceptionDeclaredInConstructors() {
-		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT);
+		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().objectType());
 
 		assertEquals(1, aConstructor.getThrownTypes().size());
 		Set<CtTypeReference<? extends Throwable>> thrownTypes = aConstructor.getThrownTypes();
@@ -135,7 +135,7 @@ public class ConstructorTest {
 
 	@Test
 	public void testTypeAnnotationWithConstructorsOnFormalType() {
-		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().OBJECT);
+		final CtConstructor<?> aConstructor = aClass.getConstructor(factory.Type().objectType());
 
 		assertEquals(1, aConstructor.getFormalCtTypeParameters().size());
 

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -101,7 +101,7 @@ public class CtClassTest {
 		// as long as we have not changed the signature, getConstructors, which is based on signatures,
 		// thinks there is one single constructor (and that's OK)
 		assertEquals(3, foo.getConstructors().size());
-		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().OBJECT));
+		cons.addParameter(cons.getFactory().createParameter().setType(cons.getFactory().Type().objectType()));
 		// now that we have changed the signature we can call getConstructors safely
 		assertEquals(4, foo.getConstructors().size());
 		// we cloned the first constructor, so it has the same position, and comes before the 2nd and 3rd constructor

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -122,7 +122,7 @@ public class CtTypeTest {
 
 		CtType<?> oCtType = factory.Type().get("spoon.test.ctType.testclasses.O");
 		CtType<?> pCtType = factory.Type().get("spoon.test.ctType.testclasses.P");
-		CtTypeReference<?> objectCtTypeRef = factory.Type().OBJECT;
+		CtTypeReference<?> objectCtTypeRef = factory.Type().objectType();
 
 		List<CtTypeParameter> oTypeParameters = oCtType.getFormalCtTypeParameters();
 		assertTrue(oTypeParameters.size() == 1);

--- a/src/test/java/spoon/test/delete/DeleteTest.java
+++ b/src/test/java/spoon/test/delete/DeleteTest.java
@@ -166,7 +166,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().integerPrimitiveType(), factory.Type().floatPrimitiveType(), factory.Type().stringType());
 
 		int n = adobada.getMethods().size();
 
@@ -182,7 +182,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().integerPrimitiveType(), factory.Type().floatPrimitiveType(), factory.Type().stringType());
 		final CtParameter param = (CtParameter) method.getParameters().get(1);
 
 		assertEquals(3, method.getParameters().size());
@@ -240,7 +240,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().integerPrimitiveType(), factory.Type().floatPrimitiveType(), factory.Type().stringType());
 		final CtIf anIf = method.getElements(new TypeFilter<>(CtIf.class)).get(0);
 
 		assertNotNull(anIf.getCondition());
@@ -255,7 +255,7 @@ public class DeleteTest {
 		final Factory factory = build(Adobada.class);
 		final CtClass<Adobada> adobada = factory.Class().get(Adobada.class);
 
-		final CtMethod method = adobada.getMethod("m4", factory.Type().INTEGER_PRIMITIVE, factory.Type().FLOAT_PRIMITIVE, factory.Type().STRING);
+		final CtMethod method = adobada.getMethod("m4", factory.Type().integerPrimitiveType(), factory.Type().floatPrimitiveType(), factory.Type().stringType());
 		final CtAssignment chainOfAssignment = method.getElements(new TypeFilter<>(CtAssignment.class)).get(0);
 
 		assertNotNull(chainOfAssignment.getAssignment());

--- a/src/test/java/spoon/test/eval/EvalTest.java
+++ b/src/test/java/spoon/test/eval/EvalTest.java
@@ -338,7 +338,7 @@ public class EvalTest {
 			case LE:
 			case GT:
 			case GE:
-				return ctBinaryOperator.getFactory().Type().BOOLEAN_PRIMITIVE;
+				return ctBinaryOperator.getFactory().Type().booleanPrimitiveType();
 			case SL:
 			case SR:
 			case USR:
@@ -490,7 +490,7 @@ public class EvalTest {
 			String.format("type of '%s' is null after evaluation", ctBinaryOperator)
 		);
 		assertEquals(
-			ctBinaryOperator.getFactory().Type().INTEGER_PRIMITIVE,
+			ctBinaryOperator.getFactory().Type().integerPrimitiveType(),
 			evaluated.getType()
 		);
 		assertEquals(

--- a/src/test/java/spoon/test/executable/ExecutableTest.java
+++ b/src/test/java/spoon/test/executable/ExecutableTest.java
@@ -54,7 +54,7 @@ public class ExecutableTest {
 
 		for (CtAnonymousExecutable anonymousExecutable : anonymousExecutables) {
 			assertEquals("", anonymousExecutable.getSimpleName());
-			assertEquals(launcher.getFactory().Type().VOID_PRIMITIVE, anonymousExecutable.getType());
+			assertEquals(launcher.getFactory().Type().voidPrimitiveType(), anonymousExecutable.getType());
 			assertEquals(0, anonymousExecutable.getParameters().size());
 			assertEquals(0, anonymousExecutable.getThrownTypes().size());
 		}

--- a/src/test/java/spoon/test/factory/FactoryTest.java
+++ b/src/test/java/spoon/test/factory/FactoryTest.java
@@ -159,7 +159,7 @@ public class FactoryTest {
 		// if we change the implem, merge is impossible
 		CtField f = spoon.getFactory().Core().createField();
 		f.setSimpleName("foo");
-		f.setType(spoon.getFactory().Type().BYTE);
+		f.setType(spoon.getFactory().Type().byteType());
 		p.getElements(new NamedElementFilter<>(CtPackage.class, "testclasses")).get(0).getType("Foo").addField(f);
 		try {
 			model.getRootPackage().addPackage(p);

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -98,9 +98,9 @@ public class FieldTest {
 
 		assertEquals(1, aClass.getFields().size());
 
-		final CtField<String> generated = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING, "generated");
+		final CtField<String> generated = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().stringType(), "generated");
 		aClass.addFieldAtTop(generated);
-		final CtField<String> generated2 = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().STRING, "generated2");
+		final CtField<String> generated2 = aClass.getFactory().Field().create(null, new HashSet<>(), aClass.getFactory().Type().stringType(), "generated2");
 		aClass.addFieldAtTop(generated2);
 
 		assertEquals(3, aClass.getFields().size());
@@ -126,7 +126,7 @@ public class FieldTest {
 	private CtField<Integer> createField(Factory factory, HashSet<ModifierKind> modifiers, String name) {
 		final CtField<Integer> first = factory.Core().createField();
 		first.setModifiers(modifiers);
-		first.setType(factory.Type().INTEGER_PRIMITIVE);
+		first.setType(factory.Type().integerPrimitiveType());
 		first.setSimpleName(name);
 		return first;
 	}

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -892,11 +892,11 @@ public class ImportTest {
 		assertThat(result, hasItem(Object.class.getName()));
 
 		//contract: super type of Object is nothing
-		List<CtTypeReference<?>> typeResult = clientClass.getFactory().Type().OBJECT.map(new SuperInheritanceHierarchyFunction().includingSelf(false).returnTypeReferences(true)).list();
+		List<CtTypeReference<?>> typeResult = clientClass.getFactory().Type().objectType().map(new SuperInheritanceHierarchyFunction().includingSelf(false).returnTypeReferences(true)).list();
 		assertEquals(0, typeResult.size());
-		typeResult = clientClass.getFactory().Type().OBJECT.map(new SuperInheritanceHierarchyFunction().includingSelf(true).returnTypeReferences(true)).list();
+		typeResult = clientClass.getFactory().Type().objectType().map(new SuperInheritanceHierarchyFunction().includingSelf(true).returnTypeReferences(true)).list();
 		assertEquals(1, typeResult.size());
-		assertEquals(clientClass.getFactory().Type().OBJECT, typeResult.get(0));
+		assertEquals(clientClass.getFactory().Type().objectType(), typeResult.get(0));
 	}
 
 	@Test

--- a/src/test/java/spoon/test/intercession/IntercessionTest.java
+++ b/src/test/java/spoon/test/intercession/IntercessionTest.java
@@ -349,7 +349,7 @@ public class IntercessionTest {
 				nullLiteral.setType(factory.Type().nullType());
 
 				final CtBinaryOperator<Boolean> checkNull = factory.Code().createBinaryOperator(variableRead, nullLiteral, BinaryOperatorKind.EQ);
-				checkNull.setType(factory.Type().BOOLEAN_PRIMITIVE);
+				checkNull.setType(factory.Type().booleanPrimitiveType());
 
 				final CtMethod<Boolean> isEmptyMethod = ctParameter.getType().getTypeDeclaration().getMethod(factory.Type().booleanPrimitiveType(), "isEmpty");
 				final CtInvocation<Boolean> isEmpty = factory.Code().createInvocation(variableRead, isEmptyMethod.getReference());

--- a/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
+++ b/src/test/java/spoon/test/issue3321/AnnotationPositionTest.java
@@ -25,7 +25,7 @@ public class AnnotationPositionTest {
 		Factory factory = launcher.getFactory();
 		final CtClass<?> ctClass = (CtClass<?>) factory.Type().get(AnnoUser.class);
 
-		CtMethod m1 = ctClass.getMethod("m1", factory.Type().STRING);
+		CtMethod m1 = ctClass.getMethod("m1", factory.Type().stringType());
 		CtParameter pm1 = (CtParameter) m1.getParameters().get(0);
 		SourcePosition paramPos1 = pm1.getType().getPosition();
 		SourcePosition typeRefPos1 = pm1.getType().getPosition();
@@ -33,7 +33,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos1,annoPos1));
 		assertTrue(contains(typeRefPos1,annoPos1));
 
-		CtMethod m2 = ctClass.getMethod("m2", factory.Type().STRING);
+		CtMethod m2 = ctClass.getMethod("m2", factory.Type().stringType());
 		CtParameter pm2 = (CtParameter) m2.getParameters().get(0);
 		SourcePosition paramPos2 = pm2.getPosition();
 		SourcePosition typeRefPos2 = pm2.getType().getPosition();
@@ -41,7 +41,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos2,annoPos2));
 		assertFalse(contains(typeRefPos2,annoPos2));
 
-		CtMethod m3 = ctClass.getMethod("m3", factory.Type().STRING);
+		CtMethod m3 = ctClass.getMethod("m3", factory.Type().stringType());
 		CtParameter pm3 = (CtParameter) m3.getParameters().get(0);
 		SourcePosition paramPos3 = pm3.getType().getPosition();
 		SourcePosition typeRefPos3 = pm3.getType().getPosition();
@@ -51,7 +51,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos3,annoPos32));
 		assertTrue(contains(typeRefPos3,annoPos32));
 
-		CtMethod m4 = ctClass.getMethod("m4", factory.Type().STRING);
+		CtMethod m4 = ctClass.getMethod("m4", factory.Type().stringType());
 		CtParameter pm4 = (CtParameter) m4.getParameters().get(0);
 		SourcePosition paramPos4 = pm4.getType().getPosition();
 		SourcePosition typeRefPos4 = pm4.getType().getPosition();
@@ -59,7 +59,7 @@ public class AnnotationPositionTest {
 		assertTrue(contains(paramPos4,annoPos4));
 		assertTrue(contains(typeRefPos4,annoPos4));
 
-		CtMethod m5 = ctClass.getMethod("m5", factory.Type().STRING);
+		CtMethod m5 = ctClass.getMethod("m5", factory.Type().stringType());
 		CtParameter pm5 = (CtParameter) m5.getParameters().get(0);
 		SourcePosition paramPos5 = pm5.getType().getPosition();
 		SourcePosition typeRefPos5 = pm5.getType().getPosition();
@@ -82,7 +82,7 @@ public class AnnotationPositionTest {
 
 
 
-		CtMethod m6 = ctClass.getMethod("m6", factory.Type().STRING);
+		CtMethod m6 = ctClass.getMethod("m6", factory.Type().stringType());
 		CtParameter pm6 = (CtParameter) m6.getParameters().get(0);
 
 		SourcePosition paramPos6 = pm6.getType().getPosition();

--- a/src/test/java/spoon/test/literal/LiteralTest.java
+++ b/src/test/java/spoon/test/literal/LiteralTest.java
@@ -82,48 +82,48 @@ public class LiteralTest {
 		CtLiteral<?> literal = (CtLiteral<?>) ctType.getField("a").getDefaultExpression();
 		assertEquals(0, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.INTEGER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.integerPrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("b").getDefaultExpression();
 		assertEquals(0x0, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.INTEGER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.integerPrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("c").getDefaultExpression();
 		assertEquals(0f, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.FLOAT_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.floatPrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("d").getDefaultExpression();
 		assertEquals(0L, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.LONG_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.longPrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("e").getDefaultExpression();
 		assertEquals(0d, literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.DOUBLE_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.doublePrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("f").getDefaultExpression();
 		assertEquals('0', literal.getValue());
 		assertTrue(literal.getType().isPrimitive());
-		assertEquals(typeFactory.CHARACTER_PRIMITIVE, literal.getType());
+		assertEquals(typeFactory.characterPrimitiveType(), literal.getType());
 
 
 		literal = (CtLiteral<?>) ctType.getField("g").getDefaultExpression();
 		assertEquals("0", literal.getValue());
 		assertFalse(literal.getType().isPrimitive());
-		assertEquals(typeFactory.STRING, literal.getType());
+		assertEquals(typeFactory.stringType(), literal.getType());
 
 		literal = (CtLiteral<?>) ctType.getField("h").getDefaultExpression();
 		assertNull(literal.getValue());
 		assertFalse(literal.getType().isPrimitive());
-		assertEquals(typeFactory.NULL_TYPE, literal.getType());
+		assertEquals(typeFactory.nullType(), literal.getType());
 
 	}
 

--- a/src/test/java/spoon/test/literal/UnicodeBugTest.java
+++ b/src/test/java/spoon/test/literal/UnicodeBugTest.java
@@ -33,7 +33,7 @@ public class UnicodeBugTest {
 	private class StringConcatProcessor extends AbstractProcessor<CtLiteral<?>> {
 		@Override
 		public boolean isToBeProcessed(CtLiteral<?> candidate) {
-			return candidate.getType().isSubtypeOf(getFactory().Type().STRING) &&
+			return candidate.getType().isSubtypeOf(getFactory().Type().stringType()) &&
 					candidate.getParent() instanceof CtBinaryOperator;
 		}
 

--- a/src/test/java/spoon/test/parameters/ParameterTest.java
+++ b/src/test/java/spoon/test/parameters/ParameterTest.java
@@ -86,7 +86,7 @@ public class ParameterTest {
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(factory.Type().STRING, refType);
+			assertEquals(factory.Type().stringType(), refType);
 		}
 
 		// test integer parameters
@@ -97,7 +97,7 @@ public class ParameterTest {
 		assertEquals(2, parameters.size());
 		for (final CtParameter param : parameters) {
 			CtTypeReference refType = param.getReference().getType();
-			assertEquals(factory.Type().INTEGER, refType);
+			assertEquals(factory.Type().integerType(), refType);
 		}
 
 		// test unknown parameters

--- a/src/test/java/spoon/test/parent/ParentTest.java
+++ b/src/test/java/spoon/test/parent/ParentTest.java
@@ -234,7 +234,7 @@ public class ParentTest {
 		final CtMethod<?> aMethod = aTacos.getMethodsByName("m").get(0);
 
 		assertNotNull(aMethod.getType().getParent());
-		assertEquals(factory.Type().INTEGER_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().integerPrimitiveType(), aMethod.getType());
 		assertEquals(aMethod, aMethod.getType().getParent());
 	}
 
@@ -390,11 +390,11 @@ public class ParentTest {
 			 */
 			private CtBinaryOperator<Boolean> createCheckNull(CtParameter<?> ctParameter) {
 				final CtLiteral nullLiteral = factory.Code().createLiteral(null);
-				nullLiteral.setType(factory.Type().NULL_TYPE.clone());
+				nullLiteral.setType(factory.Type().nullType());
 				final CtBinaryOperator<Boolean> operator = factory.Code().createBinaryOperator( //
 						factory.Code().createVariableRead(ctParameter.getReference(), true), //
 						nullLiteral, BinaryOperatorKind.EQ);
-				operator.setType(factory.Type().BOOLEAN_PRIMITIVE);
+				operator.setType(factory.Type().booleanPrimitiveType());
 				return operator;
 			}
 

--- a/src/test/java/spoon/test/path/PathTest.java
+++ b/src/test/java/spoon/test/path/PathTest.java
@@ -178,7 +178,7 @@ public class PathTest {
 
 		CtLiteral<String> literal = factory.Core().createLiteral();
 		literal.setValue("salut");
-		literal.setType(literal.getFactory().Type().STRING);
+		literal.setType(literal.getFactory().Type().stringType());
 		equals(new CtPathStringBuilder().fromString(".spoon.test.path.testclasses.Foo.toto#defaultExpression"), literal);
 	}
 

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1550,7 +1550,7 @@ public class PositionTest {
 
 		CtConstructor<?> untypedConstructor = untypedType.getConstructor();
 		CtConstructor<?> typedConstructor = typedType.getConstructor();
-		CtConstructor<?> untypedNoArgsConstructor = untypedNoArgsType.getConstructor(factory.Type().INTEGER_PRIMITIVE);
+		CtConstructor<?> untypedNoArgsConstructor = untypedNoArgsType.getConstructor(factory.Type().integerPrimitiveType());
 		CtConstructor<?> untypedSuperConstructor = untypedSuperType.getConstructor();
 		CtConstructor<?> typedSuperConstructor = typedSuperType.getConstructor();
 		CtInvocation<?> untypedInvocation = untypedConstructor.getBody().getStatement(0);

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -323,7 +323,7 @@ public class TestSniperPrinter {
 		testSniper(ToBeChanged.class.getName(), type -> {
 			Factory f = type.getFactory();
 			//create new type member
-			context.newField = f.createField(type, Collections.singleton(ModifierKind.PRIVATE), f.Type().DATE, "dateField");
+			context.newField = f.createField(type, Collections.singleton(ModifierKind.PRIVATE), f.Type().dateType(), "dateField");
 			type.addTypeMember(context.newField);
 		}, (type, printed) -> {
 			String lastMemberString = "new List<?>[7][];";
@@ -422,7 +422,7 @@ public class TestSniperPrinter {
 		Consumer<CtType<?>> addFieldAtTop = type -> {
 			Factory fact = type.getFactory();
 			CtField<?> field = fact.createCtField(
-					"newFieldAtTop", fact.Type().INTEGER_PRIMITIVE, "2");
+					"newFieldAtTop", fact.Type().integerPrimitiveType(), "2");
 			type.addFieldAtTop(field);
 		};
 
@@ -466,7 +466,7 @@ public class TestSniperPrinter {
 					.findFirst()
 					.get();
 			CtLocalVariable<?> localVar = factory.createLocalVariable(
-					factory.Type().INTEGER_PRIMITIVE, "localVar", factory.createCodeSnippetExpression("2"));
+				factory.Type().integerPrimitiveType(), "localVar", factory.createCodeSnippetExpression("2"));
 			method.getBody().addStatement(0, localVar);
 		};
 
@@ -607,7 +607,7 @@ public class TestSniperPrinter {
 
 		Consumer<CtType<?>> addElements = type -> {
 		    Factory fact = type.getFactory();
-		    fact.createField(type, new HashSet<>(), fact.Type().INTEGER_PRIMITIVE, "z", fact.createLiteral(3));
+		    fact.createField(type, new HashSet<>(), fact.Type().integerPrimitiveType(), "z", fact.createLiteral(3));
 		    type.getMethod("sum").getBody()
 					.addStatement(0, fact.createCodeSnippetStatement("System.out.println(z);"));
 		};
@@ -636,7 +636,7 @@ public class TestSniperPrinter {
 
 		Consumer<CtType<?>> addElement = type -> {
 			Factory fact = type.getFactory();
-			fact.createField(type, new HashSet<>(), fact.Type().INTEGER_PRIMITIVE, "z", fact.createLiteral(2));
+			fact.createField(type, new HashSet<>(), fact.Type().integerPrimitiveType(), "z", fact.createLiteral(2));
 		};
 		final String newField = "int z = 2;";
 
@@ -659,7 +659,7 @@ public class TestSniperPrinter {
 
 		Consumer<CtType<?>> addField = type -> {
 			Factory fact = type.getFactory();
-			fact.createField(type, new HashSet<>(), fact.Type().INTEGER_PRIMITIVE, "z", fact.createLiteral(3));
+			fact.createField(type, new HashSet<>(), fact.Type().integerPrimitiveType(), "z", fact.createLiteral(3));
 		};
 		testSniper("indentation.NoTypeMembers", addField, (type, result) -> {
 			assertThat(result, containsString("\n\tint z = 3;"));

--- a/src/test/java/spoon/test/processing/ProcessingTest.java
+++ b/src/test/java/spoon/test/processing/ProcessingTest.java
@@ -87,7 +87,7 @@ public class ProcessingTest {
 			assertEquals("int i = 0;", constructor.getBody().getStatement(1).toString(), "insert failed for constructor " + constructor.getSimpleName());
 		}
 
-		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE);
+		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().integerPrimitiveType());
 		String myBeforeStatementAsString = "int before";
 		for (CtSwitch<?> ctSwitch : constructor.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class))) {
 			ctSwitch.insertBefore(type.getFactory().Code()
@@ -120,7 +120,7 @@ public class ProcessingTest {
 			assertEquals("int i = 0", constructor.getBody().getStatement(constructor.getBody().getStatements().size() - 1).toString(), "insert failed for constructor");
 		}
 
-		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().INTEGER_PRIMITIVE);
+		CtConstructor<?> constructor = type.getConstructor(type.getFactory().Type().integerPrimitiveType());
 		String myBeforeStatementAsString = "int after";
 		for (CtSwitch<?> ctSwitch : constructor.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class))) {
 			ctSwitch.insertAfter(type.getFactory().Code()

--- a/src/test/java/spoon/test/reference/TypeReferenceTest.java
+++ b/src/test/java/spoon/test/reference/TypeReferenceTest.java
@@ -521,8 +521,8 @@ public class TypeReferenceTest {
 	@Test
 	public void testShortTypeReference() {
 
-		CtTypeReference<Short> aShort = createFactory().Type().SHORT;
-		CtTypeReference<Short> shortPrimitive = createFactory().Type().SHORT_PRIMITIVE;
+		CtTypeReference<Short> aShort = createFactory().Type().shortType();
+		CtTypeReference<Short> shortPrimitive = createFactory().Type().shortPrimitiveType();
 
 		assertSame(Short.class, aShort.getActualClass());
 		assertSame(short.class, shortPrimitive.getActualClass());
@@ -535,20 +535,20 @@ public class TypeReferenceTest {
 		final CtWildcardReference reference = factory.createWildcardReference();
 		reference.setBoundingType(factory.Type().createReference(String.class));
 
-		assertEquals(factory.Type().STRING, reference.getBoundingType());
+		assertEquals(factory.Type().stringType(), reference.getBoundingType());
 
 		reference.setBoundingType(null);
 
-		assertEquals(factory.Type().OBJECT, reference.getBoundingType());
+		assertEquals(factory.Type().objectType(), reference.getBoundingType());
 		assertTrue(reference.isDefaultBoundingType());
 
 		reference.setBoundingType(factory.Type().createReference(String.class));
 
-		assertEquals(factory.Type().STRING, reference.getBoundingType());
+		assertEquals(factory.Type().stringType(), reference.getBoundingType());
 
 		reference.setBoundingType(factory.Type().objectType());
 
-		assertEquals(factory.Type().OBJECT, reference.getBoundingType());
+		assertEquals(factory.Type().objectType(), reference.getBoundingType());
 		assertTrue(reference.isDefaultBoundingType());
 	}
 

--- a/src/test/java/spoon/test/replace/ReplaceTest.java
+++ b/src/test/java/spoon/test/replace/ReplaceTest.java
@@ -326,11 +326,11 @@ public class ReplaceTest {
 		final CtType<Tacos> aTacos = factory.Type().get(Tacos.class);
 		final CtMethod<?> aMethod = aTacos.getMethodsByName("m").get(0);
 
-		assertEquals(factory.Type().INTEGER_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().integerPrimitiveType(), aMethod.getType());
 
-		aMethod.getType().replace(factory.Type().DOUBLE_PRIMITIVE);
+		aMethod.getType().replace(factory.Type().doublePrimitiveType());
 
-		assertEquals(factory.Type().DOUBLE_PRIMITIVE, aMethod.getType());
+		assertEquals(factory.Type().doublePrimitiveType(), aMethod.getType());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/snippets/SnippetTest.java
+++ b/src/test/java/spoon/test/snippets/SnippetTest.java
@@ -120,7 +120,7 @@ public class SnippetTest {
 		// contract: a snippet with return can be compiled.
 		CtElement el = SnippetCompilationHelper.compileStatement(
 				factory.Code().createCodeSnippetStatement("return 3"),
-				factory.Type().INTEGER
+				factory.Type().integerType()
 		);
 		assertTrue(CtReturn.class.isAssignableFrom(el.getClass()));
 		assertEquals("return 3", el.toString());

--- a/src/test/java/spoon/test/template/TemplateTest.java
+++ b/src/test/java/spoon/test/template/TemplateTest.java
@@ -804,7 +804,7 @@ public class TemplateTest {
 		Factory factory = spoon.getFactory();
 
 		CtClass<?> resultKlass = factory.Class().create("Result");
-		new InvocationTemplate(factory.Type().OBJECT, "hashCode").apply(resultKlass);
+		new InvocationTemplate(factory.Type().objectType(), "hashCode").apply(resultKlass);
 		CtMethod<?> templateMethod = (CtMethod<?>) resultKlass.getElements(new NamedElementFilter<>(CtMethod.class,"invoke")).get(0);
 		CtStatement templateRoot = (CtStatement) templateMethod.getBody().getStatement(0);
 		//iface.$method$() becomes iface.hashCode()
@@ -980,7 +980,7 @@ public class TemplateTest {
 		}
 		{
 			//contract: Type value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT.getTypeDeclaration()).apply(factory.createClass());
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().objectType().getTypeDeclaration()).apply(factory.createClass());
 			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
 			//contract: the parameter of type string replaces substring in method name
 			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
@@ -991,7 +991,7 @@ public class TemplateTest {
 		}
 		{
 			//contract: Type reference value name is substituted in substring of literal, named element and reference
-			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().OBJECT).apply(factory.createClass());
+			final CtClass<?> result = (CtClass<?>) new SubStringTemplate(factory.Type().objectType()).apply(factory.createClass());
 			assertEquals("java.lang.String m_Object = \"Object is here more times: Object\";", result.getField("m_Object").toString());
 			//contract: the parameter of type string replaces substring in method name
 			CtMethod<?> method1 = result.getMethodsByName("setObject").get(0);
@@ -1105,7 +1105,7 @@ public class TemplateTest {
 
 		//contract: String value is substituted in substring of literal, named element and reference
 		CtTypeReference<?> typeRef = factory.Type().createReference("spoon.test.template.TypeReferenceClassAccess$Example");
-		typeRef.addActualTypeArgument(factory.Type().DATE);
+		typeRef.addActualTypeArgument(factory.Type().dateType());
 		
 		final CtClass<?> result = (CtClass<?>) new TypeReferenceClassAccessTemplate(typeRef).apply(factory.Class().create("spoon.test.template.TypeReferenceClassAccess"));
 		spoon.prettyprint();

--- a/src/test/java/spoon/test/variable/VariableTest.java
+++ b/src/test/java/spoon/test/variable/VariableTest.java
@@ -127,10 +127,10 @@ public class VariableTest {
         TypeFactory typeFactory = launcher.getFactory().Type();
 
         assertTrue(localVariables.get(0).isInferred());
-        assertEquals(typeFactory.STRING, localVariables.get(0).getType());
+        assertEquals(typeFactory.stringType(), localVariables.get(0).getType());
 
         assertFalse(localVariables.get(1).isInferred());
-        assertEquals(typeFactory.STRING, localVariables.get(1).getType());
+        assertEquals(typeFactory.stringType(), localVariables.get(1).getType());
 
         assertTrue(localVariables.get(2).isInferred());
         assertEquals("java.io.FileReader", localVariables.get(2).getType().getQualifiedName());
@@ -139,16 +139,16 @@ public class VariableTest {
         assertEquals("java.io.FileReader", localVariables.get(3).getType().getQualifiedName());
 
         assertTrue(localVariables.get(4).isInferred());
-        assertEquals(typeFactory.BOOLEAN_PRIMITIVE, localVariables.get(4).getType());
+        assertEquals(typeFactory.booleanPrimitiveType(), localVariables.get(4).getType());
 
         assertFalse(localVariables.get(5).isInferred());
-        assertEquals(typeFactory.BOOLEAN_PRIMITIVE, localVariables.get(5).getType());
+        assertEquals(typeFactory.booleanPrimitiveType(), localVariables.get(5).getType());
 
         assertTrue(localVariables.get(6).isInferred());
-        assertEquals(typeFactory.INTEGER_PRIMITIVE, localVariables.get(6).getType());
+        assertEquals(typeFactory.integerPrimitiveType(), localVariables.get(6).getType());
 
         assertFalse(localVariables.get(7).isInferred());
-        assertEquals(typeFactory.INTEGER_PRIMITIVE, localVariables.get(7).getType());
+        assertEquals(typeFactory.integerPrimitiveType(), localVariables.get(7).getType());
     }
 
     @Test

--- a/src/test/java/spoon/testing/CtElementAssertTest.java
+++ b/src/test/java/spoon/testing/CtElementAssertTest.java
@@ -37,7 +37,7 @@ public class CtElementAssertTest {
 		final Factory factory = createFactory();
 		final CtField<Integer> expected = factory.Core().createField();
 		expected.setSimpleName("i");
-		expected.setType(factory.Type().INTEGER_PRIMITIVE);
+		expected.setType(factory.Type().integerPrimitiveType());
 		expected.addModifier(ModifierKind.PUBLIC);
 		CtField<?> f = type.getField("i");
 		assertThat(f).isEqualTo(expected);
@@ -65,7 +65,7 @@ public class CtElementAssertTest {
 		}
 		final Factory build = buildNoClasspath(CtElementAssertTest.class);
 		final CtFieldAccess<Class<String>> actual = build.Code().createClassAccess(build.Type().<String>get(String.class).getReference());
-		final CtFieldAccess<Class<java.lang.String>> expected = createFactory().Code().createClassAccess(createFactory().Type().STRING);
+		final CtFieldAccess<Class<java.lang.String>> expected = createFactory().Code().createClassAccess(createFactory().Type().stringType());
 		assertThrows(AssertionError.class, ()-> assertThat(actual).isEqualTo(expected));
 	}
 }


### PR DESCRIPTION
Direct access allows mutating the base object, which should be prevented.