### PR TITLE
fix: fix modeling bug

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -723,7 +723,7 @@ public class JDTTreeBuilderHelper {
 		} else if (ref.isStatic()) {
 			target = createTypeAccess(qualifiedNameReference, ref);
 		} else if (!ref.isStatic() && !ref.getDeclaringType().isAnonymous()) {
-			if (!JDTTreeBuilderQuery.isResolvedField(qualifiedNameReference)) {
+			if (!JDTTreeBuilderQuery.isFieldReference(qualifiedNameReference)) {
 				target = createTypeAccessNoClasspath(qualifiedNameReference);
 			} else {
 				target = jdtTreeBuilder.getFactory().Code().createThisAccess(jdtTreeBuilder.getReferencesBuilder().<Object>getTypeReference(qualifiedNameReference.actualReceiverType), true);

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderQuery.java
@@ -217,15 +217,14 @@ class JDTTreeBuilderQuery {
 	}
 
 	/**
-	 * Check if the name reference is resolved in the JDT tree, i.e. that the declaration is available.
+	 * Check if the name reference is resolved as a field ref in the JDT tree.
 	 *
 	 * @param qualifiedNameReference
 	 * 		Reference which should contain a field binding.
 	 * @return true if the field has been resolved by the jdt builder.
 	 */
-	static boolean isResolvedField(QualifiedNameReference qualifiedNameReference) {
-		return qualifiedNameReference.binding instanceof FieldBinding
-				&& ((FieldBinding) qualifiedNameReference.binding).original().sourceField() != null;
+	static boolean isFieldReference(QualifiedNameReference qualifiedNameReference) {
+		return qualifiedNameReference.binding instanceof FieldBinding;
 	}
 
 

--- a/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
+++ b/src/test/java/spoon/test/prettyprinter/QualifiedThisRefTest.java
@@ -39,6 +39,7 @@ import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.VirtualFile;
 import spoon.support.reflect.code.CtFieldAccessImpl;
 import spoon.test.delete.testclasses.Adobada;
 import spoon.test.prettyprinter.testclasses.QualifiedThisRef;
@@ -142,6 +143,45 @@ public class QualifiedThisRefTest {
 		printer.visitCtClass(zeclass);
 
 		assertFalse(printer.getResult().isEmpty());
+
+	}
+
+	@Test
+	public void testGuavaBug() {
+		// contract: does not model buf as a typeaccess, does not write ByteArrayOutputStream.buf
+		// this bug was found by spooning Guava in Jenkins
+		final String code = "class ExposedByteArrayOutputStream extends java.io.ByteArrayOutputStream {\n" +
+				"        ExposedByteArrayOutputStream(int expectedInputSize) {\n" +
+				"            super(expectedInputSize);\n" +
+				"        }\n" +
+				"\n" +
+				"        void write(java.nio.ByteBuffer input) {\n" +
+				"            int remaining = input.remaining();\n" +
+				"            if ((count + remaining) > buf.length) {\n" +
+				"                //buf = java.util.Arrays.copyOf(buf, count + remaining);\n" +
+				"            }\n" +
+				"            input.get(buf, count, remaining);\n" +
+				"            count += remaining;\n" +
+				"        }\n" +
+				"\n" +
+				"        byte[] byteArray() {\n" +
+				"            return buf;\n" +
+				"        }\n" +
+				"\n" +
+				"        int length() {\n" +
+				"            return count;\n" +
+				"        }\n" +
+				"    }";
+
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile(code));
+		launcher.getEnvironment().setNoClasspath(false);
+		launcher.getEnvironment().setAutoImports(true);
+
+		CtClass<?> c = (CtClass<?>) launcher.buildModel().getAllTypes().iterator().next();
+		assertEquals(c.getSimpleName().toString(), "ExposedByteArrayOutputStream");
+		// contract: buf is not a static field
+		assertFalse(c.toString().contains("ByteArrayOutputStream.buf"), "that will not compile for sure");
 
 	}
 }

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -296,12 +296,16 @@ public class TargetedExpressionTest {
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setNoClasspath(true);
 		launcher.addInputResource("./src/test/resources/spoon/test/noclasspath/targeted/StaticFieldReadOnly.java");
+
 		CtModel model = launcher.buildModel();
 
 		List<CtInvocation<?>> invocations = model.getElements(e -> e.getExecutable().getSimpleName().equals("error"));
 		CtInvocation<?> inv = invocations.get(0);
 		CtFieldRead<?> fieldRead = (CtFieldRead<?>) inv.getTarget();
-		CtExpression<?> target = fieldRead.getTarget();
+		// we do have the right type access in noclasspath mode
+		// the slight behavior change is that it adds one level of indirection
+		// however correct behavior is full classpath mode is higher priority, see https://github.com/INRIA/spoon/pull/5912
+		CtTypeAccess<?> target = (CtTypeAccess<?>) fieldRead.filterChildren(new TypeFilter<>(CtTypeAccess.class)).list().get(0);
 
 		assertTrue(target instanceof CtTypeAccess);
 		assertEquals("Launcher", ((CtTypeAccess<?>) target).getAccessedType().getSimpleName());

--- a/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
+++ b/src/test/java/spoon/test/targeted/TargetedExpressionTest.java
@@ -303,7 +303,7 @@ public class TargetedExpressionTest {
 		CtInvocation<?> inv = invocations.get(0);
 		CtFieldRead<?> fieldRead = (CtFieldRead<?>) inv.getTarget();
 		// we do have the right type access in noclasspath mode
-		// the slight behavior change is that it adds one level of indirection
+		// the slight behavior change is that PR 5812 adds one level of indirection in the model, hence the filterChildren call
 		// however correct behavior is full classpath mode is higher priority, see https://github.com/INRIA/spoon/pull/5912
 		CtTypeAccess<?> target = (CtTypeAccess<?>) fieldRead.filterChildren(new TypeFilter<>(CtTypeAccess.class)).list().get(0);
 


### PR DESCRIPTION
expected behavior: buf is a field access

actual behavior: buf is a typeaccess

cause: isResolvedField assumed that everything is source-available and returned false if a library class (binary only, ByteArrayOutputStream here) 
