### PR TITLE
fix: do not crash on qualified generic types with unresolved arguments in noclasspath mode

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -649,6 +649,13 @@ public class JDTTreeBuilderHelper {
 						//keep it explicit
 						return;
 					}
+					if (packageNames != null && packageNames.length != off) {
+						/*
+						 * In no classpath mode, unresolved generic arguments can make JDT treat a declaring type as part of
+						 * the package. The package tokens cannot be aligned reliably, so keep the reference explicit.
+						 */
+						return;
+					}
 					throw new SpoonException("Unexpected QualifiedNameReference tokens " + qualifiedNameReference + " for typeRef: " + originTypeRef);
 				}
 			}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -649,10 +649,11 @@ public class JDTTreeBuilderHelper {
 						//keep it explicit
 						return;
 					}
-					if (packageNames != null) {
+					if (packageNames != null && packageNames.length > off) {
 						/*
-						 * In no classpath mode, unresolved generic arguments can make JDT treat a declaring type as part of
-						 * the package. The package tokens cannot be aligned reliably, so keep the reference explicit.
+						 * In no-classpath mode, unresolved generic type arguments cause JDT to fold the declaring type
+						 * into the package binding's compound name, making it longer than the remaining token count.
+						 * This mismatch is expected; keep the reference explicit rather than treating it as an error.
 						 */
 						return;
 					}

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -649,7 +649,7 @@ public class JDTTreeBuilderHelper {
 						//keep it explicit
 						return;
 					}
-					if (packageNames != null && packageNames.length != off) {
+					if (packageNames != null) {
 						/*
 						 * In no classpath mode, unresolved generic arguments can make JDT treat a declaring type as part of
 						 * the package. The package tokens cannot be aligned reliably, so keep the reference explicit.

--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java
@@ -649,6 +649,12 @@ public class JDTTreeBuilderHelper {
 						//keep it explicit
 						return;
 					}
+					if (originTypeRef.getFactory().getEnvironment().getNoClasspath()
+							&& qualifiedNameReference instanceof QualifiedTypeReference qualifiedTypeReference
+							&& (qualifiedTypeReference.resolvedType.tagBits & TagBits.HasUnresolvedTypeVariables) != 0) {
+						// Unresolved generic arguments can leave the enclosing type modeled as part of the package.
+						return;
+					}
 					if (packageNames != null && packageNames.length > off) {
 						/*
 						 * In no-classpath mode, unresolved generic type arguments cause JDT to fold the declaring type

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -225,4 +225,28 @@ public class NoClasspathTest {
 			.nested(it -> it.satisfies(CtExecutableReference::isConstructor))
 			.nested(it -> it.getParameters().hasSize(1));
 	}
+
+	@GitHubIssue(issueNumber = 4077, fixed = true)
+	@ModelTest(code = """
+			import foo.A;
+			import foo.B;
+
+			class Example {
+				void method() {
+					java.util.AbstractMap.SimpleEntry<A, B> entry =
+						new java.util.AbstractMap.SimpleEntry<>(A.a, B.b);
+				}
+			}
+			""")
+	void testQualifiedGenericTypeWithIncompleteClasspath(CtModel model) {
+		// contract: qualified generic types with unresolved type arguments can be modeled in no classpath mode
+		var localVariable = model.getElements(new TypeFilter<>(CtLocalVariable.class)).get(0);
+		assertThat(localVariable.getType().getQualifiedName())
+			.isEqualTo("java.util.AbstractMap$SimpleEntry");
+		assertThat(localVariable.getType().isImplicit()).isFalse();
+
+		var constructorCall = (CtConstructorCall<?>) localVariable.getDefaultExpression();
+		assertThat(constructorCall.getExecutable().getDeclaringType().getQualifiedName())
+			.isEqualTo("java.util.AbstractMap.SimpleEntry");
+	}
 }


### PR DESCRIPTION
## Summary

Building a model in no-classpath mode no longer throws `SpoonException: Unexpected QualifiedNameReference tokens` when source code uses a qualified nested generic type whose type arguments cannot be resolved (for example `java.util.AbstractMap.SimpleEntry<A, B>` where `A` and `B` come from a missing dependency). `handleImplicit` in `src/main/java/spoon/support/compiler/jdt/JDTTreeBuilderHelper.java` now keeps the package reference explicit and returns when the package tokens cannot be aligned with the JDT binding, instead of falling through to the throw.

## Why this matters

No-classpath mode exists precisely for analyzing code whose dependencies are absent, and this crash aborts the whole model build on a single unresolvable reference. The root cause is that JDT, lacking the type arguments, treats the declaring type as part of the package, so the Spoon-side package reference and the JDT package binding token arrays disagree in length. That mismatch is expected in this mode and not an internal error, which is what the remaining throw treated it as.

## Testing

Added `testQualifiedGenericTypeWithIncompleteClasspath` to `src/test/java/spoon/test/api/NoClasspathTest.java` using the `@ModelTest` harness with unresolvable imports. It asserts the model builds, the local variable's type resolves to `java.util.AbstractMap$SimpleEntry`, and the constructor call keeps its source-form declaring type. The full `NoClasspathTest` class passes (7 tests) with the change.

Fixes #4077
