### PR TITLE
fix(noclasspath): model local classes in unresolved lambdas

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTTreeBuilder.java
@@ -1847,7 +1847,7 @@ public class JDTTreeBuilder extends ASTVisitor {
 
 	@Override
 	public boolean visit(TypeDeclaration localTypeDeclaration, BlockScope scope) {
-		if (localTypeDeclaration.binding == null) {
+		if (localTypeDeclaration.binding == null && localTypeDeclaration.allocation != null) {
 			// no classpath mode but JDT returns nothing. We create an empty class.
 			final CtType<?> t = factory.Core().createClass();
 			// we create a unique class name for this anonymous class

--- a/src/test/java/spoon/test/api/NoClasspathTest.java
+++ b/src/test/java/spoon/test/api/NoClasspathTest.java
@@ -177,6 +177,27 @@ public class NoClasspathTest {
 		spoon.buildModel();
 	}
 
+	@ModelTest(code = """
+		class Sample {
+			Object transform(Missing source) {
+				return source.call(value -> {
+					final class FlatMap implements Unknown {}
+					return new FlatMap();
+				});
+			}
+		}
+		""")
+	@GitHubIssue(issueNumber = 6793, fixed = true)
+	void testLocalClassInUnresolvedLambda(Factory factory) {
+		// contract: a local class inside a lambda is modeled when the callback type is unresolved
+		CtClass<?> sample = factory.Class().get("Sample");
+		List<CtClass<?>> localClasses = sample.getElements(new TypeFilter<>(CtClass.class));
+
+		assertThat(localClasses)
+			.extracting(CtClass::getSimpleName)
+			.contains("FlatMap");
+	}
+
 	@Test
 	public void testInheritanceInNoClassPathWithClasses() {
 		// contract: when using noclasspath in combination with a source classpath


### PR DESCRIPTION
## Summary

- distinguish named local classes from anonymous local classes when [Eclipse JDT](https://github.com/eclipse-jdt/eclipse.jdt.core) supplies no binding
- send named local declarations through the existing type builder instead of dereferencing a missing allocation
- cover an unresolved callback containing a local class in no-classpath mode

## Root cause

`JDTTreeBuilder.visit(TypeDeclaration, BlockScope)` treated every local declaration with a null binding as an anonymous class. For a named local class inside a lambda whose callback type is unresolved, [Eclipse JDT](https://github.com/eclipse-jdt/eclipse.jdt.core) supplies neither a binding nor an `allocation`, so the anonymous-class fallback dereferenced `allocation.type`.

## Validation

- `mvn -q -Dtest=spoon.test.api.NoClasspathTest test`
- `mvn -q verify` on Eclipse Temurin 21: 4,460 tests, 0 failures, 0 errors
- the regression failed on `5db5c5565` with the reported `JDTTreeBuilder.java:1856` null dereference before the fix

### Installed-snapshot [StoneDetector](https://github.com/StoneDetector/StoneDetector) replay

I installed this branch as `fr.inria.gforge.spoon:spoon-core:11.5.1-SNAPSHOT` with `mvn -q -DskipTests install`, then built [StoneDetector](https://github.com/StoneDetector/StoneDetector) commit `3df05078298c5413c50252643764d71176a45df0` with a temporary Gradle dependency substitution from [Spoon](https://github.com/INRIA/spoon) 11.4.0 to that local snapshot. Gradle dependency insight selected `11.5.1-SNAPSHOT`, and the SHA-256 of `JDTTreeBuilder.class` in the [StoneDetector](https://github.com/StoneDetector/StoneDetector) fat JAR exactly matched the locally installed snapshot (`dedc5af39181c1a50c85c7c22a1bc1987de466469cff18b22f0073459d57f5d5`). No [StoneDetector](https://github.com/StoneDetector/StoneDetector) source or dependency file was changed for this replay.

Using the same [StoneDetector](https://github.com/StoneDetector/StoneDetector) commit and [ContendedRegisterAnalyzeAction.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/analyze/ContendedRegisterAnalyzeAction.java) from [Elasticsearch](https://github.com/elastic/elasticsearch):

| [Spoon](https://github.com/INRIA/spoon) artifact | Exit | AST | CFG | Dominator tree | Encoded methods | Error file |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| released 11.4.0 | 2 | 0/1 | 0/0 | 0/0 | 0/0 | `NullPointerException` at `JDTTreeBuilder.visit`, dereferencing the missing `allocation` |
| this branch, locally installed snapshot | 0 | 1/1 | 4/4 | 4/4 | 4/4 | empty |

The minimized issue reproducer also completed with exit 0, AST 1/1, and an empty error file when analyzed through the [StoneDetector](https://github.com/StoneDetector/StoneDetector) fat JAR.

A full [StoneDetector](https://github.com/StoneDetector/StoneDetector) test run with the snapshot executed 12 tests: 11 passed and one assertion failed because that test explicitly expected the no-classpath local-class analysis to fail. With this fix the same analysis succeeds, so that expectation is intentionally stale rather than evidence of a crash or incomplete analysis.

Fixes #6793.
