### PR TITLE
review: Attest build artifacts

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -6,10 +6,6 @@ on:
       release-script-to-run:
         required: true
         type: string
-      attest-artifacts:
-        required: false
-        type: boolean
-        default: true # calling workflows can opt-out of attestation
 
 permissions:
   id-token: write # for verifying identity in attestation process
@@ -38,7 +34,6 @@ jobs:
           JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD }}
 
       - name: Sign artifacts with sigstore/cosign
-        if: inputs.attest-artifacts
         uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
         with:
           subject-path: './target/staging-deploy/**/*.jar'

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -6,6 +6,14 @@ on:
       release-script-to-run:
         required: true
         type: string
+      attest-artifacts:
+        required: false
+        type: boolean
+        default: true # calling workflows can opt-out of attestation
+
+permissions:
+  id-token: write # for verifying identity in attestation process
+  attestations: write # to push attestation
 
 jobs:
   jreleaser:
@@ -28,6 +36,12 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME }}
           JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD }}
+
+      - name: Sign artifacts with sigstore/cosign
+        if: inputs.attest-artifacts
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        with:
+          subject-path: './target/staging-deploy/**/*.jar'
 
         # Log failures
       - name: JReleaser release output

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -9,4 +9,5 @@ jobs:
     uses: ./.github/workflows/jreleaser.yml
     with:
       release-script-to-run: chore/release-nightly.sh
+      attest-artifacts: false
     secrets: inherit

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -9,5 +9,4 @@ jobs:
     uses: ./.github/workflows/jreleaser.yml
     with:
       release-script-to-run: chore/release-nightly.sh
-      attest-artifacts: false
     secrets: inherit


### PR DESCRIPTION
This makes it so all release pipelines attest the artifacts they build, by signing the corresponding checksums. Optionally release workflows may opt out of this behavior, which in this commit is done for `nightly` as specified by @monperrus on the linked issue.

Closes #5957