### PR TITLE
Fix #6702: NPE in getEndColumn for VirtualFile with newlines

### DIFF
--- a/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
+++ b/src/main/java/spoon/support/reflect/cu/position/SourcePositionImpl.java
@@ -83,9 +83,11 @@ public class SourcePositionImpl implements SourcePosition {
 		if (getCompilationUnit() != null) {
 			tabSize = getCompilationUnit().getFactory().getEnvironment().getTabulationSize();
 			String source = getCompilationUnit().getOriginalSourceCode();
-			for (int j = lineSeparatorPositions[i]; j < position; j++) {
-				if (source.charAt(j) == '\t') {
-					tabCount++;
+			if (source != null) {
+				for (int j = lineSeparatorPositions[i]; j < position; j++) {
+					if (source.charAt(j) == '\t') {
+						tabCount++;
+					}
 				}
 			}
 		}

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1445,8 +1445,8 @@ public class PositionTest {
 
 		CtCompilationUnit cu = launcher.getFactory().CompilationUnit().getMap().values().iterator().next();
 		assertTrue(cu.getPosition().isValidPosition());
-		// should not throw NPE
-		cu.getPosition().getEndColumn();
+		int endColumn = assertDoesNotThrow(() -> cu.getPosition().getEndColumn());
+		assertTrue(endColumn > 0, "getEndColumn should return a positive column");
 	}
 
 	@Test

--- a/src/test/java/spoon/test/position/PositionTest.java
+++ b/src/test/java/spoon/test/position/PositionTest.java
@@ -1436,6 +1436,20 @@ public class PositionTest {
 	}
 
 	@Test
+	public void testGetEndColumnWithVirtualFileContainingNewlines() {
+		// contract: getEndColumn() should not throw NPE when using VirtualFile with newlines
+		final Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("class Source {\n// comment\n}", "x/y/z/Source.java"));
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.buildModel();
+
+		CtCompilationUnit cu = launcher.getFactory().CompilationUnit().getMap().values().iterator().next();
+		assertTrue(cu.getPosition().isValidPosition());
+		// should not throw NPE
+		cu.getPosition().getEndColumn();
+	}
+
+	@Test
 	public void testLambdaParameterPosition() {
 		// contract: position of lambda parameter is correct
 		final Factory build = build(new File("src/test/java/spoon/test/position/testclasses/FooLambda.java"));


### PR DESCRIPTION
Fixes #6702

`getOriginalSourceCode()` returns null for `VirtualFile` that contains newlines, so the loop in `searchColumnNumber()` hits NPE. Added a null check around the source access and a small regression test using `VirtualFile` with newlines. Tab counting just gets skipped when source isn't available, columns will be slightly off in that case but no crash.
