### PR TITLE
revert: remove manual trigger for nightly releases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -1,7 +1,6 @@
 name: Release nightly version
 
 on:
-    workflow_dispatch:
     schedule:
       - cron: '0 0 * * *' # Every day at 00:00 UTC (https://crontab.guru/#0_0_*_*_*)
 


### PR DESCRIPTION
SNAPSHOT release is working so I am reverting the manual trigger.

We have tested the SNAPSHOT release, but not beta and others. There [does not seem to be an option to only stage beta releases](https://jreleaser.org/guide/latest/reference/deploy/maven/maven-central.html) so let's just wing it and see how it turns out to be on Sunday?