### PR TITLE
feat: add dirty-waters workflow to CI

### DIFF
--- a/.github/workflows/dirty-waters.yml
+++ b/.github/workflows/dirty-waters.yml
@@ -1,0 +1,28 @@
+name: dirty-waters
+
+on:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  dirty-waters:
+    runs-on:
+        ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup JDK17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Dirty Waters Analysis
+        uses: chains-project/dirty-waters-action@v1.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          package_manager: maven
+          project_repo: ${{ github.repository }}
+          latest_commit_sha: ${{ github.sha }}
+          github_event_before: ${{github.event.before}}


### PR DESCRIPTION
cc @monperrus @Stamp9

Relates to https://github.com/INRIA/spoon/issues/5216, https://github.com/chains-project/dirty-waters/issues/37, https://github.com/chains-project/dirty-waters/issues/58

Key notes:

- [ ] `x_to_fail` parameter: the percentage of a single non-high severity issue present among the dependencies for the CI to break. It defaults to 5%, so what should it be here?
- [ ] `comment_on_commit`: whether the reports are allowed to be pasted as comments in the commits, in the case of high-severity issues breaking CI. Defaults to false, what do we want here?
- [ ] `allow_pr_comments`: whether the reports are allowed to be pasted as comments in pull requests. Defaults to true, what do we want here?
- [ ] By default, only static analysis happens. Do we want differential to be performed in certain scenarios too? If so, which ones?
- [ ] Gradual reporting is enabled by default -- only one of the reported smells has its table displayed per time, with the higher severity issues showing up first.
- [ ] In https://github.com/chains-project/sbom.exe/pull/317, @algomaster99 included a step before the analysis which builds the project and skips tests; should the same be done here?

For more information on the action, see the [wiki](https://github.com/chains-project/dirty-waters-action/wiki).