### PR TITLE
review: refactor: make ASTPair a record

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ASTPair.java
+++ b/src/main/java/spoon/support/compiler/jdt/ASTPair.java
@@ -9,7 +9,9 @@ package spoon.support.compiler.jdt;
 
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import spoon.reflect.declaration.CtElement;
+import spoon.support.Internal;
 
+@Internal
 public record ASTPair(CtElement element, ASTNode node) {
 
 	@Override

--- a/src/main/java/spoon/support/compiler/jdt/ASTPair.java
+++ b/src/main/java/spoon/support/compiler/jdt/ASTPair.java
@@ -10,15 +10,7 @@ package spoon.support.compiler.jdt;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import spoon.reflect.declaration.CtElement;
 
-public class ASTPair {
-	public final CtElement element;
-
-	public final ASTNode node;
-
-	public ASTPair(CtElement element, ASTNode node) {
-		this.element = element;
-		this.node = node;
-	}
+public record ASTPair(CtElement element, ASTNode node) {
 
 	@Override
 	public String toString() {

--- a/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ContextBuilder.java
@@ -97,7 +97,7 @@ public class ContextBuilder {
 		}
 
 		ASTPair pair = stack.peek();
-		CtElement current = pair.element;
+		CtElement current = pair.element();
 
 		if (current instanceof CtExpression) {
 			while (!casts.isEmpty()) {
@@ -118,13 +118,13 @@ public class ContextBuilder {
 
 	void exit(ASTNode node) {
 		ASTPair pair = stack.pop();
-		if (pair.node != node) {
-			throw new RuntimeException("Inconsistent Stack " + node + "\n" + pair.node);
+		if (pair.node() != node) {
+			throw new RuntimeException("Inconsistent Stack " + node + "\n" + pair.node());
 		}
-		CtElement current = pair.element;
+		CtElement current = pair.element();
 		if (!stack.isEmpty()) {
 			this.jdtTreeBuilder.getExiter().setChild(current);
-			this.jdtTreeBuilder.getExiter().setChild(pair.node);
+			this.jdtTreeBuilder.getExiter().setChild(pair.node());
 			ASTPair parentPair = stack.peek();
 			this.jdtTreeBuilder.getExiter().exitParent(parentPair);
 		}
@@ -150,7 +150,7 @@ public class ContextBuilder {
 	 * @throws NullPointerException if the stack is empty
 	 */
 	CtElement getCurrentElement() {
-		return stack.peek().element;
+		return stack.peek().element();
 	}
 
 	/**
@@ -158,13 +158,13 @@ public class ContextBuilder {
 	 * @throws NullPointerException if the stack is empty
 	 */
 	ASTNode getCurrentNode() {
-		return stack.peek().node;
+		return stack.peek().node();
 	}
 
 	CtElement getContextElementOnLevel(int level) {
 		for (ASTPair pair : stack) {
 			if (level == 0) {
-				return pair.element;
+				return pair.element();
 			}
 			level--;
 		}
@@ -173,8 +173,8 @@ public class ContextBuilder {
 
 	<T extends CtElement> T getParentElementOfType(Class<T> clazz) {
 		for (ASTPair pair : stack) {
-			if (clazz.isInstance(pair.element)) {
-				return (T) pair.element;
+			if (clazz.isInstance(pair.element())) {
+				return (T) pair.element();
 			}
 		}
 		return null;
@@ -182,7 +182,7 @@ public class ContextBuilder {
 
 	ASTPair getParentContextOfType(Class<? extends CtElement> clazz) {
 		for (ASTPair pair : stack) {
-			if (clazz.isInstance(pair.element)) {
+			if (clazz.isInstance(pair.element())) {
 				return pair;
 			}
 		}
@@ -259,14 +259,13 @@ public class ContextBuilder {
 			// the variable may have been declared directly by one of these elements
 			final ScopeRespectingVariableScanner<U> scanner =
 					new ScopeRespectingVariableScanner(name, clazz);
-			astPair.element.accept(scanner);
+			astPair.element().accept(scanner);
 			if (scanner.getResult() != null) {
 				return scanner.getResult();
 			}
 
 			// the variable may have been declared in a super class/interface
-			if (lookingForFields && astPair.node instanceof TypeDeclaration) {
-				final TypeDeclaration nodeDeclaration = (TypeDeclaration) astPair.node;
+			if (lookingForFields && astPair.node() instanceof TypeDeclaration nodeDeclaration) {
 				final Deque<ReferenceBinding> referenceBindings = new ArrayDeque<>();
 				// add super class if any
 				if (nodeDeclaration.superclass != null
@@ -419,11 +418,10 @@ public class ContextBuilder {
 					// `stack`. This peculiarity calls for the second condition.
 					final CtElement parentOfPotentialVariable = potentialVariable.getParent();
 					for (final ASTPair astPair : stack) {
-						if (astPair.element == parentOfPotentialVariable) {
+						if (astPair.element() == parentOfPotentialVariable) {
 							finish(potentialVariable);
 							return;
-						} else if (astPair.element instanceof CtExecutable) {
-							final CtExecutable executable = (CtExecutable) astPair.element;
+						} else if (astPair.element() instanceof CtExecutable<?> executable) {
 							if (executable.getBody() == parentOfPotentialVariable) {
 								finish(potentialVariable);
 								return;

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -217,8 +217,8 @@ public class JDTTreeBuilderHelper {
 				// find executable's corresponding jdt element
 				AbstractMethodDeclaration executableJDT = null;
 				for (final ASTPair astPair : contextBuilder.getAllContexts()) {
-					if (astPair.element == executable) {
-						executableJDT = (AbstractMethodDeclaration) astPair.node;
+					if (astPair.element() == executable) {
+						executableJDT = (AbstractMethodDeclaration) astPair.node();
 					}
 				}
 				assert executableJDT != null;

--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -140,7 +140,7 @@ public class ParentExiter extends CtInheritanceScanner {
 
 	public void exitParent(ASTPair pair) {
 		this.parentPair = pair;
-		scan(pair.element);
+		scan(pair.element());
 	}
 	public void setChild(CtElement child) {
 		this.child = child;
@@ -716,7 +716,7 @@ public class ParentExiter extends CtInheritanceScanner {
 				child.setPosition(this.child.getPosition());
 			}
 
-			IfStatement ifJDT = (IfStatement) this.parentPair.node;
+			IfStatement ifJDT = (IfStatement) this.parentPair.node();
 			if (ifJDT.thenStatement == this.childJDT) {
 				//we are visiting `then` of `if`
 				ifElement.setThenStatement(child);
@@ -777,10 +777,9 @@ public class ParentExiter extends CtInheritanceScanner {
 		// Compare with Test "correctlySetsThisTargetForUnqualifiedCalls".
 
 		// We need a MessageSend as the parent to resolve the actualType from the receiver
-		if (!(parentPair.node instanceof MessageSend)) {
+		if (!(parentPair.node() instanceof MessageSend messageSend)) {
 			return false;
 		}
-		MessageSend messageSend = (MessageSend) parentPair.node;
 		if (messageSend.actualReceiverType == null || messageSend.receiver.resolvedType == null) {
 			return false;
 		}
@@ -1094,7 +1093,7 @@ public class ParentExiter extends CtInheritanceScanner {
 			} else {
 				// we have to find it manually
 				for (ASTPair pair: this.jdtTreeBuilder.getContextBuilder().getAllContexts()) {
-					final List<CtLocalVariable> variables = pair.element.getElements(new TypeFilter<>(CtLocalVariable.class));
+					final List<CtLocalVariable> variables = pair.element().getElements(new TypeFilter<>(CtLocalVariable.class));
 					for (CtLocalVariable v: variables) {
 						if (v.getSimpleName().equals(variableRef.getSimpleName())) {
 							// we found the resource

--- a/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/PositionBuilder.java
@@ -413,7 +413,7 @@ public class PositionBuilder {
 				return handlePositionProblem("There is no CtCatch parent for CtCatchVariable");
 			}
 			//build position with appropriate context
-			return buildPositionCtElement(e, (Argument) pair.node);
+			return buildPositionCtElement(e, (Argument) pair.node());
 		} else if (node instanceof TypeReference) {
 			sourceEnd = getSourceEndOfTypeReference(contents, (TypeReference) node, sourceEnd);
 		} else if (node instanceof AllocationExpression) {
@@ -470,7 +470,7 @@ public class PositionBuilder {
 			iter.next();
 			if (iter.hasNext()) {
 				ASTPair pair = iter.next();
-				SourcePosition pos = pair.element.getPosition();
+				SourcePosition pos = pair.element().getPosition();
 				if (pos.isValidPosition()) {
 					return pos.getSourceStart();
 				}

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1346,7 +1346,7 @@ public class ReferenceBuilder {
 	public CtExecutableReference<?> getLambdaExecutableReference(SingleNameReference singleNameReference) {
 		ASTPair potentialLambda = null;
 		for (ASTPair astPair : jdtTreeBuilder.getContextBuilder().getAllContexts()) {
-			if (astPair.node instanceof LambdaExpression) {
+			if (astPair.node() instanceof LambdaExpression) {
 				potentialLambda = astPair;
 				// stop at innermost lambda, fixes #1100
 				break;
@@ -1355,14 +1355,14 @@ public class ReferenceBuilder {
 		if (potentialLambda == null) {
 			return null;
 		}
-		LambdaExpression lambdaJDT = (LambdaExpression) potentialLambda.node;
+		LambdaExpression lambdaJDT = (LambdaExpression) potentialLambda.node();
 		for (Argument argument : lambdaJDT.arguments()) {
 			if (CharOperation.equals(argument.name, singleNameReference.token)) {
 				CtTypeReference<?> declaringType = null;
 				if (lambdaJDT.enclosingScope instanceof MethodScope) {
 					declaringType = jdtTreeBuilder.getReferencesBuilder().getTypeReference(((MethodScope) lambdaJDT.enclosingScope).parent.enclosingSourceType());
 				}
-				CtLambda<?> ctLambda = (CtLambda<?>) potentialLambda.element;
+				CtLambda<?> ctLambda = (CtLambda<?>) potentialLambda.element();
 				List<CtTypeReference<?>> parametersType = new ArrayList<>();
 				List<CtParameter<?>> parameters = ctLambda.getParameters();
 				for (CtParameter<?> parameter : parameters) {


### PR DESCRIPTION
`ASTPair` is a perfect example of a class that should be a record. In theory it's breaking, but it's supposed to be used internally only anyways, and it's targeting the java17 branch.