### PR TITLE
review: fix: Fix missing parens for `(string + string).contains(...)`

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -431,7 +431,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 				return requiresBrackets == RoundBracketAnalyzer.EncloseInRoundBrackets.YES || !e.getTypeCasts().isEmpty();
 			}
 			if (e.isParentInitialized() && e.getParent() instanceof CtTargetedExpression && ((CtTargetedExpression) e.getParent()).getTarget() == e) {
-				return e instanceof CtVariableRead<?> && !e.getTypeCasts().isEmpty();
+				return e instanceof CtVariableRead<?> && !e.getTypeCasts().isEmpty() || e instanceof CtBinaryOperator<?>;
 			}
 		} else if (!e.getTypeCasts().isEmpty()) {
 			return true;

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -77,6 +77,7 @@ public class DefaultJavaPrettyPrinterTest {
             "(1 | 2) ^ 3",
             "((int) (1 + 2)) * 3",
             "(int) (int) (1 + 1)",
+            "(\"1\" + \"2\").contains(\"1\")",
     })
     public void testParenOptimizationCorrectlyPrintsParenthesesForExpressions(String rawExpression) {
         // contract: When input expressions are minimally parenthesized, pretty-printed output


### PR DESCRIPTION
For the code `(string + string).contains(string)` will remove the parenthesis which results in `string + string.contains(string)`