### PR TITLE
fix: Prevent printing spaces before a type-cast (SniperPrinter)

### DIFF
--- a/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
+++ b/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java
@@ -16,6 +16,7 @@ import spoon.reflect.code.CtComment;
 import spoon.reflect.cu.SourcePositionHolder;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtTypeReference;
 
 import static spoon.support.sniper.internal.ElementSourceFragment.findIndexOfNextFragment;
 import static spoon.support.sniper.internal.ElementSourceFragment.filter;
@@ -57,11 +58,54 @@ abstract class AbstractSourceFragmentPrinter implements SourceFragmentPrinter {
 		int index = update(event);
 		if (index != -1) { // means we have found a source code fragment corresponding to this event
 
-			// we print all spaces and comments before this fragment
-			printSpaces(getLastNonSpaceNonCommentBefore(index, prevIndex), index);
+			// We DO NOT want to print spaces between `index` and `prevIndex` in the case that there
+			// has been a "jump" from `prevIndex` to `index` and the pretty-printer is about to print a `(` token
+			// that is NOT the `(` token required for the type-cast. Note that the beginning `(` token that surrounds
+			// the type-cast is explicitly printed by the current pretty printer.
+			if (
+					// We want to PREVENT printing spaces if the large condition below is true -- thus the negation
+					!(
+							// the "next" index after the last index is in range
+							(prevIndex + 1 < childFragments.size())
+							// the "next" index would have been a type-cast token
+							&& isTypeCastFragment(childFragments.get(prevIndex + 1))
+							// the current index is actually a beginning `(` token
+							&& childFragments.get(index).getSourceCode().equals("(")
+							// explicitly checks that there has been a "jump". While the previous conditions
+							// *should* automatically make this true, this is still being added for explicitness.
+							&& (prevIndex + 1 != index)
+					)
+			) {
+				// we print all spaces and comments before this fragment
+				printSpaces(getLastNonSpaceNonCommentBefore(index, prevIndex), index);
+			}
 
 			SourceFragment fragment = childFragments.get(index);
 			event.printSourceFragment(fragment, isFragmentModified(fragment));
+		}
+	}
+
+	/**
+	 * Determines if the provided fragment is an instance of a TypeCast (ie, the CtTypeReference).
+	 * At the moment, this returns true if the fragment is either a singleton CollectionSourceFragment which
+	 * has only one element -- the CtTypeReference. It also returns true if the provided fragment is an
+	 * ElementSourceFragment that is a CtTypeReference.
+	 * A CtTypeReference is like the "(double)" in " ... = (double) b;"
+	 * */
+	private boolean isTypeCastFragment(SourceFragment fragment) {
+		if (fragment instanceof CollectionSourceFragment collection) {
+			// The type-cast fragment *generally* seems to be present inside a singleton CollectionSourceFragment.
+			// So, if there is more than one element in the collection, we are likely *not* processing a type-cast
+			// fragment
+			if (collection.getItems().size() != 1) {
+				return false;
+			}
+			ElementSourceFragment element = (ElementSourceFragment) collection.getItems().get(0);
+			return element.getElement() instanceof CtTypeReference<?>;
+		} else if (fragment instanceof ElementSourceFragment element) {
+			return element.getElement() instanceof CtTypeReference<?>;
+		} else {
+			return false;
 		}
 	}
 

--- a/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
+++ b/src/test/java/spoon/test/prettyprinter/TestSniperPrinter.java
@@ -800,7 +800,7 @@ public class TestSniperPrinter {
 	}
 
 	@Test
-	@GitHubIssue(issueNumber = 3911, fixed = false)
+	@GitHubIssue(issueNumber = 3911, fixed = true)
 	void testRoundBracketPrintingInComplexArithmeticExpression() {
 		Consumer<CtType<?>> noOpModifyFieldAssignment = type ->
 				type.getField("value")
@@ -812,6 +812,22 @@ public class TestSniperPrinter {
 				assertThat(result, containsString("((double) (3 / 2)) / 2"));
 
 		testSniper("ArithmeticExpression", noOpModifyFieldAssignment, assertPrintsRoundBracketsCorrectly);
+	}
+
+	@Test
+	@GitHubIssue(issueNumber = 3911, fixed = true)
+	void testRoundBracketPrintingInComplexArithmeticExpressionWithSpaces() {
+		Consumer<CtType<?>> noOpModifyFieldAssignment = type ->
+				type.getField("value")
+						.getAssignment()
+						.descendantIterator()
+						.forEachRemaining(TestSniperPrinter::markElementForSniperPrinting);
+
+		// This checks that we retain the ORIGINAL spaces if present in the expression.
+		BiConsumer<CtType<?>, String> assertPrintsRoundBracketsCorrectly = (type, result) ->
+				assertThat(result, containsString("( (double) (3 / 2)) / 2"));
+
+		testSniper("ArithmeticExpressionWithSpaces", noOpModifyFieldAssignment, assertPrintsRoundBracketsCorrectly);
 	}
 
 	@Test

--- a/src/test/resources/ArithmeticExpressionWithSpaces.java
+++ b/src/test/resources/ArithmeticExpressionWithSpaces.java
@@ -1,0 +1,3 @@
+class ArithmeticExpressionWithSpaces {
+    double value = ( (double) (3 / 2)) / 2;
+}


### PR DESCRIPTION
fix https://github.com/INRIA/spoon/issues/3911

I've highlighted what I believe the issue was in this comment made on the issue: https://github.com/INRIA/spoon/issues/3911#issuecomment-2697135485

The fix here prevents printing spaces before the typecast (ie, something like `...(double)`) if there are no spaces in the original code. If there is a space in the original code, then that should be retained (I've added a new test case for that). Lmk if there are any additional test cases that need to be added too! 

Now, instead of _always_ printing spaces, we *do not* print spaces if *all* of the following conditions are met: 
1. The fragment to be printed after the last printed fragment (which I assume is indicated by `prevIndex` below) is a type-cast. 
2. The current fragment about to be printed (which I assume is indicated by `index` below) is a token for `(`
3. There has been a "jump" between the last index that was printed and the next index about to be printed 
I believe (1) and (2) should automatically imply (3), but I've still kept that here for explicitness/good measure. 

So we basically guard the call to `printSpaces` and only execute it when (1) - (3) *do not* hold. 

There _might_ be other calls to `printSpaces`, such as [here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/sniper/internal/AbstractSourceFragmentPrinter.java#L94) in the file, or [here](https://github.com/INRIA/spoon/blob/master/src/main/java/spoon/support/sniper/internal/SourceFragmentContextNormal.java#L58) in a child class. The failing test case passes with just this change so I didn't add this guard anywhere else, since I wanted to keep the changes to pretty-printer limited unless really needed 🤷🏽 😅 

The code to check whether a fragment is that of a type-cast is _sort of_ extrapolated from the structure of the type-cast containing fragment I saw in the test case -- it being contained inside a singleton `CollectionSourceFragment`. I've still added an explicit case for `ElementSourceFragment` in case type-casts might be present inside simple `ElementSourceFragments` as well.

@monperrus @I-Al-Istannen @algomaster99 would love your thoughts on this whenever you get a chance! 🫡 