### PR TITLE
Update Java version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,13 @@ If you need professional support on Spoon (development, training, extension), yo
 
 ## Getting started in 2 seconds
 
-> **Java version:** Spoon version 10 and up requires Java 11 or later. Spoon 9.1.0 is the final Spoon release compatible
-> with Java 8, and we do not plan to backport any bug fixes or features to Spoon 9. Note that Spoon can of course still
-> consume source code for older versions of Java, but it needs JDK 11+ to run.
+**Required Java version:** 
+
+- Spoon 11 requires JDK 17 or later. 
+- Spoon 10 requires JDK 11 or later.
+- Spoon 9.1.0 is the final Spoon release compatible with Java 8, and we do not plan to backport any bug fixes or features to Spoon 9.
+
+Note that Spoon can of course still consume source code for older versions of Java, but it needs the above mentioned JDK version to run.
 
 Get latest stable version with Maven, see <https://search.maven.org/artifact/fr.inria.gforge.spoon/spoon-core>
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ If you need professional support on Spoon (development, training, extension), yo
 
 **Required Java version:** 
 
-- Spoon 11 requires JDK 17 or later. 
-- Spoon 10 requires JDK 11 or later.
-- Spoon 9.1.0 is the final Spoon release compatible with Java 8, and we do not plan to backport any bug fixes or features to Spoon 9.
+- Spoon 11.x requires JDK 17 or later. 
+- Spoon 10.x requires JDK 11 or later.
+- Spoon 9.x requires Java 8.
 
 Note that Spoon can of course still consume source code for older versions of Java, but it needs the above mentioned JDK version to run.
 


### PR DESCRIPTION
Spoon 11 requires JDK17+: https://github.com/INRIA/spoon/pull/5588/files#diff-da6c5ffbf044fe3aff223deb941b61a7cb0506bbc2e2e82e4b15589ec02bbf83

This should be reflected in the documentation.