### PR TITLE
fix: correct spelling mistake in API, doc and tests (#5934)

### DIFF
--- a/doc/processor_annotations.md
+++ b/doc/processor_annotations.md
@@ -73,7 +73,7 @@ public interface AnnotationProcessor<A extends Annotation, E extends CtElement> 
 	boolean inferConsumedAnnotationType();
 	Set<Class<? extends A>> getProcessedAnnotationTypes();
 	Set<Class<? extends A>> getConsumedAnnotationTypes();
-	boolean shoudBeConsumed(CtAnnotation<? extends Annotation> annotation);
+	boolean shouldBeConsumed(CtAnnotation<? extends Annotation> annotation);
 }
 ```
 
@@ -81,7 +81,7 @@ Annotation processors extend normal processors by stating the annotation type th
 carry (type parameter `A`), in addition of stating the kind of source code element they process 
 (type parameter `E`). The `process` method (line 4) receives as arguments both the `CtElement` and the 
 annotation it carries. The remaining four methods (`getProcessedAnnotationTypes`, `getConsumedAnnotationTypes`, 
-`inferConsumedAnnotationTypes` and `shoudBeConsumed`) configure the visiting of the AST during annotation 
+`inferConsumedAnnotationTypes` and `shouldBeConsumed`) configure the visiting of the AST during annotation 
 processing. The Spoon annotation processing runtime is able to infer the type of annotation a processor 
 handles from its type parameter `A`. This restricts each processor to handle a single annotation. To avoid this 
 restriction, a developer can override the `inferConsumedAnnotationType()` method to return `false`. When doing 

--- a/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AbstractAnnotationProcessor.java
@@ -124,7 +124,7 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	public final boolean isToBeProcessed(E element) {
 		if ((element != null) && (element.getAnnotations() != null)) {
 			for (CtAnnotation<? extends Annotation> a : element.getAnnotations()) {
-				if (shoudBeProcessed(a)) {
+				if (shouldBeProcessed(a)) {
 					return true;
 				}
 			}
@@ -137,13 +137,13 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	@SuppressWarnings("unchecked")
 	public final void process(E element) {
 		for (CtAnnotation<? extends Annotation> annotation : new ArrayList<>(element.getAnnotations())) {
-			if (shoudBeProcessed(annotation)) {
+			if (shouldBeProcessed(annotation)) {
 				try {
 					process((A) annotation.getActualAnnotation(), element);
 				} catch (Exception e) {
 					Launcher.LOGGER.error(e.getMessage(), e);
 				}
-				if (shoudBeConsumed(annotation)) {
+				if (shouldBeConsumed(annotation)) {
 					element.removeAnnotation(annotation);
 				}
 			}
@@ -154,13 +154,21 @@ public abstract class AbstractAnnotationProcessor<A extends Annotation, E extend
 	 * {@inheritDoc}
 	 *
 	 * Removes all annotations A on elements E.
+	 *
+	 * @deprecated use {@link #shouldBeConsumed(CtAnnotation)} instead
 	 */
+	@Deprecated
 	@Override
 	public boolean shoudBeConsumed(CtAnnotation<? extends Annotation> annotation) {
 		return consumedAnnotationTypes.containsKey(annotation.getAnnotationType().getQualifiedName());
 	}
 
-	private boolean shoudBeProcessed(CtAnnotation<? extends Annotation> annotation) {
+	@Override
+	public boolean shouldBeConsumed(CtAnnotation<? extends Annotation> annotation) {
+		return consumedAnnotationTypes.containsKey(annotation.getAnnotationType().getQualifiedName());
+	}
+
+	private boolean shouldBeProcessed(CtAnnotation<? extends Annotation> annotation) {
 		return processedAnnotationTypes.containsKey(annotation.getAnnotationType().getQualifiedName());
 	}
 

--- a/src/main/java/spoon/processing/AnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AnnotationProcessor.java
@@ -62,7 +62,15 @@ public interface AnnotationProcessor<A extends Annotation, E extends CtElement>
 
 	/**
 	 * Returns true if this annotation should be removed from the processed code.
+     *
+     * @deprecated use {@link #shouldBeConsumed(CtAnnotation)} instead
 	 */
+	@Deprecated
 	boolean shoudBeConsumed(CtAnnotation<? extends Annotation> annotation);
+
+	/**
+	 * Returns true if this annotation should be removed from the processed code.
+	 */
+	boolean shouldBeConsumed(CtAnnotation<? extends Annotation> annotation);
 
 }

--- a/src/main/java/spoon/processing/AnnotationProcessor.java
+++ b/src/main/java/spoon/processing/AnnotationProcessor.java
@@ -21,7 +21,7 @@ import spoon.reflect.declaration.CtElement;
  * the abstract default implementation of this interface.
  */
 public interface AnnotationProcessor<A extends Annotation, E extends CtElement>
-		extends Processor<E> {
+	extends Processor<E> {
 
 	/**
 	 * Do the annotation processing job for a given annotation.
@@ -62,14 +62,20 @@ public interface AnnotationProcessor<A extends Annotation, E extends CtElement>
 
 	/**
 	 * Returns true if this annotation should be removed from the processed code.
-     *
-     * @deprecated use {@link #shouldBeConsumed(CtAnnotation)} instead
+	 *
+	 * @param annotation the annotation to be checked
+	 * @return true, if the given annotation should be removed from the processed code.
+	 *
+	 * @deprecated use {@link #shouldBeConsumed(CtAnnotation)} instead
 	 */
 	@Deprecated
 	boolean shoudBeConsumed(CtAnnotation<? extends Annotation> annotation);
 
 	/**
 	 * Returns true if this annotation should be removed from the processed code.
+	 *
+	 * @param annotation the annotation to be checked
+	 * @return true, if the given annotation should be removed from the processed code.
 	 */
 	boolean shouldBeConsumed(CtAnnotation<? extends Annotation> annotation);
 

--- a/src/test/java/spoon/test/api/APITest.java
+++ b/src/test/java/spoon/test/api/APITest.java
@@ -573,7 +573,7 @@ public class APITest {
 
 	@Test
 	public void testOutputWithNoOutputProduceNoFolder() {
-		// contract: when using "NO_OUTPUT" output type, no output folder shoud be created
+		// contract: when using "NO_OUTPUT" output type, no output folder should be created
 		String destPath = "./target/nooutput_" + UUID.randomUUID().toString();
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/java/spoon/test/api/testclasses/Bar.java");

--- a/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
+++ b/src/test/java/spoon/test/reference/ExecutableReferenceTest.java
@@ -114,7 +114,7 @@ public class ExecutableReferenceTest {
 		try {
 			aMethod.getType().getAllExecutables();
 		} catch (NullPointerException e) {
-			fail("We shoudn't have a NullPointerException when we call getAllExecutables.");
+			fail("We shouldn't have a NullPointerException when we call getAllExecutables.");
 		}
 	}
 


### PR DESCRIPTION
- mark misspelled method as deprecated
- add new method with correct spelling
- correct spelling of method in docs and test classes