### PR TITLE
review: fix(control-flow): Process constructor call in control flow graph

### DIFF
--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
@@ -688,8 +688,8 @@ public class ControlFlowBuilder extends CtAbstractVisitor {
 	}
 
 	@Override
-	public <T> void visitCtConstructorCall(CtConstructorCall<T> ctConstructorCall) {
-
+	public <T> void visitCtConstructorCall(CtConstructorCall<T> constructorCall) {
+		defaultAction(BranchKind.STATEMENT, constructorCall);
 	}
 
 	@Override

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
@@ -358,6 +358,11 @@ public class ForwardFlowBuilderVisitorTest {
 	}
 
 	@Test
+	public void testConstructorCall() throws Exception {
+		testMethod("constructorCall", true, 0, 1, 5);
+	}
+
+	@Test
 	public void testtestCase() throws Exception {
 		//branchCount, stmntCount, totalCount
 		ControlFlowGraph graph = testMethod("complex1", true, null, null, null);

--- a/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
+++ b/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
@@ -377,6 +377,10 @@ public class ControlFlowArithmetic {
 		return b;
 	}
 
+	public void constructorCall() {
+		new Object();
+	}
+
 	//All lines will be tested in this method
 	public int simple(int a) {
 		a = a + a / 2;


### PR DESCRIPTION
Currently, a standalone constructor call doesn't appear in the control flow graph. With this PR it is processed like any other statement