### PR TITLE
Fix: Correctly resolve in scope variables of instanceof patterns #6645

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -355,12 +355,6 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	 * @return the scopes that apply to the parent
 	 */
 	private static List<Scope> updateChildScopesForParent(Collection<? extends Scope> childScopes, @NonNull CtElement child, @NonNull CtElement parent) {
-		List<Scope> filteredChildScopes = childScopes.stream()
-			// only keep the scopes that were valid for the child, the ones where the scope was less than the child
-			// can not escape the child, so they can be discarded
-			.filter(scope -> scope.element() == child)
-			.collect(Collectors.toCollection(ArrayList::new));
-
 		// This needs special handling, because of how the code is structured.
 		//
 		// The code related to type patterns operates on PatternScopes, and without this
@@ -369,6 +363,12 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 		if (child instanceof CtVariable<?> ctVariable && parent instanceof CtTypePattern) {
 			return List.of(new PatternScope(ctVariable, parent, true));
 		}
+
+		List<Scope> filteredChildScopes = childScopes.stream()
+			// only keep the scopes that were valid for the child, the ones where the scope was less than the child
+			// can not escape the child, so they can be discarded
+			.filter(scope -> scope.element() == child)
+			.collect(Collectors.toCollection(ArrayList::new));
 
 		if (child instanceof CtVariable<?> ctVariable) {
 			filteredChildScopes.add(new VariableScope(ctVariable, ctVariable));

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -7,26 +7,35 @@
  */
 package spoon.reflect.visitor.filter;
 
-import spoon.reflect.code.CaseKind;
+import spoon.reflect.code.BinaryOperatorKind;
+import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtBodyHolder;
+import spoon.reflect.code.CtBreak;
+import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtCase;
-import spoon.reflect.code.CtCatch;
+import spoon.reflect.code.CtCasePattern;
 import spoon.reflect.code.CtCatchVariable;
+import spoon.reflect.code.CtConditional;
+import spoon.reflect.code.CtDo;
 import spoon.reflect.code.CtFor;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtPattern;
+import spoon.reflect.code.CtRecordPattern;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
-import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypePattern;
+import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.CtWhile;
+import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
@@ -36,8 +45,13 @@ import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.CtQuery;
 import spoon.reflect.visitor.chain.CtQueryAware;
+import spoon.reflect.visitor.chain.CtQueryable;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This mapping function searches for all {@link CtVariable} instances,
@@ -81,6 +95,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 
 	/**
 	 * Searches for a variable with exact name.
+	 *
 	 * @param variableName
 	 */
 	public PotentialVariableDeclarationFunction(String variableName) {
@@ -91,23 +106,15 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	public void apply(CtElement input, CtConsumer<Object> outputConsumer) {
 		isTypeOnTheWay = false;
 		isInStaticScope = false;
-		//Search previous siblings for element which may represents the declaration of this local variable
-		CtQuery siblingsQuery = input.getFactory().createQuery()
-				.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS))
-				//select only CtVariable nodes
-				.select(new TypeFilter<>(CtVariable.class));
-		if (variableName != null) {
-			//variable name is defined so we have to search only for variables with that name
-			siblingsQuery = siblingsQuery.select(new NamedElementFilter<>(CtNamedElement.class, variableName));
-		}
 
+		List<Scope> scopes = new ArrayList<>();
 		CtElement scopeElement = input;
-		//Search input and then all parents until first CtPackage for element which may represents the declaration of this local variable
+		// Search input and then all parents until first CtPackage for element which may represents the declaration of this local variable
 		while (scopeElement != null && !(scopeElement instanceof CtPackage) && scopeElement.isParentInitialized()) {
 			CtElement parent = scopeElement.getParent();
 			if (parent instanceof CtType<?>) {
 				isTypeOnTheWay = true;
-				//visit each CtField of `parent` CtType
+				// visit each CtField of `parent` CtType
 				CtQuery q = parent.map(new AllTypeMembersFunction(CtField.class));
 				q.forEach((CtField<?> field) -> {
 					if (isInStaticScope && !field.hasModifier(ModifierKind.STATIC)) {
@@ -117,95 +124,573 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 						 */
 						return;
 					}
-					//else send field as potential variable declaration
+					// else send field as potential variable declaration
 					if (sendToOutput(field, outputConsumer)) {
 						//and terminate the internal query q if outer query is already terminated
 						q.terminate();
 					}
 				});
+
 				if (query.isTerminated()) {
 					return;
-				}
-			} else if (parent instanceof CtSwitch && scopeElement instanceof CtCase<?> caseElement) {
-				if (caseElement.getCaseKind() == CaseKind.COLON) {
-					SiblingsFunction siblingsFunction = new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS);
-					List<CtCase<?>> list = input.getFactory().createQuery()
-							.map(siblingsFunction)
-							.setInput(scopeElement)
-							.filterChildren(new TypeFilter<>(CtCase.class))
-							.list();
-
-					for (CtCase<?> c : list) {
-						for (CtStatement statement : c.getStatements()) {
-							if (statement instanceof CtLocalVariable && ((CtLocalVariable<?>) statement).getSimpleName().equals(variableName)) {
-								sendToOutput((CtVariable<?>) statement, outputConsumer);
-								return;
-							}
-						}
-					}
-				}
-
-				// search for variable declaration in case
-				var expr = caseElement.getCaseExpression();
-				searchTypePattern(outputConsumer, expr);
-			} else if (parent instanceof CtIf ifElement) {
-				// search for variable declaration in if expression
-				var cond = ifElement.getCondition();
-				searchTypePattern(outputConsumer, cond);
-			} else if (parent instanceof CtBodyHolder || parent instanceof CtStatementList || parent instanceof CtExpression<?>) {
-				//visit all previous CtVariable siblings of scopeElement element in parent BodyHolder or Statement list
-				siblingsQuery.setInput(scopeElement).forEach(outputConsumer);
-				if (query.isTerminated()) {
-					return;
-				}
-				//visit parameters of CtCatch and CtExecutable (method, lambda)
-				if (parent instanceof CtCatch ctCatch) {
-					if (sendToOutput(ctCatch.getParameter(), outputConsumer)) {
-						return;
-					}
-				} else if (parent instanceof CtExecutable<?> exec) {
-					for (CtParameter<?> param : exec.getParameters()) {
-						if (sendToOutput(param, outputConsumer)) {
-							return;
-						}
-					}
-				} else if (parent instanceof CtFor forElement) {
-					// search for variable declaration in for loop expression
-					var expr = forElement.getExpression();
-					searchTypePattern(outputConsumer, expr);
-				} else if (parent instanceof CtWhile whileElement) {
-					// search for variable declaration in while loop expression
-					var expr = whileElement.getLoopingExpression();
-					searchTypePattern(outputConsumer, expr);
-				} else if (parent instanceof CtBinaryOperator<?> op) {
-					// search for type pattern in binary operator
-					var left = op.getLeftHandOperand();
-					searchTypePattern(outputConsumer, left);
 				}
 			}
-			if (parent instanceof CtModifiable) {
-				isInStaticScope = isInStaticScope || ((CtModifiable) parent).hasModifier(ModifierKind.STATIC);
+
+			scopes = updateChildScopesForParent(scopes, scopeElement, parent);
+
+			for (var scope : scopes) {
+				if (scope.appliesTo(scopeElement) && sendToOutput(scope.ctVariable(), outputConsumer)) {
+					return;
+				}
+			}
+
+			if (parent instanceof CtModifiable ctModifiable) {
+				isInStaticScope = isInStaticScope || ctModifiable.hasModifier(ModifierKind.STATIC);
 			}
 			scopeElement = parent;
 		}
 	}
 
 	/**
-	 * Search for the variable declaration in type patterns and send matches to outputConsumer
+	 * Interface for all scopes
 	 */
-	private void searchTypePattern(CtConsumer<Object> outputConsumer, CtExpression<?> expr) {
-		expr.filterChildren(new TypeFilter<>(CtTypePattern.class))
-				.forEach(typePattern -> {
-					var var = ((CtTypePattern) typePattern).getVariable();
-					if (var != null && (variableName == null || variableName.equals(var.getSimpleName()))) {
-						outputConsumer.accept(var);
-					}
-				});
+	private interface Scope {
+		/**
+		 * The variable this scope applies to.
+		 *
+		 * @return the variable
+		 */
+		CtVariable<?> ctVariable();
+
+		/**
+		 * The element in which the variable can be referenced.
+		 *
+		 * @return the element
+		 */
+		CtElement ctElement();
+
+		/**
+		 * Checks whether the scope applies to the given element.
+		 *
+		 * @param ctElement the element to check.
+		 * @return true if it applies, false if it does not
+		 */
+		default boolean appliesTo(CtElement ctElement) {
+			return ctElement == this.ctElement() || ctElement.hasParent(this.ctElement());
+		}
 	}
 
 	/**
-	 * @param var
-	 * @param output
+	 * Represents the scope of a local pattern variable.
+	 *
+	 * @param ctVariable the local variable
+	 * @param ctElement  the element in which the variable can be referenced
+	 * @param matches    for pattern variables whether the variable matches when true or false, for other variables this should be empty
+	 */
+	private record PatternScope(CtVariable<?> ctVariable, CtElement ctElement, boolean matches) implements Scope {
+		public PatternScope with(CtElement ctElement, boolean matches) {
+			return new PatternScope(ctVariable, ctElement, matches);
+		}
+
+		@Override
+		public String toString() {
+			return "PatternScope['%s' @ %d, '%s' @ %d, matches=%s]".formatted(
+				ctVariable,
+				System.identityHashCode(ctVariable),
+				ctElement,
+				System.identityHashCode(ctElement),
+				matches
+			);
+		}
+	}
+
+	private record VariableScope(CtVariable<?> ctVariable, CtElement ctElement) implements Scope {
+	}
+
+	// This searches for new scopes introduced by the branch and returns the ones that apply to the branch
+	private static List<Scope> exploreBranchForNewScopes(CtQueryable branch) {
+		List<Scope> result = new ArrayList<>();
+
+		// Any type pattern is okay, the sibling branches will be explored by the updateChildScopesForParent.
+		CtElement child = branch.filterChildren(new TypeFilter<>(CtVariable.class)).first();
+		while (child != null && child != branch) {
+			// The children should always have a parent, given that they are children of the branch.
+			CtElement parent = child.getParent();
+			result = updateChildScopesForParent(result, child, parent);
+			child = parent;
+		}
+
+		// If the branch itself is a variable declaration, then this variable is in scope for the branch.
+		// The updateChildScopesForParent would have introduced it, but it was not called, because of the loop conidition
+		// -> it has to be manually added here
+		if (child == branch && child instanceof CtVariable<?> ctVariable) {
+			result.add(new VariableScope(ctVariable, ctVariable));
+		}
+
+		return result.stream().filter(scope -> scope.ctElement() == branch).toList();
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T> List<T> castList(List<?> sourceList) {
+		return (List<T>) sourceList;
+	}
+
+	private static List<PatternScope> exploreBranchForNewPatternScopes(CtExpression<?> branch) {
+		return castList(exploreBranchForNewScopes(branch));
+	}
+
+	private static List<PatternScope> exploreBranchForNewPatternScopes(CtPattern branch) {
+		return castList(exploreBranchForNewScopes(branch));
+	}
+
+	private static boolean completesNormally(CtStatement statement) {
+		// FIXME: The JLS has a definition for what "cannot complete normally" is
+		return !(statement instanceof CtStatementList ctStatementList
+			&& !ctStatementList.getStatements().isEmpty()
+			&& ctStatementList.getLastStatement() instanceof CtCFlowBreak);
+	}
+
+	/**
+	 * Checks if the statement contains a (potentially reachable) break with a label of the statement.
+	 * <p>
+	 * For example: {@code label: while(true) { break label; }} would be true.
+	 *
+	 * @param ctStatement the statement to check
+	 * @return true if the statement has no label or no break where the target matches the label of the statement, false otherwise
+	 */
+	private static boolean hasNoReachableBreakWithTarget(CtStatement ctStatement) {
+		// FIXME: This does not check whether the break statement is actually reachable
+		return ctStatement.getLabel() == null || (ctStatement instanceof CtBodyHolder bodyHolder ? bodyHolder.getBody() : ctStatement)
+			.filterChildren(new TypeFilter<>(CtBreak.class))
+			.filterChildren((CtLabelledFlowBreak ctBreak) -> ctBreak.getLabelledStatement() == ctStatement)
+			.first() == null;
+	}
+
+	/**
+	 * Updates the child scopes for the parent.
+	 *
+	 * @param childScopes the scopes that have been found in the child, on the first call pass an empty collection.
+	 * @param child       the child for which the scopes have been found
+	 * @param parent      the parent of the passed child, this is passed separately in case the child is not initialized with the parent
+	 * @return the scopes that apply to the parent
+	 */
+	private static List<Scope> updateChildScopesForParent(Collection<? extends Scope> childScopes, CtElement child, CtElement parent) {
+		List<Scope> filteredChildScopes = childScopes.stream()
+			// only keep the scopes that were valid for the child, the ones where the scope was less than the child
+			// can not escape the child, so they can be discarded
+			.filter(scope -> scope.ctElement() == child)
+			.collect(Collectors.toCollection(ArrayList::new));
+
+		// This needs special handling, because of how the code is structured.
+		//
+		// The code related to type patterns operates on PatternScopes, and without this
+		// if, the variables would be introduced as VariableScopes. The code that would
+		// then update these scopes for type patterns wouldn't be called.
+		if (child instanceof CtVariable<?> ctVariable && parent instanceof CtTypePattern) {
+			return List.of(new PatternScope(ctVariable, parent, true));
+		}
+
+		if (child instanceof CtVariable<?> ctVariable) {
+			filteredChildScopes.add(new VariableScope(ctVariable, ctVariable));
+		}
+
+		// Pattern scopes are introduced by a pattern and will change through parent expressions or statements, see
+		// https://docs.oracle.com/javase/specs/jls/se25/html/jls-6.html#jls-6.3.1 and the following sections.
+		//
+		// The code might promote a pattern to a regular variable scope, in which case the other rules will apply to it.
+		List<Scope> result = new ArrayList<>(updatePatternScopesForParent(filteredChildScopes.stream()
+			.filter(scope -> scope instanceof PatternScope)
+			.map(scope -> (PatternScope) scope)
+			.toList(), child, parent));
+
+		if (parent instanceof CtCase<?> ctCase) {
+			// These apply to the entire case so they are discovered and returned by the exploreBranch.
+			// This is used in the CtAbstractSwitch if to handle variables from other cases being accessible in their scopes
+			for (var statement : ctCase.getStatements()) {
+				if (statement instanceof CtLocalVariable<?> ctLocalVariable) {
+					result.add(new VariableScope(ctLocalVariable, ctCase));
+				}
+			}
+
+			// The following rules apply to a switch expression with a switch block consisting of switch labeled statement groups (§14.11.1):
+			//
+			// A pattern variable introduced by a statement S contained in a switch labeled statement group is definitely matched at all the
+			// statements following S, if any, in the switch labeled statement group.
+			if (ctCase.getStatements().stream().anyMatch(ctStatement -> child == ctStatement)) {
+				for (var statement : child.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS)).list(CtStatement.class)) {
+					if (statement instanceof CtLocalVariable<?>) { // These have already been added to the result
+						continue;
+					}
+
+					for (var scope : exploreBranchForNewScopes(statement)) {
+						result.add(new VariableScope(scope.ctVariable(), child));
+					}
+				}
+			}
+
+			return result;
+		}
+
+		// A CtAbstractSwitch can be either a CtSwitch or a CtSwitchExpression,
+		if (parent instanceof CtAbstractSwitch<?> && child instanceof CtCase<?> caseElement) {
+			List<CtCase<?>> previousSiblings = caseElement.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS))
+				.select(new TypeFilter<>(CtCase.class))
+				.list();
+
+			for (CtCase<?> previousSibling : previousSiblings) {
+				for (var scope : exploreBranchForNewScopes(previousSibling)) {
+					// Any variable introduced by a previous sibling will be in scope for the current statement.
+					//
+					// For pattern variables the JLS states this:
+					//
+					// The following rule applies to a switch statement S with switch block B:
+					// - A pattern variable introduced by a switch rule is definitely matched at all the switch rules following it, if any, in B.
+					result.add(new VariableScope(scope.ctVariable(), child));
+				}
+			}
+
+			return result;
+		}
+
+		if (parent instanceof CtTryWithResource ctTryWith) {
+			for (var resource : ctTryWith.getResources()) {
+				for (var scope : resource == child ? filteredChildScopes : exploreBranchForNewScopes(resource)) {
+					result.add(new VariableScope(scope.ctVariable(), ctTryWith.getBody()));
+				}
+			}
+
+			return result;
+		}
+
+		// This covers (CtBodyHolder):
+		// - CtCatch,
+		// - CtExecutable<R>: CtAnnotationMethod<T>, CtAnonymousExecutable, CtConstructor<T>, CtLambda<T>, CtMethod<T>
+		// - CtLoop: CtDo, CtFor, CtForEach, CtWhile
+		// - CtTry: CtTryWithResource,
+
+		// TODO: With the current implementation any new CtBodyHolders will be resolved by the below code, potentially causing
+		//       wrong variable resolution. Instead one could constrain the below if to
+		//       if (parent instanceof CtCatch || parent instanceof CtExecutable || ...)
+		//       Then in any new implementation the variables would resolve to null instead of a wrong variable (trickier to discover)
+
+		if (parent instanceof CtBodyHolder) {
+			result.addAll(child
+				.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS))
+				//select only CtVariable nodes
+				.select(new TypeFilter<>(CtVariable.class))
+				.list(CtVariable.class)
+				.stream()
+				.map(variable -> (Scope) new VariableScope(variable, child))
+				.toList());
+		}
+
+		return result;
+	}
+
+	/**
+	 * Updates the given scopes based on rules defined in
+	 * <a href=https://docs.oracle.com/javase/specs/jls/se25/html/jls-6.html#jls-6.3.1>JLS-6.3.1</a> or
+	 * <a href=https://docs.oracle.com/javase/specs/jls/se25/html/jls-6.html#jls-6.3.2>JLS-6.3.2</a>
+	 *
+	 * @param scopes the pattern scopes applying to the child
+	 * @param child the child of the given parent ({@code child.getParent() == parent})
+	 * @param parent the parent of the child
+	 * @return a list of scopes that apply to the child, a sibling or the parent. If no rules apply, an empty list will be returned.
+	 */
+	private static List<Scope> updatePatternScopesForParent(Collection<PatternScope> scopes, CtElement child, CtElement parent) {
+		if (parent instanceof CtExpression<?> ctExpression) {
+			return new ArrayList<>(updateChildScopesForParentExpression(scopes, child, ctExpression));
+		}
+
+		if (parent instanceof CtBlock<?>) {
+			// The following rule applies to a block statement S contained in a block (§14.2) that is not a switch block (§14.11.1):
+			// - A pattern variable introduced by S is definitely matched at all the block statements following S, if any, in the block.
+
+			// The child would be a statement -> visit all previous statements and check which ones apply:
+			return child.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS))
+				.list(CtStatement.class)
+				.stream()
+				.flatMap(sibling -> exploreBranchForNewScopes(sibling).stream())
+				.map(scope -> (Scope) new VariableScope(scope.ctVariable(), child))
+				.toList();
+		}
+
+		// An if without a then statement `if (a);` can introduce pattern variables, but they can only be referenced from the
+		// then, which does not exist -> these can be ignored.
+		if (parent instanceof CtIf ctIf && ctIf.getThenStatement() != null) {
+			List<Scope> result = new ArrayList<>();
+
+			boolean canThenComplete = completesNormally(ctIf.getThenStatement());
+
+			// The child could be:
+			// - the condition (can introduce scopes)
+			// - the then branch
+			// - the else branch
+			//
+			// According to the JLS scopes can only be introduced by the condition
+			// -> scopes from the then/else branch should be discarded
+			for (PatternScope scope : ctIf.getCondition() == child ? scopes : exploreBranchForNewPatternScopes(ctIf.getCondition())) {
+				// For an `if (e) S` (with maybe an else), a pattern variable introduced by `e` when `true` is definitely matched at `S`.
+				if (scope.matches()) {
+					result.add(scope.with(ctIf.getThenStatement(), true));
+				}
+
+				// A pattern variable is introduced by `if (e) S` iff
+				// -  (i) it is introduced by e when false and
+				// - (ii) S cannot complete normally.
+				if (ctIf.getElseStatement() == null && !scope.matches() && !canThenComplete) {
+					result.add(scope.with(ctIf, false));
+				}
+
+				// The following rules apply to a statement `if (e) S else T`:
+				if (ctIf.getElseStatement() != null) {
+					// A pattern variable introduced by e when false is definitely matched at T.
+					if (!scope.matches()) {
+						result.add(scope.with(ctIf.getElseStatement(), false));
+					}
+
+					// A pattern variable is introduced by if (e) S else T iff either:
+					// - It is introduced by e when true, and S can complete normally, and T cannot complete normally; or
+					boolean canElseComplete = completesNormally(ctIf.getElseStatement());
+					if (scope.matches() && canThenComplete && !canElseComplete) {
+						result.add(scope.with(ctIf, true));
+					}
+
+					// - It is introduced by e when false, and S cannot complete normally, and T can complete normally.
+					if (!scope.matches() && !canThenComplete && canElseComplete) {
+						result.add(scope.with(ctIf, false));
+					}
+				}
+			}
+
+			return result;
+		}
+
+		if (parent instanceof CtWhile ctWhile) {
+			List<Scope> result = new ArrayList<>();
+
+			for (PatternScope scope : child == ctWhile.getLoopingExpression() ? scopes :  exploreBranchForNewPatternScopes(ctWhile.getLoopingExpression())) {
+				// The following rules apply to a statement `while (e) S`:
+
+				// A pattern variable introduced by e when true is definitely matched at S.
+				if (scope.matches()) {
+					result.add(scope.with(ctWhile.getBody(), true));
+				}
+
+				// A pattern variable is introduced by while (e) S iff
+				// - (i) it is introduced by e when false and
+				// - (ii) S does not contain a reachable break statement for which the while
+				//        statement is the break target
+				if (!scope.matches() && hasNoReachableBreakWithTarget(ctWhile)) {
+					result.add(scope.with(ctWhile, false));
+				}
+			}
+
+			return result;
+		}
+
+		if (parent instanceof CtDo ctDo) {
+			List<Scope> result = new ArrayList<>();
+			// The following rule applies to a statement `do S while (e)`:
+			// - A pattern variable is introduced by do S while (e) iff
+			//   - (i) it is introduced by e when false and
+			//   - (ii) S does not contain a reachable break statement
+			//          for which the do statement is the break target.
+			for (PatternScope scope : child == ctDo.getLoopingExpression() ? scopes : exploreBranchForNewPatternScopes(ctDo.getLoopingExpression())) {
+				if (!scope.matches() && hasNoReachableBreakWithTarget(ctDo)) {
+					result.add(scope.with(ctDo, false));
+				}
+			}
+
+			return result;
+		}
+
+		if (parent instanceof CtFor ctFor) {
+			List<Scope> result = new ArrayList<>();
+
+			// The following rules apply to a basic for statement (§14.14.1):
+			for (PatternScope scope : ctFor.getExpression() == child ? scopes : exploreBranchForNewPatternScopes(ctFor.getExpression())) {
+				// - A pattern variable introduced by the condition expression when true is definitely
+				//   matched at both the incrementation part and the contained statement.
+				if (scope.matches()) {
+					for (var update : ctFor.getForUpdate()) {
+						result.add(scope.with(update, true));
+					}
+
+					result.add(scope.with(ctFor.getBody(), true));
+				}
+
+				// - A pattern variable is introduced by a basic for statement iff
+				//   - (i) it is introduced by the condition expression when false and
+				//   - (ii) the contained statement, S, does not contain a reachable break for which the
+				//          basic for statement is the break target.
+				if (!scope.matches() && hasNoReachableBreakWithTarget(ctFor)) {
+					result.add(scope.with(ctFor, false));
+				}
+
+				// FIXME: The JLS states for enhanced for statements:
+				//
+				// An enhanced for statement (§14.14.2) is defined by translation to a basic for statement, so no special rules need
+				// to be provided for it.
+				//
+				// This translation is defined in https://docs.oracle.com/javase/specs/jls/se25/html/jls-14.html#jls-14.14.2
+				//
+				// If the type of Expression is a subtype of Iterable, then the basic for statement has this form:
+				//
+				// for (I #i = Expression.iterator(); #i.hasNext(); ) {
+				//     {VariableModifier} T VarDeclId = (TargetType) #i.next();
+				//     Statement
+				// }
+				//
+				// (a similar translation is defined for arrays)
+				//
+				// The variable can only be introduced through the condition expression, which is the `#i.hasNext()`.
+				// `#i` is an automatically generated identifier
+				// -> it should be impossible to introduce a pattern variable through the enhanced for statement.
+				//
+				// The generated definition for the variable might introduce a pattern variable, but this does not seem possible
+				// as of Java 25.
+			}
+
+			return result;
+		}
+
+		// The following rule applies to a labeled statement (§14.7):
+		// - A pattern variable is introduced by a labeled statement L: S (where L is a label) iff
+		//    (i) it is introduced by the statement S, and
+		//   (ii) S does not contain a reachable break statement for which the labeled statement is the break target (§14.15).
+		//
+		// The code where this is relevant (loops) already handles this condition.
+		//
+		// If necessary, one could implement this rule at the call site of this function like this:
+		// if (parent instanceof CtStatement ctStatement && !hasNoReachableBreakWithTarget(ctStatement)) {
+		//     // filter out all scopes that apply to the full ctStatement
+		// }
+
+		// the other parts defined for switch statements are handled in the updateChildScopesForParent
+		if (parent instanceof CtCase<?> ctCase) {
+			// The following rule applies to a switch expression with a switch block consisting of switch rules:
+			//
+			// A pattern variable introduced by a switch label is definitely matched in the associated switch rule
+			// expression, switch rule block, or switch rule throw statement.
+			//
+			// -> All variables defined in the case expressions will be in scope for the case
+			List<Scope> result = new ArrayList<>();
+			for (var expr : ctCase.getCaseExpressions()) {
+				for (var scope : expr == child ? scopes : exploreBranchForNewPatternScopes(expr)) {
+					// NOTE: This assumes negated patterns can not appear in the case expression
+					result.add(new VariableScope(scope.ctVariable(), ctCase));
+				}
+			}
+
+			return result;
+		}
+
+		return List.of();
+	}
+
+	/**
+	 * Updates the scopes for the given parent expression based on the rules defined in
+	 * <a href=https://docs.oracle.com/javase/specs/jls/se25/html/jls-6.html#jls-6.3.1>JLS-6.3.1</a>
+	 *
+	 * @param filteredChildScopes the scopes that apply to the child (the ones that do not apply should already be filtered out)
+	 * @param child the child of the given parent ({@code child.getParent() == parent})
+	 * @param parent the parent of the child
+	 * @return a list of scopes that apply to the child, a sibling or the parent. If no rules apply, an empty list will be returned.
+	 */
+	private static List<PatternScope> updateChildScopesForParentExpression(Collection<PatternScope> filteredChildScopes, CtElement child, CtExpression<?> parent) {
+		// A variable defined in a child of a record pattern applies to the record as well, so these are passed along.
+		if (parent instanceof CtRecordPattern ctRecordPattern) {
+			List<PatternScope> result = new ArrayList<>();
+
+			for (var ctPattern : ctRecordPattern.getPatternList()) {
+				for (var scope : ctPattern == child ? filteredChildScopes : exploreBranchForNewPatternScopes(ctPattern)) {
+					result.add(scope.with(ctRecordPattern, scope.matches()));
+				}
+			}
+
+			return result;
+		}
+
+		// This represents a `case <Pattern>` where the pattern could for example be a `case String string`.
+		if (parent instanceof CtCasePattern ctCasePattern) {
+			// The scope applies to the parent as well
+			return filteredChildScopes.stream().map(scope -> scope.with(ctCasePattern, scope.matches())).toList();
+		}
+
+		// Besides that there is unnamed pattern, but it does not introduce any variables -> it can be ignored here
+
+		if (parent instanceof CtBinaryOperator<?> operator && (operator.getKind() == BinaryOperatorKind.AND
+			|| operator.getKind() == BinaryOperatorKind.OR)) {
+			// In `a <op> b`, both a and b can introduce pattern variables, but the passed child scopes will be for only one of the
+			// branches. This will add the other branch's scopes as well:
+			CtExpression<?> otherBranch =
+				operator.getLeftHandOperand() == child ? operator.getRightHandOperand() : operator.getLeftHandOperand();
+
+			// A pattern variable is introduced by a && b when true iff either
+			// -  (i) it is introduced by a when true or
+			// - (ii) it is introduced by b when true.
+			//
+			// A pattern variable is introduced by a || b when false iff either
+			// -  (i) it is introduced by a when false or
+			// - (ii) it is introduced by b when false.
+			//
+			// The difference between && and || is that for && it must match true,
+			// and for || it must match false. The operator.getKind() == BinaryOperatorKind.AND is true
+			// when it is an &&, and false when it is an ||, which matches the above rules.
+			//
+			// The **either** part is only relevant for code that does not compile, which is assumed to not
+			// be the case here?
+			return Stream.concat(filteredChildScopes.stream(), exploreBranchForNewPatternScopes(otherBranch).stream())
+				.filter(scope -> scope.matches() == (operator.getKind() == BinaryOperatorKind.AND))
+				.map(scope -> scope.with(operator, scope.matches()))
+				.toList();
+		}
+
+		if (parent instanceof CtUnaryOperator<?> operator && operator.getKind() == UnaryOperatorKind.NOT) {
+			// For !(expr) the following holds:
+			// - If a pattern variable is introduced by expr when true, then it is available for matching when false.
+			// - If a pattern variable is introduced by expr when false, then it is available for matching when true.
+
+			return filteredChildScopes.stream()
+				// swap the matches, because the operator is a NOT, matchesTrue will become matchesFalse and vice versa
+				.map(scope -> scope.with(operator, !scope.matches()))
+				.toList();
+		}
+
+		if (parent instanceof CtConditional<?> ctConditional) {
+			return (ctConditional.getCondition() == child ? filteredChildScopes : exploreBranchForNewPatternScopes(ctConditional.getCondition()))
+				.stream()
+				// The following rules apply to a conditional expression a ? b : c (§15.25):
+				// - A pattern variable introduced by a when true is definitely matched at b.
+				// - A pattern variable introduced by a when false is definitely matched at c.
+				.map(scope -> scope.with(scope.matches() ? ctConditional.getThenExpression() : ctConditional.getElseExpression(), scope.matches()))
+				.toList();
+		}
+
+		if (parent instanceof CtBinaryOperator<?> operator && operator.getKind() == BinaryOperatorKind.INSTANCEOF) {
+			// The following rule applies to an instanceof expression with a pattern operand, a instanceof p (§15.20.2):
+			// - A pattern variable is introduced by a instanceof p when true iff the pattern p contains a
+			//   declaration of the pattern variable (§14.30.1).
+
+			// The child might be the left hand, but patterns only come from the right hand side
+			// -> this branch must be explored here to not miss patterns
+			return (operator.getLeftHandOperand() == child ? exploreBranchForNewPatternScopes(operator.getRightHandOperand()).stream() : filteredChildScopes.stream())
+				.map(scope -> scope.with(operator, scope.matches()))
+				.toList();
+		}
+
+		// CtSwitchExpression is handled in updateChildScopesForParent, because the described behavior is very similar
+		// to the old switch style.
+
+		// Parenthesized Expressions are not a distinct type in spoon, so they do not need special handling.
+
+		return List.of();
+	}
+
+	/**
+	 * @param var a declaration the user of this class might be looking for
+	 * @param output the output to which to pass the declaration if it matches the searched variable name (if any)
 	 * @return true if query processing is terminated
 	 */
 	private boolean sendToOutput(CtVariable<?> var, CtConsumer<Object> output) {

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -248,7 +248,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	// the parent `CtBinaryOperator`, the variables introduced by the branch `CtExpression b` will become relevant too.
 	//
 	// The function below can be used to explore the variables introduced by that unexplored branch `CtExpression b`.
-	private static List<Scope> exploreBranchForNewScopes(CtQueryable branch) {
+	private static List<Scope> exploreBranchForNewScopes(@NonNull CtQueryable branch) {
 		List<Scope> result = new ArrayList<>();
 
 		// Where pattern variables apply changes depending on their parents (e.g. !(< pattern >) will change the matches),
@@ -306,14 +306,14 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	}
 
 	@SuppressWarnings("unchecked")
-	private static List<PatternScope> exploreBranchForNewPatternScopes(CtExpression<?> branch) {
+	private static List<PatternScope> exploreBranchForNewPatternScopes(@NonNull CtExpression<?> branch) {
 		// SAFETY: In an expression only PatternScope can appear
 		//      -> the returns of exploreBranchForNewScopes is guaranteed to be a list of PatternScope
 		return (List<PatternScope>) (List<?>) exploreBranchForNewScopes(branch);
 	}
 
 	@SuppressWarnings("unchecked")
-	private static List<PatternScope> exploreBranchForNewPatternScopes(CtPattern branch) {
+	private static List<PatternScope> exploreBranchForNewPatternScopes(@NonNull CtPattern branch) {
 		// SAFETY: In a pattern only PatternScope can appear
 		//      -> the returns of exploreBranchForNewScopes is guaranteed to be a list of PatternScope
 		return (List<PatternScope>) (List<?>) exploreBranchForNewScopes(branch);
@@ -577,7 +577,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 			return result;
 		}
 
-		if (parent instanceof CtFor ctFor) {
+		if (parent instanceof CtFor ctFor && ctFor.getExpression() != null) {
 			List<Scope> result = new ArrayList<>();
 
 			// The following rules apply to a basic for statement (§14.14.1):

--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -7,6 +7,8 @@
  */
 package spoon.reflect.visitor.filter;
 
+import org.jspecify.annotations.NonNull;
+import spoon.SpoonException;
 import spoon.reflect.code.BinaryOperatorKind;
 import spoon.reflect.code.CtAbstractSwitch;
 import spoon.reflect.code.CtBinaryOperator;
@@ -16,6 +18,7 @@ import spoon.reflect.code.CtBreak;
 import spoon.reflect.code.CtCFlowBreak;
 import spoon.reflect.code.CtCase;
 import spoon.reflect.code.CtCasePattern;
+import spoon.reflect.code.CtCatch;
 import spoon.reflect.code.CtCatchVariable;
 import spoon.reflect.code.CtConditional;
 import spoon.reflect.code.CtDo;
@@ -24,16 +27,19 @@ import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLabelledFlowBreak;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtLoop;
 import spoon.reflect.code.CtPattern;
 import spoon.reflect.code.CtRecordPattern;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.code.CtStatementList;
+import spoon.reflect.code.CtTry;
 import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.code.CtTypePattern;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtModifiable;
 import spoon.reflect.declaration.CtPackage;
@@ -139,111 +145,181 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 			scopes = updateChildScopesForParent(scopes, scopeElement, parent);
 
 			for (var scope : scopes) {
-				if (scope.appliesTo(scopeElement) && sendToOutput(scope.ctVariable(), outputConsumer)) {
+				if (scope.appliesTo(scopeElement) && sendToOutput(scope.variable(), outputConsumer)) {
 					return;
 				}
 			}
 
-			if (parent instanceof CtModifiable ctModifiable) {
-				isInStaticScope = isInStaticScope || ctModifiable.hasModifier(ModifierKind.STATIC);
+			if (parent instanceof CtModifiable ctModifiable && ctModifiable.hasModifier(ModifierKind.STATIC)) {
+				isInStaticScope = true;
 			}
 			scopeElement = parent;
 		}
 	}
 
 	/**
-	 * Interface for all scopes
+	 * Common interface for all scopes, declaring in which {@code CtElement} a variable is valid.
 	 */
-	private interface Scope {
+	private sealed interface Scope permits PatternScope, VariableScope {
 		/**
-		 * The variable this scope applies to.
+		 * The declaration of the variable that can be referenced where the scope applies
+		 * ({@link Scope#appliesTo(CtElement)}).
 		 *
-		 * @return the variable
+		 * @return the variable declaration, is never null.
 		 */
-		CtVariable<?> ctVariable();
+		@NonNull CtVariable<?> variable();
 
 		/**
-		 * The element in which the variable can be referenced.
+		 * The spoon {@link CtElement} in which the {@link Scope#variable()} can be referenced.
+		 * <p>
+		 * The variable is in scope/can be referenced in the element or a child of the element.
+		 * For convenience {@link Scope#appliesTo(CtElement)} can be used to check whether the variable of the scope
+		 * can be referenced by the given element.
 		 *
-		 * @return the element
+		 * @return the element in which the variable can be referenced, is never null
 		 */
-		CtElement ctElement();
+		@NonNull CtElement element();
 
 		/**
 		 * Checks whether the scope applies to the given element.
+		 * <p>
+		 * It only applies if the given element is {@link Scope#element()} or has the element as a parent.
+		 * If it applies, the {@link Scope#variable()} can be referenced from the given element. This is useful to check
+		 * whether a given reference could reference a variable.
 		 *
 		 * @param ctElement the element to check.
 		 * @return true if it applies, false if it does not
 		 */
 		default boolean appliesTo(CtElement ctElement) {
-			return ctElement == this.ctElement() || ctElement.hasParent(this.ctElement());
+			return ctElement == this.element() || ctElement.hasParent(this.element());
 		}
 	}
 
 	/**
 	 * Represents the scope of a local pattern variable.
 	 *
-	 * @param ctVariable the local variable
-	 * @param ctElement  the element in which the variable can be referenced
-	 * @param matches    for pattern variables whether the variable matches when true or false, for other variables this should be empty
+	 * @param variable the local variable
+	 * @param element  the element in which the variable can be referenced
+	 * @param matches  whether the variable matches when true or false, for example a {@code !(< pattern >)} negates the matches
 	 */
-	private record PatternScope(CtVariable<?> ctVariable, CtElement ctElement, boolean matches) implements Scope {
+	private record PatternScope(CtVariable<?> variable, CtElement element, boolean matches) implements Scope {
 		public PatternScope with(CtElement ctElement, boolean matches) {
-			return new PatternScope(ctVariable, ctElement, matches);
+			return new PatternScope(variable, ctElement, matches);
 		}
 
 		@Override
 		public String toString() {
 			return "PatternScope['%s' @ %d, '%s' @ %d, matches=%s]".formatted(
-				ctVariable,
-				System.identityHashCode(ctVariable),
-				ctElement,
-				System.identityHashCode(ctElement),
+				variable,
+				System.identityHashCode(variable),
+				element,
+				System.identityHashCode(element),
 				matches
 			);
 		}
 	}
 
-	private record VariableScope(CtVariable<?> ctVariable, CtElement ctElement) implements Scope {
+	private record VariableScope(CtVariable<?> variable, CtElement element) implements Scope {
 	}
 
-	// This searches for new scopes introduced by the branch and returns the ones that apply to the branch
+	// Note for the below code:
+	//
+	// The scopes are returned as a List of scopes. A Set would be better, because the order does not matter, and there shouldn't
+	// be any duplicates (if there are the code does something twice/needs to be adjusted).
+	// Some spoon code relies on the fact that the function does not return duplicate declarations, but with Sets the code was
+	// noticeably slower. Most of the time being spent in the equals/hash function of the scope.
+	//
+	// Therefore, it is important to use the hasExactlyPotentialDeclarations to discover when the same declaration is returned multiple
+	// times.
+
+	// This searches for new scopes introduced by the branch and returns the ones that apply to the branch.
+	//
+	// The code is represented as an Abstract Syntax Tree, for example
+	//
+	// `a && b` would be represented as
+	//
+	//     CtBinaryOperator
+	//    /                \
+	// CtExpression a     CtExpression b
+	//
+	// Here the tree has the two branches `CtExpression a` and `CtExpression b`.
+	//
+	// Given that we have explored `CtExpression a` and know which variables have been introduced by it, when moving up to
+	// the parent `CtBinaryOperator`, the variables introduced by the branch `CtExpression b` will become relevant too.
+	//
+	// The function below can be used to explore the variables introduced by that unexplored branch `CtExpression b`.
 	private static List<Scope> exploreBranchForNewScopes(CtQueryable branch) {
 		List<Scope> result = new ArrayList<>();
 
-		// Any type pattern is okay, the sibling branches will be explored by the updateChildScopesForParent.
+		// Where pattern variables apply changes depending on their parents (e.g. !(< pattern >) will change the matches),
+		// so we have to start at a declaration and then move up the tree to figure out where these variables apply.
+		//
+		// The below searches for any declaration as a starting point. This works, because the updateChildScopesForParent
+		// will explore the other branches too, for example suppose we want to explore this tree:
+		//
+		//                CtBinaryOperator &&
+		//            /                          \
+		//    CtBinaryOperator &&             instanceof
+		//     /             \                    |
+		//  instanceof     instanceof         CtVariable c
+		//    |                 |
+		//  CtVariable a  CtVariable b
+		//
+		//
+		// It has been a bit simplified, actual tree is a bit more elements, corresponding code could be
+		// (x instanceof String a && y instanceof String b) && z instanceof String c
+		//
+		// We choose any one of the variables as a starting point, for example variable b, then move up the parents.
+		//
+		// The instanceof is irrelevant for the scope of variables, so nothing changes.
+		// For the binary operator we haven't explored the left side, which might introduce variables that
+		// would be in scope. So these are explored by the updateChildScopesForParent which will call this function with
+		// the instanceof as the branch root.
+		//
+		// When it returns, it will have explored both branches.
+		//
+		// Then it moves up to the next parent which is what we were passed initially as the branch.
+		// Again it will look at branches we have not explored, then stops, because we have reached
+		// the top of the branch we wanted to explore.
+		//
+		// Which variable we choose as a starting point for exploration does not matter, because the other
+		// ones will be visited later as well.
 		CtElement child = branch.filterChildren(new TypeFilter<>(CtVariable.class)).first();
 		while (child != null && child != branch) {
-			// The children should always have a parent, given that they are children of the branch.
+			// The children should always have a parent, given that they are children of the branch
+			// -> this never returns null
 			CtElement parent = child.getParent();
 			result = updateChildScopesForParent(result, child, parent);
 			child = parent;
 		}
 
 		// If the branch itself is a variable declaration, then this variable is in scope for the branch.
-		// The updateChildScopesForParent would have introduced it, but it was not called, because of the loop conidition
+		// The updateChildScopesForParent would have introduced it, but it was not called, because of the loop condition
 		// -> it has to be manually added here
 		if (child == branch && child instanceof CtVariable<?> ctVariable) {
 			result.add(new VariableScope(ctVariable, ctVariable));
 		}
 
-		return result.stream().filter(scope -> scope.ctElement() == branch).toList();
+		// Any variables that are only valid in some child of the branch can be filtered out, because
+		// this function is expected to only return scopes that apply to the entire branch.
+		return result.stream().filter(scope -> scope.element() == branch).toList();
 	}
 
 	@SuppressWarnings("unchecked")
-	private static <T> List<T> castList(List<?> sourceList) {
-		return (List<T>) sourceList;
-	}
-
 	private static List<PatternScope> exploreBranchForNewPatternScopes(CtExpression<?> branch) {
-		return castList(exploreBranchForNewScopes(branch));
+		// SAFETY: In an expression only PatternScope can appear
+		//      -> the returns of exploreBranchForNewScopes is guaranteed to be a list of PatternScope
+		return (List<PatternScope>) (List<?>) exploreBranchForNewScopes(branch);
 	}
 
+	@SuppressWarnings("unchecked")
 	private static List<PatternScope> exploreBranchForNewPatternScopes(CtPattern branch) {
-		return castList(exploreBranchForNewScopes(branch));
+		// SAFETY: In a pattern only PatternScope can appear
+		//      -> the returns of exploreBranchForNewScopes is guaranteed to be a list of PatternScope
+		return (List<PatternScope>) (List<?>) exploreBranchForNewScopes(branch);
 	}
 
-	private static boolean completesNormally(CtStatement statement) {
+	private static boolean completesNormally(@NonNull CtStatement statement) {
 		// FIXME: The JLS has a definition for what "cannot complete normally" is
 		return !(statement instanceof CtStatementList ctStatementList
 			&& !ctStatementList.getStatements().isEmpty()
@@ -258,7 +334,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	 * @param ctStatement the statement to check
 	 * @return true if the statement has no label or no break where the target matches the label of the statement, false otherwise
 	 */
-	private static boolean hasNoReachableBreakWithTarget(CtStatement ctStatement) {
+	private static boolean hasNoReachableBreakWithTarget(@NonNull CtStatement ctStatement) {
 		// FIXME: This does not check whether the break statement is actually reachable
 		return ctStatement.getLabel() == null || (ctStatement instanceof CtBodyHolder bodyHolder ? bodyHolder.getBody() : ctStatement)
 			.filterChildren(new TypeFilter<>(CtBreak.class))
@@ -267,18 +343,22 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 	}
 
 	/**
-	 * Updates the child scopes for the parent.
+	 * Will update the list of scopes/variables that applied to the child to those that apply to the parent.
+	 * <p>
+	 * If a variable was valid in the child, it might continue to be valid in the parent (for example with instanceof patterns)
+	 * or it might not be valid anymore. In addition to that, other siblings of the child element could introduce variables
+	 * that are valid for the parent. This function will update the scopes, add new scopes and remove scopes that no longer apply.
 	 *
 	 * @param childScopes the scopes that have been found in the child, on the first call pass an empty collection.
 	 * @param child       the child for which the scopes have been found
 	 * @param parent      the parent of the passed child, this is passed separately in case the child is not initialized with the parent
 	 * @return the scopes that apply to the parent
 	 */
-	private static List<Scope> updateChildScopesForParent(Collection<? extends Scope> childScopes, CtElement child, CtElement parent) {
+	private static List<Scope> updateChildScopesForParent(Collection<? extends Scope> childScopes, @NonNull CtElement child, @NonNull CtElement parent) {
 		List<Scope> filteredChildScopes = childScopes.stream()
 			// only keep the scopes that were valid for the child, the ones where the scope was less than the child
 			// can not escape the child, so they can be discarded
-			.filter(scope -> scope.ctElement() == child)
+			.filter(scope -> scope.element() == child)
 			.collect(Collectors.toCollection(ArrayList::new));
 
 		// This needs special handling, because of how the code is structured.
@@ -323,7 +403,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 					}
 
 					for (var scope : exploreBranchForNewScopes(statement)) {
-						result.add(new VariableScope(scope.ctVariable(), child));
+						result.add(new VariableScope(scope.variable(), child));
 					}
 				}
 			}
@@ -345,7 +425,7 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 					//
 					// The following rule applies to a switch statement S with switch block B:
 					// - A pattern variable introduced by a switch rule is definitely matched at all the switch rules following it, if any, in B.
-					result.add(new VariableScope(scope.ctVariable(), child));
+					result.add(new VariableScope(scope.variable(), child));
 				}
 			}
 
@@ -355,28 +435,21 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 		if (parent instanceof CtTryWithResource ctTryWith) {
 			for (var resource : ctTryWith.getResources()) {
 				for (var scope : resource == child ? filteredChildScopes : exploreBranchForNewScopes(resource)) {
-					result.add(new VariableScope(scope.ctVariable(), ctTryWith.getBody()));
+					result.add(new VariableScope(scope.variable(), ctTryWith.getBody()));
 				}
 			}
 
 			return result;
 		}
 
-		// This covers (CtBodyHolder):
-		// - CtCatch,
-		// - CtExecutable<R>: CtAnnotationMethod<T>, CtAnonymousExecutable, CtConstructor<T>, CtLambda<T>, CtMethod<T>
-		// - CtLoop: CtDo, CtFor, CtForEach, CtWhile
-		// - CtTry: CtTryWithResource,
-
-		// TODO: With the current implementation any new CtBodyHolders will be resolved by the below code, potentially causing
-		//       wrong variable resolution. Instead one could constrain the below if to
-		//       if (parent instanceof CtCatch || parent instanceof CtExecutable || ...)
-		//       Then in any new implementation the variables would resolve to null instead of a wrong variable (trickier to discover)
-
-		if (parent instanceof CtBodyHolder) {
+		// For these elements the SiblingsFunction works fine to discover the variable declarations introduced by them like
+		// - function parameters
+		// - loop variables
+		// - catch variables
+		if (parent instanceof CtCatch || parent instanceof CtExecutable<?> || parent instanceof CtLoop || parent instanceof CtTry) {
 			result.addAll(child
 				.map(new SiblingsFunction().mode(SiblingsFunction.Mode.PREVIOUS))
-				//select only CtVariable nodes
+				// select only CtVariable nodes
 				.select(new TypeFilter<>(CtVariable.class))
 				.list(CtVariable.class)
 				.stream()
@@ -411,16 +484,15 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 				.list(CtStatement.class)
 				.stream()
 				.flatMap(sibling -> exploreBranchForNewScopes(sibling).stream())
-				.map(scope -> (Scope) new VariableScope(scope.ctVariable(), child))
+				.map(scope -> (Scope) new VariableScope(scope.variable(), child))
 				.toList();
 		}
 
-		// An if without a then statement `if (a);` can introduce pattern variables, but they can only be referenced from the
-		// then, which does not exist -> these can be ignored.
-		if (parent instanceof CtIf ctIf && ctIf.getThenStatement() != null) {
+		if (parent instanceof CtIf ctIf) {
 			List<Scope> result = new ArrayList<>();
 
-			boolean canThenComplete = completesNormally(ctIf.getThenStatement());
+			// The then is null with code `if (a);`, in this case the then branch completes normally given that it is empty.
+			boolean canThenComplete = ctIf.getThenStatement() == null || completesNormally(ctIf.getThenStatement());
 
 			// The child could be:
 			// - the condition (can introduce scopes)
@@ -431,14 +503,14 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 			// -> scopes from the then/else branch should be discarded
 			for (PatternScope scope : ctIf.getCondition() == child ? scopes : exploreBranchForNewPatternScopes(ctIf.getCondition())) {
 				// For an `if (e) S` (with maybe an else), a pattern variable introduced by `e` when `true` is definitely matched at `S`.
-				if (scope.matches()) {
+				if (scope.matches() && ctIf.getThenStatement() != null) {
 					result.add(scope.with(ctIf.getThenStatement(), true));
 				}
 
 				// A pattern variable is introduced by `if (e) S` iff
 				// -  (i) it is introduced by e when false and
 				// - (ii) S cannot complete normally.
-				if (ctIf.getElseStatement() == null && !scope.matches() && !canThenComplete) {
+				if ((ctIf.getElseStatement() == null && !scope.matches()) && !canThenComplete) {
 					result.add(scope.with(ctIf, false));
 				}
 
@@ -578,8 +650,11 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 			List<Scope> result = new ArrayList<>();
 			for (var expr : ctCase.getCaseExpressions()) {
 				for (var scope : expr == child ? scopes : exploreBranchForNewPatternScopes(expr)) {
-					// NOTE: This assumes negated patterns can not appear in the case expression
-					result.add(new VariableScope(scope.ctVariable(), ctCase));
+					if (!scope.matches()) {
+						throw new SpoonException("Unexpected negated pattern variable in a case: " + expr);
+					}
+
+					result.add(new VariableScope(scope.variable(), ctCase));
 				}
 			}
 

--- a/src/main/java/spoon/reflect/visitor/filter/SiblingsFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/SiblingsFunction.java
@@ -7,9 +7,7 @@
  */
 package spoon.reflect.visitor.filter;
 
-import spoon.reflect.code.CtIf;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
@@ -74,13 +72,6 @@ public class SiblingsFunction implements CtConsumableFunction<CtElement> {
 						canVisit = includingSelf;
 					}
 					if (canVisit) {
-						if (element instanceof CtIf ctIf) {
-							// check for flow scoped variable declarations in if conditions
-							var vars = ctIf.getCondition().getElements(new TypeFilter<>(CtVariable.class));
-							for (var var : vars) {
-								outputConsumer.accept(var);
-							}
-						}
 						outputConsumer.accept(element);
 					}
 				}

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -8,8 +8,8 @@
 
 package spoon.test.model;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,7 +53,9 @@ import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.compiler.VirtualFile;
+import spoon.testing.utils.BySimpleName;
 import spoon.testing.utils.GitHubIssue;
+import spoon.testing.utils.ModelTest;
 
 @DisplayName("Switchcase Tests")
 public class SwitchCaseTest {
@@ -330,33 +332,38 @@ public class SwitchCaseTest {
 
 		@Test
 		@GitHubIssue(issueNumber = 4696, fixed = true)
-		void testVariableScopeInSwitch() {
+		@ModelTest(code = """
+				public class A {
+					public void function(int value) {
+						switch (value) {
+							case 1: { String test; } // decoy variable declaration, should not be found
+								String test;
+								test = "first";
+								break;
+							default:
+								test = "not first";
+						}
+					}
+				}
+				""")
+		void testVariableScopeInSwitch(@BySimpleName("A") CtClass<?> ctClass) {
 			// contract: different cases do not introduce different scopes in colon-switches
-			String code = "public class A {\n" +
-					"  public void function(int value) {\n" +
-					"    switch (value) {\n" +
-					"      case 1: { String test; }\n" + // decoy variable declaration, should not be found
-					"        String test;\n" +
-					"        test = \"first\";\n" +
-					"        break;\n" +
-					"      default:\n" +
-					"        test = \"not first\";\n" +
-					"    }\n" +
-					"  }\n" +
-					"}";
-			CtModel model = createModelFromString(code);
-			List<CtVariableAccess<?>> accesses = model.<CtVariableAccess<?>>getElements(new TypeFilter<>(CtVariableAccess.class))
-					.stream()
-					.filter(a -> a.getVariable().getSimpleName().equals("test"))
-					.collect(Collectors.<CtVariableAccess<?>>toList());
-			assertEquals(2, accesses.size());
+			List<CtVariableAccess<?>> accesses = ctClass.getElements(new TypeFilter<>(CtVariableAccess.class));
+			assertThat(accesses).hasSize(3);
+			List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+
+			assertThat(accesses.get(0)).getVariable().getSimpleName().isEqualTo("value");
+			assertThat(accesses.get(0)).getVariable().hasExactlyPotentialDeclarations(variables.get(0));
 
 			// access their declarations
-			CtVariable<?> caseOneVariableDeclaration = accesses.get(0).getVariable().getDeclaration();
-			CtVariable<?> defaultVariableDeclaration = accesses.get(1).getVariable().getDeclaration();
+			CtVariable<?> caseOneVariableDeclaration = accesses.get(1).getVariable().getDeclaration();
+			CtVariable<?> defaultVariableDeclaration = accesses.get(2).getVariable().getDeclaration();
 
 			// expect the declarations to be equal (writing to the same variable)
-			assertEquals(caseOneVariableDeclaration, defaultVariableDeclaration);
+			assertThat(caseOneVariableDeclaration).isSameAs(defaultVariableDeclaration);
+
+			assertThat(accesses.get(1)).getVariable().hasExactlyPotentialDeclarations(variables.get(2));
+			assertThat(accesses.get(2)).getVariable().hasExactlyPotentialDeclarations(variables.get(2));
 		}
 	}
 
@@ -536,16 +543,15 @@ public class SwitchCaseTest {
 		}
 
 		@Test
-		public void test_setCaseExpression_removeAllCaseExpressions() {
+		@ModelTest(code = "class A { public void f(int i) { switch(i) { case 1,2,3: break; } } }")
+		public void test_setCaseExpression_removeAllCaseExpressions(@BySimpleName("A") CtClass<?> ctClass) {
 			// contract: `setCaseExpression` should clear the list of case expressions when `null` is passed as
 			// argument
-			String code = "class A { public void f(int i) { switch(i) { case 1,2,3: break; } } }";
-			CtModel model = createModelFromString(code);
-			CtCase<?> ctCase = model.getElements(new TypeFilter<>(CtCase.class)).get(0);
+			CtCase<?> ctCase = ctClass.getElements(new TypeFilter<>(CtCase.class)).get(0);
 
 			ctCase.setCaseExpression(null);
 
-			assertThat(ctCase.getCaseExpressions().size(), equalTo(0));
+			assertThat(ctCase.getCaseExpressions()).hasSize(0);
 		}
 	}
 }

--- a/src/test/java/spoon/test/model/SwitchCaseTest.java
+++ b/src/test/java/spoon/test/model/SwitchCaseTest.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -551,7 +550,7 @@ public class SwitchCaseTest {
 
 			ctCase.setCaseExpression(null);
 
-			assertThat(ctCase.getCaseExpressions()).hasSize(0);
+			assertThat(ctCase.getCaseExpressions()).isEmpty();
 		}
 	}
 }

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -575,7 +575,7 @@ public class VariableReferencesTest {
 		}
 		""")
 	public void testIfWithNullThen(@BySimpleName("Test") CtClass<?> ctClass) {
-		// contract: the code does not crash when then is null, and correctly resolves the reference to the pattern
+		// contract: a pattern variable is accessible outside the then, if the other branch returns, even if the then is empty
 		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
 		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
 
@@ -600,7 +600,8 @@ public class VariableReferencesTest {
 		}
 		""")
 	public void testForConditionNull(@BySimpleName("Test") CtClass<?> ctClass) {
-		// contract: the code must not crash if the condition in the for is null
+		// contract: a variable declared in the initialization of a for loop is correctly resolved in the body,
+		//           even if the condition and update are null
 		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
 		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
 

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -34,8 +34,6 @@ import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
-import spoon.reflect.cu.SourcePosition;
-import spoon.reflect.cu.position.NoSourcePosition;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
@@ -65,8 +63,12 @@ import spoon.reflect.visitor.filter.VariableScopeFunction;
 import spoon.test.query_function.testclasses.EnumValueReferences;
 import spoon.test.query_function.testclasses.VariableReferencesFromStaticMethod;
 import spoon.test.query_function.testclasses.VariableReferencesModelTest;
+import spoon.testing.utils.BySimpleName;
+import spoon.testing.utils.ModelTest;
 import spoon.testing.utils.ModelUtils;
 
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -128,7 +130,7 @@ public class VariableReferencesTest {
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
 		//2) the model is searched for all variable references which has same identification number and counts them
-		//Then it checks that counted number of references and found number of references is same 
+		//Then it checks that counted number of references and found number of references is same
 		modelClass.filterChildren((CtCatchVariable<?> var)->{
 			if(isTestFieldName(var.getSimpleName())) {
 				int value = getLiteralValue(var);
@@ -144,7 +146,7 @@ public class VariableReferencesTest {
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
 		//2) the model is searched for all variable references which has same identification number and counts them
-		//Then it checks that counted number of references and found number of references is same 
+		//Then it checks that counted number of references and found number of references is same
 		modelClass.filterChildren((CtLocalVariable<?> var)->{
 			if(isTestFieldName(var.getSimpleName())) {
 				int value = getLiteralValue(var);
@@ -160,7 +162,7 @@ public class VariableReferencesTest {
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
 		//2) the model is searched for all variable references which has same identification number and counts them
-		//Then it checks that counted number of references and found number of references is same 
+		//Then it checks that counted number of references and found number of references is same
 		modelClass.filterChildren((CtParameter<?> var)->{
 			if(isTestFieldName(var.getSimpleName())) {
 				int value = getLiteralValue(var);
@@ -168,7 +170,7 @@ public class VariableReferencesTest {
 			}
 			return false;
 		}).list();
-	}	
+	}
 
 	@Test
 	public void testVariableReferenceFunction() {
@@ -176,7 +178,7 @@ public class VariableReferencesTest {
 		//The test detects whether found references are correct by these two checks:
 		//1) the each found reference is on the left side of binary operator and on the right side there is unique reference identification number. Like: (field == 7)
 		//2) the model is searched for all variable references which has same identification number and counts them
-		//Then it checks that counted number of references and found number of references is same 
+		//Then it checks that counted number of references and found number of references is same
 		modelClass.filterChildren((CtVariable<?> var)->{
 			if(isTestFieldName(var.getSimpleName())) {
 				int value = getLiteralValue(var);
@@ -268,7 +270,7 @@ public class VariableReferencesTest {
 			});
 			//check that both scans found same number of references
 			assertEquals(context.expectedCount, context.realCount, "Number of references to field=" + value + " does not match");
-			
+
 		} catch (Throwable e) {
 			e.printStackTrace();
 			throw new AssertionError("Test failed on " + getParentMethodName(var), e);
@@ -302,7 +304,7 @@ public class VariableReferencesTest {
 			try {
 				return getLiteralValue(exp);
 			} catch (ClassCastException e) {
-				
+
 			}
 		}
 		if (var instanceof CtParameter) {
@@ -354,18 +356,6 @@ public class VariableReferencesTest {
 		return ((CtLiteral<Integer>) exp).getValue();
 	}
 
-	private SourcePosition getPosition(CtElement e) {
-		SourcePosition sp = e.getPosition();
-		while(sp instanceof NoSourcePosition) {
-			e = e.getParent();
-			if(e==null) {
-				break;
-			}
-			sp = e.getPosition();
-		}
-		return sp;
-	}
-
 	@Test
 	public void testPotentialVariableAccessFromStaticMethod() throws Exception {
 		Factory factory = ModelUtils.build(VariableReferencesFromStaticMethod.class);
@@ -394,5 +384,156 @@ public class VariableReferencesTest {
 			assertEquals(1, refs.size());
 			assertEquals(ev.getReference(), refs.get(0));
 		});
+	}
+
+	@ModelTest(code = """
+		class Test {
+			void method() {
+				for (int i = 0; i < 10; i++) {
+					System.out.println(i);
+				}
+			}
+		}
+		""")
+	public void testForInitReference(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a reference to a variable declared in a for loop must be resolved to the correct declaration
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(1);
+		assertThat(variables.get(0)).getSimpleName().isEqualTo("i");
+
+		assertThat(references).hasSize(3);
+		assertThat(references).extracting(CtLocalVariableReference::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(0));
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(0));
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(variables.get(0));
+	}
+
+	@ModelTest(code = """
+		import java.util.Scanner;
+
+		class Test {
+			Scanner scanner;
+			String e;
+
+			void method() {
+				try(
+					Scanner scanner = new Scanner(System.in);
+					Scanner e = new Scanner(System.err)
+				) {
+					System.out.println(scanner);
+					System.out.println(e);
+				} catch(IllegalArgumentException e) {
+					System.out.println(scanner + e.getMessage());
+				} finally {
+					System.out.println(scanner);
+				}
+			}
+		}
+		""")
+	public void testTryWithReferenceTest(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a reference to a try-with-resource variable is only accessible in the try block
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(2);
+		CtVariable<?> tryWithVariable = variables.get(0);
+		CtVariable<?> errTryWithVariable = variables.get(1);
+		assertThat(tryWithVariable).getSimpleName().isEqualTo("scanner");
+		assertThat(errTryWithVariable).getSimpleName().isEqualTo("e");
+		CtVariable<?> catchVariable = ctClass.getElements(new TypeFilter<>(CtCatchVariable.class)).get(0);
+		assertThat(catchVariable).getSimpleName().isEqualTo("e");
+
+		CtField<?> scannerField = ctClass.getField("scanner");
+		assertNotNull(scannerField);
+		CtField<?> eField = ctClass.getField("e");
+		assertNotNull(eField);
+
+
+		assertThat(references).hasSize(11);
+
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(tryWithVariable, scannerField);
+		assertThat(references.get(5)).hasExactlyPotentialDeclarations(errTryWithVariable, eField);
+		assertThat(references.get(7)).hasExactlyPotentialDeclarations(scannerField);
+		assertThat(references.get(8)).hasExactlyPotentialDeclarations(catchVariable, eField);
+		assertThat(references.get(10)).hasExactlyPotentialDeclarations(scannerField);
+	}
+
+	@ModelTest(code = """
+		class Test {
+			static void assertTrue(boolean condition) {}
+
+			void nestedClassMethodWithShadowVarAndField() {
+				int var1 = 2;
+				new Runnable() {
+					//this var1 shadows above defined var1.
+					int var1 = 3;
+					@Override
+					public void run() {
+						assertTrue(var1 == 3);
+						int var1 = 4;
+						assertTrue(var1 == 4);
+						assertTrue(this.var1 == 3);
+					}
+				}.run();
+				assertTrue(var1 == 2);
+			}
+		}
+		""")
+	public void testAnonymousClassFieldResolution(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: variable references with anonymous classes resolve correctly
+		CtMethod<?> ctMethod = ctClass.getMethodsByName("nestedClassMethodWithShadowVarAndField").get(0);
+
+		List<CtVariable<?>> variables = ctMethod.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctMethod.getElements(new TypeFilter<>(CtVariableReference.class));
+		assertThat(references).hasSize(4);
+		assertThat(variables).hasSize(3);
+
+		var outerLocalVar1 = variables.get(0);
+		assertThat(outerLocalVar1).isInstanceOf(CtLocalVariable.class).getSimpleName().isEqualTo("var1");
+		var runnableFieldVar1 = variables.get(1);
+		assertThat(runnableFieldVar1).isInstanceOf(CtField.class).getSimpleName().isEqualTo("var1");
+		var innerLocalVar1 = variables.get(2);
+		assertThat(innerLocalVar1).isInstanceOf(CtLocalVariable.class).getSimpleName().isEqualTo("var1");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(runnableFieldVar1, outerLocalVar1);
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(innerLocalVar1, runnableFieldVar1, outerLocalVar1);
+		// The code does not filter out local variables on the way for a field reference
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(innerLocalVar1, runnableFieldVar1, outerLocalVar1);
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(outerLocalVar1);
+	}
+
+
+	@ModelTest(code = """
+		class Test {
+			String string = "";
+			void method(String[] array) {
+				for (String string : array) {
+					System.out.println(string);
+				}
+			}
+		}
+		""")
+	public void testForEachVariableResolution(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: the variable referenced in a for-each resolves to the loop variable, then the field
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(3);
+		CtVariable<?> fieldVariable = variables.get(0);
+		CtVariable<?> arrayParam = variables.get(1);
+		CtVariable<?> forEachVariable = variables.get(2);
+		assertThat(fieldVariable).isSameAs(ctClass.getField("string"));
+
+		assertThat(references).hasSize(3);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(arrayParam); // for (String string : array)
+		// System.out
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(forEachVariable, fieldVariable); // println(string)
 	}
 }

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -588,4 +588,24 @@ public class VariableReferencesTest {
 		// System.out
 		assertThat(references.get(2)).hasExactlyPotentialDeclarations(patternVar, fieldVariable); // println(s)
 	}
+
+	@ModelTest(code = """
+		class Test {
+			void method() {
+				int i = 0;
+				for (; ;) {
+					System.out.println(i);
+				}
+			}
+		}
+		""")
+	public void testForConditionNull(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: the code must not crash if the condition in the for is null
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(1);
+
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(0));
+	}
 }

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -400,8 +400,7 @@ public class VariableReferencesTest {
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(1);
+		assertThat(variables).hasSize(1);
 		assertThat(variables.get(0)).getSimpleName().isEqualTo("i");
 
 		assertThat(references).hasSize(3);
@@ -439,8 +438,7 @@ public class VariableReferencesTest {
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(2);
+		assertThat(variables).hasSize(2);
 		CtVariable<?> tryWithVariable = variables.get(0);
 		CtVariable<?> errTryWithVariable = variables.get(1);
 		assertThat(tryWithVariable).getSimpleName().isEqualTo("scanner");
@@ -500,11 +498,10 @@ public class VariableReferencesTest {
 		var innerLocalVar1 = variables.get(2);
 		assertThat(innerLocalVar1).isInstanceOf(CtLocalVariable.class).getSimpleName().isEqualTo("var1");
 
-		assertThat(references.get(0)).hasExactlyPotentialDeclarations(runnableFieldVar1, outerLocalVar1);
-		assertThat(references.get(1)).hasExactlyPotentialDeclarations(innerLocalVar1, runnableFieldVar1, outerLocalVar1);
-		// The code does not filter out local variables on the way for a field reference
-		assertThat(references.get(2)).hasExactlyPotentialDeclarations(innerLocalVar1, runnableFieldVar1, outerLocalVar1);
-		assertThat(references.get(3)).hasExactlyPotentialDeclarations(outerLocalVar1);
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(runnableFieldVar1); // assertTrue(var1 == 3);
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(innerLocalVar1, runnableFieldVar1, outerLocalVar1); // assertTrue(var1 == 4);
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(runnableFieldVar1); // assertTrue(this.var1 == 3);
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(outerLocalVar1); // assertTrue(var1 == 2);
 	}
 
 
@@ -523,8 +520,7 @@ public class VariableReferencesTest {
 		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
 		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(3);
+		assertThat(variables).hasSize(3);
 		CtVariable<?> fieldVariable = variables.get(0);
 		CtVariable<?> arrayParam = variables.get(1);
 		CtVariable<?> forEachVariable = variables.get(2);
@@ -535,5 +531,61 @@ public class VariableReferencesTest {
 		assertThat(references.get(0)).hasExactlyPotentialDeclarations(arrayParam); // for (String string : array)
 		// System.out
 		assertThat(references.get(2)).hasExactlyPotentialDeclarations(forEachVariable, fieldVariable); // println(string)
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String s = "";
+
+			void method(Object in) {
+				if(in instanceof String s) {
+				} else {
+				  return;
+				}
+				System.out.println(s);
+			}
+		}
+		""")
+	public void testPatternVariableOutsideThen(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a pattern variable is accessible outside the then, if the other branch returns
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(3);
+		CtVariable<?> fieldVariable = variables.get(0);
+		CtVariable<?> paramVar = variables.get(1);
+		CtVariable<?> patternVar = variables.get(2);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(paramVar); // if(in instanceof String s)
+		// System.out
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(patternVar, fieldVariable); // println(s)
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String s = "";
+
+			void method(Object obj) {
+				if(obj instanceof String s); else {
+				  return;
+				}
+
+				System.out.println(s);
+			}
+		}
+		""")
+	public void testIfWithNullThen(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: the code does not crash when then is null, and correctly resolves the reference to the pattern
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(3);
+		CtVariable<?> fieldVariable = variables.get(0);
+		CtVariable<?> paramVar = variables.get(1);
+		CtVariable<?> patternVar = variables.get(2);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(paramVar); // if (obj instanceof String s)
+		// System.out
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(patternVar, fieldVariable); // println(s)
 	}
 }

--- a/src/test/java/spoon/test/reference/InstanceOfReferenceTest.java
+++ b/src/test/java/spoon/test/reference/InstanceOfReferenceTest.java
@@ -1,21 +1,34 @@
 package spoon.test.reference;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import spoon.reflect.CtModel;
+import spoon.reflect.code.CtInvocation;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtTypePattern;
+import spoon.reflect.code.CtVariableRead;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtLocalVariableReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.reflect.visitor.filter.VariableReferenceFunction;
+import spoon.testing.utils.BySimpleName;
 import spoon.testing.utils.GitHubIssue;
+import spoon.testing.utils.ModelTest;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static spoon.test.SpoonTestHelpers.createModelFromString;
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
 
 /**
  * Tests that references to pattern variables declared using the <code>instanceof</code> operator can be resolved.
@@ -184,6 +197,398 @@ public class InstanceOfReferenceTest {
 		assertNotNull(decl);
 		assertEquals(variable, decl);
 	}
+
+	@ModelTest(code = """
+		class Test {
+			void typePattern(Object o) {
+				if (o instanceof String i) {
+					System.out.println(i);
+				}
+
+				if (!(o instanceof String i)) {
+				} else {
+					System.out.println(i);
+				}
+
+				if (!(o instanceof String i)) {
+					throw new IllegalArgumentException();
+				}
+				System.out.println(i);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testFlowScope4(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: references to pattern variables hiding other variables with the same name are resolved correctly
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(3);
+		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references).hasSize(3);
+		assertThat(references).extracting(CtLocalVariableReference::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(0));
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(variables.get(2));
+	}
+
+	@ModelTest(code = """
+		class Test {
+			void typePattern(Object o) {
+				do {
+					if (!(o instanceof Integer i)) {
+						continue;
+					}
+
+					System.out.println(i);
+				} while (!(o instanceof String i));
+
+				System.out.println(i);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testDoWhilePattern(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: references to pattern variables introduced in a do-while are resolved correctly
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(2);
+		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
+
+		CtLocalVariable<?> doWhileVariable = variables.get(0);
+		CtLocalVariable<?> ifVariable = variables.get(1);
+
+		assertThat(doWhileVariable).getType().isEqualTo(String.class);
+		assertThat(ifVariable).getType().isEqualTo(Integer.class);
+
+
+		assertThat(references).hasSize(2);
+		assertThat(references).extracting(CtLocalVariableReference::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references.get(0)).getType().isEqualTo(Integer.class);
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(ifVariable, doWhileVariable);
+
+		assertThat(references.get(1)).getType().isEqualTo(String.class);
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(doWhileVariable);
+	}
+
+	@ModelTest(code = """
+		class Test {
+			void typePattern(Object o) {
+				while (!(o instanceof String i)) {
+					if (!(o instanceof Integer i)) {
+						continue;
+					}
+
+					System.out.println(i);
+				}
+
+				System.out.println(i);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testNegatedWhilePattern(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a pattern variable is introduced by while (e) S iff it is introduced by e when false
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(2);
+		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
+
+		CtLocalVariable<?> whileVariable = variables.get(0);
+		CtLocalVariable<?> ifVariable = variables.get(1);
+
+		assertThat(whileVariable).getType().isEqualTo(String.class);
+		assertThat(ifVariable).getType().isEqualTo(Integer.class);
+
+
+		assertThat(references).hasSize(2);
+		assertThat(references).extracting(CtLocalVariableReference::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references.get(0)).getType().isEqualTo(Integer.class);
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(ifVariable, whileVariable);
+
+		assertThat(references.get(1)).getType().isEqualTo(String.class);
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(whileVariable);
+	}
+
+
+	@ModelTest(code = """
+		class Test {
+			String i = "";
+			void typePattern(Object o) {
+				label: while (!(o instanceof String i)) {
+					if (!(o instanceof Integer i)) {
+						break label;
+					}
+
+					System.out.println(i);
+				}
+
+				System.out.println(i);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testNegatedWhilePatternWithBreakLabel(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a pattern variable is introduced by while (e) S iff it is introduced by e when false
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(4);
+
+		CtVariable<?> fieldVariable = variables.get(0);
+		assertThat(fieldVariable).getType().isEqualTo(String.class);
+		assertThat(fieldVariable).getSimpleName().isEqualTo("i");
+
+		CtVariable<?> whileVariable = variables.get(2);
+		assertThat(whileVariable).getSimpleName().isEqualTo("i");
+
+		CtVariable<?> ifVariable = variables.get(3);
+		assertThat(ifVariable).getSimpleName().isEqualTo("i");
+		assertThat(ifVariable).getType().isEqualTo(Integer.class);
+
+		assertThat(references).hasSize(6); // System.out are references to fields
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(1));
+		// skip the System.out reference
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(ifVariable, fieldVariable);
+		// skip the System.out reference
+
+		// Because of the break target label the while pattern variable is not in scope in the last print statement:
+		assertThat(references.get(5)).hasExactlyPotentialDeclarations(fieldVariable);
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String i = "";
+
+			void typePattern(Object o) {
+				while (o instanceof String i) {
+					System.out.println(i);
+				}
+
+				System.out.println(i);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testMatchingWhilePattern(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a pattern variable introduced by e when true is definitely matched at S.
+		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(1);
+		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
+
+		CtLocalVariable<?> whileVariable = variables.get(0);
+		assertThat(whileVariable).getType().isEqualTo(String.class);
+
+
+		assertThat(references).hasSize(1);
+		assertThat(references).extracting(CtLocalVariableReference::getSimpleName).allMatch("i"::equals);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(whileVariable, ctClass.getField("i"));
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String s1 = "";
+			String s2 = "";
+
+			void typePattern(Object a, Object b) {
+				if (a instanceof String s1 && b instanceof String s2) {
+					System.out.println("s1" + s1 + "s2" + s2);
+				}
+
+				if (!(a instanceof String s1) && b instanceof String s2) {
+					System.out.println("s1" + s1 + "s2" + s2);
+				}
+
+				if (a instanceof String s1 && !(b instanceof String s2)) {
+					System.out.println("s1" + s1 + "s2" + s2);
+				}
+
+				if (!(a instanceof String s1) && !(b instanceof String s2)) {
+					System.out.println("s1" + s1 + "s2" + s2);
+				}
+
+				System.out.println(s1 + s2);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testBinaryOperatorAnd(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: references to pattern variables introduced by a && b are resolved correctly
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(12);
+
+		// The fields:
+		assertThat(variables.get(0)).getSimpleName().isEqualTo("s1");
+		assertThat(variables.get(1)).getSimpleName().isEqualTo("s2");
+
+		var s1Field = variables.get(0);
+		var s2Field = variables.get(1);
+
+		// The parameters:
+		assertThat(variables.get(2)).getSimpleName().isEqualTo("a");
+		assertThat(variables.get(3)).getSimpleName().isEqualTo("b");
+
+		var aParameter = variables.get(2);
+		var bParameter = variables.get(3);
+
+		// For the first if condition, the first reference will be to the parameters, then to the pattern variables:
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(aParameter);
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(bParameter);
+
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(variables.get(4), s1Field);
+		assertThat(references.get(4)).hasExactlyPotentialDeclarations(variables.get(5), s2Field);
+
+		// The second if condition
+		assertThat(references.get(5)).hasExactlyPotentialDeclarations(aParameter);
+		assertThat(references.get(6)).hasExactlyPotentialDeclarations(bParameter);
+
+		assertThat(references.get(8)).hasExactlyPotentialDeclarations(s1Field);
+		assertThat(references.get(9)).hasExactlyPotentialDeclarations(variables.get(7), s2Field);
+
+		// The third if condition
+		assertThat(references.get(10)).hasExactlyPotentialDeclarations(aParameter);
+		assertThat(references.get(11)).hasExactlyPotentialDeclarations(bParameter);
+
+		assertThat(references.get(13)).hasExactlyPotentialDeclarations(variables.get(8), s1Field);
+		assertThat(references.get(14)).hasExactlyPotentialDeclarations(s2Field);
+
+		// The fourth if condition
+		assertThat(references.get(15)).hasExactlyPotentialDeclarations(aParameter);
+		assertThat(references.get(16)).hasExactlyPotentialDeclarations(bParameter);
+
+		assertThat(references.get(18)).hasExactlyPotentialDeclarations(s1Field);
+		assertThat(references.get(19)).hasExactlyPotentialDeclarations(s2Field);
+
+		// The last print statement (the else) references the negated pattern variables:
+		assertThat(references.get(21)).hasExactlyPotentialDeclarations(s1Field);
+		assertThat(references.get(22)).hasExactlyPotentialDeclarations(s2Field);
+	}
+
+
+	private static Stream<Arguments> provideTestCasesForNegatedScoping() {
+		return Stream.of(
+			Arguments.of("o instanceof String s", List.of("s"), List.of()),
+			Arguments.of("!(o instanceof String s)", List.of(), List.of("s")),
+			Arguments.of("!(!(o instanceof String s))", List.of("s"), List.of()),
+			Arguments.of("!(!(!(o instanceof String s)))", List.of(), List.of("s")),
+			Arguments.of("o instanceof String s && s.length() > 5", List.of("s"), List.of()),
+			Arguments.of("o instanceof String s || number > 5", List.of(), List.of()),
+			Arguments.of("!(o instanceof String s) || s.length() > 5", List.of(), List.of("s")),
+			Arguments.of("!(o instanceof String s1) || !(obj instanceof String s2)", List.of(), List.of("s1", "s2"))
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideTestCasesForNegatedScoping")
+	public void testNegatedInstanceofScoping(String condition, Collection<String> patternVarsInThen, Collection<String> patternVarsInElse) {
+		// The code declares three variables that are both referenced in the then and else branch.
+		//
+		// If a pattern is defined, this will shadow the field where it is true.
+		// The test then checks that the references resolve to either the pattern variable or the local variable.
+		String code = """
+				class Test {
+					String s = "abc";
+					String s1 = "def";
+					String s2 = "ghi";
+
+					void test(Object o, Object obj, int number) {
+						if (%s) {
+							System.out.printf("", s, s1, s2);
+							throw new IllegalArgumentException();
+						}
+
+						System.out.printf("", s, s1, s2);
+					}
+				}
+				""".formatted(condition);
+
+		CtModel model = createModelFromString(code, 21);
+
+		List<? extends CtLocalVariable<?>> patternVariables = model.getElements(new TypeFilter<>(CtTypePattern.class))
+			.stream()
+			.map(CtTypePattern::getVariable)
+			.toList();
+
+		var invocations = model.getElements(new TypeFilter<>(CtInvocation.class)).stream().filter(
+			ctInvocation -> ctInvocation.getExecutable().getSimpleName().equals("printf")
+		).toList();
+		CtInvocation<?> thenPrint = invocations.get(0);
+		CtInvocation<?> elsePrint = invocations.get(1);
+
+		for (var fallback : model.getElements(new TypeFilter<>(CtField.class))) {
+			CtLocalVariable<?> patternVariable = patternVariables.stream()
+				.filter(variable -> variable.getSimpleName().equals(fallback.getSimpleName()))
+				.findFirst()
+				.orElse(null);
+
+			CtVariableRead<?> thenVariableRead = thenPrint.getArguments()
+				.stream()
+				.filter(arg -> arg instanceof CtVariableRead<?>)
+				.map(arg -> (CtVariableRead<?>) arg)
+				.filter(access -> access.getVariable().getSimpleName().equals(fallback.getSimpleName()))
+				.findFirst()
+				.orElseThrow();
+
+			CtVariableRead<?> elseVariableRead = elsePrint.getArguments()
+				.stream()
+				.filter(arg -> arg instanceof CtVariableRead<?>)
+				.map(arg -> (CtVariableRead<?>) arg)
+				.filter(access -> access.getVariable().getSimpleName().equals(fallback.getSimpleName()))
+				.findFirst()
+				.orElseThrow();
+
+			boolean refersToPatternVarInThen = patternVarsInThen.contains(fallback.getSimpleName());
+			boolean refersToPatternVarInElse = patternVarsInElse.contains(fallback.getSimpleName());
+
+			assertThat(thenVariableRead.getVariable().getDeclaration())
+				.as("'%s' should reference the %s variable in 'then'", thenVariableRead, refersToPatternVarInThen ? "pattern" : "field")
+				.isSameAs(refersToPatternVarInThen ? patternVariable : fallback);
+
+			assertThat(elseVariableRead.getVariable().getDeclaration())
+				.as("'%s' should reference the %s variable in 'else'", elseVariableRead, refersToPatternVarInElse ? "pattern" : "field")
+				.isSameAs(refersToPatternVarInElse ? patternVariable : fallback);
+
+		}
+	}
+
+
+	@ModelTest(code = """
+		class Test {
+			String s = "";
+
+			void method(Object obj) {
+				System.out.println(obj instanceof String s ? s : s);
+				System.out.println(!(obj instanceof String s) ? s : s);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testConditionalPatternScope(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: references to pattern variables introduced in a conditional are resolved correctly
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		// System.out
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(1)); // (obj instanceof ...
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(variables.get(2), variables.get(0)); // instanceof String s ? s
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(variables.get(0)); // : s
+		// System.out
+		assertThat(references.get(5)).hasExactlyPotentialDeclarations(variables.get(1)); // !(obj instanceof ...
+		assertThat(references.get(6)).hasExactlyPotentialDeclarations(variables.get(0)); // instanceof String s ? s
+		assertThat(references.get(7)).hasExactlyPotentialDeclarations(variables.get(3), variables.get(0)); // : s
+	}
+
 
 	@Test
 	public void testCorrectScoping() {

--- a/src/test/java/spoon/test/reference/InstanceOfReferenceTest.java
+++ b/src/test/java/spoon/test/reference/InstanceOfReferenceTest.java
@@ -222,8 +222,7 @@ public class InstanceOfReferenceTest {
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(3);
+		assertThat(variables).hasSize(3);
 		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
 
 		assertThat(references).hasSize(3);
@@ -254,8 +253,7 @@ public class InstanceOfReferenceTest {
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(2);
+		assertThat(variables).hasSize(2);
 		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
 
 		CtLocalVariable<?> doWhileVariable = variables.get(0);
@@ -295,8 +293,7 @@ public class InstanceOfReferenceTest {
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(2);
+		assertThat(variables).hasSize(2);
 		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
 
 		CtLocalVariable<?> whileVariable = variables.get(0);
@@ -377,12 +374,13 @@ public class InstanceOfReferenceTest {
 		}
 		""", complianceLevel = 21)
 	public void testMatchingWhilePattern(@BySimpleName("Test") CtClass<?> ctClass) {
-		// contract: a pattern variable introduced by e when true is definitely matched at S.
+		// contract: a pattern variable introduced by condition c in `while (c) S` when true is definitely matched at S.
+		//           In simpler words: The variable `i` introduced by the instanceof pattern `o instanceof String i`, must
+		//           be accessible by the associated statement/block of the while.
 		List<CtLocalVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
 		List<CtLocalVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtLocalVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(1);
+		assertThat(variables).hasSize(1);
 		assertThat(variables).extracting(CtLocalVariable::getSimpleName).allMatch("i"::equals);
 
 		CtLocalVariable<?> whileVariable = variables.get(0);
@@ -426,8 +424,7 @@ public class InstanceOfReferenceTest {
 		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
 		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
 
-		assertThat(variables)
-			.hasSize(12);
+		assertThat(variables).hasSize(12);
 
 		// The fields:
 		assertThat(variables.get(0)).getSimpleName().isEqualTo("s1");

--- a/src/test/java/spoon/test/reference/PatternMatchingReferenceTest.java
+++ b/src/test/java/spoon/test/reference/PatternMatchingReferenceTest.java
@@ -1,54 +1,250 @@
 package spoon.test.reference;
 
-import org.junit.jupiter.api.Test;
-import spoon.reflect.CtModel;
-import spoon.reflect.code.CtLocalVariable;
-import spoon.reflect.code.CtTypePattern;
-import spoon.reflect.reference.CtLocalVariableReference;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.testing.utils.BySimpleName;
+import spoon.testing.utils.ModelTest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static spoon.test.SpoonTestHelpers.createModelFromString;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static spoon.testing.assertions.SpoonAssertions.assertThat;
 
 public class PatternMatchingReferenceTest {
-	@Test
-	public void testCasePatternReferenceArrow() {
-		String code = """
-				class X {
-					public void processShape(Shape shape) {
-						switch (shape) {
-							case Circle c -> System.out.println("This is a circle with radius: " + c.getRadius());
-						}
-					}
+	@ModelTest(code = """
+		interface Shape {}
+
+		record Circle(double radius) implements Shape {}
+
+		class X {
+			public void processShape(Shape shape) {
+				switch (shape) {
+					case Circle c -> System.out.println("This is a circle with radius: " + c.getRadius());
+					default -> {}
 				}
-				""";
-		CtModel model = createModelFromString(code, 21);
-		CtLocalVariable<?> variable = model.getElements(new TypeFilter<>(CtTypePattern.class)).get(0).getVariable();
-		CtLocalVariableReference<?> ref = model.getElements(new TypeFilter<>(CtLocalVariableReference.class)).get(0);
-		var decl = ref.getDeclaration();
-		assertNotNull(decl);
-		assertEquals(variable, decl);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testCasePatternReferenceArrow(@BySimpleName("X") CtClass<?> ctClass) {
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(2);
+		assertThat(references).hasSize(3);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(0));
+		// ignore the reference to System.out
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(variables.get(1));
 	}
 
-	@Test
-	public void testCasePatternReferenceColon() {
-		String code = """
-				class X {
-					public void processShape(Shape shape) {
-						switch (shape) {
-							case Circle c:
-								System.out.println("This is a circle with radius: " + c.getRadius());
-								break;
-						}
-					}
+	@ModelTest(code = """
+		interface Shape {}
+
+		record Circle(double radius) implements Shape {}
+
+		class X {
+			public void processShape(Shape shape) {
+				switch (shape) {
+					case Circle c:
+						System.out.println("This is a circle with radius: " + c.getRadius());
+						break;
+					default:
+						break;
 				}
-				""";
-		CtModel model = createModelFromString(code, 21);
-		CtLocalVariable<?> variable = model.getElements(new TypeFilter<>(CtTypePattern.class)).get(0).getVariable();
-		CtLocalVariableReference<?> ref = model.getElements(new TypeFilter<>(CtLocalVariableReference.class)).get(0);
-		var decl = ref.getDeclaration();
-		assertNotNull(decl);
-		assertEquals(variable, decl);
+			}
+		}
+		""", complianceLevel = 21)
+	public void testCasePatternReferenceColon(@BySimpleName("X") CtClass<?> ctClass) {
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables).hasSize(2);
+		assertThat(references).hasSize(3);
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(0));
+		// ignore the reference to System.out
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(variables.get(1));
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String i = "";
+			void method(int integer) {
+				switch (integer) {
+					case 0:
+						System.out.println(i);
+						break;
+					case 1:
+						int i = 4;
+						break;
+					case 2:
+						i = 2;
+						break;
+				}
+			}
+		}
+		""")
+	public void testVariableInOtherCase(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a variable declared in one case of a switch statement is accessible in all the following cases,
+		//           but not in the previous cases.
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(3);
+		var field = variables.get(0);
+		assertThat(field).getType().isEqualTo(String.class);
+		assertThat(variables.get(1)).getSimpleName().isEqualTo("integer");
+
+		assertThat(variables.get(2)).getSimpleName().isEqualTo("i");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(field);
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(variables.get(2), field);
+	}
+
+
+	@ModelTest(code = """
+		class Test {
+			String i = "";
+			void method(int integer) {
+				switch (integer) {
+					case 0:
+						System.out.println(i);
+						break;
+					case 1: {
+						int i = 4;
+						break;
+					}
+					case 2:
+						i = 2;
+						break;
+				}
+			}
+		}
+		""")
+	public void testVariableInOtherCaseWithBlock(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a variable declared in one case of a switch statement does not escape the block surrounding its declaration.
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(3);
+		var field = variables.get(0);
+		assertThat(field).getType().isEqualTo(String.class);
+		assertThat(variables.get(1)).getSimpleName().isEqualTo("integer");
+
+		assertThat(variables.get(2)).getSimpleName().isEqualTo("i");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(field);
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(field);
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String i = "";
+			void method(int integer) {
+				switch (integer) {
+					case 0 -> System.out.println(i);
+					case 1 -> {
+						int i = 4;
+					}
+					case 2 -> i = 2;
+				}
+			}
+		}
+		""", complianceLevel = 17)
+	public void testVariableInOtherCaseSwitchExpr(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a variable declared in a switch expression case is inaccessible in other cases, even the following ones.
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(3);
+		var field = variables.get(0);
+		assertThat(field).getType().isEqualTo(String.class);
+		assertThat(variables.get(1)).getSimpleName().isEqualTo("integer");
+
+		assertThat(variables.get(2)).getSimpleName().isEqualTo("i");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(2)).hasExactlyPotentialDeclarations(field);
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(field);
+	}
+
+
+	@ModelTest(code = """
+		class Test {
+			void method(Object obj) {
+				switch (obj) {
+					case String string when string.length() > 4 -> System.out.println(string);
+					default -> {}
+				}
+			}
+		}
+		""", complianceLevel = 21)
+	public void testSwitchGuard(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: the variable reference in the guard of a switch resolves to the variable declared in the case pattern.
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(2);
+		assertThat(variables.get(0)).getType().isEqualTo(Object.class);
+		assertThat(variables.get(1)).getSimpleName().isEqualTo("string");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(variables.get(0));
+		// the variable reference in the guard should resolve to the variable declared in the case pattern:
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(variables.get(1));
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(variables.get(1));
+	}
+
+	@ModelTest(code = """
+		class Test {
+			String string = "";
+			void method(int integer, Object obj) {
+				switch (integer) {
+					case 0:
+						if (!(obj instanceof String string)) {
+							throw new IllegalStateException();
+						}
+						System.out.println(string);
+						break;
+					case 1:
+						System.out.println(string);
+						break;
+					default:
+						break;
+				}
+			}
+		}
+		""", complianceLevel = 17)
+	public void testPatternScopeOnlyInCase(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: A pattern variable introduced in a statement in a case is not accessible in the following cases.
+		List<CtVariable<?>> variables = ctClass.getElements(new TypeFilter<>(CtVariable.class));
+		List<CtVariableReference<?>> references = ctClass.getElements(new TypeFilter<>(CtVariableReference.class));
+
+		assertThat(variables)
+			.hasSize(4);
+
+		CtVariable<?> stringField = variables.get(0);
+		CtVariable<?> integerVariable = variables.get(1);
+		CtVariable<?> objParam = variables.get(2);
+		CtVariable<?> localPattern = variables.get(3);
+
+		assertThat(stringField).getSimpleName().isEqualTo("string");
+		assertThat(integerVariable).getSimpleName().isEqualTo("integer");
+		assertThat(objParam).getSimpleName().isEqualTo("obj");
+		assertThat(localPattern).getSimpleName().isEqualTo("string");
+
+		assertThat(references.get(0)).hasExactlyPotentialDeclarations(integerVariable); // switch (integer)
+		assertThat(references.get(1)).hasExactlyPotentialDeclarations(objParam); // if (!(obj instanceof String string))
+		// System.out
+		assertThat(references.get(3)).hasExactlyPotentialDeclarations(localPattern, stringField); // println(string)
+		// System.out
+		assertThat(references.get(5)).hasExactlyPotentialDeclarations(stringField); // println(string)
 	}
 }

--- a/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
@@ -1,7 +1,6 @@
 package spoon.testing.assertions;
-import java.util.Comparator;
+import com.google.common.collect.Ordering;
 import java.util.List;
-import java.util.function.Function;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
@@ -38,12 +37,23 @@ public interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>
 			declarations = actual().map(new PotentialVariableDeclarationFunction(actual().getSimpleName())).list();
 		}
 		// By default, the containsExactly assertion checks with equals or compareTo.
-		// A declaration `String i` and an unrelated `String i` are considered equal.
-		// Given that the potential declarations will all have the same name it is important to check
-		// that they are not only equal, but the same object through ==.
+		// A declaration `String i` and an unrelated `String i` are considered equal, because that is how CtElement#equals
+		// is implemented.
 		//
-		// The code expects a comparator, so we are using the identity hash code (= pointer value) for the comparison.
-		Assertions.assertThat(declarations).as("Potential declarations of variable <%s>", actual()).usingElementComparator(Comparator.comparing(System::identityHashCode)).containsExactly(potentialDeclarations);
+		// For a list of potential declarations, all of them will have the same name and (likely) the same type,
+		// so it wouldn't work here.
+		//
+		// Therefore, we want to check for object equality through ==.
+		// To change how elements are compared in AssertJ, you have to provide a Comparator to the usingElementComparator
+		// method. A comparator is not only for equality, but also for ordering. Technically, the library should not need
+		// to sort our input/use our comparator for that, but who knows what will happen in the future. It is not ideal
+		// to use an inconsistent ordering, hence Ordering.arbitrary() is used here, which does exactly what is desired here.
+		//
+		// Previous ideas:
+		// If one were to have a unique identifier for a java object, one could sort by that. System.identityHashCode() does not work here,
+		// because:
+		// a.hashCode() == b.hashCode() =!> a == b (see equals contract)
+		Assertions.assertThat(declarations).as("Potential declarations of variable <%s>", actual()).usingElementComparator(Ordering.arbitrary()).containsExactly(potentialDeclarations);
 		return this;
 	}
 }

--- a/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
@@ -1,10 +1,44 @@
 package spoon.testing.assertions;
+import java.util.List;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
+import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 public interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReference> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
 	default AbstractStringAssert<?> getSimpleName() {
 		return Assertions.assertThat(actual().getSimpleName());
+	}
+
+	default CtElementAssert getDeclaration() {
+		return new CtElementAssert(actual().getDeclaration());
+	}
+
+	/**
+	 * Asserts that the {@link CtReferenceAssertInterface#actual()} reference resolves to the given potential declarations in that order.
+	 * <p>
+	 * The resolution in {@code CtLocalVariableReference#getDeclaration()} will choose the first declaration that matches.
+	 * For testing the variable resolution ({@link PotentialVariableDeclarationFunction}) and noticing potential mistakes
+	 * like duplicate variable declarations, it is useful to be able to assert what all potential declarations, including the ones
+	 * that are hidden by other declarations resolve to.
+	 *
+	 * @param potentialDeclarations
+	 * 		the potential declarations that the reference could resolve to, in the order they would be resolved
+	 */
+	default CtReferenceAssertInterface<? extends A, ? extends W> hasExactlyPotentialDeclarations(CtVariable<?>... potentialDeclarations) {
+		// TODO: Is this method okay here? It is technically only necessary to test the getDeclaration() resolution of a LocalVariableReference,
+		// but given that this is done in multiple test classes, I don't know where this should be placed?
+		//
+		// TODO: Open for name suggestions
+		List<CtVariable<?>> declarations = actual().map(new PotentialVariableDeclarationFunction(actual().getSimpleName())).list();
+		// By default, the containsExactly assertion checks with equals or compareTo.
+		// A declaration `String i` and an unrelated `String i` are considered equal.
+		// Given that the potential declarations will all have the same name it is important to check
+		// that they are not only equal, but the same object through ==
+		//
+		// We are not sorting, so the else should be fine.
+		Assertions.assertThat(declarations).as("Potential declarations of variable <%s>", actual()).usingElementComparator((a, b) -> a == b ? 0 : Integer.compare(System.identityHashCode(a), System.identityHashCode(b))).containsExactly(potentialDeclarations);
+		return this;
 	}
 }

--- a/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
@@ -1,6 +1,7 @@
 package spoon.testing.assertions;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Function;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtReferenceAssertInterface.java
@@ -1,9 +1,11 @@
 package spoon.testing.assertions;
+import java.util.Comparator;
 import java.util.List;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.assertj.core.api.Assertions;
 import spoon.reflect.declaration.CtVariable;
+import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtReference;
 import spoon.reflect.visitor.filter.PotentialVariableDeclarationFunction;
 public interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>, W extends CtReference> extends CtElementAssertInterface<A, W> , SpoonAssert<A, W> {
@@ -27,18 +29,20 @@ public interface CtReferenceAssertInterface<A extends AbstractObjectAssert<A, W>
 	 * 		the potential declarations that the reference could resolve to, in the order they would be resolved
 	 */
 	default CtReferenceAssertInterface<? extends A, ? extends W> hasExactlyPotentialDeclarations(CtVariable<?>... potentialDeclarations) {
-		// TODO: Is this method okay here? It is technically only necessary to test the getDeclaration() resolution of a LocalVariableReference,
-		// but given that this is done in multiple test classes, I don't know where this should be placed?
-		//
-		// TODO: Open for name suggestions
-		List<CtVariable<?>> declarations = actual().map(new PotentialVariableDeclarationFunction(actual().getSimpleName())).list();
+		List<CtVariable<?>> declarations;
+		if (actual() instanceof CtFieldReference<?> ctFieldReference) {
+			// If necessary, this can be extended to resolve hidden variables from super types as well
+			declarations = List.of(ctFieldReference.getFieldDeclaration());
+		} else {
+			declarations = actual().map(new PotentialVariableDeclarationFunction(actual().getSimpleName())).list();
+		}
 		// By default, the containsExactly assertion checks with equals or compareTo.
 		// A declaration `String i` and an unrelated `String i` are considered equal.
 		// Given that the potential declarations will all have the same name it is important to check
-		// that they are not only equal, but the same object through ==
+		// that they are not only equal, but the same object through ==.
 		//
-		// We are not sorting, so the else should be fine.
-		Assertions.assertThat(declarations).as("Potential declarations of variable <%s>", actual()).usingElementComparator((a, b) -> a == b ? 0 : Integer.compare(System.identityHashCode(a), System.identityHashCode(b))).containsExactly(potentialDeclarations);
+		// The code expects a comparator, so we are using the identity hash code (= pointer value) for the comparison.
+		Assertions.assertThat(declarations).as("Potential declarations of variable <%s>", actual()).usingElementComparator(Comparator.comparing(System::identityHashCode)).containsExactly(potentialDeclarations);
 		return this;
 	}
 }

--- a/src/test/java/spoon/testing/assertions/CtTypeReferenceAssertInterface.java
+++ b/src/test/java/spoon/testing/assertions/CtTypeReferenceAssertInterface.java
@@ -30,4 +30,9 @@ public interface CtTypeReferenceAssertInterface<A extends AbstractObjectAssert<A
 	default CtTypeReferenceAssertInterface<?, ?> getSuperclass() {
 		return SpoonAssertions.assertThat(actual().getSuperclass());
 	}
+
+	default CtTypeReferenceAssertInterface<?, ?> isEqualTo(Class<?> type) {
+		Assertions.assertThat(actual().getFactory().Type().get(type).getReference()).isEqualTo(actual());
+		return this;
+	}
 }


### PR DESCRIPTION
I have not looked at the JLS, so I might have missed something.

The code in the `SiblingsFunction` introduced in #6444 has been removed, because I think it does not belong there? Seems wrong to return the instanceof variables there.