### PR TITLE
chore: Disable fail mode for flake-checker-action

### DIFF
--- a/.github/actions/setup-tests/action.yml
+++ b/.github/actions/setup-tests/action.yml
@@ -14,7 +14,7 @@ runs:
     - name: Check Nixpkgs inputs
       uses: DeterminateSystems/flake-checker-action@3164002371bc90729c68af0e24d5aacf20d7c9f6 # v12
       with:
-        fail-mode: true
+        fail-mode: false
     - name: Use Maven dependency cache
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:


### PR DESCRIPTION
This came up again in https://github.com/INRIA/spoon/pull/6556 and we likely do not want to block contributions on our failure to keep dependencies up to date. At the same time, we really do want to update our dependencies sometime, to ensure we build against up-to-date software, hence marking this as non-fail and emitting a warning. Once JDT is updated we can adjust our CI to drop 23 and then renovate can bump the lockfile again.