### PR TITLE
fix: Correct parenthesis around type-casting for refactored code when using SniperJavaPrettyPrinter

### DIFF
--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -351,7 +351,8 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	 *
 	 * This function handles some custom logic which might be needed for special types of code-fragments.
 	 * For instance, we by default add parenthesis around the type while type-casting. The source code for the cast
-	 * has parenthesis around it as well (which would be required for the original code to be valid Java code).
+	 * has parenthesis around it as well (which would be required for the original code to be valid Java code -- the
+	 * assumption here is that the fragment supplied comes from valid/compilable Java code).
 	 * Printing that source-code without any modification would then lead to non-compilable java code. This function
 	 * can handle such special cases.
 	 * */

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -231,7 +231,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 						//push the context of this collection
 						pushContext(listContext);
 					}
-					mutableTokenWriter.directPrint(fragment.getSourceCode());
+					mutableTokenWriter.directPrint(getSourceCodeForSniperPrinting(fragment));
 				}
 			}
 		});
@@ -324,7 +324,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 					//and scan first element of that collection again in new context of that collection
 					if (ModificationStatus.NOT_MODIFIED.equals(isModified)) {
 						// we print the original source code
-						mutableTokenWriter.directPrint(fragment.getSourceCode());
+						mutableTokenWriter.directPrint(getSourceCodeForSniperPrinting(fragment));
 					} else {
 						// we print with the new list context
 						listContext.print(this);
@@ -333,7 +333,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 					ElementSourceFragment sourceFragment = (ElementSourceFragment) fragment;
 					if (isModified == ModificationStatus.NOT_MODIFIED) {
 						//nothing is changed, we can print origin sources of this element
-						mutableTokenWriter.directPrint(fragment.getSourceCode());
+						mutableTokenWriter.directPrint(getSourceCodeForSniperPrinting(fragment));
 						return;
 					}
 
@@ -344,6 +344,23 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 				}
 			}
 		};
+	}
+
+	private String getSourceCodeForSniperPrinting(SourceFragment fragment) {
+		if (fragment instanceof ElementSourceFragment elementFragment) {
+			if (elementFragment.getRoleInParent() == CtRole.CAST) {
+				return elementFragment.getSourceCode(elementFragment.getStart()+1, elementFragment.getEnd()-1);
+			}
+			return elementFragment.getSourceCode();
+		} else if (fragment instanceof CollectionSourceFragment collectionSourceFragment) {
+			StringBuilder sb = new StringBuilder();
+			for (SourceFragment childSourceFragment : collectionSourceFragment.getItems()) {
+				sb.append(getSourceCodeForSniperPrinting(childSourceFragment));
+			}
+			return sb.toString();
+		} else {
+			return fragment.getSourceCode();
+		}
 	}
 
 	private CtRole getRoleInCompilationUnit(CtElement element) {

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -359,7 +359,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 	private String getSourceCodeForSniperPrinting(SourceFragment fragment) {
 		if (fragment instanceof ElementSourceFragment elementFragment) {
 			if (elementFragment.getRoleInParent() == CtRole.CAST) {
-				return elementFragment.getSourceCode(elementFragment.getStart()+1, elementFragment.getEnd()-1);
+				return elementFragment.getSourceCode(elementFragment.getStart() + 1, elementFragment.getEnd() - 1);
 			}
 			return elementFragment.getSourceCode();
 		} else if (fragment instanceof CollectionSourceFragment collectionSourceFragment) {

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -369,6 +369,7 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 			}
 			return sb.toString();
 		} else {
+			// We have a TokenSourceFragment.
 			return fragment.getSourceCode();
 		}
 	}

--- a/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
+++ b/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java
@@ -346,6 +346,15 @@ public class SniperJavaPrettyPrinter extends DefaultJavaPrettyPrinter implements
 		};
 	}
 
+	/**
+	 * Gets modified source code for pretty-printing when using the SniperJavaPrettyPrinter.
+	 *
+	 * This function handles some custom logic which might be needed for special types of code-fragments.
+	 * For instance, we by default add parenthesis around the type while type-casting. The source code for the cast
+	 * has parenthesis around it as well (which would be required for the original code to be valid Java code).
+	 * Printing that source-code without any modification would then lead to non-compilable java code. This function
+	 * can handle such special cases.
+	 * */
 	private String getSourceCodeForSniperPrinting(SourceFragment fragment) {
 		if (fragment instanceof ElementSourceFragment elementFragment) {
 			if (elementFragment.getRoleInParent() == CtRole.CAST) {

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -17,6 +17,7 @@ import spoon.Launcher;
 import spoon.SpoonException;
 import spoon.compiler.Environment;
 import spoon.processing.AbstractProcessor;
+import spoon.refactoring.CtRenameLocalVariableRefactoring;
 import spoon.refactoring.Refactoring;
 import spoon.reflect.CtModel;
 import spoon.reflect.code.CtConstructorCall;
@@ -50,6 +51,7 @@ import spoon.support.modelobs.ChangeCollector;
 import spoon.support.modelobs.SourceFragmentCreator;
 import spoon.support.sniper.SniperJavaPrettyPrinter;
 import spoon.test.prettyprinter.testclasses.OneLineMultipleVariableDeclaration;
+import spoon.test.prettyprinter.testclasses.RefactorCast;
 import spoon.test.prettyprinter.testclasses.Throw;
 import spoon.test.prettyprinter.testclasses.InvocationReplacement;
 import spoon.test.prettyprinter.testclasses.ToBeChanged;
@@ -1143,6 +1145,20 @@ public class TestSniperPrinter {
 	void noChangeDiffMethodComment() throws IOException {
 			testNoChangeDiffFailing(
 					Paths.get("src/test/java/spoon/test/prettyprinter/testclasses/difftest/MethodComment").toFile());
+	}
+
+
+	@Test
+	@GitHubIssue(issueNumber = 4335, fixed = true)
+	public void testCorrectTypeCastParenthesisAfterRefactor() {
+		testSniper(RefactorCast.class.getName(), type -> {
+			List<CtStatement> blocks = type.getMethodsByName("example").get(0).getBody().getStatements();
+			CtLocalVariable<?> localVar = (CtLocalVariable<?>) blocks.get(0);
+			CtRenameLocalVariableRefactoring refactor = new CtRenameLocalVariableRefactoring();
+			refactor.setTarget(localVar);
+			refactor.setNewName("b");
+			refactor.refactor();
+		}, (type, result) -> assertThat(result, containsString("((Double) b).toString();")));
 	}
 	/**
 	 * Test various syntax by doing an change to every element that should not

--- a/src/test/java/spoon/test/prettyprinter/testclasses/RefactorCast.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/RefactorCast.java
@@ -2,7 +2,7 @@ package spoon.test.prettyprinter.testclasses;
 
 public class RefactorCast {
     void example() {
-        var a = 12345.0;
-        var x = ((Double) a).toString();
+        double a = 12345.0;
+        String x = ((Double) a).toString();
     }
 }

--- a/src/test/java/spoon/test/prettyprinter/testclasses/RefactorCast.java
+++ b/src/test/java/spoon/test/prettyprinter/testclasses/RefactorCast.java
@@ -1,0 +1,8 @@
+package spoon.test.prettyprinter.testclasses;
+
+public class RefactorCast {
+    void example() {
+        var a = 12345.0;
+        var x = ((Double) a).toString();
+    }
+}


### PR DESCRIPTION
Fix https://github.com/INRIA/spoon/issues/4335

# Context and Fix
When a piece of code involving a type-cast is refactored and then printed using `SniperJavaPrettyPrinter` (where the `cast` itself is to be printed from the source-code) , we seem to be printing extra parenthesis around the type-cast, leading to non-compilable java code. 

I believe this was occurring because when processing a `CAST` fragment specifically, we by default seem to add extra `(...)` pairs around it [here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java#L311).

Then, when the `scan` between those 2 additions visits the `SniperJavaPrettyPrinter` scan [here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/sniper/SniperJavaPrettyPrinter.java#L299), we eventually get to a call to print the fragment's source-code as is -- which involves the `(...)` that already come with a cast. I believe this is will always be the case, since explicit casting (that I believe we are interested with here) will always be enclosed within its own `(...)` for it to be valid Java source code (according to references like this: https://www.w3schools.com/java/java_type_casting.asp). 

So, in `SniperJavaPrettyPrinter`, instead of just printing the fragment's source-code as is, I've added a helper function which can be used to modify the source-code being printed to account for such "default" behaviour being done by our pretty-printing code. So, all calls to `fragment.getSourceCode()` in `SniperJavaPrettyPrinter` should have been replaced with this helper now. For now it just involves special logic to handle `CAST` type-fragments, but I can see that being expanded in the future if there are other "special cases" like this one. 

# Testing
I've recreated the example found in the original github issue (changing `var` to valid `Java` types that seem to be required according to a list in this test file: [link](https://github.com/INRIA/spoon/blob/master/src/test/java/spoon/test/prettyprinter/PrinterTest.java#L313) -- with `var` the `testPrinterTokenListener` in `PrinterTest` was failing). Now I believe there are no longer extra parenthesis around `(Double)`. 

I _think_ this fix might also resolve https://github.com/INRIA/spoon/issues/4221? I'm not entirely sure how to go about testing that though, since from my understanding `SniperJavaPrettyPrinter` really comes in to play whenever there is a change/refactoring from the original source code to the new one, and in https://github.com/INRIA/spoon/issues/4221 I can't see what the change being made is, just the `Expected` and the `Original`. The use of non-standard Java library packages (OracleConnecteion, etc) also makes it a little hard to recreate exactly. If there is a way/need to recreate that test or something that is similar, let me know how and I'll add/verify that test here!

If there are any other tests that I should add, please let me know as well! All the existing tests pass, which I think is a good sign 😄 

# Additional Notes
I was also investigating another `SniperJavaPrettyPrinter` bug related to extra spaces being added around type-casts. The source code still seems compilable (which imo makes this fix a little more important), but I think the explicit addition of `(` brackets in the `enterCtExpression` function of `DefaultJavaPrettyPrinter` might be making things difficult. Here, the fix works in the confines of that explicit addition. More info can be found on my comment here: https://github.com/INRIA/spoon/issues/3911#issuecomment-2697135485

cc @algomaster99 @monperrus @I-Al-Istannen would appreciate your thoughts on this whenever you get the time 🙏🏽 !