### PR TITLE
review: fix: Improve comment handling in lambda parameters and local variables

### DIFF
--- a/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
+++ b/src/main/java/spoon/reflect/visitor/ElementPrinterHelper.java
@@ -454,7 +454,10 @@ public class ElementPrinterHelper {
 			final int line = element.getPosition().getLine();
 			final int sourceEnd = element.getPosition().getSourceEnd();
 			final int sourceStart = element.getPosition().getSourceStart();
-			if (offset == CommentOffset.BEFORE && (comment.getPosition().getLine() < line || (sourceStart <= comment.getPosition().getSourceStart() && sourceEnd > comment.getPosition().getSourceEnd()))) {
+			boolean commentStartsInLineBefore = comment.getPosition().getLine() < line;
+			boolean commentStartsInsideUs = sourceStart <= comment.getPosition().getSourceStart() && sourceEnd > comment.getPosition().getSourceEnd();
+			boolean commentStartsBeforeUs = sourceStart >= comment.getPosition().getSourceStart() && sourceEnd > comment.getPosition().getSourceEnd();
+			if (offset == CommentOffset.BEFORE && (commentStartsInLineBefore || commentStartsInsideUs || commentStartsBeforeUs)) {
 				commentsToPrint.add(comment);
 			} else if (offset == CommentOffset.AFTER && (comment.getPosition().getSourceStart() > sourceEnd || comment.getPosition().getSourceEnd() == sourceEnd)) {
 				commentsToPrint.add(comment);

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -22,9 +22,11 @@ import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtComment;
 import spoon.reflect.code.CtConditional;
+import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtNewArray;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
@@ -350,7 +352,21 @@ public class JDTCommentBuilder {
 
 			@Override
 			public <T> void scanCtVariable(CtVariable<T> e) {
-				e.addComment(comment);
+				if (e instanceof CtLocalVariable<T> lv && lv.getDefaultExpression() != null) {
+					CtExpression<T> defaultExpression = lv.getDefaultExpression();
+					int variableStart = e.getPosition().getSourceStart();
+					int commentStart = comment.getPosition().getSourceStart();
+					int defaultExprStart = defaultExpression.getPosition().getSourceStart();
+					// Handle `int a = /* foobar */ foo();` by attaching the comment to `foo()`
+					// In those cases the comment and `foo()` start at the same position
+					if (commentStart > variableStart && commentStart >= defaultExprStart) {
+						defaultExpression.addComment(comment);
+					} else {
+						e.addComment(comment);
+					}
+				} else {
+					e.addComment(comment);
+				}
 			}
 
 			private <S> void visitSwitch(CtAbstractSwitch<S> e) {

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -456,7 +456,9 @@ public class JDTCommentBuilder {
 
 			@Override
 			public <T> void visitCtLambda(CtLambda<T> e) {
-				if (e.getExpression() != null) {
+				if (e.getExpression() != null && e.getParameters().isEmpty()) {
+					e.getExpression().addComment(comment);
+				} else if (e.getExpression() != null && !e.getParameters().isEmpty()) {
 					CtParameter<?> lastParameter = e.getParameters().get(e.getParameters().size() - 1);
 					if (comment.getPosition().getSourceStart() > lastParameter.getPosition().getSourceEnd()) {
 						e.getExpression().addComment(comment);

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.ExtendWith;
 import spoon.Launcher;
+import spoon.LauncherTest;
 import spoon.SpoonException;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtArrayAccess;
@@ -110,6 +111,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
 
 
 public class CommentTest {
@@ -1324,5 +1326,31 @@ public class CommentTest {
 		assertEquals("comment 2", typeParameters.get(1).getComments().get(0).getContent());
 		assertEquals("comment 3", typeParameters.get(1).getComments().get(1).getContent());
 		assertEquals("comment 4", typeParameters.get(1).getComments().get(2).getContent());
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 6069, fixed = true)
+	@ExtendWith(LineSeparatorExtension.class)
+	public void testCommentInLambda() {
+		// contract: Comments inside lambdas should not crash or disappear.
+		CtClass<?> ctClass = Launcher.parseClass("""
+			class Foo {
+			  public void bar() {
+			    Runnable r = () -> {
+			        /* hello */ System.exit(1);
+			    };
+				Runnable b = () -> /* hello2 */ System.exit(1);
+				Runnable c = /* hello3 */ () -> System.exit(1);
+				java.util.function.IntFunction<Void> d = ( /* hello4 */ int a ) -> null;
+				int e = /* hello5 */ 5;
+			  }
+			}
+			""");
+		assertThat(ctClass).asString().contains("/* hello */");
+		// Wrong output, there should not be a newline here. Codify it for now in the test case
+		assertThat(ctClass).asString().containsPattern("/\\* hello2 \\*/\n\\s+System");
+		assertThat(ctClass).asString().contains("/* hello3 */");
+		assertThat(ctClass).asString().contains("/* hello4 */");
+		assertThat(ctClass).asString().contains("/* hello5 */");
 	}
 }


### PR DESCRIPTION
This fixes two or three different bugs:
- Comments inside lambda parameters crashed the comment builder
- Comments before the default expression of a local variable were never printed
- Inline comments appearing on the same line as their element (e.g. `/* foo */ System.exit();`) were never printed

Closes: #6069.