### PR TITLE
Fix SortedList.addAll(...) to be JLS compliant and provide unit tests

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -7,6 +7,10 @@ on:
         required: true
         type: string
 
+permissions:
+  id-token: write # for verifying identity in attestation process
+  attestations: write # to push attestation
+
 jobs:
   jreleaser:
     runs-on: ubuntu-latest
@@ -28,6 +32,11 @@ jobs:
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_USERNAME }}
           JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_MAVEN_CENTRAL_PASSWORD }}
+
+      - name: Sign artifacts with sigstore/cosign
+        uses: actions/attest-build-provenance@1c608d11d69870c2092266b3f9a6f3abbf17002c # v1.4.3
+        with:
+          subject-path: './target/staging-deploy/**/*.jar'
 
         # Log failures
       - name: JReleaser release output

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -18,7 +18,7 @@ jobs:
           with:
             fetch-depth: 0
         - name: 'Qodana Scan'
-          uses: JetBrains/qodana-action@a040a784cc28cb9cabdf884c4e8c32d0aa3fcdb3 # v2023.3.2
+          uses: JetBrains/qodana-action@4f04143e8d52028fee27c2a219c8856035094962 # v2024.2.5
           with:
             args: --source-directory,./src/main/java , --fail-threshold, 0
             post-pr-comment: "false"
@@ -33,7 +33,7 @@ jobs:
           with:
             fetch-depth: 0
         - name: 'Qodana Scan (spoon-javadoc)'
-          uses: JetBrains/qodana-action@a040a784cc28cb9cabdf884c4e8c32d0aa3fcdb3 # v2023.3.2
+          uses: JetBrains/qodana-action@4f04143e8d52028fee27c2a219c8856035094962 # v2024.2.5
           with:
             args: --source-directory,./spoon-javadoc/src/main/java , --fail-threshold, 0
             post-pr-comment: "false"
@@ -48,7 +48,7 @@ jobs:
           with:
             fetch-depth: 0
         - name: 'Qodana Scan (spoon-control-flow)'
-          uses: JetBrains/qodana-action@a040a784cc28cb9cabdf884c4e8c32d0aa3fcdb3 # v2023.3.2
+          uses: JetBrains/qodana-action@4f04143e8d52028fee27c2a219c8856035094962 # v2024.2.5
           with:
             args: --source-directory,./spoon-control-flow/src/main/java , --fail-threshold, 0
             post-pr-comment: "false"

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729256560,
-        "narHash": "sha256-/uilDXvCIEs3C9l73JTACm4quuHUsIHcns1c+cHUJwA=",
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4c2fcb090b1f3e5b47eaa7bd33913b574a11e0a0",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
         "type": "github"
       },
       "original": {

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
   <parent>
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
-    <version>11.1.1-beta-11</version>
+    <version>11.1.1-SNAPSHOT</version>
     <relativePath>spoon-pom</relativePath>
   </parent>
 
   <artifactId>spoon-core</artifactId>
   <packaging>jar</packaging>
-  <version>11.1.1-beta-11</version>
+  <version>11.1.1-SNAPSHOT</version>
   <name>Spoon Core</name>
   <description>Spoon is a tool for meta-programming, analysis and transformation of Java programs.</description>
   <url>https://spoon.gforge.inria.fr/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <configuration>
           <failsOnError>true</failsOnError>
           <consoleOutput>true</consoleOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.38.0</version>
+      <version>3.39.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.platform</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
   <parent>
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
-    <version>11.1.1-SNAPSHOT</version>
+    <version>11.1.1-beta-11</version>
     <relativePath>spoon-pom</relativePath>
   </parent>
 
   <artifactId>spoon-core</artifactId>
   <packaging>jar</packaging>
-  <version>11.1.1-SNAPSHOT</version>
+  <version>11.1.1-beta-11</version>
   <name>Spoon Core</name>
   <description>Spoon is a tool for meta-programming, analysis and transformation of Java programs.</description>
   <url>https://spoon.gforge.inria.fr/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.5.11</version>
+        <version>1.5.12</version>
         <scope>test</scope>
     </dependency>
     <dependency>

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -37,3 +37,7 @@ exclude:
       - src/main/java/spoon/support/visitor/clone/CloneBuilder.java
       - src/main/java/spoon/support/visitor/clone/CloneVisitor.java
       - src/main/java/spoon/reflect/meta/impl/ModelRoleHandlers.java
+
+
+#Specify Qodana linter for analysis (Applied in CI/CD pipeline)
+linter: jetbrains/qodana-jvm-community:latest

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -27,7 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/AllBranchesReturnTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/AllBranchesReturnTest.java
@@ -121,7 +121,7 @@ public class AllBranchesReturnTest {
 		//        "nestedIfSomeNotReturning", false);
 
 		Factory factory = new SpoonMetaFactory().buildNewFactory(
-				this.getClass().getResource("/control-flow").toURI().getPath(), 7);
+				this.getClass().getResource("/control-flow").toURI().getPath(), 11);
 		ProcessingManager pm = new QueueProcessingManager(factory);
 		pm.addProcessor(processor);
 		pm.process(factory.getModel().getRootPackage());

--- a/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
+++ b/spoon-control-flow/src/test/java/fr/inria/controlflow/ForwardFlowBuilderVisitorTest.java
@@ -46,7 +46,7 @@ public class ForwardFlowBuilderVisitorTest {
 			throws Exception {
 		final ControlFlowBuilder visitor = new ControlFlowBuilder();
 
-		Factory factory = new SpoonMetaFactory().buildNewFactory(folder, 5);
+		Factory factory = new SpoonMetaFactory().buildNewFactory(folder, 11);
 		ProcessingManager pm = new QueueProcessingManager(factory);
 		pm.addProcessor(new AbstractProcessor<CtMethod>() {
 			@Override

--- a/spoon-decompiler/pom.xml
+++ b/spoon-decompiler/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-		        <version>3.5.0</version>
+		        <version>3.6.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/spoon-javadoc/pom.xml
+++ b/spoon-javadoc/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>spoon-pom</artifactId>
         <groupId>fr.inria.gforge.spoon</groupId>
-        <version>11.1.1-beta-11</version>
+        <version>11.1.1-SNAPSHOT</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spoon-javadoc</artifactId>
     <packaging>jar</packaging>
-    <version>11.1.1-beta-11</version>
+    <version>11.1.1-SNAPSHOT</version>
     <name>Spoon Javadoc</name>
     <description>A javadoc parser for the java source code analysis tool spoon.</description>
     <url>http://spoon.gforge.inria.fr/</url>

--- a/spoon-javadoc/pom.xml
+++ b/spoon-javadoc/pom.xml
@@ -5,14 +5,14 @@
     <parent>
         <artifactId>spoon-pom</artifactId>
         <groupId>fr.inria.gforge.spoon</groupId>
-        <version>11.1.1-SNAPSHOT</version>
+        <version>11.1.1-beta-11</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spoon-javadoc</artifactId>
     <packaging>jar</packaging>
-    <version>11.1.1-SNAPSHOT</version>
+    <version>11.1.1-beta-11</version>
     <name>Spoon Javadoc</name>
     <description>A javadoc parser for the java source code analysis tool spoon.</description>
     <url>http://spoon.gforge.inria.fr/</url>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -235,7 +235,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -13,7 +13,7 @@
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
     <packaging>pom</packaging>
-    <version>11.1.1-beta-11</version>
+    <version>11.1.1-SNAPSHOT</version>
     <name>Spoon POM</name>
     <description>Common Maven config for Spoon modules</description>
     <url>http://spoon.gforge.inria.fr/</url>
@@ -28,7 +28,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <runtime.log>target/velocity.log</runtime.log>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>1729994033</project.build.outputTimestamp>
+        <project.build.outputTimestamp>1723395513</project.build.outputTimestamp>
     </properties>
 
     <dependencies>

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -13,7 +13,7 @@
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
     <packaging>pom</packaging>
-    <version>11.1.1-SNAPSHOT</version>
+    <version>11.1.1-beta-11</version>
     <name>Spoon POM</name>
     <description>Common Maven config for Spoon modules</description>
     <url>http://spoon.gforge.inria.fr/</url>
@@ -28,7 +28,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <runtime.log>target/velocity.log</runtime.log>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.build.outputTimestamp>1723395513</project.build.outputTimestamp>
+        <project.build.outputTimestamp>1729994033</project.build.outputTimestamp>
     </properties>
 
     <dependencies>

--- a/spoon-smpl/pom.xml
+++ b/spoon-smpl/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <failsOnError>true</failsOnError>
                     <configLocation>../checkstyle.xml</configLocation>

--- a/src/main/java/spoon/support/util/SortedList.java
+++ b/src/main/java/spoon/support/util/SortedList.java
@@ -42,9 +42,9 @@ public class SortedList<E> extends LinkedList<E> {
 
 	@Override
 	public boolean addAll(Collection<? extends E> c) {
-		boolean ret = true;
+		boolean ret = false;
 		for (E e : c) {
-			ret &= add(e);
+			ret |= add(e);
 		}
 		return ret;
 	}

--- a/src/test/java/spoon/support/util/SortedListTest.java
+++ b/src/test/java/spoon/support/util/SortedListTest.java
@@ -1,0 +1,154 @@
+package spoon.support.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+
+public class SortedListTest {
+    public class BasicComparator implements Comparator<CtElement> {
+
+        private final List<CtElement> myOrdering;
+        
+        public BasicComparator(List<CtElement> orderList) {
+            this.myOrdering = orderList;
+        }
+        
+        @Override
+        public int compare(CtElement o1, CtElement o2) {
+            int idxFirst = - 1;
+            int idxSecond = -1;
+            int idx = 1;
+            for(CtElement clazz : myOrdering) {
+                if (o1 == o2 && o1 == clazz) {
+                    return 0;
+                } else if (clazz == o1) {
+                    if (idxFirst == -1) {
+                        idxFirst = idx;
+                        idx++;    
+                    } else {
+                        throw new IllegalStateException();
+                    }
+                    
+                } else if (clazz == o2) {
+                    if (idxSecond == -1) {
+                        idxSecond = idx;
+                        idx++;
+                    } else {
+                        throw new IllegalStateException();
+                    }
+                };
+            }
+            
+            return idxFirst - idxSecond;
+        }
+        
+    }
+    
+    @Test
+    public void sortedListUsesComparatorTestPass() {
+        Comparator<CtClass<?>> cmp1 = mock();
+        SortedList<CtClass<?>> sl1 = new SortedList<>(cmp1);
+        CtClass<?> lc1 = mock();
+        CtClass<?> lc2 = mock();
+        assertTrue(sl1.add(lc1), "Element should have been inserted");
+        assertTrue(sl1.add(lc2), "Element should have been inserted");
+        verify(cmp1).compare(lc2, lc1);
+    }
+    
+    @Test
+    public void verifyAddWithIndexThrowsException() {
+        Comparator<CtClass<?>> cmp1 = mock();
+        SortedList<CtClass<?>> sl1 = new SortedList<>(cmp1);
+        CtClass<?> lc1 = mock();
+        IllegalArgumentException ex = assertThrows( 
+                IllegalArgumentException.class, 
+                new Executable() {
+
+                    @Override
+                    public void execute() throws Throwable {
+                        sl1.add(1, lc1);
+                    }
+                    
+                },
+                "Add with index should trhow IllegalArgumentException");
+        assertEquals(
+                "cannot force a position with a sorted list that has its own ordering",
+                ex.getMessage(),
+                "Exception message does not match the expected");
+    }
+    
+    @Test
+    public void verifyThatGetComparatorReturnsTheComparatorTestPass() {
+        Comparator<CtClass<?>> cmp1 = mock();
+        SortedList<CtClass<?>> sl1 = new SortedList<>(cmp1);
+        assertTrue(cmp1 == sl1.getComparator(), "Comparator does not match the expected");
+    }
+    
+    @Test
+    public void verifyThatComparatorCanBeReplacedTestPass() {
+        Comparator<? super CtClass<?>> cmp1 = mock();
+        SortedList<CtClass<?>> sl1 = new SortedList<>(cmp1);
+        BasicComparator bc1 = new BasicComparator(null);
+        sl1.setComparator(bc1);
+        assertTrue(bc1 == sl1.getComparator(), "Comparator does not match the expected");
+    }
+    
+    @Test
+    public void addAllInsertsAllElementsAndTheyAreOrderedTestPass() {
+        List<CtElement> orderedList = new ArrayList<>(3);        
+        CtClass<?> lc1 = mock();
+        CtClass<?> lc2 = mock();
+        CtClass<?> lc3 = mock();
+        orderedList.add(lc1);
+        orderedList.add(lc2);
+        orderedList.add(lc3);
+        
+        BasicComparator bc1 = new BasicComparator(orderedList);
+        SortedList<CtElement> sl1 = new SortedList<>(bc1);
+        
+        List<CtElement> unorderedList = new ArrayList<>(3);
+        unorderedList.add(lc3);
+        unorderedList.add(lc1);
+        unorderedList.add(lc2);
+        assertTrue(sl1.addAll(unorderedList), "All elements should have been added");
+        
+        //Verify ordering
+        assertTrue(sl1.get(0) == lc1, 
+                "First element does not match the expected ordering");
+        assertTrue(sl1.get(1) == lc2, 
+                "Second element does not match the expected ordering");
+        assertTrue(sl1.get(2) == lc3,
+                "Third element does not match the expected ordering");
+    }
+ 
+    @Test
+    public void addAllWithEmptyListShouldLeaveTheListUnchangedTestPass() {
+        List<CtElement> orderedList = new ArrayList<>(3);        
+        CtClass<?> lc1 = mock();
+        CtClass<?> lc2 = mock();
+        CtClass<?> lc3 = mock();
+        orderedList.add(lc1);
+        orderedList.add(lc2);
+        orderedList.add(lc3);
+        
+        BasicComparator bc1 = new BasicComparator(orderedList);
+        SortedList<CtElement> sl1 = new SortedList<>(bc1);
+
+        assertTrue(sl1.add(lc1), "List should have changed");
+        assertFalse(sl1.addAll(new LinkedList<>()), "List should not have changed");
+    }
+}

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -42,6 +42,7 @@ import spoon.support.SpoonClassNotFoundException;
 import spoon.support.visitor.SignaturePrinter;
 import spoon.test.api.testclasses.Bar;
 import spoon.testing.assertions.SpoonAssertions;
+import spoon.testing.utils.GitHubIssue;
 import spoon.testing.utils.ModelTest;
 
 import static java.util.function.Predicate.not;
@@ -209,6 +210,7 @@ public class NoClasspathTest {
 		assertTrue(field.getType().isSubtypeOf(myInterfaceReference));
 	}
 
+	@GitHubIssue(issueNumber = 5977, fixed = false)
 	@ModelTest("src/test/resources/noclasspath/issue5591/DiamondConstructorCallTypeInference.java")
 	void testJdtFactoryMethodsForDiamond(CtModel model) {
 		// contract: Leftover <factory> methods from JDT's diamond constructor type inference are handled in

--- a/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
+++ b/src/test/java/spoon/test/reference/ElasticsearchStackoverflowTest.java
@@ -28,6 +28,7 @@ import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.GitHubIssue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -45,6 +46,7 @@ public class ElasticsearchStackoverflowTest {
 		}
 	}
 
+	@GitHubIssue(issueNumber = 5977, fixed = false)
 	@Test
 	public void testStackOverflow() {
 		Launcher launcher = new Launcher();


### PR DESCRIPTION
- Fixes #6034 
- SortedList.addAll(...) should return a boolean value indicating if the Collection was modified is any way as a result of the call.
- Previously addAll(...) would return false if only partial changes occurred and would only return true if all elements had been inserted, or if adding an empty list which in not in accordance to the Java JLS/API as documented in https://docs.oracle.com/javase/8/docs/api/?java/util/Collections.html.