### PR TITLE
chore: Add spoon-control-flow scan to Qodana GitHub workflow

### DIFF
--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -40,3 +40,18 @@ jobs:
         - uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3
           with:
             sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
+    code-quality-spoon-control-flow:
+      runs-on: ubuntu-latest
+      name: code-quality spoon-controlflow qodana
+      steps:
+        - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+          with:
+            fetch-depth: 0
+        - name: 'Qodana Scan (spoon-control-flow)'
+          uses: JetBrains/qodana-action@a040a784cc28cb9cabdf884c4e8c32d0aa3fcdb3 # v2023.3.2
+          with:
+            args: --source-directory,./spoon-control-flow/src/main/java , --fail-threshold, 0
+            post-pr-comment: "false"
+        - uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3
+          with:
+            sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json


### PR DESCRIPTION
This commit introduces a new Qodana scan for the 'spoon-control-flow' in the project's GitHub Actions workflow. The scan uses the JetBrains Qodana action and produces a SARIF result file that is subsequently uploaded using the CodeQL action.