### PR TITLE
chore: Update extraChecks JDK to v23 in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -188,7 +188,7 @@
                 jdk17 = mkShell system { javaVersion = 17; };
                 jdk21 = mkShell system { javaVersion = 21; };
                 jdk22 = mkShell system { javaVersion = 22; };
-                extraChecks = mkShell system { extraChecks = true; javaVersion = 21; };
+                extraChecks = mkShell system { extraChecks = true; javaVersion = 22; };
                 jReleaser = mkShell system { release = true; javaVersion = 21; };
               });
         in

--- a/flake.nix
+++ b/flake.nix
@@ -187,7 +187,6 @@
                 default = jdk17;
                 jdk17 = mkShell system { javaVersion = 17; };
                 jdk21 = mkShell system { javaVersion = 21; };
-                jdk22 = mkShell system { javaVersion = 22; };
                 extraChecks = mkShell system { extraChecks = true; javaVersion = 23; };
                 jReleaser = mkShell system { release = true; javaVersion = 21; };
               });

--- a/flake.nix
+++ b/flake.nix
@@ -188,7 +188,7 @@
                 jdk17 = mkShell system { javaVersion = 17; };
                 jdk21 = mkShell system { javaVersion = 21; };
                 jdk22 = mkShell system { javaVersion = 22; };
-                extraChecks = mkShell system { extraChecks = true; javaVersion = 22; };
+                extraChecks = mkShell system { extraChecks = true; javaVersion = 23; };
                 jReleaser = mkShell system { release = true; javaVersion = 21; };
               });
         in


### PR DESCRIPTION
See discussion in https://github.com/INRIA/spoon/pull/6158 for context. 

Based on the [discussion](https://github.com/INRIA/spoon/pull/6158#issuecomment-2667121734) it looks like only the `extraChecks` runtime needs this bump. I've just manually changed that version to 22. Are there any other chores that need to be performed associated with this bump ? 

cc @monperrus @I-Al-Istannen 