### PR TITLE
chore: port CD to new OSSRH pipeline

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,9 +1,9 @@
 project:
   name: spoon
   description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code.
-  longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
-                   It parses source files to build a well-designed AST with powerful analysis and transformation API. 
-                   It supports modern Java versions up to Java 20.
+  longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code.
+    It parses source files to build a well-designed AST with powerful analysis and transformation API.
+    It supports modern Java versions up to Java 20.
   authors:
     - monperrus
     - nharrand

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -42,6 +42,7 @@ deploy:
       sonatype:
         active: ALWAYS
         url: https://central.sonatype.com/api/v1/publisher
+        applyMavenCentralRules: true
         stagingRepositories:
           - target/staging-deploy
     nexus2:

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,6 +1,6 @@
 project:
   name: spoon
-  description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
+  description: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code.
   longDescription: Spoon is an open-source library to analyze, rewrite, transform, transpile Java source code. 
                    It parses source files to build a well-designed AST with powerful analysis and transformation API. 
                    It supports modern Java versions up to Java 20.
@@ -38,14 +38,19 @@ signing:
   armored: true
 deploy:
   maven:
-    nexus2:
-      maven-central:
+    mavenCentral:
+      sonatype:
         active: ALWAYS
-        # Spoon is hosted on the legacy sonatype instance, see
-        # https://central.sonatype.org/publish/publish-guide/#releasing-to-central
-        url: https://oss.sonatype.org/service/local
-        snapshotUrl: https://oss.sonatype.org/content/repositories/snapshots
+        url: https://central.sonatype.com/api/v1/publisher
+        stagingRepositories:
+          - target/staging-deploy
+    nexus2:
+      snapshot-deploy:
+        active: ALWAYS
+        snapshotUrl: https://central.sonatype.com/repository/maven-snapshots/
+        applyMavenCentralRules: true
+        snapshotSupported: true
         closeRepository: true
-        releaseRepository: true
+        releaseRepository: false # for the first trial, we do a manual click on the Sonatype UI to release
         stagingRepositories:
           - target/staging-deploy


### PR DESCRIPTION
Fixes #6313 

I follwed the documentation [here](https://jreleaser.org/guide/latest/examples/maven/maven-central.html) and it seems `jreleaser.json` has only some URL changes.

Now I don't know what type of authentication is set for `fr.inria.gforge.spoon` namespace. Based on that we need to set up the following env variables.
```
JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME or JRELEASER_MAVENCENTRAL_USERNAME
JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD or JRELEASER_MAVENCENTRAL_PASSWORD
OR
JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME or JRELEASER_MAVENCENTRAL_USERNAME
JRELEASER_MAVENCENTRAL_SONATYPE_TOKEN or JRELEASER_MAVENCENTRAL_TOKEN
```

and remove `NEXUS2` related env variables. Finally, we can keep GPG related env variables.