### PR TITLE
doc: adding Javadoc tags to CtImport

### DIFF
--- a/src/main/java/spoon/reflect/declaration/CtImport.java
+++ b/src/main/java/spoon/reflect/declaration/CtImport.java
@@ -34,13 +34,13 @@ import static spoon.reflect.path.CtRole.IMPORT_REFERENCE;
  */
 public interface CtImport extends CtElement {
 	/**
-	 * Returns the kind of import (see {@link CtImportKind})
+	 * @return The kind of import (see {@link CtImportKind})
 	 */
 	@DerivedProperty
 	CtImportKind getImportKind();
 
 	/**
-	 * Returns the reference of the import.
+	 * @return The reference of the import.
 	 */
 	@PropertyGetter(role = IMPORT_REFERENCE)
 	CtReference getReference();
@@ -48,12 +48,17 @@ public interface CtImport extends CtElement {
 	/**
 	 * Sets the reference of the import.
 	 * The import kind will be computed based on this reference.
+	 *
+	 * @param reference The {@link CtReference} to be set for the import.
+	 * @param <T> The import kind determined based on the provided {@link CtReference}.
+	 * @return The determined import kind.
 	 */
 	@PropertySetter(role = IMPORT_REFERENCE)
 	<T extends CtImport> T setReference(CtReference reference);
 
 	/**
 	 * Accepts a {@link CtImportVisitor}
+	 * @param visitor The {@link CtImportVisitor} to be accepted.
 	 */
 	void accept(CtImportVisitor visitor);
 


### PR DESCRIPTION
https://github.com/INRIA/spoon/issues/3923

This adds Javadoc tags (`@param` and `@return`) to the methods of the `CtImport` interface. Using the `check-javadoc-regressions.py` now does not show any Javadoc errors in the `CtImport.java` file. 

### Before the change
```
$ chore/run-with-spoon-javadoc-classpath.sh chore/CheckJavadoc.java
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/Users/rishivijayvargiya/.m2/repository/org/slf4j/slf4j-nop/1.7.36/slf4j-nop-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:40:15: Missing @return tag in getImportKind()
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:46:14: Missing @return tag in getReference()
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:53:25: Missing @param 'reference' tag in setReference(CtReference)
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:53:25: Missing @param '<T>' tag in setReference(CtReference)
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:53:25: Missing @return tag in setReference(CtReference)
[ERROR] src/main/java/spoon/reflect/declaration/CtImport.java:58:7: Missing @param 'visitor' tag in accept(CtImportVisitor)
```

### After the change
```
$ chore/run-with-spoon-javadoc-classpath.sh chore/CheckJavadoc.java
SLF4J(W): No SLF4J providers were found.
SLF4J(W): Defaulting to no-operation (NOP) logger implementation
SLF4J(W): See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J(W): Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J(W): Ignoring binding found at [jar:file:/Users/rishivijayvargiya/.m2/repository/org/slf4j/slf4j-nop/1.7.36/slf4j-nop-1.7.36.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J(W): See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```