### PR TITLE
chore: fix how latest version is computed

### DIFF
--- a/chore/release-beta.sh
+++ b/chore/release-beta.sh
@@ -13,7 +13,7 @@ fi
 
 # Compute next beta number
 echo "::group::Computing next beta number"
-LAST_BETA_NUMBER="$(curl -L "http://search.maven.org/solrsearch/select?q=a:spoon-core+g:fr.inria.gforge.spoon&rows=40&wt=json&core=gav" | jq -r ".response.docs | map(.v) | map((match(\"$OLD_VERSION-beta-(.*)\") | .captures[0].string) // \"0\") | .[0]")"
+LAST_BETA_NUMBER="$(curl -L "https://central.sonatype.com/solrsearch/select?q=a:spoon-core+g:fr.inria.gforge.spoon" | jq -r ".response.docs | map(.latestVersion) | map((match(\"$OLD_VERSION-beta-(.*)\") | .captures[0].string) // \"0\") | .[0]")"
 echo "LAST_BETA_NUMBER $LAST_BETA_NUMBER"
 
 NEW_BETA_NUMBER=$((LAST_BETA_NUMBER + 1))

--- a/doc/_config.yml
+++ b/doc/_config.yml
@@ -20,7 +20,7 @@ include: [_includes]
 sidebar_tagline: Spoon
 
 # this is replaced at deployment time by job https://ci.inria.fr/sos/job/Website Deployer/
-# LATESTVERSION=`curl -s "http://search.maven.org/solrsearch/select?q=g:%22fr.inria.gforge.spoon%22+AND+a:%22spoon-core%22" | jq .response.docs[0].latestVersion`
+# LATESTVERSION=`curl -s "https://central.sonatype.com/solrsearch/select?q=a:spoon-core+g:fr.inria.gforge.spoon" | jq .response.docs[0].latestVersion`
 # sed -i -e "s/^spoon_release: .*/spoon_release: $LATESTVERSION/" _config.yml
 spoon_release: "TO_BE_REPLACED"
 

--- a/doc/_release/deploy_production.sh
+++ b/doc/_release/deploy_production.sh
@@ -28,7 +28,7 @@ cd $DIR_WEBSITE
 cp ../README.md doc_homepage.md
 
 # Generate the website.
-LATESTVERSION=`curl -s "http://search.maven.org/solrsearch/select?q=g:%22fr.inria.gforge.spoon%22+AND+a:%22spoon-core%22&core=gav" | jq -r '.response.docs | map(select(.v | match("^[0-9.]+$")) | .v )| .[0]'`
+LATESTVERSION=`curl -s "https://central.sonatype.com/solrsearch/select?q=a:spoon-core+g:fr.inria.gforge.spoon" | jq -r '.response.docs | map(select(.latestVersion | match("^[0-9.]+$")) | .v )| .[0]'`
 sed -i -e "s/^spoon_release: .*/spoon_release: $LATESTVERSION/" _config.yml
 SNAPSHOTVERSION=`xmlstarlet sel -t -v /_:project/_:version ../pom.xml`
 sed -i -e "s/^spoon_snapshot: .*/spoon_snapshot: \"$SNAPSHOTVERSION\"/" _config.yml


### PR DESCRIPTION
The [last beta release](https://github.com/INRIA/spoon/actions/runs/16395171080/job/46326404462#step:4:224) failed because the latest version is not computed correctly. The [new API](https://central.sonatype.com/solrsearch/select?q=a:spoon-core+g:fr.inria.gforge.spoon) (`rows`, `wt`, and `core` did not have any effect) is required. 