### PR TITLE
chore: mark beta releases as pre-release

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -21,6 +21,8 @@ project:
 release:
   github:
     owner: INRIA
+    prerelease:
+      pattern: .*beta.*
     changelog:
       formatted: ALWAYS
       preset: conventional-commits


### PR DESCRIPTION
We should mark the beta releases as non-production ready pre-releases. Here is an automated way to do it based on [JReleaser configuration](https://jreleaser.org/guide/latest/reference/release/github.html#_configuration).