### PR TITLE
refactor(SpoonPom): Replace deprecated methods

### DIFF
--- a/src/main/java/spoon/support/compiler/SpoonPom.java
+++ b/src/main/java/spoon/support/compiler/SpoonPom.java
@@ -470,7 +470,7 @@ public class SpoonPom implements SpoonResource {
 			InvocationRequest request = new DefaultInvocationRequest();
 			request.setBatchMode(true);
 			request.setPomFile(pomFile);
-			request.setGoals(Collections.singletonList("dependency:build-classpath"));
+			request.addArg("dependency:build-classpath");
 			Properties properties = new Properties();
 			if (sourceType == MavenLauncher.SOURCE_TYPE.APP_SOURCE) {
 				properties.setProperty("includeScope", "runtime");
@@ -483,16 +483,14 @@ public class SpoonPom implements SpoonResource {
 				request.addShellEnvironment(entry.getKey(), entry.getValue());
 			}
 
+			request.setBaseDirectory(directory);
 			if (LOGGER != null) {
-				request.getOutputHandler(s -> LOGGER.debug(s));
-				request.getErrorHandler(s -> LOGGER.debug(s));
+				request.setOutputHandler(LOGGER::debug);
+				request.setErrorHandler(LOGGER::debug);
 			}
 
 			Invoker invoker = new DefaultInvoker();
 			invoker.setMavenHome(mvnHome);
-			invoker.setWorkingDirectory(directory);
-			invoker.setErrorHandler(s -> LOGGER.debug(s));
-			invoker.setOutputHandler(s -> LOGGER.debug(s));
 			try {
 				invoker.execute(request);
 			} catch (MavenInvocationException e) {


### PR DESCRIPTION
This PR replaces deprecated methods in `SpoonPom` with recommended ones.

| Deprecated | Recommended |
| ---- | ---- |
| Invoker.setWorkingDirectory | InvocationRequest.setBaseDirectory |
| Invoker.setErrorHandler | InvocationRequest.setErrorHandler |
| Invoker.setOutputHandler | InvocationRequest.setOutputHandler |
| InvocationRequest.setGoals | InvocationRequest.addArg |

Also it deletes `getOutputHandler` and `getErrorHandler`  because the values obtained are not used.