### PR TITLE
chore: Update nix lockfile

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1736012469,
+        "narHash": "sha256-/qlNWm/IEVVH7GfgAIyP6EsVZI6zjAx1cV5zNyrs+rI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "8f3e1f807051e32d8c95cd12b9b421623850a34d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -44,26 +44,6 @@
               sha256 = "sha256-wl5UEu2U11Q0lZfm9reMhGMCI7y6sabk18j7SPWgy1k=";
             };
           };
-          jreleaser = pkgs.stdenv.mkDerivation rec {
-            pname = "jreleaser-cli";
-            version = "1.11.0";
-
-            src = pkgs.fetchurl {
-              url = "https://github.com/jreleaser/jreleaser/releases/download/v${version}/jreleaser-tool-provider-${version}.jar";
-              sha256 = "sha256-VkINXKVBBBK6/PIRPMVKZGY9afE7mAsqrcFPh2Algqk=";
-            };
-
-            nativeBuildInputs = with pkgs; [ makeWrapper ];
-
-            dontUnpack = true;
-
-            installPhase = ''
-              mkdir -p $out/share/java/ $out/bin/
-              cp $src $out/share/java/${pname}.jar
-              makeWrapper ${pkgs.jdk}/bin/java $out/bin/${pname} \
-                --add-flags "-jar $out/share/java/${pname}.jar"
-            '';
-          };
         in
         pkgs.mkShell rec {
           test = pkgs.writeScriptBin "test" ''
@@ -179,7 +159,7 @@
           packages = with pkgs;
             [ jdk maven test codegen coverage mavenPomQuality javadocQuality reproducibleBuilds ]
             ++ (if extraChecks then [ gradle pythonEnv extra extraRemote jbang ] else [ ])
-            ++ (if release then [ semver jreleaser ] else [ ]);
+            ++ (if release then [ semver pkgs.jreleaser-cli ] else [ ]);
         };
     in
     {

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,19 @@
           };
         in
         pkgs.mkShell rec {
+          shellHook = ''
+            if [ "$LANG" = "C.UTF-8" ]; then
+                echo "You are using the C locale. Tests will fail. Changing it to en_US if possible"
+
+                if locale -a | grep -iP "en_us.utf(-?)8"; then
+                    echo "Changing your locale to en_US.UTF-8"
+                    export LANG=en_US.UTF-8
+                else
+                    echo "You do not have en_US.UTF-8 installed ('localectl list-locales'/'locale -a')"
+                    echo "Please change it something else yourself"
+                fi
+            fi
+          '';
           test = pkgs.writeScriptBin "test" ''
             set -eu
 


### PR DESCRIPTION
The existing PR by dependabot fails because either the LANG variable has changed, or how java interprets it. On the runner the lang var is `C.UTF-8`, which does not contain all unicode mappings required for the `JavaOutputProcessorTest`. This test creates a file with accents in its name, causing a java file malformed input exception.

Closes #6124 