### PR TITLE
fix: Turning CtField elements in CtRecord explicit before asserting

### DIFF
--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -88,6 +88,16 @@ public class CtRecordTest {
 		assertEquals(1, records.size());
 		assertEquals("public record MultiParameter(int first, float second) {}", head(records).toString());
 
+		// Make them explicit so we can print them (but assert they were implicit initially)
+		assertThat(head(records)).getFields().allSatisfy(CtElement::isImplicit);
+		head(records).getFields().forEach(f -> f.accept(new CtScanner() {
+			@Override
+			protected void enter(CtElement e) {
+				e.setImplicit(false);
+			}
+		}));
+		head(records).getFields().forEach(f -> f.getExtendedModifiers().forEach(em -> em.setImplicit(false)));
+
 		// test fields
 		assertEquals(
 				Arrays.asList(


### PR DESCRIPTION
Before version 3.42.0, JDT was adding explicit fields corresponding to record components in the AST for records. Starting with 3.42.0 this is no longer the case. We have to rely on the way Spoon is handing this: addRecordComponent generate implicit fields. So this PR turns implicit fields into explicit ones before asserting.