### PR TITLE
fix: allow package-info and module-info as valid identifiers

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -176,7 +176,9 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 	private static boolean isSpecialType(String identifier) {
 		return identifier.isEmpty()
 				|| "?".equals(identifier) // is wildcard, used for intersection types
-				|| (identifier.startsWith("<") && identifier.endsWith(">"));
+				|| (identifier.startsWith("<") && identifier.endsWith(">"))
+				|| "package-info".equals(identifier)
+				|| "module-info".equals(identifier);
 	}
 
 	/**

--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -205,6 +205,21 @@ public class PackageTest {
 		});
 	}
 
+	@Test
+	@GitHubIssue(issueNumber = 6707, fixed = true)
+	public void testPackageInfoWithFullyQualifiedAnnotationNoclasspath() {
+		// package-info.java with fully-qualified annotation refs should not throw JLSViolation
+		assertDoesNotThrow(() -> {
+			Launcher launcher = new Launcher();
+			launcher.addInputResource("src/test/resources/noclasspath/package-info-fqn");
+			launcher.getEnvironment().setNoClasspath(true);
+			launcher.getEnvironment().setSourceClasspath(new String[0]);
+			launcher.getEnvironment().setCommentEnabled(false);
+			launcher.getEnvironment().setComplianceLevel(17);
+			launcher.buildModel();
+		});
+	}
+
 	@ModelTest("./src/test/java/spoon/test/pkg/testclasses/Foo.java")
 	public void testRenamePackageAndPrettyPrint(CtModel model, Launcher launcher, Factory factory) {
 		CtPackage ctPackage = model.getElements(new NamedElementFilter<>(CtPackage.class, "spoon")).get(0);

--- a/src/test/resources/noclasspath/package-info-fqn/demo/pudong/package-info.java
+++ b/src/test/resources/noclasspath/package-info-fqn/demo/pudong/package-info.java
@@ -1,0 +1,11 @@
+@javax.xml.bind.annotation.XmlSchema(
+    namespace = "http://www.example.com/schema",
+    xmlns = {
+        @javax.xml.bind.annotation.XmlNs(
+            prefix = "",
+            namespaceURI = "http://www.example.com/schema"
+        )
+    },
+    elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED
+)
+package demo.pudong;


### PR DESCRIPTION
Fixes #6707

`package-info.java` with fully qualified annotations (like `@javax.xml.bind.annotation.XmlSchema`) was throwing a JLSViolation because `package-info` isn't a valid Java identifier. Same issue would happen with `module-info`. Added both to the special type check so the validation skips them.