### PR TITLE
chore: Allow workflow dispatch for release-nightly

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,6 +1,7 @@
 name: Release nightly version
 
 on:
+    workflow_dispatch:
     schedule:
       - cron: '0 0 * * *' # Every day at 00:00 UTC (https://crontab.guru/#0_0_*_*_*)
 


### PR DESCRIPTION
This is required to test the new release workflow