### PR TITLE
Update spoon pom to current version in spoon-control-flow

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-pom</artifactId>
-        <version>1.0</version>
+        <version>10.4.2</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     


### PR DESCRIPTION
The `spoon-pom` parent in `spoon-control-flow` was still on version 1.0. This caused `mvn test` to fail with a compiler error because `spoon-pom` only includes junit4. I updated the version to the latest spoon version.