### PR TITLE
Fix and simplify packaging and running of `spoon-visualization`

### DIFF
--- a/spoon-visualisation/README.md
+++ b/spoon-visualisation/README.md
@@ -9,11 +9,9 @@ It is an alternative to the Swing-based GUI of Spoon ASTs (`$ java -cp spoon...-
 
 ## How to run
 
-The app requires a JDK 11.
-We currently do not provide any packaging of the app (`jlink` cannot package apps having non-modular libraries, such as Spoon).
-
-So, to run the app, run: `mvn clean package`. 
-Then go into the `target/modules` folder and launch: `java --module-path . --add-modules=ALL-MODULE-PATH -jar visualisation-1.1.jar`
+1. Install Java **22** or newer.
+2. Run: `mvn javafx:run`. Alternativatively, build a fat jar using `mvn
+   package` and then run `java -jar target/spoon-visualisation-all.jar`.
 
 ## Features Summary
 

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -9,7 +9,7 @@
     <licenses>
         <license>
             <name>The MIT license</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
@@ -17,7 +17,7 @@
     <parent>
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-pom</artifactId>
-        <version>1.0</version>
+        <version>11.1.0</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
 
@@ -30,70 +30,9 @@
         <plugins>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.4.2</version>
                 <configuration>
                     <outputDirectory>${project.build.directory}/modules</outputDirectory>
                 </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.0</version>
-                <executions>
-                    <execution>
-                        <id>main deps</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <excludeClassifiers>linux,win,mac</excludeClassifiers>
-                            <outputDirectory>
-                                ${project.build.directory}/modules
-                            </outputDirectory>
-                            <includeScope>runtime</includeScope>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>JFX deps</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>
-                                ${project.build.directory}/modules
-                            </outputDirectory>
-                            <includeScope>runtime</includeScope>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.4.1</version>
-                <executions>
-                    <execution>
-                        <id>main module</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>${java.home}/bin/jar</executable>
-                            <arguments>
-                                <argument>--update</argument>
-                                <argument>--file=${project.build.directory}/modules/${project.build.finalName}.jar</argument>
-                                <argument>--main-class=spoon.visualisation.ShowMe</argument>
-                                <argument>--module-version=${project.version}</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
             <plugin>
@@ -102,13 +41,14 @@
                 <configuration>
                     <testFailureIgnore>false</testFailureIgnore>
                     <useModulePath>false</useModulePath>
-                    <argLine>-Xmx2000m
-                        -Dglass.platform=Monocle
+                    <argLine>
+                        -Xmx2000m
                         -Dheadless.geometry=1280x1024-32
                         -Djava.awt.headless=true
                         -Dtestfx.robot=glass
                         -Dtestfx.headless=true
-                        -Dprism.order=sw</argLine>
+                        -Dprism.order=sw
+                    </argLine>
                 </configuration>
             </plugin>
         </plugins>
@@ -130,36 +70,6 @@
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
             <version>11.1.0</version>
-            <exclusions>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>org.codehaus.plexus</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>org.apache.maven.shared</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>org.apache.maven</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>org.eclipse.platform</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>*</artifactId>
-                        <groupId>org.tukaani</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>commons-compress</artifactId>
-                        <groupId>org.apache.commons</groupId>
-                    </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
@@ -212,14 +122,4 @@
             </exclusions>
         </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>spoon-snapshot</id>
-            <name>Maven Repository for Spoon Snapshots</name>
-            <url>https://repository.ow2.org/nexus/content/repositories/snapshots/</url>
-            <snapshots><enabled>true</enabled></snapshots>
-            <releases><enabled>false</enabled></releases>
-        </repository>
-    </repositories>
 </project>

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -41,6 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <id>shade-jar</id>
@@ -96,6 +97,7 @@
                 <version>0.0.8</version>
                 <configuration>
                     <mainClass>spoon.visualisation/spoon.visualisation.Launcher</mainClass>
+                    <runtimePathOption>CLASSPATH</runtimePathOption>
                 </configuration>
             </plugin>
         </plugins>

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -29,9 +29,47 @@
     <build>
         <plugins>
             <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-jar</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                    </execution>
+                </executions>
                 <configuration>
-                    <outputDirectory>${project.build.directory}/modules</outputDirectory>
+                    <finalName>spoon-${project.name}-all</finalName>
+                    <transformers>
+                        <transformer
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>spoon.visualisation.Launcher</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
             </plugin>
 

--- a/spoon-visualisation/pom.xml
+++ b/spoon-visualisation/pom.xml
@@ -89,6 +89,15 @@
                     </argLine>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.openjfx</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>0.0.8</version>
+                <configuration>
+                    <mainClass>spoon.visualisation/spoon.visualisation.Launcher</mainClass>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/spoon-visualisation/src/main/java/spoon/visualisation/Launcher.java
+++ b/spoon-visualisation/src/main/java/spoon/visualisation/Launcher.java
@@ -1,0 +1,9 @@
+package spoon.visualisation;
+
+import javafx.application.Application;
+
+public class Launcher {
+	public static void main(String[] args) {
+		Application.launch(ShowMe.class);
+	}
+}

--- a/spoon-visualisation/src/main/java/spoon/visualisation/command/SpoonTreeCmdBase.java
+++ b/spoon-visualisation/src/main/java/spoon/visualisation/command/SpoonTreeCmdBase.java
@@ -82,7 +82,7 @@ abstract class SpoonTreeCmdBase extends CommandImpl {
 		env.setAutoImports(true);
 		env.disableConsistencyChecks();
 		env.setLevel("OFF");
-		env.setComplianceLevel(11);
+		env.setComplianceLevel(22);
 
 		launcher.buildModel().getRootPackage().accept(new SpoonTreeScanner(createSpoonVisitor(levelsToIgnore), hideImplicit));
 


### PR DESCRIPTION
This PR fixes the POM for spoon-visualization and radically simplifies the execution to `mvn javafx:run` or building a runnable fat jar with `mvn package`.

Fixes: #5795 