### PR TITLE
review: fix: Use new line symbol from system also for BLOCK comments when printing

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -98,7 +98,7 @@ public class CommentHelper {
 			if (commentType == CtComment.CommentType.BLOCK) {
 				printer.write(transfo.apply(line));
 				if (hasMoreThanOneElement(content.lines())) {
-					printer.write(CtComment.LINE_SEPARATOR);
+					printer.writeln();
 				}
 			} else {
 				printer.write(transfo.apply(line)).writeln(); // removing spaces at the end of the space


### PR DESCRIPTION
I encounter small problem when I tried to output processed classes to disk.

There are comments which I think have sort of bad syntax 

```java
/* (non-Javadoc)
  @see com.some.package.SomeObject#getSomeField()
 */
@Transient
public Long getSomeField() {
.......
}
```

Due to missing 'star' in the middle line it is marked as BLOCK comment. Later during processing of printing of comments there is hardcoded CtComment.LINE_SEPARATOR for new lines which will not match rest of the class which is written with system specific new line symbol (windows \r\n\ in my case).

This will mark class as changed in Git due to this change in new line character.

Every where in comments in the code is written that these hardcoded new line \n should not affect how comments are rendered so I guess it is bug.