### PR TITLE
refactor: Resolving unchecked-cast warnings in ContractVerifier

### DIFF
--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -548,6 +548,7 @@ public class ContractVerifier {
 	}
 
 	/** contract: element is contained in attribute of element's parent */
+	@SuppressWarnings("unchecked")
 	public void checkElementIsContainedInAttributeOfItsParent() {
 		_rootPackage.accept(new CtScanner() {
 			@Override

--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -548,7 +548,6 @@ public class ContractVerifier {
 	}
 
 	/** contract: element is contained in attribute of element's parent */
-	@SuppressWarnings("unchecked")
 	public void checkElementIsContainedInAttributeOfItsParent() {
 		_rootPackage.accept(new CtScanner() {
 			@Override
@@ -565,12 +564,12 @@ public class ContractVerifier {
 						assertTrue("Element of type " + element.getClass().getName()
 										+ " not found in Collection value of attribute of role " + role.name()
 										+ " of parent type " + parent.getClass().getName(),
-								((Collection<CtElement>) attributeOfParent).stream().anyMatch(e -> e == element));
+								((Collection<?>) attributeOfParent).stream().anyMatch(e -> e == element));
 					} else if (attributeOfParent instanceof Map) {
 						assertTrue("Element of type " + element.getClass().getName()
 										+ " not found in Map#values of attribute of role " + role.name()
 										+ " of parent type " + parent.getClass().getName(),
-								((Map<String, ?>) attributeOfParent).values().stream().anyMatch(e -> e == element));
+								((Map<?, ?>) attributeOfParent).values().stream().anyMatch(e -> e == element));
 					} else {
 						fail("Attribute of Role " + role + " not checked");
 					}


### PR DESCRIPTION
https://github.com/INRIA/spoon/issues/4924

Not entirely sure if this is an acceptable fix because I don't feel _too_ good about using `SuppressWarnings` here (and we generally seem to be against doing that as seen in https://github.com/INRIA/spoon/pull/4925), but the unchecked cast issue here was caused by `(Collection<CtElement>) attributeOfParent...` and `(Map<String, ?>) attributeOfParent`. 

I wasn't sure how to go about fixing these, since they weren't really related to returning `this` or `super.clone()` and a quick Google search wasn't helpful either  (giving suggestions such as [this](https://stackoverflow.com/questions/75959553/how-to-cast-object-to-mapstring-object-avoiding-unchecked-cast-and-illegal-g))-- so I'm more than open to alternative ways of fixing this, if there are any!

### Before
These 2 Warnings appeared when running `mvn compile` after a clean
```
...
[WARNING] .../ContractVerifier.java:[567,90] unchecked cast
  required: java.util.Collection<spoon.reflect.declaration.CtElement>
  found:    java.lang.Object
[WARNING] .../ContractVerifier.java:[572,83] unchecked cast
  required: java.util.Map<java.lang.String,?>
  found:    java.lang.Object
...
```

### After
Those 2 warnings are gone! :) 

@SirYwell would appreciate your thoughts on this, since I believe you've been involved with the effort in clearing out unchecked-cast warnings before 😅 