### PR TITLE
Remove junit dependency in spoon-control-flow

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -84,12 +84,6 @@
             <version>1.5.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
The `junit` dependency is causing test compilation to fail.