### PR TITLE
 chore: ensure in CI that there is no dependency to snapshots

### DIFF
--- a/chore/release-beta.sh
+++ b/chore/release-beta.sh
@@ -24,9 +24,7 @@ echo "::endgroup::"
 BRANCH_NAME="beta-release/$NEXT_BETA_VERSION"
 
 echo "::group::Setting beta-release version"
-mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_BETA_VERSION" -DprocessAllModules
-mvn --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_BETA_VERSION" -DprocessAllModules
-mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_BETA_VERSION" -DprocessAllModules
+mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_BETA_VERSION" -DprocessAllModules -DprocessParent=false
 echo "::endgroup::"
 
 echo "::group::Commit & Push changes"

--- a/chore/release.sh
+++ b/chore/release.sh
@@ -37,9 +37,7 @@ fi
 BRANCH_NAME="release/$NEXT_VERSION"
 
 echo "::group::Setting release version"
-mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
-mvn --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
-mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
+mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules -DprocessParent=false
 echo "::endgroup::"
 
 echo "::group::Commit & Push changes"

--- a/chore/release.sh
+++ b/chore/release.sh
@@ -37,9 +37,7 @@ fi
 BRANCH_NAME="release/$NEXT_VERSION"
 
 echo "::group::Setting release version"
-mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
-mvn --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
-mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
+mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules -DprocessParent=false
 echo "::endgroup::"
 
 echo "::group::Commit & Push changes"

--- a/chore/release.sh
+++ b/chore/release.sh
@@ -68,9 +68,7 @@ echo "::endgroup::"
 NEXT_RELEASE_VERSION="$(semver next patch "$NEXT_VERSION")-SNAPSHOT"
 
 echo "::group::Updating poms to next target version"
-mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules
-mvn --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules
-mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules
+mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules -DprocessParent=false
 echo "::endgroup::"
 
 echo "::group::Committing changes"

--- a/chore/release.sh
+++ b/chore/release.sh
@@ -37,7 +37,9 @@ fi
 BRANCH_NAME="release/$NEXT_VERSION"
 
 echo "::group::Setting release version"
-mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_RELEASE_VERSION" -DprocessAllModules -DprocessParent=false
+mvn -f spoon-pom --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
+mvn --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
+mvn -f spoon-javadoc --no-transfer-progress --batch-mode versions:set -DnewVersion="$NEXT_VERSION" -DprocessAllModules
 echo "::endgroup::"
 
 echo "::group::Commit & Push changes"

--- a/chore/run-with-spoon-javadoc-classpath.sh
+++ b/chore/run-with-spoon-javadoc-classpath.sh
@@ -9,7 +9,7 @@ export CLASSPATH="$(cd "$SCRIPT_DIR/../spoon-javadoc" && mvn dependency:build-cl
 
 # Ourselves
 LOCAL_REPO="$(mvn help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)"
-SPOON_VERSION="$(cd "$SCRIPT_DIR/../spoon-javadoc" && mvn help:evaluate -Dexpression=project.parent.version -q -DforceStdout)"
+SPOON_VERSION="$(cd "$SCRIPT_DIR/../spoon-javadoc" && mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
 export CLASSPATH="$CLASSPATH:$LOCAL_REPO/fr/inria/gforge/spoon/spoon-javadoc/$SPOON_VERSION/spoon-javadoc-$SPOON_VERSION.jar"
 
 # A simple logger to disable the warning

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,10 @@
-<!--
-
-    Copyright (C) 2006-2019 INRIA and contributors
-
-    Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) of the Cecill-C License (see LICENSE-CECILL-C.txt).
-    You as the user are entitled to choose the terms under which to adopt Spoon.
-
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>fr.inria.gforge.spoon</groupId>
     <artifactId>spoon-pom</artifactId>
-    <version>11.2.1-SNAPSHOT</version>
+    <version>11.2.0</version>
     <relativePath>spoon-pom</relativePath>
   </parent>
 
@@ -172,6 +164,27 @@
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.4.1</version>
+        <executions>
+          <execution>
+            <id>enforce-no-snapshots</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireReleaseDeps>
+                  <message>No Snapshots Allowed!</message>
+                </requireReleaseDeps>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+        </plugin>
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>

--- a/spoon-javadoc/pom.xml
+++ b/spoon-javadoc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spoon-pom</artifactId>
         <groupId>fr.inria.gforge.spoon</groupId>
-        <version>11.2.1-SNAPSHOT</version>
+        <version>11.2.0</version>
         <relativePath>../spoon-pom</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
reviving  #5395 

the top doc change in pom.xml is required by maven-enforcer-plugin 