### PR TITLE
doc: Remove outdated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ If you need professional support on Spoon (development, training, extension), yo
 
 ## Getting started in 2 seconds
 
-**Required Java version:** 
+**Required Java version:**
 
-- Spoon 11.x requires JDK 17 or later. 
+- Spoon 11.x requires JDK 17 or later.
 - Spoon 10.x requires JDK 11 or later.
 - Spoon 9.x requires Java 8.
 
@@ -90,21 +90,6 @@ mvn compile
 To run the tests:
 ```
 mvn test
-```
-
-### Download
-
-Latest version: <https://search.maven.org/remote_content?g=fr.inria.gforge.spoon&a=spoon-core&v=LATEST&c=jar-with-dependencies> - [Javadoc](https://spoon.gforge.inria.fr/mvnsites/spoon-core/apidocs/index.html)
-
-Maven:
-
-```xml
-<dependency>
-    <groupId>fr.inria.gforge.spoon</groupId>
-    <artifactId>spoon-core</artifactId>
-    <!-- See rendered release value at https://spoon.gforge.inria.fr/ -->
-    <version>{{site.spoon_release}}</version>
-</dependency>
 ```
 
 ## Releases


### PR DESCRIPTION
The Download section of README.md reports about:

1. The URL for the latest version of Spoon on maven central,
2. The URL of the Javadoc,
3. The Maven pom snippet for Spoon.

Item 1 provides a broken URL and is redundant with the correct URL that is provided earlier in section Getting started in 2 seconds.

Item 2 refers to an old version of the Javadoc since the deployment of the Spoon doc site is unfortunately broken for some time, see https://github.com/INRIA/spoon/issues/6242

Item 3 refers to the "rendered release value at https://spoon.gforge.inria.fr". Basically this is the same issue as the one for item 2: the rendered release value is outdated.

Basically it seems to me that this Download section is too outdated and somewhat redundant. So I guess it is better to remove it.