### PR TITLE
chore: Set Launcher's compliance level to 17 for some default-pretty-printer tests

### DIFF
--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -450,7 +450,7 @@ public class Launcher implements SpoonAPI {
 
 		Environment environment = factory.getEnvironment();
 		// environment initialization
-		environment.setComplianceLevel(jsapActualArgs.getInt("compliance", 17));
+		environment.setComplianceLevel(jsapActualArgs.getInt("compliance"));
 		environment.setLevel(jsapActualArgs.getString("level"));
 		if (jsapActualArgs.getBoolean("imports")) {
 			environment.setPrettyPrintingMode(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT);

--- a/src/main/java/spoon/Launcher.java
+++ b/src/main/java/spoon/Launcher.java
@@ -450,7 +450,7 @@ public class Launcher implements SpoonAPI {
 
 		Environment environment = factory.getEnvironment();
 		// environment initialization
-		environment.setComplianceLevel(jsapActualArgs.getInt("compliance"));
+		environment.setComplianceLevel(jsapActualArgs.getInt("compliance", 17));
 		environment.setLevel(jsapActualArgs.getString("level"));
 		if (jsapActualArgs.getBoolean("imports")) {
 			environment.setPrettyPrintingMode(Environment.PRETTY_PRINTING_MODE.AUTOIMPORT);

--- a/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
+++ b/src/test/java/spoon/reflect/visitor/DefaultJavaPrettyPrinterTest.java
@@ -121,6 +121,7 @@ public class DefaultJavaPrettyPrinterTest {
 
     private static Launcher createLauncherWithOptimizeParenthesesPrinter() {
         Launcher launcher = new Launcher();
+        launcher.getEnvironment().setComplianceLevel(17);
         launcher.getEnvironment().setPrettyPrinterCreator(() -> {
             DefaultJavaPrettyPrinter printer = new DefaultJavaPrettyPrinter(launcher.getEnvironment());
             printer.setMinimizeRoundBrackets(true);


### PR DESCRIPTION
See discussion here: https://github.com/INRIA/spoon/pull/6226#discussion_r2009030723

I believe this should set the compliance level of Launcher to 17 **always** if not provided, based on the `JSAPResult` documentation [here](https://www.martiansoftware.com/jsap/doc/javadoc/com/martiansoftware/jsap/JSAPResult#getInt(java.lang.String,%20int)).

cc @SirYwell 