### PR TITLE
Update FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # file such that Spoon is considered as sponsorable by Github
-
+github: [spoonlabs]
 # https://opencollective.com/spoon-java
 open_collective: spoon-java


### PR DESCRIPTION
problem: Spoon is not recognisable as sponsorable (https://github.com/search?q=org%3AINRIA%20is%3Asponsorable&type=repositories)

reason: the definition of sponsorable is not only "having a funding.yml" file, it's actually "having a funding.yml with a sponsorable github handle" [ref](https://github.com/orgs/community/discussions/55497#discussioncomment-5929886)

This PR fixes it. Note that SpoonLabs has the same open-collective destination as Spoon itself.
