### PR TITLE
chore: activate mavenCentral release only on normal releases

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -40,7 +40,7 @@ deploy:
   maven:
     mavenCentral:
       sonatype:
-        active: ALWAYS
+        active: RELEASE
         url: https://central.sonatype.com/api/v1/publisher
         applyMavenCentralRules: true
         stagingRepositories:


### PR DESCRIPTION
`RELEASE` should only activate it for non SNAPSHOT releases.