### PR TITLE
fix:in no classpath, something error in toString of CtExecutableRefer…

### DIFF
--- a/src/main/java/spoon/support/visitor/SignaturePrinter.java
+++ b/src/main/java/spoon/support/visitor/SignaturePrinter.java
@@ -47,7 +47,7 @@ public class SignaturePrinter extends CtScanner {
 
 	/** writes only the name and parameters' types */
 	public <T> void writeNameAndParameters(CtExecutableReference<T> reference) {
-		if (reference.isConstructor()) {
+		if (reference.isConstructor() && reference.getDeclaringType() != null) {
 			write(reference.getDeclaringType().getQualifiedName());
 		} else {
 			write(reference.getSimpleName());


### PR DESCRIPTION
    @Test()
    void foo(){
        Launcher launcher = new Launcher();
        launcher.getEnvironment().setComplianceLevel(11);
        launcher.getEnvironment().setAutoImports(true);
        launcher.addInputResource(new VirtualFile("import java.util.List;\n" +
            "import org.apache.maven.api.model.Profile;\n" +
            "class A{\n" +
            "    public void run(List<Integer> list){\n" +
            "        list.stream().map(org.apache.maven.api.model.Profile::new);\n" +
            "    }\n" +
            "}\n"));
        CtModel ctModel = launcher.buildModel();
        List<CtExecutableReference> elements = ctModel.getElements(new TypeFilter<>(CtExecutableReference.class));
        for (CtExecutableReference element : elements) {
            try{
                element.toString();
            }catch(Exception e){
                e.printStackTrace();
            }
        }
    }