### PR TITLE
Fix spoon-control-flow pom version

### DIFF
--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-pom</artifactId>
-        <version>1.0</version>
+        <version>11.2.1-SNAPSHOT</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-pom</artifactId>
-        <version>11.2.1-SNAPSHOT</version>
+        <version>11.2.1</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     

--- a/spoon-control-flow/pom.xml
+++ b/spoon-control-flow/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>fr.inria.gforge.spoon</groupId>
         <artifactId>spoon-pom</artifactId>
-        <version>11.2.1</version>
+        <version>11.2.0</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     


### PR DESCRIPTION
It seems that `spoon-control-flow` was pointing to the wrong parent pom version. Sometimes builds will break. This should fix the versioning, consistent with the other modules.