### PR TITLE
fix: Add extra newline after printing enum values

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -797,6 +797,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 						printer.writeln();
 						scan(enumValue);
 					});
+			printer.writeln();
 		}
 
 		elementPrinterHelper.writeElementList(ctEnum.getTypeMembers());

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -294,7 +294,7 @@ public class DefaultPrettyPrinterTest {
 
 		expected =
 			"public enum ENUM {" + nl + nl
-			+ "    E1(spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField, spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1);" + nl
+			+ "    E1(spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.globalField, spoon.test.prettyprinter.testclasses.sub.TypeIdentifierCollision.ENUM.E1);" + nl + nl
 			+ "    final int NUM;" + nl + nl
 			+ "    final Enum<?> e;" + nl + nl
 			+ "    private ENUM(int num, Enum<?> e) {" + nl


### PR DESCRIPTION
This partly solves #4129 by adding an extra newline after printing the enum values.

So instead of printing this:

```java
public enum SimpleEnum {

    CONSTANT;}
```

It now prints this:

```java
public enum SimpleEnum {

    CONSTANT;
}
```

This does have a small impact on enums with members, as previously they would be printed like this:

```java
public enum EnumWithMembers {

    ONE,
    TWO,
    THREE;
    private static int len = -1;

    public static void f() {
        len = 44;
    }
}
```

And now they will be printed like this:

```java
public enum EnumWithMembers {

    ONE,
    TWO,
    THREE;

    private static int len = -1;

    public static void f() {
        len = 44;
    }
}
```

To be honest I prefer the second anyway.