### PR TITLE
style: remove redundant options

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -51,7 +51,5 @@ deploy:
         snapshotUrl: https://central.sonatype.com/repository/maven-snapshots/
         applyMavenCentralRules: true
         snapshotSupported: true
-        closeRepository: true
-        releaseRepository: false # for the first trial, we do a manual click on the Sonatype UI to release
         stagingRepositories:
           - target/staging-deploy


### PR DESCRIPTION
Because the [previous SNAPSHOT was released](https://central.sonatype.com/repository/maven-snapshots/fr/inria/gforge/spoon/spoon-core/11.2.2-SNAPSHOT/spoon-core-11.2.2-20250709.200721-1.jar) without even showing up on UI, I have a feeling these options are redundant. @I-Al-Istannen can we give these changes a try and release another SNAPSHOT?