### PR TITLE
review: add renaming of annotation methods

### DIFF
--- a/src/test/java/spoon/test/refactoring/RefactoringTest.java
+++ b/src/test/java/spoon/test/refactoring/RefactoringTest.java
@@ -40,8 +40,14 @@ import spoon.reflect.CtModel;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtAnnotationMethod;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.Query;
 import spoon.reflect.visitor.filter.AbstractFilter;
@@ -50,6 +56,11 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.VirtualFile;
 import spoon.test.refactoring.processors.ThisTransformationProcessor;
 import spoon.test.refactoring.testclasses.AClass;
+import spoon.test.refactoring.testclasses.AnnotationMethodRenaming;
+import spoon.test.refactoring.testclasses.ExampleAnnotation;
+import spoon.test.refactoring.testclasses.InterfaceRenaming;
+import spoon.test.refactoring.testclasses.MethodRenaming;
+import spoon.testing.utils.ModelUtils;
 
 public class RefactoringTest {
 	@Test
@@ -212,4 +223,64 @@ public class RefactoringTest {
 		);
 	}
 
+	@Test
+	void testChangeMethodName() throws Exception {
+		String newName = "methodRenamed";
+		String newNameStaticMethod = "nestedStaticMethodRenamed";
+		String newNameNestedMethod = "nestedMethodRenamed";
+
+		Factory factory = ModelUtils.build(MethodRenaming.class);
+		CtClass<?> clazz = factory.Class().get(MethodRenaming.class);
+		var methods = clazz.getElements(new TypeFilter<>(CtMethod.class));
+		Refactoring.changeMethodName(methods.get(1), newName);
+		Refactoring.changeMethodName(methods.get(2), newNameStaticMethod);
+		Refactoring.changeMethodName(methods.get(3), newNameNestedMethod);
+
+		var refs = clazz.getElements(new TypeFilter<>(CtExecutableReference.class))
+				.stream().filter(e -> !e.getSimpleName().equals("<init>")).toList();
+
+		assertEquals(newName, methods.get(1).getSimpleName());
+		assertEquals(newNameStaticMethod, methods.get(2).getSimpleName());
+		assertEquals(newNameNestedMethod, methods.get(3).getSimpleName());
+
+		assertEquals(newName, refs.get(1).getSimpleName());
+		assertEquals(newNameStaticMethod, refs.get(2).getSimpleName());
+		assertEquals(newNameNestedMethod, refs.get(3).getSimpleName());
+	}
+
+	@Test
+	void testChangeDefaultInterfaceMethodName() throws Exception {
+		String newName = "defaultInterfaceMethodRenamed";
+		Factory factory = ModelUtils.build(MethodRenaming.class, InterfaceRenaming.class);
+		CtType<?> ctInterface = factory.Interface().get(InterfaceRenaming.class);
+		var methods = ctInterface.getElements(new TypeFilter<>(CtMethod.class));
+		Refactoring.changeMethodName(methods.get(0), newName);
+
+		assertEquals(newName, methods.get(0).getSimpleName(), "Default interface method name was not changed");
+		CtClass<?> clazz = factory.Class().get(MethodRenaming.class);
+		var executableRefs = clazz.getElements(new TypeFilter<>(CtExecutableReference.class));
+		assertEquals(newName, executableRefs.get(2).getSimpleName(), "Default interface method reference was not changed");
+	}
+
+	@Test
+	void testChangeAnnotationMethodName() throws Exception {
+		String newName = "annotationMethodRenamed";
+		Factory factory = ModelUtils.build(AnnotationMethodRenaming.class, ExampleAnnotation.class);
+		CtType<?> ctInterface = factory.Annotation().get(ExampleAnnotation.class);
+		var methods = ctInterface.getElements(new TypeFilter<>(CtAnnotationMethod.class));
+		Refactoring.changeMethodName(methods.get(0), newName);
+
+		assertEquals(newName, methods.get(0).getSimpleName(), "Annotation method name was not changed");
+		CtClass<?> clazz = factory.Class().get(AnnotationMethodRenaming.class);
+		var annotations = clazz.getElements(new TypeFilter<>(CtAnnotation.class));
+		assertEquals(5, annotations.size());
+		assertEquals((Integer) 0, annotations.get(0).getValue(newName).getValueByRole(CtRole.VALUE));
+		assertEquals((Integer) 1, annotations.get(1).getValue(newName).getValueByRole(CtRole.VALUE));
+		assertEquals((Integer) 1, annotations.get(2).getValue(newName).getValueByRole(CtRole.VALUE));
+		assertEquals((Integer) 2, annotations.get(3).getValue(newName).getValueByRole(CtRole.VALUE));
+		assertEquals((Integer) 3, annotations.get(4).getValue(newName).getValueByRole(CtRole.VALUE));
+
+		var refs = clazz.getMethodsByName("processingTheAnnotation").get(0).getElements(new TypeFilter<>(CtExecutableReference.class));
+		assertEquals(newName, refs.get(3).getSimpleName());
+	}
 }

--- a/src/test/java/spoon/test/refactoring/testclasses/AnnotationMethodRenaming.java
+++ b/src/test/java/spoon/test/refactoring/testclasses/AnnotationMethodRenaming.java
@@ -1,0 +1,19 @@
+package spoon.test.refactoring.testclasses;
+
+@ExampleAnnotation(someAnnotationMethod = 0)
+public class AnnotationMethodRenaming {
+	@ExampleAnnotation(someAnnotationMethod = 1)
+	public void mentioningTheAnnotation() {
+		@ExampleAnnotation(someAnnotationMethod = 2)
+		class SomeClass {
+		}
+
+		var test = new @ExampleAnnotation(someAnnotationMethod = 3) SomeClass();
+	}
+
+	public void processingTheAnnotation() {
+		var annotation = this.getClass().getAnnotation(ExampleAnnotation.class);
+		System.out.println(annotation.someAnnotationMethod());
+	}
+}
+

--- a/src/test/java/spoon/test/refactoring/testclasses/ExampleAnnotation.java
+++ b/src/test/java/spoon/test/refactoring/testclasses/ExampleAnnotation.java
@@ -1,0 +1,13 @@
+package spoon.test.refactoring.testclasses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.TYPE_USE})
+public @interface ExampleAnnotation {
+	int someAnnotationMethod();
+	String anotherAnnotationMethod() default "no";
+}

--- a/src/test/java/spoon/test/refactoring/testclasses/InterfaceRenaming.java
+++ b/src/test/java/spoon/test/refactoring/testclasses/InterfaceRenaming.java
@@ -1,0 +1,7 @@
+package spoon.test.refactoring.testclasses;
+
+public interface InterfaceRenaming {
+	default void defaultMethod() {
+		System.out.println("This is a default method in an interface.");
+	}
+}

--- a/src/test/java/spoon/test/refactoring/testclasses/MethodRenaming.java
+++ b/src/test/java/spoon/test/refactoring/testclasses/MethodRenaming.java
@@ -1,0 +1,24 @@
+package spoon.test.refactoring.testclasses;
+
+public class MethodRenaming implements InterfaceRenaming {
+
+	public static void main(String[] args) {
+		MethodRenaming example = new MethodRenaming();
+		example.defaultMethod();
+		example.regularMethod();
+		SimpleNestedClass.staticNestedMethod();
+		SimpleNestedClass nestedInstance = new SimpleNestedClass();
+		nestedInstance.nestedMethod();
+	}
+
+	public void regularMethod() {
+	}
+
+	public static class SimpleNestedClass {
+		public static void staticNestedMethod() {
+		}
+
+		public void nestedMethod() {
+		}
+	}
+}


### PR DESCRIPTION
Before this change, if an annotation method was renamed, references in annotations would not be updated.