### PR TITLE
Fix: Anonymous class names

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -101,11 +101,26 @@ public class JDTTreeBuilderHelper {
 	 *
 	 * @param anonymousQualifiedName
 	 * 		Qualified name which contains the anonymous name.
+	 * @param sourceName
+	 * 		The source name.
 	 * @return Anonymous simple name.
 	 */
-	static String computeAnonymousName(char[] anonymousQualifiedName) {
+	static String computeAnonymousName(char[] anonymousQualifiedName, char[] sourceName) {
+		/*
+		 * Case 1: Anonymous inner class such as
+		 * class A { void m() { new Runnable() { public void run() {} } } }
+		 * For the anonymous class that implements Runnable, anonymousQualifiedName is "A$1", and sourceName is "".
+		 *
+		 * Case 2: Non-anonymous inner class such as
+		 * class A { void m() { class B$1 {} } }
+		 * For class B$1, anonymousQualifiedName is "A$1B$1", and sourceName is "B$1".
+		 */
+		int idx = anonymousQualifiedName.length - sourceName.length - 1;
+		while (idx >= 0 && Character.isDigit(anonymousQualifiedName[idx])) {
+			idx--;
+		}
 		final String poolName = CharOperation.charToString(anonymousQualifiedName);
-		return poolName.substring(poolName.lastIndexOf(CtType.INNERTTYPE_SEPARATOR) + 1);
+		return poolName.substring(idx + 1);
 	}
 
 	/**
@@ -863,7 +878,7 @@ public class JDTTreeBuilderHelper {
 		if ((type instanceof CtClass || type instanceof CtInterface)
 				&& typeDeclaration.binding != null
 				&& (typeDeclaration.binding.isAnonymousType() || typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null)) {
-			type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName()));
+			type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName(), typeDeclaration.binding.sourceName));
 		} else {
 			type.setSimpleName(new String(typeDeclaration.name));
 		}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -98,7 +98,7 @@ public class JDTTreeBuilderHelper {
 	}
 
 	/**
-	 * Computes the anonymous simple name of the specified type..
+	 * Computes the anonymous simple name of the specified type.
 	 *
 	 * @param binding the binding for the type.
 	 * @return Anonymous simple name.

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
+import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.VariableBinding;
@@ -97,31 +98,22 @@ public class JDTTreeBuilderHelper {
 	}
 
 	/**
-	 * Computes the anonymous simple name from its fully qualified type name.
+	 * Computes the anonymous simple name of the specified type..
 	 *
-	 * @param anonymousQualifiedName
-	 * 		Qualified name which contains the anonymous name.
-	 * @param sourceName
-	 * 		The source name.
+	 * @param binding the binding for the type.
 	 * @return Anonymous simple name.
 	 */
-	static String computeAnonymousName(char[] anonymousQualifiedName, char[] sourceName) {
+	static String computeAnonymousName(SourceTypeBinding binding) {
 		/*
 		 * Case 1: Anonymous inner class such as
 		 * class A { void m() { new Runnable() { public void run() {} } } }
-		 * For the anonymous class that implements Runnable, anonymousQualifiedName is "A$1", and sourceName is "".
 		 *
 		 * Case 2: Non-anonymous inner class such as
 		 * class A { void m() { class B$1 {} } }
-		 * For class B$1, anonymousQualifiedName is "A$1B$1", and sourceName is "B$1".
 		 */
-		int idx = anonymousQualifiedName.length - sourceName.length - 1;
-		while (idx >= 0 && Character.isDigit(anonymousQualifiedName[idx])) {
-			idx--;
-		}
-		final String poolName = CharOperation.charToString(anonymousQualifiedName);
-		return poolName.substring(idx + 1);
-	}
+		char[] name = binding.constantPoolName();
+		int n = binding.enclosingType().constantPoolName().length + 1;
+		return new String(name, n, name.length - n);	}
 
 	/**
 	 * Creates a qualified type name from a two-dimensional array.
@@ -878,7 +870,7 @@ public class JDTTreeBuilderHelper {
 		if ((type instanceof CtClass || type instanceof CtInterface)
 				&& typeDeclaration.binding != null
 				&& (typeDeclaration.binding.isAnonymousType() || typeDeclaration.binding instanceof LocalTypeBinding && typeDeclaration.binding.enclosingMethod() != null)) {
-			type.setSimpleName(computeAnonymousName(typeDeclaration.binding.constantPoolName(), typeDeclaration.binding.sourceName));
+			type.setSimpleName(computeAnonymousName(typeDeclaration.binding));
 		} else {
 			type.setSimpleName(new String(typeDeclaration.name));
 		}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -113,7 +113,8 @@ public class JDTTreeBuilderHelper {
 		 */
 		char[] name = binding.constantPoolName();
 		int n = binding.enclosingType().constantPoolName().length + 1;
-		return new String(name, n, name.length - n);	}
+		return new String(name, n, name.length - n);
+	}
 
 	/**
 	 * Creates a qualified type name from a two-dimensional array.

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1185,14 +1185,14 @@ public class ReferenceBuilder {
 	private CtTypeReference<?> getTypeReferenceFromLocalTypeBinding(LocalTypeBinding binding) {
 		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 		if (binding.isAnonymousType()) {
-			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding));
 			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 		} else {
 			ref.setSimpleName(new String(binding.sourceName()));
 			if (binding.enclosingMethod == null && binding.enclosingType() != null && binding.enclosingType() instanceof LocalTypeBinding) {
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 			} else if (binding.enclosingMethod() != null) {
-				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
+				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding));
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 			}
 		}
@@ -1203,7 +1203,7 @@ public class ReferenceBuilder {
 	private CtTypeReference<?> getTypeReferenceFromSourceTypeBinding(SourceTypeBinding binding) {
 		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 		if (binding.isAnonymousType()) {
-			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding));
 			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 		} else {
 			ref.setSimpleName(new String(binding.sourceName()));

--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1185,14 +1185,14 @@ public class ReferenceBuilder {
 	private CtTypeReference<?> getTypeReferenceFromLocalTypeBinding(LocalTypeBinding binding) {
 		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 		if (binding.isAnonymousType()) {
-			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
 			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 		} else {
 			ref.setSimpleName(new String(binding.sourceName()));
 			if (binding.enclosingMethod == null && binding.enclosingType() != null && binding.enclosingType() instanceof LocalTypeBinding) {
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 			} else if (binding.enclosingMethod() != null) {
-				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+				ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
 				ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 			}
 		}
@@ -1203,7 +1203,7 @@ public class ReferenceBuilder {
 	private CtTypeReference<?> getTypeReferenceFromSourceTypeBinding(SourceTypeBinding binding) {
 		CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeReference();
 		if (binding.isAnonymousType()) {
-			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName()));
+			ref.setSimpleName(JDTTreeBuilderHelper.computeAnonymousName(binding.constantPoolName(), binding.sourceName));
 			ref.setDeclaringType(getTypeReference(binding.enclosingType()));
 		} else {
 			ref.setSimpleName(new String(binding.sourceName()));

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -474,4 +474,55 @@ public class CtClassTest {
 				final java.lang.String message = "Hello, World!";
 				""");
 	}
+
+	@ModelTest(value = "src/test/resources/ctClass/DollarSignInInnerClassName.java")
+	@ExtendWith(LineSeparatorExtension.class)
+	void testDollarSignInInnerClassName(@BySimpleName("DollarSignInInnerClassName") CtClass<?> cl) {
+		// contract: the $ sign in an inner class name is supported
+		assertThat(cl).getMethods().hasSize(1);
+		assertThat(cl.getMethod("m")).getBody().getStatements().hasSize(2);
+		CtMethod<?> m = cl.getMethod("m");
+		assertThat(m).getBody().getStatements().hasSize(2);
+		CtStatement stat0 = m.getBody().getStatements().get(0);
+		CtStatement stat1 = m.getBody().getStatements().get(1);
+		assertThat(stat0).isInstanceOf(CtClass.class);
+		assertThat(stat1).isInstanceOf(CtClass.class);
+		CtClass<?> b = (CtClass<?>) stat0;
+		CtClass<?> c = (CtClass<?>) stat1;
+		assertThat(b).getSimpleName().isEqualTo("1B$1");
+		assertThat(c).getSimpleName().isEqualTo("1C$42");
+		assertThat(c).getMethods().hasSize(1);
+		CtMethod<?> n = c.getMethod("n");
+		assertThat(n).getBody().getStatements().hasSize(1);
+		CtStatement stat2 = n.getBody().getStatements().get(0);
+		assertThat(stat2).isInstanceOf(CtClass.class);
+		CtClass<?> d = (CtClass<?>) stat2;
+		assertThat(d).getSimpleName().isEqualTo("1D$1");
+
+		org.assertj.core.api.Assertions.assertThat(cl.toString()).isEqualTo(
+			"""
+			class DollarSignInInnerClassName {
+			    void m() {
+			        class B$1 {}
+			        class C$42 {
+			            void n() {
+			                class D$1 {}
+			            }
+			        }
+			    }
+			}"""
+		);
+	}
+
+	@ModelTest(value = "src/test/resources/ctClass/ClassWith10InnerClasses.java")
+	void testClassWith10InnerClasses(@BySimpleName("ClassWith10InnerClasses")  CtClass<?> cl) {
+		// contract: inner class names in classes with 10 or more inner classes are supported
+		assertThat(cl).getMethods().hasSize(10);
+		CtMethod<?> m10 = cl.getMethod("m10");
+		assertThat(m10).getBody().getStatements().hasSize(1);
+		CtStatement stat = m10.getBody().getStatements().get(0);
+		assertThat(stat).isInstanceOf(CtClass.class);
+		CtClass<?> b = (CtClass<?>) stat;
+		assertThat(b).getSimpleName().isEqualTo("10B");
+	}
 }

--- a/src/test/java/spoon/test/ctClass/CtClassTest.java
+++ b/src/test/java/spoon/test/ctClass/CtClassTest.java
@@ -480,7 +480,6 @@ public class CtClassTest {
 	void testDollarSignInInnerClassName(@BySimpleName("DollarSignInInnerClassName") CtClass<?> cl) {
 		// contract: the $ sign in an inner class name is supported
 		assertThat(cl).getMethods().hasSize(1);
-		assertThat(cl.getMethod("m")).getBody().getStatements().hasSize(2);
 		CtMethod<?> m = cl.getMethod("m");
 		assertThat(m).getBody().getStatements().hasSize(2);
 		CtStatement stat0 = m.getBody().getStatements().get(0);

--- a/src/test/resources/ctClass/ClassWith10InnerClasses.java
+++ b/src/test/resources/ctClass/ClassWith10InnerClasses.java
@@ -1,0 +1,32 @@
+class ClassWith10InnerClasses {
+	void m1() {
+		class B {}
+	}
+	void m2() {
+		class B {}
+	}
+	void m3() {
+		class B {}
+	}
+	void m4() {
+		class B {}
+	}
+	void m5() {
+		class B {}
+	}
+	void m6() {
+		class B {}
+	}
+	void m7() {
+		class B {}
+	}
+	void m8() {
+		class B {}
+	}
+	void m9() {
+		class B {}
+	}
+	void m10() {
+		class B {}
+	}
+}

--- a/src/test/resources/ctClass/DollarSignInInnerClassName.java
+++ b/src/test/resources/ctClass/DollarSignInInnerClassName.java
@@ -1,0 +1,10 @@
+class DollarSignInInnerClassName {
+    void m() {
+        class B$1 {}
+        class C$42 {
+            void n() {
+                class D$1 {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a fix for:

- inner class names that contains the $ sign,
- classes with 10 or more inner classes.

Both cases are dealt with by fixing method https://github.com/INRIA/spoon/blob/2ecfe9d52519ad52263ea0d2534fa07134fe1966/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java#L106

An example of an inner class whose name contains the $ sign follows:

`class A { void m() { class B$1 {} }}
`

The qualified name of the inner class is:
- the source name of the outer class,
- followed by the $ sign,
- followed by the index (starting at value 1) of the inner class in the outer class,
- the source name of the inner class.

In the example, the qualified name of class B$1 is A$1B$1, and the contract of the computeAnonymousName method leads to return 1B$1.

~~For that, the computeAnonymousName method reversely iterates over anonymousQualifiedName:~~
~~- starting by skipping the trailing sourceName (in the example B$1),~~
~~- as long as digits are encountered in anonymousQualifiedName,~~
~~and returns the substring starting at the index of the first digit.~~
