### PR TITLE
chore: port CD to new OSSRH pipeline (#6341)

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -47,7 +47,7 @@ deploy:
           - target/staging-deploy
     nexus2:
       snapshot-deploy:
-        active: ALWAYS
+        active: SNAPSHOT
         snapshotUrl: https://central.sonatype.com/repository/maven-snapshots/
         applyMavenCentralRules: true
         snapshotSupported: true


### PR DESCRIPTION
The `active` status for snapshot release should be `SNAPSHOT` as documented [here](https://jreleaser.org/guide/latest/examples/maven/maven-central.html).

@I-Al-Istannen please merge when tests pass.