### PR TITLE
Fix: Ensure refs in record canonical constructor resolve correctly and fix factory method creating broken variable writes

### DIFF
--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -436,9 +436,9 @@ public class CodeFactory extends SubFactory {
 			// creates a this target for non-static fields to avoid name conflicts...
 			if (!isStatic) {
 				// We do not want to change the parent of the declaring type, so clone here
-				CtTypeReference<T> declaringTypeRef = null;
+				CtTypeReference<?> declaringTypeRef = null;
 				if (ctFieldReference.getDeclaringType() != null) {
-					declaringTypeRef = (CtTypeReference<T>) ctFieldReference.getDeclaringType().clone();
+					declaringTypeRef = ctFieldReference.getDeclaringType().clone();
 				}
 
 				((CtFieldAccess<T>) va).setTarget(createThisAccess(declaringTypeRef));
@@ -466,7 +466,6 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a variable access for write.
 	 */
-	@SuppressWarnings("unchecked")
 	public <T> CtVariableAccess<T> createVariableWrite(CtVariableReference<T> variable, boolean isStatic) {
 		CtVariableAccess<T> va;
 		if (variable instanceof CtFieldReference<T> ctFieldReference) {
@@ -474,9 +473,9 @@ public class CodeFactory extends SubFactory {
 			// creates a this target for non-static fields to avoid name conflicts...
 			if (!isStatic) {
 				// We do not want to change the parent of the declaring type, so clone here
-				CtTypeReference<T> declaringTypeRef = null;
+				CtTypeReference<?> declaringTypeRef = null;
 				if (ctFieldReference.getDeclaringType() != null) {
-					declaringTypeRef = (CtTypeReference<T>) ctFieldReference.getDeclaringType().clone();
+					declaringTypeRef = ctFieldReference.getDeclaringType().clone();
 				}
 
 				((CtFieldAccess<T>) va).setTarget(createThisAccess(declaringTypeRef));

--- a/src/main/java/spoon/reflect/factory/CodeFactory.java
+++ b/src/main/java/spoon/reflect/factory/CodeFactory.java
@@ -431,14 +431,17 @@ public class CodeFactory extends SubFactory {
 	 */
 	public <T> CtVariableAccess<T> createVariableRead(CtVariableReference<T> variable, boolean isStatic) {
 		CtVariableAccess<T> va;
-		if (variable instanceof CtFieldReference) {
+		if (variable instanceof CtFieldReference<T> ctFieldReference) {
 			va = factory.Core().createFieldRead();
 			// creates a this target for non-static fields to avoid name conflicts...
 			if (!isStatic) {
 				// We do not want to change the parent of the declaring type, so clone here
-				((CtFieldAccess<T>) va).setTarget(
-					createThisAccess(((CtFieldReference<T>) variable).getDeclaringType().clone())
-				);
+				CtTypeReference<T> declaringTypeRef = null;
+				if (ctFieldReference.getDeclaringType() != null) {
+					declaringTypeRef = (CtTypeReference<T>) ctFieldReference.getDeclaringType().clone();
+				}
+
+				((CtFieldAccess<T>) va).setTarget(createThisAccess(declaringTypeRef));
 			}
 		} else {
 			va = factory.Core().createVariableRead();
@@ -463,13 +466,20 @@ public class CodeFactory extends SubFactory {
 	/**
 	 * Creates a variable access for write.
 	 */
+	@SuppressWarnings("unchecked")
 	public <T> CtVariableAccess<T> createVariableWrite(CtVariableReference<T> variable, boolean isStatic) {
 		CtVariableAccess<T> va;
-		if (variable instanceof CtFieldReference) {
+		if (variable instanceof CtFieldReference<T> ctFieldReference) {
 			va = factory.Core().createFieldWrite();
 			// creates a this target for non-static fields to avoid name conflicts...
 			if (!isStatic) {
-				((CtFieldAccess<T>) va).setTarget(createThisAccess(((CtFieldReference<T>) variable).getDeclaringType()));
+				// We do not want to change the parent of the declaring type, so clone here
+				CtTypeReference<T> declaringTypeRef = null;
+				if (ctFieldReference.getDeclaringType() != null) {
+					declaringTypeRef = (CtTypeReference<T>) ctFieldReference.getDeclaringType().clone();
+				}
+
+				((CtFieldAccess<T>) va).setTarget(createThisAccess(declaringTypeRef));
 			}
 		} else {
 			va = factory.Core().createVariableWrite();

--- a/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtRecordImpl.java
@@ -22,9 +22,6 @@ import java.util.Set;
 import org.jspecify.annotations.Nullable;
 import spoon.JLSViolation;
 import spoon.reflect.annotations.MetamodelPropertyField;
-import spoon.reflect.code.CtAssignment;
-import spoon.reflect.code.CtBlock;
-import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtConstructor;
@@ -40,10 +37,10 @@ import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.CtTypedElement;
 import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
-import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.reference.CtVariableReference;
 import spoon.reflect.visitor.CtVisitor;
+import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 import spoon.support.reflect.CtExtendedModifier;
@@ -101,48 +98,58 @@ public class CtRecordImpl extends CtClassImpl<Object> implements CtRecord {
 	}
 
 	@Override
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	public CtRecord createCanonicalConstructorIfMissing() {
-
 		CtTypeReference<?>[] typeReferences =
 			getRecordComponents().stream()
 				.map(CtTypedElement::getType)
 				.toList().toArray(new CtTypeReference[0]);
 
-		// If a canonical constructor is not already present, adds one
+		// Nothing to do if the canonical constructor is already defined:
 		CtConstructor<?> constructor = getConstructor(typeReferences);
-		if (constructor == null) {
-			CtConstructor<?> canonical = getFactory().createConstructor();
-			canonical.setImplicit(true);
-			// Set the same visibility as the one of the record
-			if (hasModifier(ModifierKind.PUBLIC)) {
-				canonical.setExtendedModifiers(Set.of(CtExtendedModifier.implicit(ModifierKind.PUBLIC)));
-			} else if (hasModifier(ModifierKind.PROTECTED)) {
-				canonical.setExtendedModifiers(Set.of(CtExtendedModifier.implicit(ModifierKind.PROTECTED)));
-			} else if (hasModifier(ModifierKind.PRIVATE)) {
-				canonical.setExtendedModifiers(Set.of(CtExtendedModifier.implicit(ModifierKind.PRIVATE)));
-			}
-			CtBlock<?> body = getFactory().createBlock();
-			for (CtField<?> field: getFields()) {
-				if (field.isImplicit()) {
-					CtParameter<?> parameter = getFactory().createParameter();
-					CtTypeReference<?> type = getClonedType(field.getType());
-					parameter.setType(type);
-					parameter.setSimpleName(field.getSimpleName());
-					canonical.addParameter(parameter);
-					CtFieldReference<?> fieldReference = getFactory().createFieldReference();
-					fieldReference.setSimpleName(field.getSimpleName());
-					fieldReference.setType(getClonedType(field.getType()));
-					CtVariableAccess<?> write = getFactory().Code().createVariableWrite(fieldReference, false);
-					CtVariableReference<?> writeRef = write.getVariable();
-					CtVariableAccess<?> read = getFactory().Code().createVariableRead(parameter.getReference(), false);
-					@SuppressWarnings({"rawtypes", "unchecked"})
-					CtAssignment<?, ?> assignment = getFactory().Code().createVariableAssignment((CtVariableReference) writeRef, false, read);
-					body.addStatement(assignment);
-				}
-			}
-			canonical.setBody(body);
-			addTypeMember(canonical);
+		if (constructor != null) {
+			return this;
 		}
+
+		CtConstructor<?> canonical = getFactory().createConstructor();
+		canonical.setImplicit(true);
+		canonical.setBody(getFactory().createBlock());
+
+		// Set the same visibility as the one of the record
+		for (var modifier : List.of(ModifierKind.PUBLIC, ModifierKind.PROTECTED, ModifierKind.PRIVATE)) {
+			if (this.hasModifier(modifier)) {
+				canonical.setExtendedModifiers(Set.of(CtExtendedModifier.implicit(modifier)));
+				break;
+			}
+		}
+
+		// For the constructor we have:
+		// Constructor(Type1 field1, Type2 field2, ...) {
+		//     this.field1 = field1;
+		//     this.field2 = field2;
+		//     ...
+		// }
+		//
+		// For this we have to generate for each field a parameter, and an assignment to that field.
+		for (CtField<?> field : getFields()) {
+			if (!field.isImplicit()) {
+				continue;
+			}
+
+			// The factory method will automatically add the new parameter to canonical
+			var parameter = getFactory().Executable().createParameter(canonical, getClonedType(field.getType()), field.getSimpleName());
+
+			canonical.getBody().addStatement(getFactory().Code().createVariableAssignment(
+				(CtVariableReference) getFactory().Field().createReference(field),
+				false,
+				getFactory().Code().createVariableRead(parameter.getReference(), false)
+			));
+		}
+
+		// The entire constructor does not exist in the source, therefore all children are marked as implicit:
+		canonical.filterChildren(new TypeFilter<>(CtElement.class)).forEach((CtElement ctElement) -> ctElement.setImplicit(true));
+
+		addTypeMember(canonical);
 
 		return this;
 	}

--- a/src/test/java/spoon/test/record/CtRecordTest.java
+++ b/src/test/java/spoon/test/record/CtRecordTest.java
@@ -20,7 +20,9 @@ import org.assertj.core.api.InstanceOfAssertFactory;
 import org.junit.jupiter.api.Test;
 import spoon.Launcher;
 import spoon.reflect.CtModel;
+import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.code.CtReturn;
 import spoon.reflect.code.CtStatement;
 import spoon.reflect.declaration.CtAnonymousExecutable;
@@ -37,6 +39,7 @@ import spoon.reflect.factory.Factory;
 import spoon.reflect.visitor.CtScanner;
 import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.testing.assertions.SpoonAssertions;
+import spoon.testing.utils.BySimpleName;
 import spoon.testing.utils.ModelTest;
 
 public class CtRecordTest {
@@ -362,6 +365,30 @@ public class CtRecordTest {
 		assertThat(record.getFields())
 			.map(CtField::getSimpleName)
 			.containsExactly("first", "second");
+	}
+
+	@ModelTest(code = "record Point(int x, int y) {}", complianceLevel = 17)
+	void testCanonicalConstructorFieldReferenceResolves(@BySimpleName("Point") CtClass<?> ctClass) {
+		// contract: field writes in the generated constructor resolve to the record fields
+		assertThat(ctClass.getConstructors()).hasSize(1);
+
+		var constructor = ctClass.getConstructors().iterator().next();
+
+		for (var statement : constructor.getBody().getStatements()) {
+			if (!(statement instanceof CtAssignment<?,?> ctAssignment)) {
+				continue;
+			}
+
+			var fieldRef = assertThat(ctAssignment.getAssigned())
+				.isInstanceOf(CtFieldWrite.class)
+				.extracting(write -> (CtFieldWrite<?>) write)
+				.extracting(CtFieldWrite::getVariable)
+				.actual();
+
+			var actualField = assertThat(ctClass.getField(fieldRef.getSimpleName())).isNotNull().actual();
+
+			assertThat(fieldRef.getFieldDeclaration()).isSameAs(actualField);
+		}
 	}
 
 	private <T> T head(Collection<T> collection) {


### PR DESCRIPTION
This is a regression introduced by #6572.

While fixing it, I noticed that the factory method did not behave correctly (caught by my new record test in combination with the model test integrity check), so I fixed that as well.

In addition to that, I went ahead and cleaned up the code.

Regarding the setting of implicit:

If I remember correctly, anything not in the actual source code is supposed to be implicit, so I added some code that marks all generated elements as implicit.