### PR TITLE
review: fix(control-flow): Proper generation of CFG for constructor

### DIFF
--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
@@ -443,8 +443,8 @@ public class ControlFlowBuilder extends CtAbstractVisitor {
 	}
 
 	@Override
-	public <T> void visitCtConstructor(CtConstructor<T> c) {
-
+	public <T> void visitCtConstructor(CtConstructor<T> constructor) {
+		constructor.getBody().accept(this);
 	}
 
 	@Override

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
@@ -25,15 +25,17 @@ package fr.inria.controlflow;
 import org.junit.jupiter.api.Test;
 import spoon.processing.AbstractProcessor;
 import spoon.processing.ProcessingManager;
+import spoon.reflect.declaration.CtConstructor;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.support.QueueProcessingManager;
 
 import java.io.PrintWriter;
+import java.net.URISyntaxException;
 
-import static fr.inria.controlflow.BranchKind.BRANCH;
-import static fr.inria.controlflow.BranchKind.STATEMENT;
+import static fr.inria.controlflow.BranchKind.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Created by marodrig on 14/10/2015.
@@ -329,6 +331,30 @@ public class ForwardFlowBuilderVisitorTest {
 		ControlFlowGraph graph = testMethod("invocation", true, 1, 2, null);
 		//Branches-Statement Branches-Branches sStatement-Statement total
 		testEdges(graph, 1, 0, 0, null);
+	}
+
+	@Test
+	public void testConstructor() throws URISyntaxException, ClassNotFoundException, IllegalAccessException, InstantiationException {
+		ControlFlowBuilder visitor = new ControlFlowBuilder();
+
+		Factory factory = new SpoonMetaFactory().buildNewFactory(this.getClass().getResource("/control-flow").toURI().getPath(), 17);
+		ProcessingManager pm = new QueueProcessingManager(factory);
+		pm.addProcessor(new AbstractProcessor<CtConstructor<?>>() {
+			@Override
+			public void process(CtConstructor<?> element) {
+				if (!element.getBody().getStatements().isEmpty()) {
+					visitor.build(element);
+				}
+			}
+
+		});
+		pm.process(factory.getModel().getRootPackage());
+
+		ControlFlowGraph graph = visitor.getResult();
+		ControlFlowNode entryNode = graph.findNodesOfKind(BEGIN).getFirst();
+		ControlFlowNode exitNode = graph.getExitNode();
+
+		assertFalse(graph.containsEdge(entryNode, exitNode), "Graph is missing statements");
 	}
 
 	@Test

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
@@ -351,7 +351,7 @@ public class ForwardFlowBuilderVisitorTest {
 		pm.process(factory.getModel().getRootPackage());
 
 		ControlFlowGraph graph = visitor.getResult();
-		ControlFlowNode entryNode = graph.findNodesOfKind(BEGIN).getFirst();
+		ControlFlowNode entryNode = graph.findNodesOfKind(BEGIN).get(0);
 		ControlFlowNode exitNode = graph.getExitNode();
 
 		assertFalse(graph.containsEdge(entryNode, exitNode), "Graph is missing statements");

--- a/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
+++ b/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
@@ -383,6 +383,10 @@ public class ControlFlowArithmetic {
 		return 10 * a;
 	}
 
+	public ControlFlowArithmetic() {
+		int a = 1;
+	}
+
 	///////////////////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
Currently, generating a control flow graph for a `CtConstructor` generates an "empty" CFG, consisting just of the `BEGIN` and `EXIT` node and an edge between them. With this PR they are processed the same as a `CtMethod`