### PR TITLE
review: test: Fixed 2 non-deterministic flaky tests 

### DIFF
--- a/src/test/java/spoon/test/imports/ImportTest.java
+++ b/src/test/java/spoon/test/imports/ImportTest.java
@@ -89,6 +89,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1878,7 +1879,7 @@ public class ImportTest {
 		// assert
 		List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
 		assertThat(imports, hasSize(2));
-
+		imports.sort(Comparator.comparing(importElement -> importElement.getReference().getSimpleName()));
 		CtImport import0 = imports.get(0);
 		assertThat(import0.getReference().getSimpleName(), is("InnerClass"));
 	}
@@ -1894,7 +1895,7 @@ public class ImportTest {
 		// assert
 		List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
 		assertThat(imports, hasSize(2));
-
+		imports.sort(Comparator.comparing(importElement -> importElement.getReference().getSimpleName()));
 		CtImport import0 = imports.get(0);
 		assertThat(import0.getImportKind(), is(CtImportKind.METHOD));
 		assertThat(import0.getReference().getSimpleName(), is("foo"));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Sorting the order of _imports_ list variable in 2 flaky tests in order to make them deterministic. The assertions are written with an assumption that the list will always be in a particular predefined order, but that may not be the case. The PR contains fix for the below test cases to make them deterministic:

- spoon.test.imports.ImportTest#staticImports_ofNestedTypes_shouldBeRecorded
- spoon.test.imports.ImportTest#staticTypeAndMethodImport_importShouldAppearOnlyOnceIfTheirSimpleNamesAreEqual


### Why are the changes needed?
Multiple flaky tests were detected while trying to run the tests using the nondex tool. [NonDex](https://github.com/TestingResearchIllinois/NonDex) is a tool for detecting and debugging wrong assumptions on under-determined Java APIs. 



#### Sample ERROR logs: 
 
<img width="958" alt="Screenshot 2024-11-24 at 8 40 54 PM" src="https://github.com/user-attachments/assets/5082357a-8ef5-48a7-ac3b-a52d8e32f2d1">

<img width="854" alt="Screenshot 2024-11-24 at 8 43 33 PM" src="https://github.com/user-attachments/assets/2a259dc2-032b-4389-925b-5465a9ca99aa">

### Reason for Failure 
As mentioned above, the assertions assume that the list will always be in a particular predefined order, but that may not be the case. For eg, in test case : staticImports_ofNestedTypes_shouldBeRecorded, we have the following test case

```
List<CtImport> imports = mainType.getPosition().getCompilationUnit().getImports();
assertThat(imports, hasSize(2));

CtImport import0 = imports.get(0);
assertThat(import0.getReference().getSimpleName(), is("InnerClass"));
```
The above code assumes that the first element of the list will be `InnerClass` which may not be true. This is because the imports is being set by `JDTImportBuilder.java` class where the [imports](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/JDTImportBuilder.java#L47) variable is implemented as HashSet. As per the javadocs, the order of elements is not maintained in HashSet.
<img width="1415" alt="Screenshot 2024-11-24 at 8 55 01 PM" src="https://github.com/user-attachments/assets/ab56cba0-bd97-4194-b480-4b458b2107ac">

Hence, we sort the fields before asserting based on certain fields to make the order deterministic.

#### Steps to reproduce flakiness using nondex -
```
mvn install -DskipTests

mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.imports.ImportTest#staticTypeAndMethodImport_importShouldAppearOnlyOnceIfTheirSimpleNamesAreEqual
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=spoon.test.imports.ImportTest#staticImports_ofNestedTypes_shouldBeRecorded
```


Please let me know if you have any questions or would like to discuss this further for any clarificaitions. 

More discussion on this PR can be found here : https://github.com/INRIA/spoon/pull/6084