### PR TITLE
review: test: Fixed 4 non-deterministic flaky tests 

### DIFF
--- a/src/main/java/spoon/support/util/RtHelper.java
+++ b/src/main/java/spoon/support/util/RtHelper.java
@@ -22,12 +22,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * This class is a helper for runtime reflection.
@@ -50,7 +45,9 @@ public abstract class RtHelper {
 
 	private static void addAllFields(Class<?> c, List<Field> fields) {
 		if (c != null && c != Object.class) {
-			Collections.addAll(fields, c.getDeclaredFields());
+			Field[] declaredFields = c.getDeclaredFields();
+			Arrays.sort(declaredFields, Comparator.comparing(Field::getName));
+			Collections.addAll(fields, declaredFields);
 			addAllFields(c.getSuperclass(), fields);
 			for (Class<?> iface : c.getInterfaces()) {
 				addAllFields(iface, fields);

--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -89,6 +89,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1877,6 +1878,7 @@ public class ImportTest {
 
 		// assert
 		List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
+		imports.sort(Comparator.comparing(importElement -> importElement.getReference().getSimpleName()));
 		assertThat(imports, hasSize(2));
 
 		CtImport import0 = imports.get(0);
@@ -1894,6 +1896,7 @@ public class ImportTest {
 		// assert
 		List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
 		assertThat(imports, hasSize(2));
+		imports.sort(Comparator.comparing(importElement -> importElement.getImportKind().toString()));
 
 		CtImport import0 = imports.get(0);
 		assertThat(import0.getImportKind(), is(CtImportKind.METHOD));

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -19,6 +19,7 @@ package spoon.test.position;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -806,6 +807,8 @@ public class PositionTest {
 			AnnonymousClassNewIface.class);
 		String originSources = foo.getPosition().getCompilationUnit().getOriginalSourceCode();
 		List<CtImport> imports = foo.getPosition().getCompilationUnit().getImports();
+		// Sorting using position of import element so that they are sorted in the order they are imported
+		imports.sort(Comparator.comparing(importElement -> importElement.getPosition().getSourceStart()));
 		assertEquals(2, imports.size());
 		Iterator<CtImport> iter = imports.iterator();
 		{

--- a/src/test/java/spoon/test/template/SubstitutionTest.java
+++ b/src/test/java/spoon/test/template/SubstitutionTest.java
@@ -176,8 +176,12 @@ public class SubstitutionTest {
         assertNotNull(genEnum);
         assertSame(genEnum, factory.Type().get("generated.GenEnum"));
         assertEquals(2, genEnum.getEnumValues().size());
-        assertEquals("GOOD", genEnum.getEnumValues().get(0).getSimpleName());
-        assertEquals("BETTER", genEnum.getEnumValues().get(1).getSimpleName());
+        List<String> enumValueNames = genEnum.getEnumValues().stream()
+                .map(CtEnumValue::getSimpleName)
+                .sorted()
+                .toList();
+        assertEquals("GOOD", enumValueNames.get(1));
+        assertEquals("BETTER", enumValueNames.get(0));
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sorting the order of _imports_ list variable  and _enums_ list variable in 4 flaky tests in order to make them deterministic. The assertions are written with an assumption that the list will always be in a particular predefined order, but that may not be the case. The PR contains fix for the below test cases to make them deterministic:

- spoon.test.imports.ImportTest#staticImports_ofNestedTypes_shouldBeRecorded
- spoon.test.imports.ImportTest#staticTypeAndMethodImport_importShouldAppearOnlyOnceIfTheirSimpleNamesAreEqual
- spoon.test.position.PositionTest#testPositionOfCtImport
- spoon.test.template.SubstitutionTest#testCreateTypeFromTemplate


### Why are the changes needed?
Multiple flaky tests were detected while trying to run the tests using the nondex tool. [NonDex](https://github.com/TestingResearchIllinois/NonDex) is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. 




#### Sample ERROR logs: 
 
<img width="958" alt="Screenshot 2024-11-24 at 8 40 54 PM" src="https://github.com/user-attachments/assets/5082357a-8ef5-48a7-ac3b-a52d8e32f2d1">

<img width="854" alt="Screenshot 2024-11-24 at 8 43 33 PM" src="https://github.com/user-attachments/assets/2a259dc2-032b-4389-925b-5465a9ca99aa">

### Reason for Failure 
As mentioned above, the assertions assume that the list will always be in a particular predefined order, but that may not be the case. For eg, in test case : staticImports_ofNestedTypes_shouldBeRecorded, we have the following test case

```
List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
assertThat(imports, hasSize(2));

CtImport import0 = imports.get(0);
assertThat(import0.getReference().getSimpleName(), is("InnerClass"));
```
The above code assumes that the first element of the list will be `InnerClass` which may not be true. This is because the imports is being set by `JDTImportBuilder.java` class where the [imports](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java#L47) variable is implemented as HashSet. As per the javadocs, the order of elements is not maintained in HashSet.
<img width="1415" alt="Screenshot 2024-11-24 at 8 55 01 PM" src="https://github.com/user-attachments/assets/ab56cba0-bd97-4194-b480-4b458b2107ac">

Hence, we sort the fields before asserting based on certain fields to make the order deterministic.

#### Steps to reproduce flakiness using nondex -
```
mvn install -DskipTests

mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.position.PositionTest#testPositionOfCtImport
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.template.SubstitutionTest#testCreateTypeFromTemplate
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.imports.ImportTest#staticTypeAndMethodImport_importShouldAppearOnlyOnceIfTheirSimpleNamesAreEqual
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.imports.ImportTest#staticImports_ofNestedTypes_shouldBeRecorded
```


Please let me know if you have any questions or would like to discuss this further for any clarificaitions. 