### PR TITLE
cd: Remove git merge into master for beta releases

### DIFF
--- a/chore/release-beta.sh
+++ b/chore/release-beta.sh
@@ -41,3 +41,7 @@ echo "::endgroup::"
 echo "::group::Running jreleaser"
 JRELEASER_PROJECT_VERSION="$NEXT_BETA_VERSION" jreleaser-cli release
 echo "::endgroup::"
+
+echo "::group::Delete branch"
+git push origin --delete "$BRANCH_NAME"
+echo "::endgroup::"


### PR DESCRIPTION
PR from discussion on CHAINS meeting.

Currently every week the beta-releases cause two commits to the master branch
```
release: Reverting to SNAPSHOT version 11.2.2-SNAPSHOT
release: Releasing version 11.2.2-beta-9
```

These make the commit history longer and more difficult to overview.

We can instead leave the release commits in separate branches without merging into master.
```
* master
|
| * beta-releases/11.2.2-beta-11 
|/
| * beta-releases/11.2.2-beta-10
|/
| * beta-releases/11.2.2-beta-9
|/
```