### PR TITLE
refactor: fixing sonarqube issues in Pattern.java

### DIFF
--- a/src/main/java/spoon/pattern/Pattern.java
+++ b/src/main/java/spoon/pattern/Pattern.java
@@ -96,7 +96,7 @@ public class Pattern {
 		if (input instanceof Collection<?>) {
 			scanner.scan(null, (Collection<CtElement>) input);
 		} else if (input instanceof Map) {
-			scanner.scan(null, (Map<String, ?>) input);
+			scanner.scan(null, input);
 		} else {
 			scanner.scan(null, (CtElement) input);
 		}
@@ -110,9 +110,7 @@ public class Pattern {
 	 */
 	public List<Match> getMatches(CtElement root) {
 		List<Match> matches = new ArrayList<>();
-		forEachMatch(root, match -> {
-			matches.add(match);
-		});
+		forEachMatch(root, matches::add);
 		return matches;
 	}
 


### PR DESCRIPTION
https://github.com/INRIA/spoon/issues/2228

This fixes a few sonarqube warnings in the file `Pattern.java` that were pointed out by the [SonarQube for IDE Plugin](https://plugins.jetbrains.com/plugin/7973-sonarqube-for-ide). Namely, the issues were:

- **java:S1905** (Redundant casts should not be used)
- **java:S1612** (Lambdas should be replaced with method references)
- **java:S1602** (when a lambda expression uses block notation while expression notation could be used)

I believe removing the explicit cast to `Map<...,...>` also seems to get rid of one of the warnings during compile time, so..._yay!_ ? 