### PR TITLE
fix: ReferenceBuilder.getTypeReference can handle complex type-params in generics

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -790,7 +790,7 @@ public class ReferenceBuilder {
 			}
 			if (m.find()) {
 				main.setSimpleName(m.group(1));
-				final String[] split = m.group(2).split(",");
+				final String[] split = getStringTypeParameters(m.group(2)).toArray(new String[0]);
 				for (String parameter : split) {
 					main.addActualTypeArgument(getTypeParameterReference(parameter.trim()));
 				}
@@ -810,6 +810,59 @@ public class ReferenceBuilder {
 			return (CtTypeReference) this.jdtTreeBuilder.getFactory().Core().createWildcardReference();
 		}
 		return main;
+	}
+
+
+	/**
+	 * Helper method which accepts a WELL-FORMATTED type-parameter string (ie, the type parameters of a generic type
+	 * separated by commas) and returns the individual parameters in an ordered list. DOES NOT do recursion on
+	 * nested generics.
+	 * Eg: "Integer, Double" would give List.of("Integer", "Double")
+	 * Eg: "Integer, Nested<Double, String>" would give List.of("Integer", "Nested<Double, String>")
+	 * See comments in code for why "WELL-FORMATTED" is important.
+	 * */
+	private List<String> getStringTypeParameters(String typeParamString) {
+		if(!typeParamString.contains("<")) {
+			// There are no nested generic types present in the parameter string
+			return List.of(typeParamString.split(","));
+		}
+
+		List<String> typeParams = new ArrayList<>();
+		// Since there are nested generic types present, we cannot split my "," -- since
+		// nested generics can also have multiple parameters (which would also be separated
+		// by ","). So, iterate character by character, splitting on either the ",", or when the
+		// right set of "<" and ">" have been accumulated.
+
+		int bracketsEncountered = 0;
+		StringBuilder paramAccumulator = new StringBuilder();
+		for(int idx = 0; idx < typeParamString.length(); idx++) {
+			char currChar = typeParamString.charAt(idx);
+
+			if (currChar == ',' && bracketsEncountered == 0) {
+				// We have reached the end of a type-parameter, and there are no longer
+				// any lingering "<" to close. Thia assumes that the "typeParamString" is
+				// correctly formed (ie, it does not start as ",Integer,Foo<...>..." etc)
+				typeParams.add(paramAccumulator.toString());
+				paramAccumulator.setLength(0);
+			} else if (currChar == '<') {
+				bracketsEncountered += 1;
+				paramAccumulator.append('<');
+			} else if (currChar == '>') {
+				bracketsEncountered -= 1;
+				paramAccumulator.append('>');
+			} else {
+				paramAccumulator.append(currChar);
+			}
+		}
+
+		// The last type-parameter would not have been appended
+		// since it isn't suffixed by a ",". So append that as well.
+		// We again assume that the provided typeParamString is correctly
+		// formed (eg: it does not end in a form like "...String,")
+		typeParams.add(paramAccumulator.toString());
+
+
+		return typeParams;
 	}
 
 	/**

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -822,7 +822,7 @@ public class ReferenceBuilder {
 	 * See comments in code for why "WELL-FORMATTED" is important.
 	 * */
 	private List<String> getStringTypeParameters(String typeParamString) {
-		if(!typeParamString.contains("<")) {
+		if (!typeParamString.contains("<")) {
 			// There are no nested generic types present in the parameter string
 			return List.of(typeParamString.split(","));
 		}
@@ -835,7 +835,7 @@ public class ReferenceBuilder {
 
 		int bracketsEncountered = 0;
 		StringBuilder paramAccumulator = new StringBuilder();
-		for(int idx = 0; idx < typeParamString.length(); idx++) {
+		for (int idx = 0; idx < typeParamString.length(); idx++) {
 			char currChar = typeParamString.charAt(idx);
 
 			if (currChar == ',' && bracketsEncountered == 0) {

--- a/src/test/java/spoon/support/compiler/jdt/ReferenceBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/ReferenceBuilderTest.java
@@ -1,0 +1,113 @@
+package spoon.support.compiler.jdt;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReferenceBuilderTest {
+    private static ReferenceBuilder referenceBuilder;
+
+
+    @BeforeAll
+    public static void setUp() {
+        Launcher launcher = new Launcher();
+        Factory factory = launcher.getFactory();
+        JDTTreeBuilder treeBuilder = new JDTTreeBuilder(factory);
+        referenceBuilder = treeBuilder.references;
+    }
+
+    @Test
+    public void testGetTypeReferenceSimpleCase() {
+        CtTypeReference<Object> typeReference = referenceBuilder.getTypeReference("SomeType<Integer, Double, String>");
+        List<CtTypeReference<?>> typeArgList = typeReference.getActualTypeArguments();
+
+        // Assertions about main type
+        assertEquals("SomeType", typeReference.getSimpleName());
+        assertEquals(3, typeArgList.size());
+        // Assertions about first type-argument
+        CtTypeReference<?> firstType = typeArgList.get(0);
+        assertEquals("Integer", firstType.getSimpleName());
+        assertEquals(0, firstType.getActualTypeArguments().size());
+        // Assertions about second type-argument
+        CtTypeReference<?> secondType = typeArgList.get(1);
+        assertEquals("Double", secondType.getSimpleName());
+        assertEquals(0, secondType.getActualTypeArguments().size());
+        // Assertions about third type-argument
+        CtTypeReference<?> thirdType = typeArgList.get(2);
+        assertEquals("String", thirdType.getSimpleName());
+        assertEquals(0, thirdType.getActualTypeArguments().size());
+    }
+
+    @Test
+    public void testGetTypeReferenceComplexGenericsCase() {
+        CtTypeReference<?> typeReference = referenceBuilder
+                .getTypeReference("SomeType<Integer, NestedFirst<Double, String>, Boolean, NestedSecond<Integer, MoreNested<Double>>>");
+        List<CtTypeReference<?>> typeArgList = typeReference.getActualTypeArguments();
+
+        // Assertions about main type
+        assertEquals("SomeType", typeReference.getSimpleName());
+        assertEquals(4, typeArgList.size());
+        // Assertions about first type-argument
+        CtTypeReference<?> firstType = typeArgList.get(0);
+        assertEquals("Integer", firstType.getSimpleName());
+        assertEquals(0, firstType.getActualTypeArguments().size());
+        // Assertions about second type-argument (and its nested types)
+        CtTypeReference<?> secondType = typeArgList.get(1);
+        List<CtTypeReference<?>> secondTypeArgList = secondType.getActualTypeArguments();
+        assertEquals("NestedFirst", secondType.getSimpleName());
+        assertEquals(2, secondTypeArgList.size());
+        assertEquals("Double", secondTypeArgList.get(0).getSimpleName());
+        assertEquals(0, secondTypeArgList.get(0).getActualTypeArguments().size());
+        assertEquals("String", secondTypeArgList.get(1).getSimpleName());
+        assertEquals(0, secondTypeArgList.get(1).getActualTypeArguments().size());
+        // Assertions about third type-argument
+        CtTypeReference<?> thirdType = typeArgList.get(2);
+        assertEquals("Boolean", thirdType.getSimpleName());
+        assertEquals(0, thirdType.getActualTypeArguments().size());
+        // Assertions about fourth type-argument (and its nested types)
+        CtTypeReference<?> fourthType = typeArgList.get(3);
+        List<CtTypeReference<?>> fourthTypeArgList = fourthType.getActualTypeArguments();
+        assertEquals("NestedSecond", fourthType.getSimpleName());
+        assertEquals(2, fourthTypeArgList.size());
+        assertEquals("Integer", fourthTypeArgList.get(0).getSimpleName());
+        assertEquals(0, fourthTypeArgList.get(0).getActualTypeArguments().size());
+        CtTypeReference<?> fourthTypeMoreNested = fourthTypeArgList.get(1);
+        assertEquals("MoreNested", fourthTypeMoreNested.getSimpleName());
+        assertEquals(1, fourthTypeMoreNested.getActualTypeArguments().size());
+        assertEquals("Double", fourthTypeMoreNested.getActualTypeArguments().get(0).getSimpleName());
+        assertEquals(0 , fourthTypeMoreNested.getActualTypeArguments().get(0).getActualTypeArguments().size());
+    }
+
+    @Test
+    public void testGetTypeReferenceWildcardWithTypeArgsCase() {
+        CtTypeReference<?> typeReference = referenceBuilder.getTypeReference("?<Integer, String>");
+
+        // Assertions
+        assertEquals("?", typeReference.getSimpleName());
+        assertEquals(0, typeReference.getActualTypeArguments().size());
+    }
+
+    @Test
+    public void testGetTypeReferenceSimpleWildcardCase() {
+        CtTypeReference<?> typeReference = referenceBuilder.getTypeReference("?");
+
+        // Assertions
+        assertEquals("?", typeReference.getSimpleName());
+        assertEquals(0, typeReference.getActualTypeArguments().size());
+    }
+
+    @Test
+    public void testGetTypeReferenceSimpleTypeCase() {
+        CtTypeReference<?> typeReference = referenceBuilder.getTypeReference("Integer");
+
+        // Assertions
+        assertEquals("Integer", typeReference.getSimpleName());
+        assertEquals(0, typeReference.getActualTypeArguments().size());
+    }
+}

--- a/src/test/java/spoon/support/compiler/jdt/ReferenceBuilderTest.java
+++ b/src/test/java/spoon/support/compiler/jdt/ReferenceBuilderTest.java
@@ -8,7 +8,7 @@ import spoon.reflect.reference.CtTypeReference;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ReferenceBuilderTest {
     private static ReferenceBuilder referenceBuilder;


### PR DESCRIPTION
Fix https://github.com/INRIA/spoon/issues/6068

The code is similar to and inspired from the local fix that was submitted in the Github issue/bug-report itself by @josple. 

I have also added a total of 5 test-cases: 1 of which (`testGetTypeReferenceComplexGenericsCase`) failed with the original code, but passes with the new version of the code. 

Included in the test cases are also 3 "sanity check" tests (the last 3) for some of the other things that `getTypeReference` should be doing based on my understanding, though they might not be strictly related to this change. 

Apart from the `null` return check (when the argument is not a type) and the `array` case, I _think_ there should be sanity checks for the other cases of input for `getReferenceType` here (more on why these 2 are absent in the Notes below). If they're not needed in this PR, let me know and I will remove :) 

## Some Notes
- The main issue here, as indicated in the GitHub issue, was that we were splitting generics type-parameters using `,` with the following code: `final String[] split = m.group(2).split(",");`. **We also seem to be doing that exact same thing** in the `getTypeParameterReference` method ([here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java#L833)). I didn't look in to this and not entirely sure if this is also an issue (wanted to keep the scope of this fix limited), but just wanted to call out in case anyone else might know more of it and if that is something which should be fixed too.
- I'm not entirely sure why `getTypeReference` is public, since its only usages seem to be in `ReferenceBuilder` itself (as seen below, the extra 5 were the tests that I've added). I **made this fix (and added the tests) assuming we want to keep `getTypeReference` public**, but if we think this should be a private method, then another way to fix this could be to make the new `getStringTypeParameters` function I've added a static function in a utility class (and convert these tests to tests of that utility function). Let me know if that's a better approach!
<img width="980" alt="Screenshot 2025-02-09 at 10 41 35 PM" src="https://github.com/user-attachments/assets/3b295c1c-f2a0-436f-9e41-aaec2011816b" />

- While writing some sanity-tests for `ReferenceBuilder.getTypeReference`, I noticed that for **the case `getTypeReference("notType<Integer>")`, the function actually returned a `CtTypeReference` instead of `null`**. I thought `null` was supposed to be returned based on the [documentation](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java#L779) since `notType` won't be a name of an actual type (since it does not start with an upper-case letter)? Or does that only apply to the case when the type is not a generic type? In any case, there is no test which checks for the `null` return here.
- There is also **no "sanity test" for the [array case](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java#L799)**, because I was having some issue with NPE in the [`setPackageOrDeclaringType`](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java#L1309) method. I tried a string with an array of a custom generic type first, then a `HashMap` array, then a simple `String` array, but in all cases I got an error similar to this. Eventually decided against digging deep in to this since that could have added more setup and bloated this PR even more.
<img width="1111" alt="Screenshot 2025-02-09 at 10 09 58 PM" src="https://github.com/user-attachments/assets/b672a70a-1476-4ddc-9ef6-a0a440633478" />


@algomaster99 @monperrus @I-Al-Istannen would appreciate a peek whenever you have the time! 😄 🙏🏽 