### PR TITLE
Fix: Preserve the anonymity status of inner classes declared in methods

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -861,9 +861,13 @@ public class JDTTreeBuilderHelper {
 			((CtClass) type).setSuperclass(jdtTreeBuilder.references.buildTypeReference(typeDeclaration.superclass, typeDeclaration.scope));
 		}
 		if ((type instanceof CtClass || type instanceof CtInterface)
-				&& typeDeclaration.binding != null
-				&& (typeDeclaration.binding.isAnonymousType() || typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null)) {
-			type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName()));
+				&& typeDeclaration.binding instanceof LocalTypeBinding
+				&& typeDeclaration.binding.enclosingMethod() != null) {
+			if (typeDeclaration.binding.isAnonymousType()) {
+				type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName()));
+			} else {
+				type.setSimpleName(new String(typeDeclaration.name));
+			}
 		} else {
 			type.setSimpleName(new String(typeDeclaration.name));
 		}

--- a/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
+++ b/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
@@ -1,0 +1,40 @@
+package spoon.test.innerClassInMethod;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
+
+import spoon.reflect.CtModel;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.ModelTest;
+
+public class InnerClassInMethodTest {
+
+	@ModelTest(value = "./src/test/resources/innerClassInMethod/InnerClassInMethod.java")
+	void testAnonymicity(Factory factory) {
+		// contract: inner classes declared in methods are supported
+		CtModel model = factory.getModel();
+		CtMethod<?> method = model.getElements(new TypeFilter<>(CtMethod.class)).get(0);
+		assertThat(method).isNotNull();
+		CtClass<?> anonymousClass = method.getElements(new TypeFilter<>(CtClass.class)).get(0);
+		assertThat(anonymousClass).isNotNull();
+		assertTrue(anonymousClass.isAnonymous());
+		CtClass<?> notAnonymousClass = method.getElements(new TypeFilter<>(CtClass.class)).get(1);
+		assertThat(notAnonymousClass).isNotNull();
+		assertFalse(notAnonymousClass.isAnonymous());
+		assertThat(notAnonymousClass).getSimpleName().isEqualTo("NotAnonymousClass$1");
+		String expected =
+			"void m() {\n" +
+			"    new java.lang.Runnable() {\n" +
+			"        public void run() {\n" +
+			"        }\n" +
+			"    };\n" +
+			"    class NotAnonymousClass$1 {}\n" +
+			"}";
+		assertEquals(expected, method.toString());
+	}
+}

--- a/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
+++ b/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
@@ -15,7 +15,7 @@ import spoon.testing.utils.ModelTest;
 public class InnerClassInMethodTest {
 
 	@ModelTest(value = "./src/test/resources/innerClassInMethod/InnerClassInMethod.java")
-	void testAnonymicity(Factory factory) {
+	void testAnonymity(Factory factory) {
 		// contract: inner classes declared in methods are supported
 		CtModel model = factory.getModel();
 		CtMethod<?> method = model.getElements(new TypeFilter<>(CtMethod.class)).get(0);

--- a/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
+++ b/src/test/java/spoon/test/innerClassInMethod/InnerClassInMethodTest.java
@@ -16,7 +16,7 @@ public class InnerClassInMethodTest {
 
 	@ModelTest(value = "./src/test/resources/innerClassInMethod/InnerClassInMethod.java")
 	void testAnonymity(Factory factory) {
-		// contract: inner classes declared in methods are supported
+		// contract: the anonymity status of inner classes declared in methods is preserved
 		CtModel model = factory.getModel();
 		CtMethod<?> method = model.getElements(new TypeFilter<>(CtMethod.class)).get(0);
 		assertThat(method).isNotNull();

--- a/src/test/resources/innerClassInMethod/InnerClassInMethod.java
+++ b/src/test/resources/innerClassInMethod/InnerClassInMethod.java
@@ -1,0 +1,9 @@
+package innerClassInMethod;
+
+public class InnerClassInMethod {
+
+	void m() {
+		new Runnable() { public void run() {}};
+		class NotAnonymousClass$1 {}
+	}
+}


### PR DESCRIPTION
This PR preserves the anonymity status of inner classes declared in methods.

Previously, all classes declared in methods were assumed to be anonymous. This PR fixes that.
