### PR TITLE
fix: avoid unnecessary downcast in ReferenceBuilder

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -8,6 +8,7 @@
 package spoon.support.compiler.jdt;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.internal.compiler.Compiler;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
@@ -285,7 +286,7 @@ public class ReferenceBuilder {
 		if (enclosingType != null && Collections.disjoint(PUBLIC_PROTECTED, JDTTreeBuilderQuery.getModifiers(enclosingType.modifiers, false, ModifierTarget.NONE))) {
 			String access = "";
 			int i = 0;
-			final CompilationUnitDeclaration[] units = ((TreeBuilderCompiler) this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.scope.environment.typeRequestor).unitsToProcess;
+			final CompilationUnitDeclaration[] units = ((Compiler) this.jdtTreeBuilder.getContextBuilder().compilationunitdeclaration.scope.environment.typeRequestor).unitsToProcess;
 			for (; i < tokens.length; i++) {
 				final char[][] qualified = Arrays.copyOfRange(tokens, 0, i + 1);
 				if (searchPackage(qualified, units) == null) {


### PR DESCRIPTION
TL;DR: The cast to `(TreeBulderCompiler)` is overly restrictive here.

### Context

For a specific use case, I would like Spoon to use a custom JDT parser/compiler. Specifically, I do not care about method bodies in the parsed code as I only focus on the extracted API, so passing `ignoreMethodBodies` to JDT is a _huge_ performance boost in terms of time and memory (30 to 70% faster `buildModel()` on my projects).

My understanding is that Spoon does not and will not provide an "easy" way for clients to provide their own JDT parser/compiler or their own parsing/compiling options to JDT, which is perfectly understandable.

My current solution involves injecting a custom `JDTBatchCompiler` into the `Launcher`. Because `JDTBatchCompiler` depends on the package-private `TreeBuilderCompiler`, one must implement its own `Compiler` implementation instead, which eventually propagates to this unnecessary downcast and crashes. This PR would allow anyone to pass their own compiler without disrupting Spoon's policy regarding JDT customizations.