### PR TITLE
review: feat: Add newline at file end and refactor type calculation

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -2185,27 +2185,27 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	public void calculate(CtCompilationUnit sourceCompilationUnit, List<CtType<?>> types) {
 		reset();
 		 // if empty => is package-info.java, we cannot call types.get(0) in the then branch
-        if (!types.isEmpty()) {
-            CtType<?> type = types.get(0);
-            if (sourceCompilationUnit == null) {
-                sourceCompilationUnit = type.getFactory().CompilationUnit().getOrCreate(type);
-            }
-            if (type.getPackage() == null) {
-                type.setParent(type.getFactory().Package().getRootPackage());
-            }
-            CtPackageReference packRef = type.getPackage().getReference();
-            if (!packRef.equals(sourceCompilationUnit.getPackageDeclaration().getReference())) {
-                //the type was cloned and moved to different package. Adapt package reference of compilation unit too
-                sourceCompilationUnit.getPackageDeclaration().setReference(packRef);
-            }
-            if (!hasSameTypes(sourceCompilationUnit, types)) {
-                //the provided CU has different types, then these which has to be printed
-                //clone CU and assign it expected types
-                sourceCompilationUnit = sourceCompilationUnit.clone();
-                sourceCompilationUnit.setDeclaredTypes(types);
-            }
-        }
-        applyPreProcessors(sourceCompilationUnit);
+		if (!types.isEmpty()) {
+			CtType<?> type = types.get(0);
+			if (sourceCompilationUnit == null) {
+				sourceCompilationUnit = type.getFactory().CompilationUnit().getOrCreate(type);
+			}
+			if (type.getPackage() == null) {
+				type.setParent(type.getFactory().Package().getRootPackage());
+			}
+			CtPackageReference packRef = type.getPackage().getReference();
+			if (!packRef.equals(sourceCompilationUnit.getPackageDeclaration().getReference())) {
+				//the type was cloned and moved to different package. Adapt package reference of compilation unit too
+				sourceCompilationUnit.getPackageDeclaration().setReference(packRef);
+			}
+			if (!hasSameTypes(sourceCompilationUnit, types)) {
+				//the provided CU has different types, then these which has to be printed
+				//clone CU and assign it expected types
+				sourceCompilationUnit = sourceCompilationUnit.clone();
+				sourceCompilationUnit.setDeclaredTypes(types);
+			}
+		}
+		applyPreProcessors(sourceCompilationUnit);
 		scan(sourceCompilationUnit);
 	}
 
@@ -2303,7 +2303,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	 * When set to true, this activates round bracket minimization for expressions. This means that
 	 * the printer will attempt to only write round brackets strictly necessary for preserving
 	 * syntactical structure (and by extension, semantics).
-     *
+	 *
 	 * As an example, the expression <code>1 + 2 + 3 + 4</code> is written as
 	 * <code>((1 + 2) + 3) + 4</code> without round bracket minimization, but entirely without
 	 * parentheses when minimization is enabled. However, an expression <code>1 + 2 + (3 + 4)</code>

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -2187,7 +2187,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	@Override
 	public void calculate(CtCompilationUnit sourceCompilationUnit, List<CtType<?>> types) {
 		reset();
-		 // if empty => is package-info.java, we cannot call types.get(0) in the then branch
+		// if empty => is package-info.java, we cannot call types.get(0) in the then branch
 		if (!types.isEmpty()) {
 			CtType<?> type = types.get(0);
 			if (sourceCompilationUnit == null) {

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1212,6 +1212,8 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		} finally {
 			this.sourceCompilationUnit = outerCompilationUnit;
 		}
+		// by convention, we add a newline at the end of the file
+		printer.writeln();
 	}
 
 	protected ModelList<CtImport> getImports(CtCompilationUnit compilationUnit) {
@@ -2182,29 +2184,28 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 	@Override
 	public void calculate(CtCompilationUnit sourceCompilationUnit, List<CtType<?>> types) {
 		reset();
-		if (types.isEmpty()) {
-			// is package-info.java, we cannot call types.get(0) in the then branch
-		} else {
-			CtType<?> type = types.get(0);
-			if (sourceCompilationUnit == null) {
-				sourceCompilationUnit = type.getFactory().CompilationUnit().getOrCreate(type);
-			}
-			if (type.getPackage() == null) {
-				type.setParent(type.getFactory().Package().getRootPackage());
-			}
-			CtPackageReference packRef = type.getPackage().getReference();
-			if (!packRef.equals(sourceCompilationUnit.getPackageDeclaration().getReference())) {
-				//the type was cloned and moved to different package. Adapt package reference of compilation unit too
-				sourceCompilationUnit.getPackageDeclaration().setReference(packRef);
-			}
-			if (!hasSameTypes(sourceCompilationUnit, types)) {
-				//the provided CU has different types, then these which has to be printed
-				//clone CU and assign it expected types
-				sourceCompilationUnit = sourceCompilationUnit.clone();
-				sourceCompilationUnit.setDeclaredTypes(types);
-			}
-		}
-		applyPreProcessors(sourceCompilationUnit);
+		 // if empty => is package-info.java, we cannot call types.get(0) in the then branch
+        if (!types.isEmpty()) {
+            CtType<?> type = types.get(0);
+            if (sourceCompilationUnit == null) {
+                sourceCompilationUnit = type.getFactory().CompilationUnit().getOrCreate(type);
+            }
+            if (type.getPackage() == null) {
+                type.setParent(type.getFactory().Package().getRootPackage());
+            }
+            CtPackageReference packRef = type.getPackage().getReference();
+            if (!packRef.equals(sourceCompilationUnit.getPackageDeclaration().getReference())) {
+                //the type was cloned and moved to different package. Adapt package reference of compilation unit too
+                sourceCompilationUnit.getPackageDeclaration().setReference(packRef);
+            }
+            if (!hasSameTypes(sourceCompilationUnit, types)) {
+                //the provided CU has different types, then these which has to be printed
+                //clone CU and assign it expected types
+                sourceCompilationUnit = sourceCompilationUnit.clone();
+                sourceCompilationUnit.setDeclaredTypes(types);
+            }
+        }
+        applyPreProcessors(sourceCompilationUnit);
 		scan(sourceCompilationUnit);
 	}
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1213,7 +1213,10 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 			this.sourceCompilationUnit = outerCompilationUnit;
 		}
 		// by convention, we add a newline at the end of the file
-		printer.writeln();
+		// we guard this with a check to avoid adding a newline if there is already one
+		if (!getResult().endsWith(System.lineSeparator())) {
+			printer.writeln();
+		}
 	}
 
 	protected ModelList<CtImport> getImports(CtCompilationUnit compilationUnit) {

--- a/src/test/java/spoon/support/JavaOutputProcessorTest.java
+++ b/src/test/java/spoon/support/JavaOutputProcessorTest.java
@@ -1,12 +1,10 @@
 package spoon.support;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
 import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
-import spoon.testing.utils.LineSeparatorExtension;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -40,7 +38,6 @@ class JavaOutputProcessorTest {
 		assertEquals(1, javaOutputProcessor.printedFiles.size());
 	}
 
-	@ExtendWith(LineSeparatorExtension.class)
 	@Test
 	void testCreateJavaFileAssertFileEncodingChanged(@TempDir File tempDir) throws Exception {
 

--- a/src/test/java/spoon/support/JavaOutputProcessorTest.java
+++ b/src/test/java/spoon/support/JavaOutputProcessorTest.java
@@ -48,7 +48,7 @@ class JavaOutputProcessorTest {
 		Factory factory = launcher.getFactory();
 
 		// use characters encoded differently in ISO-8859-01 and UTFs
-		String code = "class ÈmptyÇlàss {}"+ System.lineSeparator();
+		String code = "class ÈmptyÇlàss {}" + System.lineSeparator();
 		CtClass<?> ctClass =  Launcher.parseClass(code);
 
 		JavaOutputProcessor javaOutputProcessor = new JavaOutputProcessor();

--- a/src/test/java/spoon/support/JavaOutputProcessorTest.java
+++ b/src/test/java/spoon/support/JavaOutputProcessorTest.java
@@ -1,10 +1,12 @@
 package spoon.support;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 import spoon.Launcher;
 import spoon.reflect.declaration.*;
 import spoon.reflect.factory.Factory;
+import spoon.testing.utils.LineSeparatorExtension;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -38,6 +40,7 @@ class JavaOutputProcessorTest {
 		assertEquals(1, javaOutputProcessor.printedFiles.size());
 	}
 
+	@ExtendWith(LineSeparatorExtension.class)
 	@Test
 	void testCreateJavaFileAssertFileEncodingChanged(@TempDir File tempDir) throws Exception {
 
@@ -48,7 +51,7 @@ class JavaOutputProcessorTest {
 		Factory factory = launcher.getFactory();
 
 		// use characters encoded differently in ISO-8859-01 and UTFs
-		String code = "class ÈmptyÇlàss {}\n";
+		String code = "class ÈmptyÇlàss {}"+ System.lineSeparator();
 		CtClass<?> ctClass =  Launcher.parseClass(code);
 
 		JavaOutputProcessor javaOutputProcessor = new JavaOutputProcessor();

--- a/src/test/java/spoon/support/JavaOutputProcessorTest.java
+++ b/src/test/java/spoon/support/JavaOutputProcessorTest.java
@@ -48,7 +48,7 @@ class JavaOutputProcessorTest {
 		Factory factory = launcher.getFactory();
 
 		// use characters encoded differently in ISO-8859-01 and UTFs
-		String code = "class ÈmptyÇlàss {}";
+		String code = "class ÈmptyÇlàss {}\n";
 		CtClass<?> ctClass =  Launcher.parseClass(code);
 
 		JavaOutputProcessor javaOutputProcessor = new JavaOutputProcessor();

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -146,7 +146,7 @@ public class CommentTest {
 				+ " * Comment3" + EOL
 				+ " */" + EOL
 				+ "@java.lang.Deprecated" + EOL
-				+ "package spoon.test.comment.testclasses;", l_content);
+				+ "package spoon.test.comment.testclasses;" + EOL, l_content);
 	}
 
 	private List<CtJavaDocTag> getTagByType(List<CtJavaDocTag> elements, CtJavaDocTag.TagType type) {

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -146,7 +146,7 @@ public class CommentTest {
 				+ " * Comment3" + EOL
 				+ " */" + EOL
 				+ "@java.lang.Deprecated" + EOL
-				+ "package spoon.test.comment.testclasses;" + EOL, l_content);
+				+ "package spoon.test.comment.testclasses;", l_content);
 	}
 
 	private List<CtJavaDocTag> getTagByType(List<CtJavaDocTag> elements, CtJavaDocTag.TagType type) {

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -261,7 +261,7 @@ public class CtClassTest {
 				"            return 0;" + newLine +
 				"        }" + newLine +
 				"    }.compare(1, 2);" + newLine +
-				"}", aClass2.toStringWithImports());
+				"}" + newLine, aClass2.toStringWithImports());
 
 		// contract: a class can be printed with full context in autoimports
 		aClass2.getFactory().getEnvironment().setAutoImports(true);
@@ -277,12 +277,12 @@ public class CtClassTest {
 				"            return 0;" + newLine +
 				"        }" + newLine +
 				"    }.compare(1, 2);" + newLine +
-				"}", aClass2.toStringWithImports());
+				"}" + newLine, aClass2.toStringWithImports());
 
 		// contract: toStringWithImports works with a new class with no position
 		assertEquals("package foo;" + newLine +
 				"import java.io.File;" + newLine +
-				"class Bar extends File {}", launcher2.getFactory().createClass("foo.Bar").setSuperclass(launcher2.getFactory().Type().get(File.class).getReference()).toStringWithImports());
+				"class Bar extends File {}" + newLine, launcher2.getFactory().createClass("foo.Bar").setSuperclass(launcher2.getFactory().Type().get(File.class).getReference()).toStringWithImports());
 	}
 
 	@Test

--- a/src/test/java/spoon/test/field/FieldTest.java
+++ b/src/test/java/spoon/test/field/FieldTest.java
@@ -216,7 +216,7 @@ public class FieldTest {
 				"import java.io.File;\n" +
 				"class A {\n" +
 				"    public static final String separator = File.separator;\n" +
-				"}", klass.toStringWithImports());
+				"}\n", klass.toStringWithImports());
 
 	}
 

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -1858,7 +1858,7 @@ public class ImportTest {
 				"        System.out.println(Locale.HELLO);\n" +
 				"        System.out.println(java.util.Locale.GERMANY);\n" +
 				"    }\n" +
-				"}",
+				"}\n",
 			user.toStringWithImports()
 		);
 	}

--- a/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/DefaultPrettyPrinterTest.java
@@ -104,7 +104,7 @@ public class DefaultPrettyPrinterTest {
 				"        findFirst();" + nl +
                 "        new ClassWithStaticMethod().notStaticFindFirst();" + nl +
 				"    }" + nl +
-				"}";
+				"}" + nl;
 
 		final CtClass<?> classUsingStaticMethod = (CtClass<?>) factory.Type().get(ClassUsingStaticMethod.class);
 		final String printed = factory.getEnvironment().createPrettyPrinter().printTypes(classUsingStaticMethod);
@@ -343,7 +343,7 @@ public class DefaultPrettyPrinterTest {
 		File javaFile = new File(pathname);
 		assertTrue(javaFile.exists());
 
-		assertEquals("package foo;" + nl + "class Bar {}",
+		assertEquals("package foo;" + nl + "class Bar {}" + nl,
 				Files.readString(javaFile.toPath(), StandardCharsets.UTF_8));
 	}
 
@@ -464,7 +464,7 @@ public class DefaultPrettyPrinterTest {
 				"        } else if (a == 3) {\n" +
 				"        }\n" +
 				"    }\n" +
-				"}";
+				"}\n";
 		assertEquals(expected, result);
 	}
 

--- a/src/test/resources/spoon/test/module/simple_module/module-info-tpl
+++ b/src/test/resources/spoon/test/module/simple_module/module-info-tpl
@@ -7,3 +7,4 @@ module simple_module {
     provides com.greetings.pkg.ConsumedService with com.greetings.pkg.ProvidedClass1, com.greetings.otherpkg.ProvidedClass2;
     provides java.logging.Service with com.greetings.logging.Logger;
 }
+


### PR DESCRIPTION
A newline has been added to the end of each file by convention. Additionally, the calculate method in DefaultJavaPrettyPrinter has been refactored. The type calculation logic is now cleaner and easier to understand, as unnecessary conditional checks have been removed.