### PR TITLE
review: fix(control-flow): Handle synchronized statement in CFG

### DIFF
--- a/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
+++ b/spoon-control-flow/src/main/java/fr/inria/controlflow/ControlFlowBuilder.java
@@ -798,7 +798,11 @@ public class ControlFlowBuilder extends CtAbstractVisitor {
 
 	@Override
 	public void visitCtSynchronized(CtSynchronized synchro) {
+		ControlFlowNode expressionNode = new ControlFlowNode(synchro.getExpression(), result, BranchKind.STATEMENT);
+		tryAddEdge(lastNode, expressionNode);
+		lastNode = expressionNode;
 
+		synchro.getBlock().accept(this);
 	}
 
 	@Override

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
@@ -332,6 +332,11 @@ public class ForwardFlowBuilderVisitorTest {
 	}
 
 	@Test
+	public void testSynchronized() throws Exception {
+		testMethod("synchronization", true, 0, 2, 8);
+	}
+
+	@Test
 	public void testtestCase() throws Exception {
 		//branchCount, stmntCount, totalCount
 		ControlFlowGraph graph = testMethod("complex1", true, null, null, null);

--- a/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
+++ b/spoon-control-flow/src/test/resources/control-flow/ControlFlowArithmetic.java
@@ -383,6 +383,12 @@ public class ControlFlowArithmetic {
 		return 10 * a;
 	}
 
+	public void synchronization() {
+		synchronized (new Object()) {
+			int a = 0;
+		}
+	}
+
 	///////////////////////////////////////////////////////////////////////////////////////////
 
 


### PR DESCRIPTION
Currently, a `synchronized` statement is completely ignored in the CFG. This PR adds it to the CFG properly.