### PR TITLE
review: test: only run tests with compliance level >=8

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -251,7 +251,7 @@ public class Launcher implements SpoonAPI {
 			// java compliance
 			opt2 = new FlaggedOption("compliance");
 			opt2.setLongFlag("compliance");
-			opt2.setHelp("Java source code compliance level (1,2,3,4,5, 6, 7 or 8).");
+			opt2.setHelp("Java source code compliance level (e.g. 21 for Java 21).");
 			opt2.setStringParser(JSAP.INTEGER_PARSER);
 			opt2.setDefault(DEFAULT_CODE_COMPLIANCE_LEVEL + "");
 			jsap.registerParameter(opt2);

--- a/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTBasedSpoonCompiler.java
@@ -41,6 +41,7 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.Query;
 import spoon.support.Level;
 import spoon.support.QueueProcessingManager;
+import spoon.support.StandardEnvironment;
 import spoon.support.comparator.FixedOrderBasedOnFileNameCompilationUnitComparator;
 import spoon.support.compiler.SnippetCompilationError;
 import spoon.support.compiler.SpoonProgress;
@@ -73,7 +74,7 @@ public class JDTBasedSpoonCompiler implements spoon.SpoonModelBuilder {
 	protected final List<CategorizedProblem> probs = new ArrayList<>();
 	protected final TreeBuilderRequestor requestor = new TreeBuilderRequestor(this);
 	protected Factory factory;
-	protected int javaCompliance = 7;
+	protected int javaCompliance = StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL;
 	//list of java files or folders with java files which represents source of the CtModel
 	protected SpoonFolder sources = new VirtualFolder();
 	//list of java files or folders with java files which represents templates. Templates are added to CtModel too.

--- a/src/test/java/spoon/test/compilation/CompilationTest.java
+++ b/src/test/java/spoon/test/compilation/CompilationTest.java
@@ -55,6 +55,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.SpoonClassNotFoundException;
+import spoon.support.StandardEnvironment;
 import spoon.support.compiler.FileSystemFolder;
 import spoon.support.compiler.ProgressLogger;
 import spoon.support.compiler.jdt.JDTBasedSpoonCompiler;
@@ -116,7 +117,7 @@ public class CompilationTest {
 				"-i", sourceFile,
 				"-o", "target/spooned",
 				"--compile",
-				"--compliance", "7",
+				"--compliance", String.valueOf(StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL),
 				"--level", "OFF"
 		});
 

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -50,6 +50,7 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.DefaultJavaPrettyPrinter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.StandardEnvironment;
 import spoon.test.SpoonTestHelpers;
 import spoon.test.ctClass.testclasses.AnonymousClass;
 import spoon.test.ctClass.testclasses.Foo;
@@ -398,7 +399,7 @@ public class CtClassTest {
 		assertFalse(secondRemovalSuccessful);
 	}
 
-	@org.junit.jupiter.api.Test
+	@Test
 	void testLocalClassExists() {
 		// contract: local classes and their members are part of the model
 		String code = SpoonTestHelpers.wrapLocal(
@@ -407,7 +408,7 @@ public class CtClassTest {
 						"			public void doNothing() { }\n" +
 						"		}\n"
 		);
-		CtModel model = SpoonTestHelpers.createModelFromString(code, 5);
+		CtModel model = SpoonTestHelpers.createModelFromString(code, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 		CtBlock<?> block = SpoonTestHelpers.getBlock(model);
 
 		MatcherAssert.assertThat("The local class does not exist in the model", block.getStatements().size(), CoreMatchers.is(1));

--- a/src/test/java/spoon/test/ctType/CtTypeTest.java
+++ b/src/test/java/spoon/test/ctType/CtTypeTest.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.ctType;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
@@ -295,6 +296,7 @@ public class CtTypeTest {
 	 * "enum" was only introduced in Java 5
 	 */
 	@Test
+	@Disabled("Compliance level 4 is not supported anymore")
 	public void testEnumPackage() {
 		final Launcher launcher = new Launcher();
 		launcher.addInputResource("./src/test/resources/keywordCompliance/enum/Foo.java");

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -16,6 +16,7 @@
  */
 package spoon.test.imports;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -776,7 +777,7 @@ public class ImportTest {
 				output,
 				not(containsString("import static spoon.test.imports.testclasses.ItfWithEnum$Bar.Lip;"))
 		);
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -799,7 +800,7 @@ public class ImportTest {
 
 		assertThat("The file should not contain the import of enum", output, not(containsString("import spoon.reflect.path.CtRole;")));
 		assertThat("The file should contain the static import of enum field", output, not(containsString("import spoon.reflect.path.CtRole.NAME;")));
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -820,7 +821,7 @@ public class ImportTest {
 		String output = prettyPrinter.getResult();
 
 		assertThat("The file should not contain a static import for NOFOLLOW_LINKS", output, not(containsString("import static java.nio.file.LinkOption.NOFOLLOW_LINKS;")));
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -840,7 +841,7 @@ public class ImportTest {
 		prettyPrinter.calculate(element.getPosition().getCompilationUnit(), toPrint);
 		String output = prettyPrinter.getResult();
 
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -1014,7 +1015,7 @@ public class ImportTest {
 		launcher.setSourceOutputDirectory(outputDir);
 		launcher.run();
 
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -1026,7 +1027,7 @@ public class ImportTest {
 		launcher.setSourceOutputDirectory(outputDir);
 		launcher.run();
 
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -1064,7 +1065,7 @@ public class ImportTest {
 		launcher.setSourceOutputDirectory(outputDir);
 		launcher.run();
 
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 
 		Path outputDirPath = Path.of(outputDir);
 		Path pathA = outputDirPath.resolve("spoon/test/imports/testclasses/multiplecu/A.java");
@@ -1080,7 +1081,7 @@ public class ImportTest {
 	}
 
 	@Test
-	public void testStaticMethodWithDifferentClassSameNameJava7NoCollision() {
+	public void testStaticMethodWithDifferentClassSameNameJava7PlusNoCollision() {
 		// contract: when there is a collision between class names when using static method, we should create a static import for the method
 		final Launcher launcher = new Launcher();
 		launcher.getEnvironment().setAutoImports(true);
@@ -1090,7 +1091,7 @@ public class ImportTest {
 		launcher.addInputResource("./src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/enum2/");
 		launcher.addInputResource("./src/test/resources/spoon/test/imports/testclasses2/apachetestsuite/LangTestSuite.java");
 		launcher.setSourceOutputDirectory(outputDir);
-		launcher.getEnvironment().setComplianceLevel(7);
+		launcher.getEnvironment().setComplianceLevel(StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 		launcher.run();
 		PrettyPrinter prettyPrinter = launcher.createPrettyPrinter();
 
@@ -1104,10 +1105,11 @@ public class ImportTest {
 		assertThat("The file should contain a static import ", output, containsString("import static spoon.test.imports.testclasses2.apachetestsuite.enums.EnumTestSuite.suite;"));
 		assertThat("The call to the last EnumTestSuite should be in FQN", output, containsString("suite.add(suite());"));
 
-		canBeBuilt(outputDir, 7);
+		canBeBuilt(outputDir, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
+	@Disabled("Compliance level 3 is not supported anymore")
 	public void testStaticMethodWithDifferentClassSameNameJava3NoCollision() {
 		// contract: when there is a collision between class names when using static method, we could not create a static import
 		// as it is not compliant with java < 1.5, so we should use fully qualified name of the class
@@ -1137,6 +1139,7 @@ public class ImportTest {
 	}
 
 	@Test
+	@Disabled("Compliance level 3 is not supported anymore")
 	public void testStaticMethodWithDifferentClassSameNameCollision() {
 		// contract: when using static method, if there is a collision between class name AND between method names,
 		// we can only use the fully qualified name of the class to call the static method

--- a/src/test/java/spoon/test/prettyprinter/PrinterTest.java
+++ b/src/test/java/spoon/test/prettyprinter/PrinterTest.java
@@ -44,6 +44,7 @@ import spoon.reflect.visitor.PrettyPrinter;
 import spoon.reflect.visitor.PrinterHelper;
 import spoon.reflect.visitor.TokenWriter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.StandardEnvironment;
 import spoon.test.prettyprinter.testclasses.MissingVariableDeclaration;
 import spoon.testing.utils.ModelUtils;
 
@@ -213,7 +214,7 @@ public class PrinterTest {
 		String result = printer.getResult();
 
 		assertTrue(!result.contains("Rule.Phoneme.this.phonemeText"), "The result should contain direct this accessor for field: " + result);
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 
@@ -252,7 +253,7 @@ public class PrinterTest {
 		String result = printer.getResult();
 
 		assertTrue(!result.contains("Rule.Phoneme.this.phonemeText"), "The result should contain direct this accessor for field: " + result);
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test

--- a/src/test/java/spoon/test/trycatch/TryCatchTest.java
+++ b/src/test/java/spoon/test/trycatch/TryCatchTest.java
@@ -53,6 +53,7 @@ import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.filter.AbstractFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.StandardEnvironment;
 import spoon.support.compiler.VirtualFile;
 import spoon.support.reflect.CtExtendedModifier;
 import spoon.test.trycatch.testclasses.Foo;
@@ -298,7 +299,7 @@ public class TryCatchTest {
 		String inputResource = "./src/test/java/spoon/test/trycatch/testclasses/Bar.java";
 		Launcher launcher = new Launcher();
 		launcher.addInputResource(inputResource);
-		launcher.getEnvironment().setComplianceLevel(5);
+		launcher.getEnvironment().setComplianceLevel(StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 		launcher.buildModel();
 
 		CtTry tryStmt = launcher.getModel().getElements(new TypeFilter<>(CtTry.class)).get(0);
@@ -317,7 +318,7 @@ public class TryCatchTest {
 		launcher.addInputResource(inputResource);
 		launcher.setSourceOutputDirectory("./target/spoon-trycatch");
 		launcher.getEnvironment().setShouldCompile(true);
-		launcher.getEnvironment().setComplianceLevel(5);
+		launcher.getEnvironment().setComplianceLevel(StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 		launcher.run();
 
 		File f = new File("target/spoon-trycatch/spoon/test/trycatch/testclasses/Bar.java");

--- a/src/test/java/spoon/test/variable/AccessFullyQualifiedFieldTest.java
+++ b/src/test/java/spoon/test/variable/AccessFullyQualifiedFieldTest.java
@@ -26,6 +26,7 @@ import spoon.Launcher;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.PrettyPrinter;
+import spoon.support.StandardEnvironment;
 import spoon.test.variable.testclasses.Tacos;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -66,7 +67,7 @@ public class AccessFullyQualifiedFieldTest {
 
 		assertTrue(result.contains("import spoon.Launcher;"), "The java file should contain import for Launcher");
 		assertTrue(result.contains("xx = Launcher.SPOONED_CLASSES"), "The xx variable is attributed with Launcher.SPOONED_CLASSES");
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -81,7 +82,7 @@ public class AccessFullyQualifiedFieldTest {
 		assertTrue(!result.contains("import java.util.Map"), "The java.util.Map is not imported");
 		assertTrue(result.contains("java.util.Map uneMap"), "The Map type use FQN");
 		assertTrue(result.contains("ForStaticVariables.Map"), "The other variable use FQN too");
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -93,7 +94,7 @@ public class AccessFullyQualifiedFieldTest {
 		//the package name `spoon.test.variable.testclasses` cannot be used in FQN mode because it is shadowed by local variable `spoon`
 		//so use at least Type name
 		assertTrue(result.contains(" BurritosStaticMethod.toto();"), "The inner class should contain call using import");
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -104,7 +105,7 @@ public class AccessFullyQualifiedFieldTest {
 		String result = this.buildResourceAndReturnResult(pathResource, output);
 		assertTrue(result.contains("import spoon.Launcher;"), "The java file should contain import for Launcher");
 		assertTrue(result.contains("xx = Launcher.SPOONED_CLASSES"), "The xx variable should be attributed with SPOONED_CLASSES");
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -115,7 +116,7 @@ public class AccessFullyQualifiedFieldTest {
 		String result = this.buildResourceAndReturnResult(pathResource, output);
 		assertTrue(result.contains("import spoon.Launcher;"), "The java file should contain import for Launcher");
 		assertTrue(result.contains("xx = Launcher.SPOONED_CLASSES"), "The xx variable should be attributed with SPOONED_CLASSES");
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -144,7 +145,7 @@ public class AccessFullyQualifiedFieldTest {
 		assertTrue(!result.contains("spoon.test.variable.testclasses.MultiBurritos.spoon = \"truc\";"), "The result should not contain a FQN for spoon access");
 		assertTrue(!result.contains("spoon.test.variable.testclasses.ForStaticVariables.foo();"), "The result should not contain a FQN for foo");
 
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -156,7 +157,7 @@ public class AccessFullyQualifiedFieldTest {
 		assertTrue(result.contains("import static spoon.Launcher.SPOONED_CLASSES;"), "The result should contain a static import for spoon.Launcher.SPOONED_CLASSES");
 		assertTrue(!result.contains("spoon.test.variable.testclasses.ForStaticVariables.foo()"), "The result should not contain a FQN call for foo (i.e. spoon.test.variable.testclasses.ForStaticVariables.foo())");
 
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test
@@ -166,6 +167,6 @@ public class AccessFullyQualifiedFieldTest {
 		String result = this.buildResourceAndReturnResult(pathResource, output);
 		assertTrue(!result.contains("import static spoon.test.variable.testclasses.digest.DigestUtil.STREAM_BUFFER_LENGTH;"), "The result should not contain a static import for STREAM_BUFFER_LENGTH");
 
-		canBeBuilt(output, 7);
+		canBeBuilt(output, StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 }

--- a/src/test/java/spoon/test/visibility/VisibilityTest.java
+++ b/src/test/java/spoon/test/visibility/VisibilityTest.java
@@ -37,6 +37,7 @@ import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractReferenceFilter;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.StandardEnvironment;
 import spoon.test.visibility.testclasses.A;
 import spoon.test.visibility.testclasses.A2;
 
@@ -85,7 +86,7 @@ public class VisibilityTest {
 		assertNotNull(aFloat);
 		assertSame(spoon.test.visibility.testclasses.Float.class, aFloat.getActualClass());
 
-		canBeBuilt(new File("./target/spooned/spoon/test/visibility_package/testclasses/"), 7);
+		canBeBuilt(new File("./target/spooned/spoon/test/visibility_package/testclasses/"), StandardEnvironment.DEFAULT_CODE_COMPLIANCE_LEVEL);
 	}
 
 	@Test


### PR DESCRIPTION
In preparation for #5977, we need to make sure that tests only run with a compliance level >= 8.

I went through the affected tests trying to figure out if there is a specific reason why they used a lower language level. Those where it doesn't seem to make sense to run on higher language levels are disabled now with a comment. I'm not sure if we want to remove them directly.

Note: There are more failing tests in #5977, but the others have different reasons that we need to analyze more closely I guess. That's why I'd like to address them separately.