### PR TITLE
review: Use java 17 for tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -136,7 +136,7 @@
             mvn -q versions:use-latest-versions -DallowSnapshots=true -Dincludes=fr.inria.gforge.spoon
             mvn -q versions:update-parent -DallowSnapshots=true
             git diff
-            mvn -q -Djava.src.version=17 test
+            mvn -q test
             mvn -q checkstyle:checkstyle license:check
             popd || exit 1
           '');

--- a/spoon-pom/pom.xml
+++ b/spoon-pom/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.testRelease>17</maven.compiler.testRelease>
         <runtime.log>target/velocity.log</runtime.log>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>1737612198</project.build.outputTimestamp>
@@ -135,10 +136,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${java.src.version}</source>
-                    <target>${java.src.version}</target>
-                    <testSource>${java.test.version}</testSource>
-                    <testTarget>${java.test.version}</testTarget>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:deprecation,unchecked</arg>


### PR DESCRIPTION
Previously spoon-pom used not-existent properties to configure the maven compiler, which tripped up intellij. This patch consistently uses maven.compiler.(test)Release.