### PR TITLE
review: chore: Use `RELEASE` version for jbang instead of `LATEST`

### DIFF
--- a/chore/CheckJavadoc.java
+++ b/chore/CheckJavadoc.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS fr.inria.gforge.spoon:spoon-core:LATEST
-//DEPS fr.inria.gforge.spoon:spoon-javadoc:LATEST
+//DEPS fr.inria.gforge.spoon:spoon-core:RELEASE
+//DEPS fr.inria.gforge.spoon:spoon-javadoc:RELEASE
 //DEPS org.slf4j:slf4j-nop:1.7.36
 //JAVA 17+
 

--- a/chore/check-javadoc-regressions.py
+++ b/chore/check-javadoc-regressions.py
@@ -86,6 +86,7 @@ def run_quality_check(config_path: Path, target_branch: Optional[str] = None) ->
 
     return run_command([
         "jbang",
+        "--verbose",
         str(check_path)
     ])
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707268954,
-        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Somehow `LATEST` often fails to resolve in CI (never locally). Many people in the issues of jbang use `RELEASE`, so maybe that one actually works.