### PR TITLE
chore: allow for manual beta releases

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,6 +1,7 @@
 name: Release beta version
 
 on:
+    workflow_disptach:
     schedule:
       - cron: '0 0 * * 0' # Sundays at 00:00 (https://crontab.guru/#0_0_*_*_0)
 


### PR DESCRIPTION
In the last automatic action for beta release, the workflow failed because renovate merged in between and now that workflow is unable to push more commits. We want to enable manual trigger for beta release.