### PR TITLE
review: test: fix AssertJ code generation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,9 +102,9 @@
           '';
           codegen = pkgs.writeScriptBin "codegen" ''
            set -eu
-           mvn test -Dgroups=codegen
+           mvn test -Dtest=spoon.testing.assertions.codegen.AssertJCodegen
            mvn spotless:apply
-           git diff --exit-code || "::error::Generated code is not up to date. Execute mvn test -Dgroups=codegen, mvn spotless:apply and commit your changes."
+           git diff --exit-code || echo "::error::Generated code is not up to date. Execute mvn test -Dtest=spoon.testing.assertions.codegen.AssertJCodegen, mvn spotless:apply and commit your changes."
            '';
           extra = pkgs.writeScriptBin "extra" (if !extraChecks then "exit 2" else ''
             set -eu

--- a/src/test/java/spoon/testing/assertions/CtAbstractInvocationAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtAbstractInvocationAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtAbstractInvocation;
+public class CtAbstractInvocationAssert extends AbstractObjectAssert<CtAbstractInvocationAssert, CtAbstractInvocation<?>> implements CtAbstractInvocationAssertInterface<CtAbstractInvocationAssert, CtAbstractInvocation<?>> {
+	CtAbstractInvocationAssert(CtAbstractInvocation<?> actual) {
+		super(actual, CtAbstractInvocationAssert.class);
+	}
+
+	@Override
+	public CtAbstractInvocationAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtAbstractInvocation<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtAbstractInvocationAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAbstractInvocationAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtAbstractInvocation;
 import spoon.reflect.code.CtExpression;
-interface CtAbstractInvocationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAbstractInvocation<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtAbstractInvocationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAbstractInvocation<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default ListAssert<CtExpression<?>> getArguments() {
 		return Assertions.assertThat(actual().getArguments());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAbstractSwitchAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtAbstractSwitchAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtAbstractSwitch;
+public class CtAbstractSwitchAssert extends AbstractObjectAssert<CtAbstractSwitchAssert, CtAbstractSwitch<?>> implements CtAbstractSwitchAssertInterface<CtAbstractSwitchAssert, CtAbstractSwitch<?>> {
+	CtAbstractSwitchAssert(CtAbstractSwitch<?> actual) {
+		super(actual, CtAbstractSwitchAssert.class);
+	}
+
+	@Override
+	public CtAbstractSwitchAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtAbstractSwitch<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtAbstractSwitchAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAbstractSwitchAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtCase;
-interface CtAbstractSwitchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAbstractSwitch<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtAbstractSwitchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAbstractSwitch<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default ListAssert<CtCase<?>> getCases() {
 		return Assertions.assertThat(actual().getCases());
 	}

--- a/src/test/java/spoon/testing/assertions/CtActualTypeContainerAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtActualTypeContainerAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.reference.CtActualTypeContainer;
+public class CtActualTypeContainerAssert extends AbstractObjectAssert<CtActualTypeContainerAssert, CtActualTypeContainer> implements CtActualTypeContainerAssertInterface<CtActualTypeContainerAssert, CtActualTypeContainer> {
+	CtActualTypeContainerAssert(CtActualTypeContainer actual) {
+		super(actual, CtActualTypeContainerAssert.class);
+	}
+
+	@Override
+	public CtActualTypeContainerAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtActualTypeContainer actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtActualTypeContainerAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtActualTypeContainerAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtTypeReference;
-interface CtActualTypeContainerAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtActualTypeContainer> extends SpoonAssert<A, W> {
+public interface CtActualTypeContainerAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtActualTypeContainer> extends SpoonAssert<A, W> {
 	default ListAssert<CtTypeReference<?>> getActualTypeArguments() {
 		return Assertions.assertThat(actual().getActualTypeArguments());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAnnotationAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAnnotationAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.MapAssert;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.declaration.CtAnnotation;
-interface CtAnnotationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotation<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtAnnotationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotation<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getAnnotationType() {
 		return SpoonAssertions.assertThat(actual().getAnnotationType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAnnotationFieldAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAnnotationFieldAccessAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtAnnotationFieldAccess;
-interface CtAnnotationFieldAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationFieldAccess<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
+public interface CtAnnotationFieldAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationFieldAccess<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
 	default CtFieldReferenceAssertInterface<?, ?> getVariable() {
 		return SpoonAssertions.assertThat(actual().getVariable());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAnnotationMethodAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAnnotationMethodAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtAnnotationMethod;
-interface CtAnnotationMethodAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationMethod<?>> extends SpoonAssert<A, W> , CtMethodAssertInterface<A, W> {
+public interface CtAnnotationMethodAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationMethod<?>> extends SpoonAssert<A, W> , CtMethodAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getDefaultExpression() {
 		return SpoonAssertions.assertThat(actual().getDefaultExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAnnotationTypeAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAnnotationTypeAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtAnnotationType;
-interface CtAnnotationTypeAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationType<?>> extends SpoonAssert<A, W> , CtTypeAssertInterface<A, W> {}
+public interface CtAnnotationTypeAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnnotationType<?>> extends SpoonAssert<A, W> , CtTypeAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtAnonymousExecutableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAnonymousExecutableAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtAnonymousExecutable;
-interface CtAnonymousExecutableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnonymousExecutable> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {}
+public interface CtAnonymousExecutableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAnonymousExecutable> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtArrayAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtArrayAccessAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtArrayAccess;
-interface CtArrayAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayAccess<?, ?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
+public interface CtArrayAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayAccess<?, ?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getIndexExpression() {
 		return SpoonAssertions.assertThat(actual().getIndexExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtArrayReadAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtArrayReadAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtArrayRead;
-interface CtArrayReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayRead<?>> extends SpoonAssert<A, W> , CtArrayAccessAssertInterface<A, W> {}
+public interface CtArrayReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayRead<?>> extends SpoonAssert<A, W> , CtArrayAccessAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtArrayTypeReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtArrayTypeReferenceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.reference.CtArrayTypeReference;
-interface CtArrayTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayTypeReference<?>> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtArrayTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayTypeReference<?>> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getComponentType() {
 		return SpoonAssertions.assertThat(actual().getComponentType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtArrayWriteAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtArrayWriteAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtArrayWrite;
-interface CtArrayWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayWrite<?>> extends SpoonAssert<A, W> , CtArrayAccessAssertInterface<A, W> {}
+public interface CtArrayWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtArrayWrite<?>> extends SpoonAssert<A, W> , CtArrayAccessAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtAssertAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAssertAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtAssert;
-interface CtAssertAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAssert<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtAssertAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAssert<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getAssertExpression() {
 		return SpoonAssertions.assertThat(actual().getAssertExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtAssignmentAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtAssignmentAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtAssignment;
-interface CtAssignmentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAssignment<?, ?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtRHSReceiverAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtAssignmentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtAssignment<?, ?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtRHSReceiverAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getAssigned() {
 		return SpoonAssertions.assertThat(actual().getAssigned());
 	}

--- a/src/test/java/spoon/testing/assertions/CtBinaryOperatorAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtBinaryOperatorAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
-interface CtBinaryOperatorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBinaryOperator<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtBinaryOperatorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBinaryOperator<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default ObjectAssert<BinaryOperatorKind> getKind() {
 		return Assertions.assertThatObject(actual().getKind());
 	}

--- a/src/test/java/spoon/testing/assertions/CtBlockAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtBlockAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtBlock;
-interface CtBlockAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBlock<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtStatementListAssertInterface<A, W> {}
+public interface CtBlockAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBlock<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtStatementListAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtBodyHolderAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtBodyHolderAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtBodyHolder;
+public class CtBodyHolderAssert extends AbstractObjectAssert<CtBodyHolderAssert, CtBodyHolder> implements CtBodyHolderAssertInterface<CtBodyHolderAssert, CtBodyHolder> {
+	CtBodyHolderAssert(CtBodyHolder actual) {
+		super(actual, CtBodyHolderAssert.class);
+	}
+
+	@Override
+	public CtBodyHolderAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtBodyHolder actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtBodyHolderAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtBodyHolderAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtBodyHolder;
-interface CtBodyHolderAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBodyHolder> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtBodyHolderAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBodyHolder> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtStatementAssertInterface<?, ?> getBody() {
 		return SpoonAssertions.assertThat(actual().getBody());
 	}

--- a/src/test/java/spoon/testing/assertions/CtBreakAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtBreakAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtBreak;
-interface CtBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBreak> extends SpoonAssert<A, W> , CtLabelledFlowBreakAssertInterface<A, W> {}
+public interface CtBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtBreak> extends SpoonAssert<A, W> , CtLabelledFlowBreakAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtCFlowBreakAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtCFlowBreakAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtCFlowBreak;
+public class CtCFlowBreakAssert extends AbstractObjectAssert<CtCFlowBreakAssert, CtCFlowBreak> implements CtCFlowBreakAssertInterface<CtCFlowBreakAssert, CtCFlowBreak> {
+	CtCFlowBreakAssert(CtCFlowBreak actual) {
+		super(actual, CtCFlowBreakAssert.class);
+	}
+
+	@Override
+	public CtCFlowBreakAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtCFlowBreak actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtCFlowBreakAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCFlowBreakAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCFlowBreak;
-interface CtCFlowBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCFlowBreak> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {}
+public interface CtCFlowBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCFlowBreak> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtCaseAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCaseAssertInterface.java
@@ -1,4 +1,5 @@
 package spoon.testing.assertions;
+import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
@@ -6,12 +7,16 @@ import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.CaseKind;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtExpression;
-interface CtCaseAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCase<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtStatementListAssertInterface<A, W> {
+public interface CtCaseAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCase<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtStatementListAssertInterface<A, W> {
 	default ListAssert<CtExpression<?>> getCaseExpressions() {
 		return Assertions.assertThat(actual().getCaseExpressions());
 	}
 
 	default ObjectAssert<CaseKind> getCaseKind() {
 		return Assertions.assertThatObject(actual().getCaseKind());
+	}
+
+	default AbstractBooleanAssert<?> getIncludesDefault() {
+		return Assertions.assertThat(actual().getIncludesDefault());
 	}
 }

--- a/src/test/java/spoon/testing/assertions/CtCasePatternAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtCasePatternAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtCasePattern;
+public class CtCasePatternAssert extends AbstractObjectAssert<CtCasePatternAssert, CtCasePattern> implements CtCasePatternAssertInterface<CtCasePatternAssert, CtCasePattern> {
+	CtCasePatternAssert(CtCasePattern actual) {
+		super(actual, CtCasePatternAssert.class);
+	}
+
+	@Override
+	public CtCasePatternAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtCasePattern actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtCasePatternAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCasePatternAssertInterface.java
@@ -1,0 +1,12 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtCasePattern;
+public interface CtCasePatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCasePattern> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+	default CtExpressionAssertInterface<?, ?> getGuard() {
+		return SpoonAssertions.assertThat(actual().getGuard());
+	}
+
+	default CtPatternAssertInterface<?, ?> getPattern() {
+		return SpoonAssertions.assertThat(actual().getPattern());
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtCatchAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCatchAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCatch;
-interface CtCatchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatch> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
+public interface CtCatchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatch> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
 	default CtBlockAssertInterface<?, ?> getBody() {
 		return SpoonAssertions.assertThat(actual().getBody());
 	}

--- a/src/test/java/spoon/testing/assertions/CtCatchVariableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCatchVariableAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCatchVariable;
-interface CtCatchVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatchVariable<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtMultiTypedElementAssertInterface<A, W> , CtCodeElementAssertInterface<A, W> {
+public interface CtCatchVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatchVariable<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtMultiTypedElementAssertInterface<A, W> , CtCodeElementAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getType() {
 		return SpoonAssertions.assertThat(actual().getType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtCatchVariableReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCatchVariableReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtCatchVariableReference;
-interface CtCatchVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatchVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtCatchVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCatchVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtClassAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtClassAssertInterface.java
@@ -7,7 +7,7 @@ import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtConstructor;
-interface CtClassAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtClass<?>> extends CtSealableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtTypeAssertInterface<A, W> {
+public interface CtClassAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtClass<?>> extends CtSealableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtTypeAssertInterface<A, W> {
 	default ListAssert<CtAnonymousExecutable> getAnonymousExecutables() {
 		return Assertions.assertThat(actual().getAnonymousExecutables());
 	}

--- a/src/test/java/spoon/testing/assertions/CtCodeElementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCodeElementAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCodeElement;
-interface CtCodeElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtCodeElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtCodeSnippetAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtCodeSnippetAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtCodeSnippet;
+public class CtCodeSnippetAssert extends AbstractObjectAssert<CtCodeSnippetAssert, CtCodeSnippet> implements CtCodeSnippetAssertInterface<CtCodeSnippetAssert, CtCodeSnippet> {
+	CtCodeSnippetAssert(CtCodeSnippet actual) {
+		super(actual, CtCodeSnippetAssert.class);
+	}
+
+	@Override
+	public CtCodeSnippetAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtCodeSnippet actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtCodeSnippetAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCodeSnippetAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtCodeSnippet;
-interface CtCodeSnippetAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippet> extends SpoonAssert<A, W> {
+public interface CtCodeSnippetAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippet> extends SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getValue() {
 		return Assertions.assertThat(actual().getValue());
 	}

--- a/src/test/java/spoon/testing/assertions/CtCodeSnippetExpressionAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCodeSnippetExpressionAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCodeSnippetExpression;
-interface CtCodeSnippetExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippetExpression<?>> extends CtCodeSnippetAssertInterface<A, W> , SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {}
+public interface CtCodeSnippetExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippetExpression<?>> extends CtCodeSnippetAssertInterface<A, W> , SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtCodeSnippetStatementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCodeSnippetStatementAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtCodeSnippetStatement;
-interface CtCodeSnippetStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippetStatement> extends CtCodeSnippetAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {}
+public interface CtCodeSnippetStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCodeSnippetStatement> extends CtCodeSnippetAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtCommentAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCommentAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.CtComment;
-interface CtCommentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtComment> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtCommentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtComment> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default ObjectAssert<CtComment.CommentType> getCommentType() {
 		return Assertions.assertThatObject(actual().getCommentType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtCompilationUnitAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtCompilationUnitAssertInterface.java
@@ -6,7 +6,7 @@ import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.reference.CtTypeReference;
-interface CtCompilationUnitAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCompilationUnit> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtCompilationUnitAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtCompilationUnit> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtModuleAssertInterface<?, ?> getDeclaredModule() {
 		return SpoonAssertions.assertThat(actual().getDeclaredModule());
 	}

--- a/src/test/java/spoon/testing/assertions/CtConditionalAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtConditionalAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtConditional;
-interface CtConditionalAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConditional<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtConditionalAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConditional<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getCondition() {
 		return SpoonAssertions.assertThat(actual().getCondition());
 	}

--- a/src/test/java/spoon/testing/assertions/CtConstructorAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtConstructorAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtConstructor;
-interface CtConstructorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConstructor<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtConstructorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConstructor<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
 	default AbstractStringAssert<?> getSimpleName() {
 		return Assertions.assertThat(actual().getSimpleName());
 	}

--- a/src/test/java/spoon/testing/assertions/CtConstructorCallAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtConstructorCallAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.reference.CtTypeReference;
-interface CtConstructorCallAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConstructorCall<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtStatementAssertInterface<A, W> , CtTargetedExpressionAssertInterface<A, W> , CtAbstractInvocationAssertInterface<A, W> {
+public interface CtConstructorCallAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtConstructorCall<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtStatementAssertInterface<A, W> , CtTargetedExpressionAssertInterface<A, W> , CtAbstractInvocationAssertInterface<A, W> {
 	default ListAssert<CtTypeReference<?>> getActualTypeArguments() {
 		return Assertions.assertThat(actual().getActualTypeArguments());
 	}

--- a/src/test/java/spoon/testing/assertions/CtContinueAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtContinueAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtContinue;
-interface CtContinueAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtContinue> extends SpoonAssert<A, W> , CtLabelledFlowBreakAssertInterface<A, W> {}
+public interface CtContinueAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtContinue> extends SpoonAssert<A, W> , CtLabelledFlowBreakAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtDoAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtDoAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtDo;
-interface CtDoAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtDo> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
+public interface CtDoAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtDo> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getLoopingExpression() {
 		return SpoonAssertions.assertThat(actual().getLoopingExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtElementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtElementAssertInterface.java
@@ -9,7 +9,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
-interface CtElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtElement> extends SpoonAssert<A, W> {
+public interface CtElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtElement> extends SpoonAssert<A, W> {
 	default ListAssert<CtAnnotation<? extends Annotation>> getAnnotations() {
 		return Assertions.assertThat(actual().getAnnotations());
 	}

--- a/src/test/java/spoon/testing/assertions/CtEnumAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtEnumAssertInterface.java
@@ -7,7 +7,7 @@ import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.reference.CtTypeReference;
-interface CtEnumAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtEnum<?>> extends SpoonAssert<A, W> , CtClassAssertInterface<A, W> {
+public interface CtEnumAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtEnum<?>> extends SpoonAssert<A, W> , CtClassAssertInterface<A, W> {
 	default ListAssert<CtEnumValue<?>> getEnumValues() {
 		return Assertions.assertThat(actual().getEnumValues());
 	}

--- a/src/test/java/spoon/testing/assertions/CtEnumValueAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtEnumValueAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtEnumValue;
-interface CtEnumValueAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtEnumValue<?>> extends SpoonAssert<A, W> , CtFieldAssertInterface<A, W> {}
+public interface CtEnumValueAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtEnumValue<?>> extends SpoonAssert<A, W> , CtFieldAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtExecutableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtExecutableAssertInterface.java
@@ -7,7 +7,7 @@ import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.reference.CtTypeReference;
-interface CtExecutableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutable<?>> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> {
+public interface CtExecutableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutable<?>> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> {
 	default CtBlockAssertInterface<?, ?> getBody() {
 		return SpoonAssertions.assertThat(actual().getBody());
 	}

--- a/src/test/java/spoon/testing/assertions/CtExecutableReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtExecutableReferenceAssertInterface.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
-interface CtExecutableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutableReference<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtReferenceAssertInterface<A, W> {
+public interface CtExecutableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutableReference<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtReferenceAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getDeclaringType() {
 		return SpoonAssertions.assertThat(actual().getDeclaringType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtExecutableReferenceExpressionAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtExecutableReferenceExpressionAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtExecutableReferenceExpression;
-interface CtExecutableReferenceExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutableReferenceExpression<?, ?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
+public interface CtExecutableReferenceExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExecutableReferenceExpression<?, ?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
 	default CtExecutableReferenceAssertInterface<?, ?> getExecutable() {
 		return SpoonAssertions.assertThat(actual().getExecutable());
 	}

--- a/src/test/java/spoon/testing/assertions/CtExpressionAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtExpressionAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.reference.CtTypeReference;
-interface CtExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExpression<?>> extends SpoonAssert<A, W> , CtTypedElementAssertInterface<A, W> , CtCodeElementAssertInterface<A, W> {
+public interface CtExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtExpression<?>> extends SpoonAssert<A, W> , CtTypedElementAssertInterface<A, W> , CtCodeElementAssertInterface<A, W> {
 	default ListAssert<CtTypeReference<?>> getTypeCasts() {
 		return Assertions.assertThat(actual().getTypeCasts());
 	}

--- a/src/test/java/spoon/testing/assertions/CtFieldAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFieldAccessAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtFieldAccess;
-interface CtFieldAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldAccess<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
+public interface CtFieldAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldAccess<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
 	default CtFieldReferenceAssertInterface<?, ?> getVariable() {
 		return SpoonAssertions.assertThat(actual().getVariable());
 	}

--- a/src/test/java/spoon/testing/assertions/CtFieldAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFieldAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtField;
-interface CtFieldAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtField<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtRHSReceiverAssertInterface<A, W> , CtShadowableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {}
+public interface CtFieldAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtField<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtRHSReceiverAssertInterface<A, W> , CtShadowableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtFieldReadAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFieldReadAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtFieldRead;
-interface CtFieldReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldRead<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtFieldAccessAssertInterface<A, W> {}
+public interface CtFieldReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldRead<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtFieldAccessAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtFieldReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFieldReferenceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.reference.CtFieldReference;
-interface CtFieldReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtFieldReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getDeclaringType() {
 		return SpoonAssertions.assertThat(actual().getDeclaringType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtFieldWriteAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFieldWriteAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtFieldWrite;
-interface CtFieldWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldWrite<?>> extends SpoonAssert<A, W> , CtVariableWriteAssertInterface<A, W> , CtFieldAccessAssertInterface<A, W> {}
+public interface CtFieldWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFieldWrite<?>> extends SpoonAssert<A, W> , CtVariableWriteAssertInterface<A, W> , CtFieldAccessAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtForAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtForAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtStatement;
-interface CtForAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFor> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
+public interface CtForAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFor> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getExpression() {
 		return SpoonAssertions.assertThat(actual().getExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtForEachAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtForEachAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtForEach;
-interface CtForEachAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtForEach> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
+public interface CtForEachAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtForEach> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getExpression() {
 		return SpoonAssertions.assertThat(actual().getExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtFormalTypeDeclarerAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtFormalTypeDeclarerAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
+public class CtFormalTypeDeclarerAssert extends AbstractObjectAssert<CtFormalTypeDeclarerAssert, CtFormalTypeDeclarer> implements CtFormalTypeDeclarerAssertInterface<CtFormalTypeDeclarerAssert, CtFormalTypeDeclarer> {
+	CtFormalTypeDeclarerAssert(CtFormalTypeDeclarer actual) {
+		super(actual, CtFormalTypeDeclarerAssert.class);
+	}
+
+	@Override
+	public CtFormalTypeDeclarerAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtFormalTypeDeclarer actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtFormalTypeDeclarerAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtFormalTypeDeclarerAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtTypeParameter;
-interface CtFormalTypeDeclarerAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFormalTypeDeclarer> extends SpoonAssert<A, W> , CtTypeMemberAssertInterface<A, W> {
+public interface CtFormalTypeDeclarerAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtFormalTypeDeclarer> extends SpoonAssert<A, W> , CtTypeMemberAssertInterface<A, W> {
 	default ListAssert<CtTypeParameter> getFormalCtTypeParameters() {
 		return Assertions.assertThat(actual().getFormalCtTypeParameters());
 	}

--- a/src/test/java/spoon/testing/assertions/CtIfAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtIfAssertInterface.java
@@ -2,7 +2,7 @@ package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
-interface CtIfAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtIf> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtIfAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtIf> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getCondition() {
 		return SpoonAssertions.assertThat(actual().getCondition());
 	}

--- a/src/test/java/spoon/testing/assertions/CtImportAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtImportAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtImport;
-interface CtImportAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtImport> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtImportAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtImport> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtReferenceAssertInterface<?, ?> getReference() {
 		return SpoonAssertions.assertThat(actual().getReference());
 	}

--- a/src/test/java/spoon/testing/assertions/CtInterfaceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtInterfaceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtInterface;
-interface CtInterfaceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtInterface<?>> extends CtSealableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtTypeAssertInterface<A, W> {
+public interface CtInterfaceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtInterface<?>> extends CtSealableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtTypeAssertInterface<A, W> {
 	default AbstractStringAssert<?> getLabel() {
 		return Assertions.assertThat(actual().getLabel());
 	}

--- a/src/test/java/spoon/testing/assertions/CtIntersectionTypeReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtIntersectionTypeReferenceAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.reference.CtIntersectionTypeReference;
 import spoon.reflect.reference.CtTypeReference;
-interface CtIntersectionTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtIntersectionTypeReference<?>> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtIntersectionTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtIntersectionTypeReference<?>> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {
 	default ListAssert<CtTypeReference<?>> getBounds() {
 		return Assertions.assertThat(actual().getBounds());
 	}

--- a/src/test/java/spoon/testing/assertions/CtInvocationAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtInvocationAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.reference.CtTypeReference;
-interface CtInvocationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtInvocation<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtStatementAssertInterface<A, W> , CtTargetedExpressionAssertInterface<A, W> , CtAbstractInvocationAssertInterface<A, W> {
+public interface CtInvocationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtInvocation<?>> extends SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtStatementAssertInterface<A, W> , CtTargetedExpressionAssertInterface<A, W> , CtAbstractInvocationAssertInterface<A, W> {
 	default ListAssert<CtTypeReference<?>> getActualTypeArguments() {
 		return Assertions.assertThat(actual().getActualTypeArguments());
 	}

--- a/src/test/java/spoon/testing/assertions/CtJavaDocAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtJavaDocAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
-interface CtJavaDocAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtJavaDoc> extends SpoonAssert<A, W> , CtCommentAssertInterface<A, W> {
+public interface CtJavaDocAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtJavaDoc> extends SpoonAssert<A, W> , CtCommentAssertInterface<A, W> {
 	default ListAssert<CtJavaDocTag> getTags() {
 		return Assertions.assertThat(actual().getTags());
 	}

--- a/src/test/java/spoon/testing/assertions/CtJavaDocTagAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtJavaDocTagAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.CtJavaDocTag;
-interface CtJavaDocTagAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtJavaDocTag> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtJavaDocTagAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtJavaDocTag> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getContent() {
 		return Assertions.assertThat(actual().getContent());
 	}

--- a/src/test/java/spoon/testing/assertions/CtLabelledFlowBreakAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtLabelledFlowBreakAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtLabelledFlowBreak;
+public class CtLabelledFlowBreakAssert extends AbstractObjectAssert<CtLabelledFlowBreakAssert, CtLabelledFlowBreak> implements CtLabelledFlowBreakAssertInterface<CtLabelledFlowBreakAssert, CtLabelledFlowBreak> {
+	CtLabelledFlowBreakAssert(CtLabelledFlowBreak actual) {
+		super(actual, CtLabelledFlowBreakAssert.class);
+	}
+
+	@Override
+	public CtLabelledFlowBreakAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtLabelledFlowBreak actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtLabelledFlowBreakAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLabelledFlowBreakAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.code.CtLabelledFlowBreak;
-interface CtLabelledFlowBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLabelledFlowBreak> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtLabelledFlowBreakAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLabelledFlowBreak> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getTargetLabel() {
 		return Assertions.assertThat(actual().getTargetLabel());
 	}

--- a/src/test/java/spoon/testing/assertions/CtLambdaAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLambdaAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtLambda;
-interface CtLambdaAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLambda<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtLambdaAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLambda<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getExpression() {
 		return SpoonAssertions.assertThat(actual().getExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtLiteralAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLiteralAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.LiteralBase;
-interface CtLiteralAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLiteral<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtLiteralAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLiteral<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default ObjectAssert<LiteralBase> getBase() {
 		return Assertions.assertThatObject(actual().getBase());
 	}

--- a/src/test/java/spoon/testing/assertions/CtLocalVariableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLocalVariableAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.code.CtLocalVariable;
-interface CtLocalVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLocalVariable<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtRHSReceiverAssertInterface<A, W> , CtResourceAssertInterface<A, W> {
+public interface CtLocalVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLocalVariable<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtRHSReceiverAssertInterface<A, W> , CtResourceAssertInterface<A, W> {
 	default AbstractBooleanAssert<?> isInferred() {
 		return Assertions.assertThat(actual().isInferred());
 	}

--- a/src/test/java/spoon/testing/assertions/CtLocalVariableReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLocalVariableReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtLocalVariableReference;
-interface CtLocalVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLocalVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtLocalVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLocalVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtLoopAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtLoopAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtLoop;
-interface CtLoopAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLoop> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtLoopAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtLoop> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default CtStatementAssertInterface<?, ?> getBody() {
 		return SpoonAssertions.assertThat(actual().getBody());
 	}

--- a/src/test/java/spoon/testing/assertions/CtMethodAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtMethodAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtMethod;
-interface CtMethodAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtMethod<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtMethodAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtMethod<?>> extends SpoonAssert<A, W> , CtExecutableAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
 	default AbstractBooleanAssert<?> isDefaultMethod() {
 		return Assertions.assertThat(actual().isDefaultMethod());
 	}

--- a/src/test/java/spoon/testing/assertions/CtModifiableAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtModifiableAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtModifiable;
+public class CtModifiableAssert extends AbstractObjectAssert<CtModifiableAssert, CtModifiable> implements CtModifiableAssertInterface<CtModifiableAssert, CtModifiable> {
+	CtModifiableAssert(CtModifiable actual) {
+		super(actual, CtModifiableAssert.class);
+	}
+
+	@Override
+	public CtModifiableAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtModifiable actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtModifiableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtModifiableAssertInterface.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.support.reflect.CtExtendedModifier;
-interface CtModifiableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModifiable> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtModifiableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModifiable> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractCollectionAssert<?, Collection<? extends CtExtendedModifier>, CtExtendedModifier, ?> getExtendedModifiers() {
 		return Assertions.assertThat(actual().getExtendedModifiers());
 	}

--- a/src/test/java/spoon/testing/assertions/CtModuleAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtModuleAssertInterface.java
@@ -9,7 +9,7 @@ import spoon.reflect.declaration.CtModuleRequirement;
 import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtUsedService;
-interface CtModuleAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModule> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> {
+public interface CtModuleAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModule> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> {
 	default ListAssert<CtPackageExport> getExportedPackages() {
 		return Assertions.assertThat(actual().getExportedPackages());
 	}

--- a/src/test/java/spoon/testing/assertions/CtModuleDirectiveAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtModuleDirectiveAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtModuleDirective;
+public class CtModuleDirectiveAssert extends AbstractObjectAssert<CtModuleDirectiveAssert, CtModuleDirective> implements CtModuleDirectiveAssertInterface<CtModuleDirectiveAssert, CtModuleDirective> {
+	CtModuleDirectiveAssert(CtModuleDirective actual) {
+		super(actual, CtModuleDirectiveAssert.class);
+	}
+
+	@Override
+	public CtModuleDirectiveAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtModuleDirective actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtModuleDirectiveAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtModuleDirectiveAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtModuleDirective;
-interface CtModuleDirectiveAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleDirective> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtModuleDirectiveAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleDirective> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtModuleReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtModuleReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtModuleReference;
-interface CtModuleReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {}
+public interface CtModuleReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtModuleRequirementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtModuleRequirementAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.AbstractCollectionAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtModuleRequirement;
-interface CtModuleRequirementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleRequirement> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
+public interface CtModuleRequirementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtModuleRequirement> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
 	default CtModuleReferenceAssertInterface<?, ?> getModuleReference() {
 		return SpoonAssertions.assertThat(actual().getModuleReference());
 	}

--- a/src/test/java/spoon/testing/assertions/CtMultiTypedElementAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtMultiTypedElementAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtMultiTypedElement;
+public class CtMultiTypedElementAssert extends AbstractObjectAssert<CtMultiTypedElementAssert, CtMultiTypedElement> implements CtMultiTypedElementAssertInterface<CtMultiTypedElementAssert, CtMultiTypedElement> {
+	CtMultiTypedElementAssert(CtMultiTypedElement actual) {
+		super(actual, CtMultiTypedElementAssert.class);
+	}
+
+	@Override
+	public CtMultiTypedElementAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtMultiTypedElement actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtMultiTypedElementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtMultiTypedElementAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtMultiTypedElement;
 import spoon.reflect.reference.CtTypeReference;
-interface CtMultiTypedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtMultiTypedElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtMultiTypedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtMultiTypedElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default ListAssert<CtTypeReference<?>> getMultiTypes() {
 		return Assertions.assertThat(actual().getMultiTypes());
 	}

--- a/src/test/java/spoon/testing/assertions/CtNamedElementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtNamedElementAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtNamedElement;
-interface CtNamedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNamedElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtNamedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNamedElement> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getSimpleName() {
 		return Assertions.assertThat(actual().getSimpleName());
 	}

--- a/src/test/java/spoon/testing/assertions/CtNewArrayAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtNewArrayAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtNewArray;
-interface CtNewArrayAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNewArray<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtNewArrayAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNewArray<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default ListAssert<CtExpression<Integer>> getDimensionExpressions() {
 		return Assertions.assertThat(actual().getDimensionExpressions());
 	}

--- a/src/test/java/spoon/testing/assertions/CtNewClassAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtNewClassAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.reference.CtTypeReference;
-interface CtNewClassAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNewClass<?>> extends SpoonAssert<A, W> , CtConstructorCallAssertInterface<A, W> {
+public interface CtNewClassAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtNewClass<?>> extends SpoonAssert<A, W> , CtConstructorCallAssertInterface<A, W> {
 	default ListAssert<CtTypeReference<?>> getActualTypeArguments() {
 		return Assertions.assertThat(actual().getActualTypeArguments());
 	}

--- a/src/test/java/spoon/testing/assertions/CtOperatorAssignmentAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtOperatorAssignmentAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtOperatorAssignment;
-interface CtOperatorAssignmentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtOperatorAssignment<?, ?>> extends SpoonAssert<A, W> , CtAssignmentAssertInterface<A, W> {
+public interface CtOperatorAssignmentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtOperatorAssignment<?, ?>> extends SpoonAssert<A, W> , CtAssignmentAssertInterface<A, W> {
 	default ObjectAssert<BinaryOperatorKind> getKind() {
 		return Assertions.assertThatObject(actual().getKind());
 	}

--- a/src/test/java/spoon/testing/assertions/CtPackageAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtPackageAssertInterface.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
-interface CtPackageAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackage> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtPackageAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackage> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
 	default AbstractCollectionAssert<?, Collection<? extends CtPackage>, CtPackage, ?> getPackages() {
 		return Assertions.assertThat(actual().getPackages());
 	}

--- a/src/test/java/spoon/testing/assertions/CtPackageDeclarationAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtPackageDeclarationAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtPackageDeclaration;
-interface CtPackageDeclarationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageDeclaration> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtPackageDeclarationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageDeclaration> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtPackageReferenceAssertInterface<?, ?> getReference() {
 		return SpoonAssertions.assertThat(actual().getReference());
 	}

--- a/src/test/java/spoon/testing/assertions/CtPackageExportAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtPackageExportAssertInterface.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtPackageExport;
 import spoon.reflect.reference.CtModuleReference;
-interface CtPackageExportAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageExport> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
+public interface CtPackageExportAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageExport> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
 	default CtPackageReferenceAssertInterface<?, ?> getPackageReference() {
 		return SpoonAssertions.assertThat(actual().getPackageReference());
 	}

--- a/src/test/java/spoon/testing/assertions/CtPackageReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtPackageReferenceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.reference.CtPackageReference;
-interface CtPackageReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
+public interface CtPackageReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPackageReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
 	default AbstractStringAssert<?> getSimpleName() {
 		return Assertions.assertThat(actual().getSimpleName());
 	}

--- a/src/test/java/spoon/testing/assertions/CtParameterAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtParameterAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtParameter;
-interface CtParameterAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtParameter<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtParameterAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtParameter<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> , CtShadowableAssertInterface<A, W> {
 	default AbstractBooleanAssert<?> isInferred() {
 		return Assertions.assertThat(actual().isInferred());
 	}

--- a/src/test/java/spoon/testing/assertions/CtParameterReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtParameterReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtParameterReference;
-interface CtParameterReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtParameterReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtParameterReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtParameterReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtPatternAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtPatternAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtPattern;
+public class CtPatternAssert extends AbstractObjectAssert<CtPatternAssert, CtPattern> implements CtPatternAssertInterface<CtPatternAssert, CtPattern> {
+	CtPatternAssert(CtPattern actual) {
+		super(actual, CtPatternAssert.class);
+	}
+
+	@Override
+	public CtPatternAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtPattern actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtPatternAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtPatternAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtPattern;
-interface CtPatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPattern> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtPatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtPattern> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtProvidedServiceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtProvidedServiceAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.reference.CtTypeReference;
-interface CtProvidedServiceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtProvidedService> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
+public interface CtProvidedServiceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtProvidedService> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
 	default ListAssert<CtTypeReference> getImplementationTypes() {
 		return Assertions.assertThat(actual().getImplementationTypes());
 	}

--- a/src/test/java/spoon/testing/assertions/CtRHSReceiverAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtRHSReceiverAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtRHSReceiver;
+public class CtRHSReceiverAssert extends AbstractObjectAssert<CtRHSReceiverAssert, CtRHSReceiver<?>> implements CtRHSReceiverAssertInterface<CtRHSReceiverAssert, CtRHSReceiver<?>> {
+	CtRHSReceiverAssert(CtRHSReceiver<?> actual) {
+		super(actual, CtRHSReceiverAssert.class);
+	}
+
+	@Override
+	public CtRHSReceiverAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtRHSReceiver<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtRHSReceiverAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtRHSReceiverAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtRHSReceiver;
-interface CtRHSReceiverAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRHSReceiver<?>> extends SpoonAssert<A, W> {
+public interface CtRHSReceiverAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRHSReceiver<?>> extends SpoonAssert<A, W> {
 	default CtExpressionAssertInterface<?, ?> getAssignment() {
 		return SpoonAssertions.assertThat(actual().getAssignment());
 	}

--- a/src/test/java/spoon/testing/assertions/CtRecordAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtRecordAssertInterface.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtRecord;
 import spoon.reflect.declaration.CtRecordComponent;
 import spoon.reflect.reference.CtTypeReference;
-interface CtRecordAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRecord> extends SpoonAssert<A, W> , CtClassAssertInterface<A, W> {
+public interface CtRecordAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRecord> extends SpoonAssert<A, W> , CtClassAssertInterface<A, W> {
 	default AbstractCollectionAssert<?, Collection<? extends CtTypeReference<?>>, CtTypeReference<?>, ?> getPermittedTypes() {
 		return Assertions.assertThat(actual().getPermittedTypes());
 	}

--- a/src/test/java/spoon/testing/assertions/CtRecordComponentAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtRecordComponentAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtRecordComponent;
-interface CtRecordComponentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRecordComponent> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {}
+public interface CtRecordComponentAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRecordComponent> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtRecordPatternAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtRecordPatternAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtRecordPattern;
+public class CtRecordPatternAssert extends AbstractObjectAssert<CtRecordPatternAssert, CtRecordPattern> implements CtRecordPatternAssertInterface<CtRecordPatternAssert, CtRecordPattern> {
+	CtRecordPatternAssert(CtRecordPattern actual) {
+		super(actual, CtRecordPatternAssert.class);
+	}
+
+	@Override
+	public CtRecordPatternAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtRecordPattern actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtRecordPatternAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtRecordPatternAssertInterface.java
@@ -1,0 +1,20 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+import spoon.reflect.code.CtPattern;
+import spoon.reflect.code.CtRecordPattern;
+import spoon.reflect.reference.CtTypeReference;
+public interface CtRecordPatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtRecordPattern> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtPatternAssertInterface<A, W> {
+	default ListAssert<CtPattern> getPatternList() {
+		return Assertions.assertThat(actual().getPatternList());
+	}
+
+	default CtTypeReferenceAssertInterface<?, ?> getRecordType() {
+		return SpoonAssertions.assertThat(actual().getRecordType());
+	}
+
+	default ListAssert<CtTypeReference<?>> getTypeCasts() {
+		return Assertions.assertThat(actual().getTypeCasts());
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.reference.CtReference;
-interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReference> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReference> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getSimpleName() {
 		return Assertions.assertThat(actual().getSimpleName());
 	}

--- a/src/test/java/spoon/testing/assertions/CtResourceAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtResourceAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.code.CtResource;
+public class CtResourceAssert extends AbstractObjectAssert<CtResourceAssert, CtResource<?>> implements CtResourceAssertInterface<CtResourceAssert, CtResource<?>> {
+	CtResourceAssert(CtResource<?> actual) {
+		super(actual, CtResourceAssert.class);
+	}
+
+	@Override
+	public CtResourceAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtResource<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtResourceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtResourceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtResource;
-interface CtResourceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtResource<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtResourceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtResource<?>> extends CtVariableAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtReturnAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReturnAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtReturn;
-interface CtReturnAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReturn<?>> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtReturnAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReturn<?>> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtExpressionAssertInterface<?, ?> getReturnedExpression() {
 		return SpoonAssertions.assertThat(actual().getReturnedExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtSealableAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtSealableAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtSealable;
+public class CtSealableAssert extends AbstractObjectAssert<CtSealableAssert, CtSealable> implements CtSealableAssertInterface<CtSealableAssert, CtSealable> {
+	CtSealableAssert(CtSealable actual) {
+		super(actual, CtSealableAssert.class);
+	}
+
+	@Override
+	public CtSealableAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtSealable actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtSealableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtSealableAssertInterface.java
@@ -5,7 +5,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtSealable;
 import spoon.reflect.reference.CtTypeReference;
-interface CtSealableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSealable> extends SpoonAssert<A, W> {
+public interface CtSealableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSealable> extends SpoonAssert<A, W> {
 	default AbstractCollectionAssert<?, Collection<? extends CtTypeReference<?>>, CtTypeReference<?>, ?> getPermittedTypes() {
 		return Assertions.assertThat(actual().getPermittedTypes());
 	}

--- a/src/test/java/spoon/testing/assertions/CtShadowableAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtShadowableAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtShadowable;
+public class CtShadowableAssert extends AbstractObjectAssert<CtShadowableAssert, CtShadowable> implements CtShadowableAssertInterface<CtShadowableAssert, CtShadowable> {
+	CtShadowableAssert(CtShadowable actual) {
+		super(actual, CtShadowableAssert.class);
+	}
+
+	@Override
+	public CtShadowableAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtShadowable actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtShadowableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtShadowableAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtShadowable;
-interface CtShadowableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtShadowable> extends SpoonAssert<A, W> {
+public interface CtShadowableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtShadowable> extends SpoonAssert<A, W> {
 	default AbstractBooleanAssert<?> isShadow() {
 		return Assertions.assertThat(actual().isShadow());
 	}

--- a/src/test/java/spoon/testing/assertions/CtStatementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtStatementAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.code.CtStatement;
-interface CtStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtStatement> extends SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
+public interface CtStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtStatement> extends SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
 	default AbstractStringAssert<?> getLabel() {
 		return Assertions.assertThat(actual().getLabel());
 	}

--- a/src/test/java/spoon/testing/assertions/CtStatementListAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtStatementListAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
-interface CtStatementListAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtStatementList> extends SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
+public interface CtStatementListAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtStatementList> extends SpoonAssert<A, W> , CtCodeElementAssertInterface<A, W> {
 	default ListAssert<CtStatement> getStatements() {
 		return Assertions.assertThat(actual().getStatements());
 	}

--- a/src/test/java/spoon/testing/assertions/CtSuperAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtSuperAccessAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtSuperAccess;
-interface CtSuperAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSuperAccess<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
+public interface CtSuperAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSuperAccess<?>> extends CtVariableReadAssertInterface<A, W> , SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getType() {
 		return SpoonAssertions.assertThat(actual().getType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtSwitchAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtSwitchAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtSwitch;
-interface CtSwitchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSwitch<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtAbstractSwitchAssertInterface<A, W> {}
+public interface CtSwitchAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSwitch<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtAbstractSwitchAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtSwitchExpressionAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtSwitchExpressionAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtSwitchExpression;
-interface CtSwitchExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSwitchExpression<?, ?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtAbstractSwitchAssertInterface<A, W> {}
+public interface CtSwitchExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSwitchExpression<?, ?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtAbstractSwitchAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtSynchronizedAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtSynchronizedAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtSynchronized;
-interface CtSynchronizedAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSynchronized> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtSynchronizedAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtSynchronized> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default CtBlockAssertInterface<?, ?> getBlock() {
 		return SpoonAssertions.assertThat(actual().getBlock());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTargetedExpressionAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTargetedExpressionAssertInterface.java
@@ -2,7 +2,7 @@ package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtTargetedExpression;
-interface CtTargetedExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTargetedExpression<?, ?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtTargetedExpressionAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTargetedExpression<?, ?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getTarget() {
 		return SpoonAssertions.assertThat(((CtExpression<?>) (actual().getTarget())));
 	}

--- a/src/test/java/spoon/testing/assertions/CtTextBlockAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTextBlockAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtTextBlock;
-interface CtTextBlockAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTextBlock> extends SpoonAssert<A, W> , CtLiteralAssertInterface<A, W> {}
+public interface CtTextBlockAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTextBlock> extends SpoonAssert<A, W> , CtLiteralAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtThisAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtThisAccessAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtThisAccess;
-interface CtThisAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtThisAccess<?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {}
+public interface CtThisAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtThisAccess<?>> extends SpoonAssert<A, W> , CtTargetedExpressionAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtThrowAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtThrowAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtThrow;
-interface CtThrowAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtThrow> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtThrowAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtThrow> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtExpressionAssertInterface<?, ?> getThrownExpression() {
 		return SpoonAssertions.assertThat(actual().getThrownExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTryAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTryAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtTry;
-interface CtTryAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTry> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
+public interface CtTryAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTry> extends CtBodyHolderAssertInterface<A, W> , SpoonAssert<A, W> , CtStatementAssertInterface<A, W> {
 	default CtBlockAssertInterface<?, ?> getBody() {
 		return SpoonAssertions.assertThat(actual().getBody());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTryWithResourceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTryWithResourceAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtResource;
 import spoon.reflect.code.CtTryWithResource;
-interface CtTryWithResourceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTryWithResource> extends SpoonAssert<A, W> , CtTryAssertInterface<A, W> {
+public interface CtTryWithResourceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTryWithResource> extends SpoonAssert<A, W> , CtTryAssertInterface<A, W> {
 	default ListAssert<CtResource<?>> getResources() {
 		return Assertions.assertThat(actual().getResources());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeAccessAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.code.CtTypeAccess;
-interface CtTypeAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeAccess<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtTypeAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeAccess<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getAccessedType() {
 		return SpoonAssertions.assertThat(actual().getAccessedType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeAssertInterface.java
@@ -10,7 +10,7 @@ import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.ModifierKind;
-interface CtTypeAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtType<?>> extends CtTypeInformationAssertInterface<A, W> , SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {
+public interface CtTypeAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtType<?>> extends CtTypeInformationAssertInterface<A, W> , SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtFormalTypeDeclarerAssertInterface<A, W> , CtShadowableAssertInterface<A, W> , CtTypeMemberAssertInterface<A, W> {
 	default ListAssert<CtField<?>> getFields() {
 		return Assertions.assertThat(actual().getFields());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeInformationAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeInformationAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtTypeInformation;
+public class CtTypeInformationAssert extends AbstractObjectAssert<CtTypeInformationAssert, CtTypeInformation> implements CtTypeInformationAssertInterface<CtTypeInformationAssert, CtTypeInformation> {
+	CtTypeInformationAssert(CtTypeInformation actual) {
+		super(actual, CtTypeInformationAssert.class);
+	}
+
+	@Override
+	public CtTypeInformationAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtTypeInformation actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtTypeInformationAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeInformationAssertInterface.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtTypeInformation;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtTypeReference;
-interface CtTypeInformationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeInformation> extends SpoonAssert<A, W> {
+public interface CtTypeInformationAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeInformation> extends SpoonAssert<A, W> {
 	default AbstractCollectionAssert<?, Collection<? extends ModifierKind>, ModifierKind, ?> getModifiers() {
 		return Assertions.assertThat(actual().getModifiers());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeMemberAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeMemberAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtTypeMember;
+public class CtTypeMemberAssert extends AbstractObjectAssert<CtTypeMemberAssert, CtTypeMember> implements CtTypeMemberAssertInterface<CtTypeMemberAssert, CtTypeMember> {
+	CtTypeMemberAssert(CtTypeMember actual) {
+		super(actual, CtTypeMemberAssert.class);
+	}
+
+	@Override
+	public CtTypeMemberAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtTypeMember actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtTypeMemberAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeMemberAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtTypeMember;
-interface CtTypeMemberAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeMember> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtModifiableAssertInterface<A, W> {}
+public interface CtTypeMemberAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeMember> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtModifiableAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtTypeMemberWildcardImportReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeMemberWildcardImportReferenceAssertInterface.java
@@ -7,7 +7,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.reference.CtTypeMemberWildcardImportReference;
-interface CtTypeMemberWildcardImportReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeMemberWildcardImportReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
+public interface CtTypeMemberWildcardImportReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeMemberWildcardImportReference> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
 	default ListAssert<CtAnnotation<? extends Annotation>> getAnnotations() {
 		return Assertions.assertThat(actual().getAnnotations());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeParameterAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeParameterAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtTypeParameter;
-interface CtTypeParameterAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeParameter> extends SpoonAssert<A, W> , CtTypeAssertInterface<A, W> {}
+public interface CtTypeParameterAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeParameter> extends SpoonAssert<A, W> , CtTypeAssertInterface<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtTypeParameterReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeParameterReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtTypeParameterReference;
-interface CtTypeParameterReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeParameterReference> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtTypeParameterReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeParameterReference> extends CtTypeReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtTypePatternAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypePatternAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 import spoon.reflect.code.CtTypePattern;
 import spoon.reflect.reference.CtTypeReference;
-interface CtTypePatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypePattern> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtPatternAssertInterface<A, W> {
+public interface CtTypePatternAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypePattern> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> , CtPatternAssertInterface<A, W> {
 	default ListAssert<CtTypeReference<?>> getTypeCasts() {
 		return Assertions.assertThat(actual().getTypeCasts());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypeReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeReferenceAssertInterface.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtTypeReference;
-interface CtTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeReference<?>> extends CtTypeInformationAssertInterface<A, W> , SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtReferenceAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
+public interface CtTypeReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypeReference<?>> extends CtTypeInformationAssertInterface<A, W> , SpoonAssert<A, W> , CtActualTypeContainerAssertInterface<A, W> , CtReferenceAssertInterface<A, W> , CtShadowableAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getDeclaringType() {
 		return SpoonAssertions.assertThat(actual().getDeclaringType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtTypedElementAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtTypedElementAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtTypedElement;
+public class CtTypedElementAssert extends AbstractObjectAssert<CtTypedElementAssert, CtTypedElement<?>> implements CtTypedElementAssertInterface<CtTypedElementAssert, CtTypedElement<?>> {
+	CtTypedElementAssert(CtTypedElement<?> actual) {
+		super(actual, CtTypedElementAssert.class);
+	}
+
+	@Override
+	public CtTypedElementAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtTypedElement<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtTypedElementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypedElementAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtTypedElement;
-interface CtTypedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypedElement<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtTypedElementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtTypedElement<?>> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getType() {
 		return SpoonAssertions.assertThat(actual().getType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtUnaryOperatorAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtUnaryOperatorAssertInterface.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ObjectAssert;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
-interface CtUnaryOperatorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUnaryOperator<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtUnaryOperatorAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUnaryOperator<?>> extends SpoonAssert<A, W> , CtStatementAssertInterface<A, W> , CtExpressionAssertInterface<A, W> {
 	default ObjectAssert<UnaryOperatorKind> getKind() {
 		return Assertions.assertThatObject(actual().getKind());
 	}

--- a/src/test/java/spoon/testing/assertions/CtUnboundVariableReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtUnboundVariableReferenceAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtUnboundVariableReference;
-interface CtUnboundVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUnboundVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtUnboundVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUnboundVariableReference<?>> extends CtVariableReferenceAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtUsedServiceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtUsedServiceAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtUsedService;
-interface CtUsedServiceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUsedService> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
+public interface CtUsedServiceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtUsedService> extends SpoonAssert<A, W> , CtModuleDirectiveAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getServiceType() {
 		return SpoonAssertions.assertThat(actual().getServiceType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtVariableAccessAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableAccessAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtVariableAccess;
-interface CtVariableAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableAccess<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
+public interface CtVariableAccessAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableAccess<?>> extends SpoonAssert<A, W> , CtExpressionAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getType() {
 		return SpoonAssertions.assertThat(actual().getType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtVariableAssert.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableAssert.java
@@ -1,0 +1,23 @@
+package spoon.testing.assertions;
+import org.assertj.core.api.AbstractObjectAssert;
+import spoon.reflect.declaration.CtVariable;
+public class CtVariableAssert extends AbstractObjectAssert<CtVariableAssert, CtVariable<?>> implements CtVariableAssertInterface<CtVariableAssert, CtVariable<?>> {
+	CtVariableAssert(CtVariable<?> actual) {
+		super(actual, CtVariableAssert.class);
+	}
+
+	@Override
+	public CtVariableAssert self() {
+		return this;
+	}
+
+	@Override
+	public CtVariable<?> actual() {
+		return this.actual;
+	}
+
+	@Override
+	public void failWithMessage(String errorMessage, Object... arguments) {
+		super.failWithMessage(errorMessage, arguments);
+	}
+}

--- a/src/test/java/spoon/testing/assertions/CtVariableAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.declaration.CtVariable;
-interface CtVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariable<?>> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> , CtModifiableAssertInterface<A, W> {
+public interface CtVariableAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariable<?>> extends SpoonAssert<A, W> , CtNamedElementAssertInterface<A, W> , CtTypedElementAssertInterface<A, W> , CtModifiableAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getDefaultExpression() {
 		return SpoonAssertions.assertThat(actual().getDefaultExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtVariableReadAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableReadAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtVariableRead;
-interface CtVariableReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableRead<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtVariableReadAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableRead<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtVariableReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableReferenceAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.reference.CtVariableReference;
-interface CtVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableReference<?>> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
+public interface CtVariableReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableReference<?>> extends SpoonAssert<A, W> , CtReferenceAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getType() {
 		return SpoonAssertions.assertThat(actual().getType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtVariableWriteAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtVariableWriteAssertInterface.java
@@ -1,4 +1,4 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtVariableWrite;
-interface CtVariableWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableWrite<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> {}
+public interface CtVariableWriteAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtVariableWrite<?>> extends CtVariableAccessAssertInterface<A, W> , SpoonAssert<A, W> {}

--- a/src/test/java/spoon/testing/assertions/CtWhileAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtWhileAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtWhile;
-interface CtWhileAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtWhile> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
+public interface CtWhileAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtWhile> extends SpoonAssert<A, W> , CtLoopAssertInterface<A, W> {
 	default CtExpressionAssertInterface<?, ?> getLoopingExpression() {
 		return SpoonAssertions.assertThat(actual().getLoopingExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/CtWildcardReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtWildcardReferenceAssertInterface.java
@@ -3,7 +3,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.reference.CtWildcardReference;
-interface CtWildcardReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtWildcardReference> extends SpoonAssert<A, W> , CtTypeParameterReferenceAssertInterface<A, W> {
+public interface CtWildcardReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtWildcardReference> extends SpoonAssert<A, W> , CtTypeParameterReferenceAssertInterface<A, W> {
 	default CtTypeReferenceAssertInterface<?, ?> getBoundingType() {
 		return SpoonAssertions.assertThat(actual().getBoundingType());
 	}

--- a/src/test/java/spoon/testing/assertions/CtYieldStatementAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtYieldStatementAssertInterface.java
@@ -1,7 +1,7 @@
 package spoon.testing.assertions;
 import org.assertj.core.api.AbstractObjectAssert;
 import spoon.reflect.code.CtYieldStatement;
-interface CtYieldStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtYieldStatement> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
+public interface CtYieldStatementAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtYieldStatement> extends CtCFlowBreakAssertInterface<A, W> , SpoonAssert<A, W> {
 	default CtExpressionAssertInterface<?, ?> getExpression() {
 		return SpoonAssertions.assertThat(actual().getExpression());
 	}

--- a/src/test/java/spoon/testing/assertions/SpoonAssertions.java
+++ b/src/test/java/spoon/testing/assertions/SpoonAssertions.java
@@ -1,4 +1,6 @@
 package spoon.testing.assertions;
+import spoon.reflect.code.CtAbstractInvocation;
+import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtAnnotationFieldAccess;
 import spoon.reflect.code.CtArrayAccess;
 import spoon.reflect.code.CtArrayRead;
@@ -7,8 +9,11 @@ import spoon.reflect.code.CtAssert;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtBlock;
+import spoon.reflect.code.CtBodyHolder;
 import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtCasePattern;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtCodeElement;
@@ -30,6 +35,7 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtJavaDoc;
 import spoon.reflect.code.CtJavaDocTag;
+import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
@@ -37,6 +43,10 @@ import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtNewClass;
 import spoon.reflect.code.CtOperatorAssignment;
+import spoon.reflect.code.CtPattern;
+import spoon.reflect.code.CtRHSReceiver;
+import spoon.reflect.code.CtRecordPattern;
+import spoon.reflect.code.CtResource;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
@@ -63,6 +73,7 @@ import spoon.reflect.declaration.CtAnnotationMethod;
 import spoon.reflect.declaration.CtAnnotationType;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtCodeSnippet;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtElement;
@@ -70,11 +81,15 @@ import spoon.reflect.declaration.CtEnum;
 import spoon.reflect.declaration.CtEnumValue;
 import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtFormalTypeDeclarer;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtModule;
+import spoon.reflect.declaration.CtModuleDirective;
 import spoon.reflect.declaration.CtModuleRequirement;
+import spoon.reflect.declaration.CtMultiTypedElement;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtPackageDeclaration;
@@ -83,9 +98,16 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtProvidedService;
 import spoon.reflect.declaration.CtRecord;
 import spoon.reflect.declaration.CtRecordComponent;
+import spoon.reflect.declaration.CtSealable;
+import spoon.reflect.declaration.CtShadowable;
 import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeInformation;
+import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.CtUsedService;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtCatchVariableReference;
 import spoon.reflect.reference.CtExecutableReference;
@@ -103,12 +125,28 @@ import spoon.reflect.reference.CtUnboundVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.reference.CtWildcardReference;
 public final class SpoonAssertions {
+	public static CtAbstractInvocationAssert assertThat(CtAbstractInvocation<?> ctAbstractInvocation) {
+		return new CtAbstractInvocationAssert(ctAbstractInvocation);
+	}
+
+	public static CtResourceAssert assertThat(CtResource<?> ctResource) {
+		return new CtResourceAssert(ctResource);
+	}
+
 	public static CtProvidedServiceAssert assertThat(CtProvidedService ctProvidedService) {
 		return new CtProvidedServiceAssert(ctProvidedService);
 	}
 
+	public static CtAbstractSwitchAssert assertThat(CtAbstractSwitch<?> ctAbstractSwitch) {
+		return new CtAbstractSwitchAssert(ctAbstractSwitch);
+	}
+
 	public static CtConditionalAssert assertThat(CtConditional<?> ctConditional) {
 		return new CtConditionalAssert(ctConditional);
+	}
+
+	public static CtCFlowBreakAssert assertThat(CtCFlowBreak ctCFlowBreak) {
+		return new CtCFlowBreakAssert(ctCFlowBreak);
 	}
 
 	public static CtParameterAssert assertThat(CtParameter<?> ctParameter) {
@@ -155,6 +193,10 @@ public final class SpoonAssertions {
 		return new CtBinaryOperatorAssert(ctBinaryOperator);
 	}
 
+	public static CtRecordPatternAssert assertThat(CtRecordPattern ctRecordPattern) {
+		return new CtRecordPatternAssert(ctRecordPattern);
+	}
+
 	public static CtForEachAssert assertThat(CtForEach ctForEach) {
 		return new CtForEachAssert(ctForEach);
 	}
@@ -165,6 +207,10 @@ public final class SpoonAssertions {
 
 	public static CtModuleRequirementAssert assertThat(CtModuleRequirement ctModuleRequirement) {
 		return new CtModuleRequirementAssert(ctModuleRequirement);
+	}
+
+	public static CtRHSReceiverAssert assertThat(CtRHSReceiver<?> ctRHSReceiver) {
+		return new CtRHSReceiverAssert(ctRHSReceiver);
 	}
 
 	public static CtSuperAccessAssert assertThat(CtSuperAccess<?> ctSuperAccess) {
@@ -183,6 +229,14 @@ public final class SpoonAssertions {
 		return new CtNamedElementAssert(ctNamedElement);
 	}
 
+	public static CtSealableAssert assertThat(CtSealable ctSealable) {
+		return new CtSealableAssert(ctSealable);
+	}
+
+	public static CtModifiableAssert assertThat(CtModifiable ctModifiable) {
+		return new CtModifiableAssert(ctModifiable);
+	}
+
 	public static CtPackageDeclarationAssert assertThat(CtPackageDeclaration ctPackageDeclaration) {
 		return new CtPackageDeclarationAssert(ctPackageDeclaration);
 	}
@@ -199,8 +253,16 @@ public final class SpoonAssertions {
 		return new CtFieldAccessAssert(ctFieldAccess);
 	}
 
+	public static CtCodeSnippetAssert assertThat(CtCodeSnippet ctCodeSnippet) {
+		return new CtCodeSnippetAssert(ctCodeSnippet);
+	}
+
 	public static CtWildcardReferenceAssert assertThat(CtWildcardReference ctWildcardReference) {
 		return new CtWildcardReferenceAssert(ctWildcardReference);
+	}
+
+	public static CtTypeInformationAssert assertThat(CtTypeInformation ctTypeInformation) {
+		return new CtTypeInformationAssert(ctTypeInformation);
 	}
 
 	public static CtRecordComponentAssert assertThat(CtRecordComponent ctRecordComponent) {
@@ -255,6 +317,10 @@ public final class SpoonAssertions {
 		return new CtUnboundVariableReferenceAssert(ctUnboundVariableReference);
 	}
 
+	public static CtLabelledFlowBreakAssert assertThat(CtLabelledFlowBreak ctLabelledFlowBreak) {
+		return new CtLabelledFlowBreakAssert(ctLabelledFlowBreak);
+	}
+
 	public static CtArrayAccessAssert assertThat(CtArrayAccess<?, ?> ctArrayAccess) {
 		return new CtArrayAccessAssert(ctArrayAccess);
 	}
@@ -269,6 +335,10 @@ public final class SpoonAssertions {
 
 	public static CtTryWithResourceAssert assertThat(CtTryWithResource ctTryWithResource) {
 		return new CtTryWithResourceAssert(ctTryWithResource);
+	}
+
+	public static CtActualTypeContainerAssert assertThat(CtActualTypeContainer ctActualTypeContainer) {
+		return new CtActualTypeContainerAssert(ctActualTypeContainer);
 	}
 
 	public static CtClassAssert assertThat(CtClass<?> ctClass) {
@@ -335,6 +405,10 @@ public final class SpoonAssertions {
 		return new CtCodeSnippetExpressionAssert(ctCodeSnippetExpression);
 	}
 
+	public static CtTypedElementAssert assertThat(CtTypedElement<?> ctTypedElement) {
+		return new CtTypedElementAssert(ctTypedElement);
+	}
+
 	public static CtForAssert assertThat(CtFor ctFor) {
 		return new CtForAssert(ctFor);
 	}
@@ -343,12 +417,20 @@ public final class SpoonAssertions {
 		return new CtTypeParameterAssert(ctTypeParameter);
 	}
 
+	public static CtFormalTypeDeclarerAssert assertThat(CtFormalTypeDeclarer ctFormalTypeDeclarer) {
+		return new CtFormalTypeDeclarerAssert(ctFormalTypeDeclarer);
+	}
+
 	public static CtExecutableAssert assertThat(CtExecutable<?> ctExecutable) {
 		return new CtExecutableAssert(ctExecutable);
 	}
 
 	public static CtLocalVariableAssert assertThat(CtLocalVariable<?> ctLocalVariable) {
 		return new CtLocalVariableAssert(ctLocalVariable);
+	}
+
+	public static CtMultiTypedElementAssert assertThat(CtMultiTypedElement ctMultiTypedElement) {
+		return new CtMultiTypedElementAssert(ctMultiTypedElement);
 	}
 
 	public static CtModuleAssert assertThat(CtModule ctModule) {
@@ -373,6 +455,10 @@ public final class SpoonAssertions {
 
 	public static CtTypeAssert assertThat(CtType<?> ctType) {
 		return new CtTypeAssert(ctType);
+	}
+
+	public static CtVariableAssert assertThat(CtVariable<?> ctVariable) {
+		return new CtVariableAssert(ctVariable);
 	}
 
 	public static CtCaseAssert assertThat(CtCase<?> ctCase) {
@@ -411,6 +497,10 @@ public final class SpoonAssertions {
 		return new CtLambdaAssert(ctLambda);
 	}
 
+	public static CtPatternAssert assertThat(CtPattern ctPattern) {
+		return new CtPatternAssert(ctPattern);
+	}
+
 	public static CtTypePatternAssert assertThat(CtTypePattern ctTypePattern) {
 		return new CtTypePatternAssert(ctTypePattern);
 	}
@@ -419,8 +509,16 @@ public final class SpoonAssertions {
 		return new CtTypeAccessAssert(ctTypeAccess);
 	}
 
+	public static CtBodyHolderAssert assertThat(CtBodyHolder ctBodyHolder) {
+		return new CtBodyHolderAssert(ctBodyHolder);
+	}
+
 	public static CtNewArrayAssert assertThat(CtNewArray<?> ctNewArray) {
 		return new CtNewArrayAssert(ctNewArray);
+	}
+
+	public static CtShadowableAssert assertThat(CtShadowable ctShadowable) {
+		return new CtShadowableAssert(ctShadowable);
 	}
 
 	public static CtTextBlockAssert assertThat(CtTextBlock ctTextBlock) {
@@ -491,6 +589,14 @@ public final class SpoonAssertions {
 		return new CtEnumAssert(ctEnum);
 	}
 
+	public static CtCasePatternAssert assertThat(CtCasePattern ctCasePattern) {
+		return new CtCasePatternAssert(ctCasePattern);
+	}
+
+	public static CtModuleDirectiveAssert assertThat(CtModuleDirective ctModuleDirective) {
+		return new CtModuleDirectiveAssert(ctModuleDirective);
+	}
+
 	public static CtTypeMemberWildcardImportReferenceAssert assertThat(CtTypeMemberWildcardImportReference ctTypeMemberWildcardImportReference) {
 		return new CtTypeMemberWildcardImportReferenceAssert(ctTypeMemberWildcardImportReference);
 	}
@@ -501,6 +607,10 @@ public final class SpoonAssertions {
 
 	public static CtLocalVariableReferenceAssert assertThat(CtLocalVariableReference<?> ctLocalVariableReference) {
 		return new CtLocalVariableReferenceAssert(ctLocalVariableReference);
+	}
+
+	public static CtTypeMemberAssert assertThat(CtTypeMember ctTypeMember) {
+		return new CtTypeMemberAssert(ctTypeMember);
 	}
 
 	public static CtAnnotationTypeAssert assertThat(CtAnnotationType<?> ctAnnotationType) {

--- a/src/test/java/spoon/testing/assertions/codegen/AssertJCodegen.java
+++ b/src/test/java/spoon/testing/assertions/codegen/AssertJCodegen.java
@@ -119,10 +119,6 @@ public class AssertJCodegen {
 			// TODO remove SpoonAssert interface if unneeded
 
 			writeType(assertInterface, launcher);
-			CtClass<?> impl = Metamodel.getImplementationOfInterface(modelInterface);
-			if (impl == null) {
-				continue;
-			}
 			CtClass<?> anAssert = createAssert(modelInterface, assertInterface);
 			assertClasses.add(new AssertModelPair(anAssert, modelInterface));
 			writeType(anAssert, launcher);
@@ -195,11 +191,11 @@ public class AssertJCodegen {
 	}
 
 	private static void writeType(CtType<?> type, Launcher launcher) throws IOException {
+		System.out.println(type.toStringWithImports());
 		String targetLocation = GEN_ROOT + "/" + type.getQualifiedName().replace(".", "/") + ".java";
 		Path path = Path.of(targetLocation);
 		Files.createDirectories(path.getParent());
 		Files.writeString(path.toAbsolutePath(), launcher.createPrettyPrinter().printTypes(type));
-		System.out.println(type.toStringWithImports());
 	}
 
 	private CtClass<?> createAssert(CtInterface<?> modelInterface, CtInterface<?> assertInterface) {
@@ -287,8 +283,9 @@ public class AssertJCodegen {
 
 	CtInterface<?> createInterface(CtType<?> type) {
 		Factory factory = type.getFactory();
-		CtInterface<?> ctInterface =
-			factory.createInterface("spoon.testing.assertions." + type.getSimpleName() + "AssertInterface");
+		CtInterface<?> ctInterface = factory
+				.createInterface("spoon.testing.assertions." + type.getSimpleName() + "AssertInterface")
+				.addModifier(ModifierKind.PUBLIC);
 		CtTypeReference<?> abstractAssertRef = factory.createCtTypeReference(ASSERT_J_SUPERCLASS);
 		CtTypeParameter a =
 			factory.createTypeParameter().setSuperclass(abstractAssertRef).setSimpleName("A");


### PR DESCRIPTION
The check to ensure the assertions are all up-to-date didn't run.
This PR fixes that, and also fixes the missing types. We also need concrete classes for interfaces that don't have one specific implementation, otherwise newly introduced code wouldn't compile anymore.

Additionally, interfaces are public now, otherwise methods returning those interfaces are basically useless.