### PR TITLE
test: cover DeclarationNode.toString

### DIFF
--- a/src/test/java/spoon/support/adaption/DeclarationNodeTest.java
+++ b/src/test/java/spoon/support/adaption/DeclarationNodeTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
+ *
+ * Copyright (C) 2006-2023 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) or the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.support.adaption;
+
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtTypeReference;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DeclarationNodeTest {
+
+	@Test
+	void testToStringContainsQualifiedName() {
+		// contract: DeclarationNode.toString() includes the qualified name of the induced type
+		Factory factory = new Launcher().getFactory();
+		CtTypeReference<?> listRef = factory.Type().createReference(List.class);
+
+		DeclarationNode node = new DeclarationNode(listRef);
+		String result = node.toString();
+
+		assertTrue(result.contains("java.util.List"), "toString() should contain the qualified name");
+		assertTrue(result.startsWith("{"), "toString() should start with '{'");
+		assertTrue(result.endsWith("}"), "toString() should end with '}'");
+		// No children: the result should not contain the children section marker "  [\n"
+		assertFalse(result.contains("  [\n"), "toString() without children should not contain children section");
+	}
+
+	@Test
+	void testToStringWithChildren() {
+		// contract: DeclarationNode.toString() includes children when present
+		Factory factory = new Launcher().getFactory();
+		CtTypeReference<?> listRef = factory.Type().createReference(List.class);
+		CtTypeReference<?> arrayListRef = factory.Type().createReference(java.util.ArrayList.class);
+
+		DeclarationNode declarationNode = new DeclarationNode(listRef);
+		GlueNode glueChild = new GlueNode(arrayListRef);
+		declarationNode.addChild(glueChild);
+
+		String result = declarationNode.toString();
+
+		assertTrue(result.contains("java.util.List"), "toString() should contain the qualified name of the declaration node");
+		assertTrue(result.contains("java.util.ArrayList"), "toString() with children should contain the child's qualified name");
+		assertTrue(result.contains("["), "toString() with children should contain '['");
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `DeclarationNodeTest` (package `spoon.support.adaption`) with 2 tests covering `DeclarationNode.toString` (72 missed instructions per JaCoCo)
- Tests the leaf case (no children) and the tree case (with a `GlueNode` child), asserting qualified name presence and the children section marker

## Test plan

- [ ] `mvn test -Dtest=DeclarationNodeTest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)