### PR TITLE
perf: resolve declaration once

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtExecutableReferenceImpl.java
@@ -91,10 +91,15 @@ public class CtExecutableReferenceImpl<T> extends CtReferenceImpl implements CtE
 	@SuppressWarnings("unchecked")
 	public CtExecutable<T> getDeclaration() {
 		final CtTypeReference<?> typeRef = getDeclaringType();
-		if (typeRef == null || typeRef.getDeclaration() == null) {
+		if (typeRef == null) {
 			return null;
 		}
-		return getCtExecutable(typeRef.getDeclaration());
+		CtType<?> declaration = typeRef.getDeclaration();
+		if (declaration == null) {
+			return null;
+		}
+
+		return getCtExecutable(declaration);
 	}
 
 	@Override


### PR DESCRIPTION
I recently realized through profiling that calls to `CtTypeReferenceImpl.getDeclaration()` are relatively computationally complex. Therefore, computing the same result twice when resolving the declaration site for a `CtExecutableReference` seems excessive.

Let me know if you need anything else!

**More background:** I was attempting to rename all methods in a Spoon model via `Refactoring.changeMethodName(final CtMethod<?> method, String newName)`. Because this refactoring traverses all `CtExecutableReference`s and resolves their declarations each time, the runtime exploded. `n` methods and `m` references would lead to `n*m` runtime.
I have not checked, but the underlying call to `CtTypeImpl.getNestedType(final String name)`, which uses a `EarlyTerminatingScanner`, probably increases this complexity further.

To solve this problem for my use case, I reduced the complexity by resolving the declaration site for all `CtExecutableReference`s once and build a map that associates each method with a list of its references in linear time.