### PR TITLE
chore: Remove jbang. It falls apart randomly during dependency resolution

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,8 +119,10 @@ jobs:
 
       - name: Time nix setup
         run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command true
+      - name: Time nix setup
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command mvn -f spoon-pom -B install -Dmaven.test.skip=true -DskipDepClean
       - name: Run Javadoc quality check
-        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command ci-javadoc-quality
+        run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command javadoc-quality
 
   reproducible-builds:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Time nix setup
         run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command true
-      - name: Time nix setup
+      - name: Build spoon
         run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command mvn -f spoon-pom -B install -Dmaven.test.skip=true -DskipDepClean
       - name: Run Javadoc quality check
         run: nix develop ${{ env.NIX_OPTIONS }} .#extraChecks --command javadoc-quality

--- a/chore/run-with-spoon-javadoc-classpath.sh
+++ b/chore/run-with-spoon-javadoc-classpath.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# If anything fails we are done for
+set -eu
+
+# Our dependencies
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export CLASSPATH="$(cd "$SCRIPT_DIR/../spoon-javadoc" && mvn dependency:build-classpath -Dmdep.outputFile="/dev/stderr" 2>&1 > /dev/null)"
+
+# Ourselves
+LOCAL_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
+SPOON_VERSION="$(cd "$SCRIPT_DIR/../spoon-javadoc" && mvn help:evaluate -Dexpression=project.parent.version -q -DforceStdout)"
+export CLASSPATH="$CLASSPATH:$LOCAL_REPO/fr/inria/gforge/spoon/spoon-javadoc/$SPOON_VERSION/spoon-javadoc-$SPOON_VERSION.jar"
+
+# A simple logger to disable the warning
+mvn dependency:get -Dartifact=org.slf4j:slf4j-nop:1.7.36
+export CLASSPATH="$CLASSPATH:$LOCAL_REPO/org/slf4j/slf4j-nop/1.7.36/slf4j-nop-1.7.36.jar"
+
+# Delegate
+java "$@"

--- a/flake.nix
+++ b/flake.nix
@@ -168,24 +168,6 @@
 
             chore/check-reproducible-builds.sh
           '';
-          ciJavadocQuality = pkgs.writeScriptBin "ci-javadoc-quality" ''
-            set -eu
-
-            # Help jbang. Build locally and update the version. Otherwise it fails to resolve sometimes.
-            pushd spoon-pom || exit 1
-            mvn clean install -Dmaven.test.skip=true -DskipDepClean &>/dev/null
-            popd || exit 2
-
-            # Use concrete version
-            sed -i "s/:RELEASE/:$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)/" chore/CheckJavadoc.java
-            git add chore/CheckJavadoc.java
-            git config user.email "jbang-fixup@example.com"
-            git config user.name "Jbang fixup"
-            git commit -m "Fixup version"
-
-            # Delegate
-            javadoc-quality
-          '';
           javadocQuality = pkgs.writeScriptBin "javadoc-quality" ''
             set -eu
 
@@ -200,7 +182,7 @@
               ])
             else [ ];
           packages = with pkgs;
-            [ jdk maven test codegen coverage mavenPomQuality javadocQuality ciJavadocQuality reproducibleBuilds ]
+            [ jdk maven test codegen coverage mavenPomQuality javadocQuality reproducibleBuilds ]
             ++ (if extraChecks then [ gradle pythonEnv extra extraRemote jbang ] else [ ])
             ++ (if release then [ semver jreleaser ] else [ ]);
         };


### PR DESCRIPTION
The downside is that we commit a lot of sins. This is a giant clusterfuck, but the nice way to run a java file with dependencies via jbang sporadically runs into dependency resolution failures...