### PR TITLE
review: fix: consolidate and improve targeted expression precedence

### DIFF
--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -427,7 +427,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		boolean hasCasts = !e.getTypeCasts().isEmpty();
 		if (isMinimizeRoundBrackets()) {
 			RoundBracketAnalyzer.EncloseInRoundBrackets requiresBrackets =
-					RoundBracketAnalyzer.requiresRoundBrackets(e);
+				RoundBracketAnalyzer.requiresRoundBrackets(e);
 			if (requiresBrackets != RoundBracketAnalyzer.EncloseInRoundBrackets.UNKNOWN) {
 				return requiresBrackets == RoundBracketAnalyzer.EncloseInRoundBrackets.YES || hasCasts;
 			}
@@ -456,8 +456,8 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		if (expression.isParentInitialized() && expression.getParent() instanceof CtTargetedExpression<?, ?> targeted && targeted.getTarget() == expression) {
 			return !expression.getTypeCasts().isEmpty()
 				|| expression instanceof CtBinaryOperator<?>
-				|| expression instanceof CtSwitchExpression<?,?>
-				|| expression instanceof CtAssignment<?,?>
+				|| expression instanceof CtSwitchExpression<?, ?>
+				|| expression instanceof CtAssignment<?, ?>
 				|| expression instanceof CtConditional<?>
 				|| expression instanceof CtUnaryOperator<?>;
 		}

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -35,8 +35,10 @@ import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.VirtualFile;
 import spoon.support.reflect.reference.CtArrayTypeReferenceImpl;
 import spoon.test.SpoonTestHelpers;
+import spoon.testing.assertions.SpoonAssertions;
 import spoon.testing.utils.GitHubIssue;
 import spoon.testing.utils.ModelTest;
 
@@ -78,13 +80,26 @@ public class DefaultJavaPrettyPrinterTest {
             "((int) (1 + 2)) * 3",
             "(int) (int) (1 + 1)",
             "(\"1\" + \"2\").contains(\"1\")",
+            "null instanceof java.lang.String s && (s = \"1\").contains(\"1\")",
+            "null instanceof java.lang.String s && (s += \"1\").contains(\"1\")",
+            "null instanceof java.lang.String[] arr && (arr[0] = \"1\").contains(\"1\")",
+            "null instanceof java.lang.Integer i && (++i).toString().isEmpty()",
+            "null instanceof java.lang.Integer i && (i--).toString().isEmpty()",
+            "(true ? \"1\" : \"2\").contains(\"1\")",
+            """
+            (switch (0) {
+                default -> "1";
+            }).contains("1")
+            """,
     })
     public void testParenOptimizationCorrectlyPrintsParenthesesForExpressions(String rawExpression) {
         // contract: When input expressions are minimally parenthesized, pretty-printed output
         // should match the input
         CtExpression<?> expr = createLauncherWithOptimizeParenthesesPrinter()
                 .getFactory().createCodeSnippetExpression(rawExpression).compile();
-        assertThat(expr.toString(), equalTo(rawExpression));
+        SpoonAssertions.assertThat(expr)
+            .asString()
+            .containsIgnoringWhitespaces(rawExpression);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Whether a targeted expression requires additional parentheses got out of sync in two situations. By deduplicating the code, this can be avoided. This PR also addresses other expressions that need parentheses and adds tests for them.