### PR TITLE
fix: recover anonymous resource problem bindings

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -14,12 +14,14 @@ import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.Argument;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ConditionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
 import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.ModuleReference;
+import org.eclipse.jdt.internal.compiler.ast.NullLiteral;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedNameReference;
@@ -54,6 +56,7 @@ import org.eclipse.jdt.internal.compiler.lookup.PolyTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemPackageBinding;
+import org.eclipse.jdt.internal.compiler.lookup.ProblemReasons;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.RawTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
@@ -61,6 +64,7 @@ import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.SyntheticFactoryMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.UnresolvedReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.VariableBinding;
@@ -95,6 +99,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -495,12 +500,17 @@ public class ReferenceBuilder {
 	}
 
 	<T> CtExecutableReference<T> getExecutableReference(AllocationExpression allocationExpression) {
+		cacheInferredResourceTypeReferences(allocationExpression.arguments);
 		CtExecutableReference<T> ref;
 		if (allocationExpression.binding != null) {
 			ref = getExecutableReference(allocationExpression.binding);
 			// in some cases the binding is not null but points wrong to object type see #4643
 			if (isIncorrectlyBoundExecutableInNoClasspath(ref, allocationExpression)) {
 				adjustExecutableAccordingToResolvedType(ref, allocationExpression);
+			}
+			if (allocationExpression.binding instanceof ProblemMethodBinding problemBinding
+					&& problemBinding.closestMatch == null) {
+				recoverInferredResourceArgumentTypes(ref, allocationExpression.arguments);
 			}
 		} else {
 			ref = jdtTreeBuilder.getFactory().Core().createExecutableReference();
@@ -509,8 +519,11 @@ public class ReferenceBuilder {
 
 			final List<CtTypeReference<?>> parameters =
 					new ArrayList<>(allocationExpression.argumentTypes.length);
-			for (TypeBinding b : allocationExpression.argumentTypes) {
-				parameters.add(getTypeReference(b, true));
+			for (int index = 0; index < allocationExpression.argumentTypes.length; index++) {
+				Expression argument = allocationExpression.arguments == null || index >= allocationExpression.arguments.length
+						? null
+						: allocationExpression.arguments[index];
+				parameters.add(getExpressionTypeReference(argument, allocationExpression.argumentTypes[index]));
 			}
 			ref.setParameters(parameters);
 		}
@@ -565,12 +578,18 @@ public class ReferenceBuilder {
 	}
 
 	<T> CtExecutableReference<T> getExecutableReference(MessageSend messageSend) {
+		cacheInferredResourceTypeReferences(messageSend.arguments);
 		if (messageSend.binding != null) {
-			return getExecutableReference(
+			CtExecutableReference<T> ref = getExecutableReference(
 				messageSend.binding,
 				getExecutableRefSourceStart(messageSend.typeArguments, messageSend.nameSourceStart()),
 				messageSend.nameSourceEnd()
 			);
+			if (messageSend.binding instanceof ProblemMethodBinding problemBinding
+					&& problemBinding.closestMatch == null) {
+				recoverInferredResourceArgumentTypes(ref, messageSend.arguments);
+			}
+			return ref;
 		}
 		CtExecutableReference<T> ref = jdtTreeBuilder.getFactory().Core().createExecutableReference();
 		ref.setSimpleName(CharOperation.charToString(messageSend.selector));
@@ -587,17 +606,68 @@ public class ReferenceBuilder {
 			} else if (messageSend.receiver instanceof QualifiedNameReference) {
 				ref.setDeclaringType(jdtTreeBuilder.getHelper().createTypeAccessNoClasspath((QualifiedNameReference) messageSend.receiver).getAccessedType());
 			}
+		} else if (messageSend.receiver instanceof SingleNameReference singleNameReference
+				&& singleNameReference.binding instanceof LocalVariableBinding localVariableBinding) {
+			ref.setDeclaringType(getLocalVariableTypeReference(localVariableBinding));
 		} else {
 			ref.setDeclaringType(getTypeReference(messageSend.receiver.resolvedType));
 		}
 		if (messageSend.arguments != null) {
 			final List<CtTypeReference<?>> parameters = new ArrayList<>();
 			for (Expression expression : messageSend.arguments) {
-				parameters.add(getTypeReference(expression.resolvedType, true));
+				parameters.add(getExpressionTypeReference(expression, expression.resolvedType));
 			}
 			ref.setParameters(parameters);
 		}
 		return ref;
+	}
+
+	private CtTypeReference<?> getExpressionTypeReference(@Nullable Expression expression, TypeBinding fallbackType) {
+		return getInferredResourceTypeReference(expression)
+				.orElseGet(() -> getTypeReference(fallbackType, true));
+	}
+
+	private Optional<CtTypeReference<?>> getInferredResourceTypeReference(@Nullable Expression expression) {
+		if (expression instanceof SingleNameReference singleNameReference
+				&& singleNameReference.binding instanceof LocalVariableBinding localVariableBinding
+				&& isInferredAnonymousResource(localVariableBinding)) {
+			return Optional.of(getLocalVariableTypeReference(localVariableBinding));
+		}
+		if (expression instanceof ConditionalExpression conditionalExpression) {
+			Optional<CtTypeReference<?>> trueType = getInferredResourceTypeReference(conditionalExpression.valueIfTrue);
+			Optional<CtTypeReference<?>> falseType = getInferredResourceTypeReference(conditionalExpression.valueIfFalse);
+			if (conditionalExpression.valueIfTrue instanceof NullLiteral) {
+				return falseType;
+			}
+			if (conditionalExpression.valueIfFalse instanceof NullLiteral) {
+				return trueType;
+			}
+			return trueType.flatMap(candidate -> falseType.filter(candidate::equals));
+		}
+		return Optional.empty();
+	}
+
+	private void recoverInferredResourceArgumentTypes(
+			CtExecutableReference<?> executableReference, @Nullable Expression[] arguments) {
+		if (arguments == null || executableReference.getParameters().size() != arguments.length) {
+			return;
+		}
+		List<CtTypeReference<?>> parameters = new ArrayList<>(executableReference.getParameters());
+		for (int index = 0; index < arguments.length; index++) {
+			int parameterIndex = index;
+			getInferredResourceTypeReference(arguments[index])
+					.ifPresent(type -> parameters.set(parameterIndex, type));
+		}
+		executableReference.setParameters(parameters);
+	}
+
+	private void cacheInferredResourceTypeReferences(@Nullable Expression[] expressions) {
+		if (expressions == null) {
+			return;
+		}
+		for (Expression expression : expressions) {
+			getInferredResourceTypeReference(expression);
+		}
 	}
 
 	private CtPackageReference getPackageReference(PackageBinding reference) {
@@ -614,6 +684,7 @@ public class ReferenceBuilder {
 	}
 
 	final Map<TypeBinding, CtTypeReference> bindingCache = new HashMap<>();
+	private final Map<ProblemReferenceBinding, CtTypeReference<?>> inferredResourceTypeReferences = new IdentityHashMap<>();
 
 	<T> CtTypeReference<T> getTypeReference(TypeBinding binding, TypeReference ref) {
 		CtTypeReference<T> ctRef = getTypeReference(binding);
@@ -1231,6 +1302,10 @@ public class ReferenceBuilder {
 	}
 
 	private CtTypeReference<?> getTypeReferenceFromProblemReferenceBinding(ProblemReferenceBinding binding) {
+		CtTypeReference<?> inferredResourceType = inferredResourceTypeReferences.get(binding);
+		if (inferredResourceType != null) {
+			return inferredResourceType.clone();
+		}
 		// Spoon is able to analyze also without the classpath
 		String readableName = String.valueOf(binding.readableName());
 		if (isParameterizedProblemReferenceBinding(binding)) {
@@ -1338,7 +1413,7 @@ public class ReferenceBuilder {
 			} else {
 				CtLocalVariableReference<T> ref = this.jdtTreeBuilder.getFactory().Core().createLocalVariableReference();
 				ref.setSimpleName(new String(varbin.name));
-				CtTypeReference<T> ref2 = getTypeReference(varbin.type);
+				CtTypeReference<T> ref2 = getLocalVariableTypeReference(localVariableBinding);
 				ref.setType(ref2);
 				return ref;
 			}
@@ -1346,6 +1421,30 @@ public class ReferenceBuilder {
 			// unknown VariableBinding, the caller must do something
 			return null;
 		}
+	}
+
+	private <T> CtTypeReference<T> getLocalVariableTypeReference(LocalVariableBinding binding) {
+		if (isInferredAnonymousResource(binding)) {
+			ProblemReferenceBinding problemBinding = (ProblemReferenceBinding) binding.type;
+			AllocationExpression allocation = (AllocationExpression) binding.declaration.initialization;
+			CtTypeReference<T> recoveredType = getTypeReference(allocation.type.resolvedType, allocation.type);
+			inferredResourceTypeReferences.put(problemBinding, recoveredType);
+			return recoveredType;
+		}
+		return getTypeReference(binding.type);
+	}
+
+	private boolean isInferredAnonymousResource(LocalVariableBinding binding) {
+		return binding.type instanceof ProblemReferenceBinding problemBinding
+				&& problemBinding.problemId() == ProblemReasons.InvalidTypeForAutoManagedResource
+				&& jdtTreeBuilder.getFactory().getEnvironment().getComplianceLevel() >= 10
+				&& binding.declaration.type != null
+				&& CharOperation.equals(binding.declaration.type.getLastToken(), TypeConstants.VAR)
+				&& binding.declaration.initialization instanceof AllocationExpression allocation
+				&& allocation.resolvedType != null
+				&& allocation.resolvedType.isAnonymousType()
+				&& allocation.type != null
+				&& allocation.type.resolvedType != null;
 	}
 
 	<T> CtVariableReference<T> getVariableReference(ProblemBinding binding) {

--- a/src/test/java/spoon/test/reference/ProblemReferenceBindingTest.java
+++ b/src/test/java/spoon/test/reference/ProblemReferenceBindingTest.java
@@ -1,0 +1,447 @@
+package spoon.test.reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import spoon.Launcher;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtVariableRead;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.visitor.Filter;
+import spoon.reflect.visitor.chain.CtQueryable;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+class ProblemReferenceBindingTest {
+	@Test
+	void conditionalAnonymousResourceCanBeUsedAsAConstructorArgument() {
+		// contract: inferred anonymous resources nested in argument expressions retain their declared type
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(constructorParameter(model, "MissingConditionalWrapper").getSimpleName())
+				.isEqualTo("MissingResource");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"conditional invocation argument, consumeConditional",
+		"direct invocation argument, consume"
+	})
+	void anonymousResourceCanBeUsedAsAnInvocationArgument(String scenario, String invocationName) {
+		// contract: inferred anonymous resources used as invocation arguments retain their declared type
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtInvocation<?> invocation = invocationNamed(model, invocationName, 1);
+		assertThat(invocation.getExecutable().getParameters())
+				.as(scenario)
+				.singleElement()
+				.extracting(spoon.reflect.reference.CtTypeReference::getSimpleName)
+				.isEqualTo("MissingResource");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"resolved method parameter, acceptObject, java.lang.Object",
+		"closest matching method signature, acceptString, java.lang.String"
+	})
+	void anonymousResourceKeepsItsExpectedMethodParameter(
+			String scenario, String invocationName, String expectedType) {
+		// contract: recovery preserves resolved and closest-matching method parameter types
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtInvocation<?> invocation = invocationNamed(model, invocationName);
+		assertThat(invocation.getExecutable().getParameters())
+				.as(scenario)
+				.singleElement()
+				.extracting(spoon.reflect.reference.CtTypeReference::getQualifiedName)
+				.isEqualTo(expectedType);
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"closest matching constructor signature, KnownStringWrapper, java.lang.String",
+		"different conditional resource types, MissingMixedWrapper, java.lang.Object",
+		"different conditional resource parameterizations, MissingGenericMixedWrapper, java.lang.Object",
+		"imported resource type, MissingImportedWrapper, ext.ImportedResource",
+		"directly imported nested resource type, MissingDirectNestedWrapper, ext.QualifiedOuter$Resource"
+	})
+	void constructorArgumentKeepsItsExpectedQualifiedType(
+			String scenario, String constructedType, String expectedType) {
+		// contract: argument recovery preserves the type selected by imports and executable applicability
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(constructorParameter(model, constructedType).getQualifiedName())
+				.as(scenario)
+				.isEqualTo(expectedType);
+	}
+
+	@Test
+	void parameterizedAnonymousResourcePreservesItsTypeArgument() {
+		// contract: recovery uses the source type when an unresolved binding omits generic arguments
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "parameterizedCall").getTarget();
+		assertThat(variableRead.getVariable().getType().getActualTypeArguments())
+				.singleElement()
+				.extracting(CtTypeReference::getQualifiedName)
+				.isEqualTo("java.lang.String");
+	}
+
+	@Test
+	void parameterizedAnonymousResourceKeepsItsConstructorArgumentType() {
+		// contract: executable argument recovery retains source-declared generic arguments
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(constructorParameter(model, "MissingParameterizedWrapper").getActualTypeArguments())
+				.singleElement()
+				.extracting(CtTypeReference::getQualifiedName)
+				.isEqualTo("java.lang.String");
+	}
+
+	@Test
+	void nullConditionalBranchesKeepTheAnonymousResourceType() {
+		// contract: null does not erase the inferred resource type from either conditional branch
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(List.of(
+				constructorParameter(model, "MissingNullableWrapper"),
+				constructorParameter(model, "MissingNullFirstWrapper")))
+				.as("constructor parameter types for both null-conditional branches")
+				.extracting(CtTypeReference::getSimpleName)
+				.containsExactly("MissingResource", "MissingResource");
+	}
+
+	@Test
+	void anonymousResourceProblemBindingUsesItsDeclaredTypeName() {
+		// contract: unresolved anonymous resources use a legal type name for later invocations
+		// (#6800)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/ProblemReferenceBinding.java");
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtInvocation<?> invocation = invocationNamed(model, "call");
+		assertThat(invocation.getTarget())
+				.isInstanceOfSatisfying(CtVariableRead.class, variableRead -> assertThat(
+						variableRead.getVariable().getType().getSimpleName())
+						.as("anonymous-resource target type")
+						.isEqualTo("MissingResource"));
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"parameterized inferred resource, parameterizedCall, MissingResource",
+		"explicit resource, baseCall, BaseResource"
+	})
+	void resourceTargetRetainsItsExpectedSimpleType(String scenario, String invocationName, String expectedType) {
+		// contract: inferred normalization and explicit declarations retain legal simple type names
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, invocationName).getTarget();
+		assertThat(variableRead.getVariable().getType().getSimpleName())
+				.as(scenario)
+				.isEqualTo(expectedType);
+	}
+
+	@Test
+	void unresolvedExecutableUsesTheRecoveredResourceType() {
+		// contract: executable references reuse recovered inferred-resource evidence
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtInvocation<?> invocation = invocationNamed(model, "configure");
+		assertThat(invocation.getExecutable().getDeclaringType().getSimpleName()).isEqualTo("MissingService");
+	}
+
+	@Test
+	void nestedAnonymousResourcePreservesItsDeclaringType() {
+		// contract: a nested resource problem binding represents the nested and declaring names separately
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "nestedCall").getTarget();
+		assertThat(variableRead.getVariable().getType())
+				.as("nested resource type [simple name, declaring type, qualified name]")
+				.extracting(
+						CtTypeReference::getSimpleName,
+						type -> type.getDeclaringType().getSimpleName(),
+						CtTypeReference::getQualifiedName)
+				.containsExactly("Resource", "Outer", "spoon.test.reference.Outer$Resource");
+	}
+
+	@Test
+	void nestedParameterizedAnonymousResourcePreservesEveryTypeSegment() {
+		// contract: erasing nested type arguments does not discard later nested type names
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "nestedGenericCall").getTarget();
+		assertThat(variableRead.getVariable().getType())
+				.as("nested generic resource type [simple name, declaring type]")
+				.extracting(
+						CtTypeReference::getSimpleName,
+						type -> type.getDeclaringType().getSimpleName())
+				.containsExactly("Resource", "GenericOuter");
+	}
+
+	@Test
+	void genericEnclosingResourceDropsTypeArgumentsBeforeResolvingItsNestedType() {
+		// contract: enclosing-only type arguments are erased without discarding the nested resource
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "genericEnclosingCall").getTarget();
+		assertThat(variableRead.getVariable().getType())
+				.as("resource in generic enclosing type [simple name, declaring type]")
+				.extracting(
+						CtTypeReference::getSimpleName,
+						type -> type.getDeclaringType().getSimpleName())
+				.containsExactly("PlainResource", "GenericOuter");
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"imported resource type, importedCall, ext.ImportedResource",
+		"package-qualified nested resource type, qualifiedNestedCall, ext.QualifiedOuter$Resource"
+	})
+	void resourceInvocationRetainsItsQualifiedType(String scenario, String invocationName, String expectedType) {
+		// contract: normalization retains imported packages and nested-type separators
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, invocationName).getTarget();
+		assertThat(variableRead.getVariable().getType().getQualifiedName())
+				.as(scenario)
+				.isEqualTo(expectedType);
+	}
+
+	@Test
+	void lowercaseDeclaringTypeIsNotTreatedAsAPackage() {
+		// contract: source binding evidence takes precedence over capitalization conventions
+		// (#6800)
+		// given
+		Launcher launcher = launcherForProblemReferenceBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "lowercaseNestedCall").getTarget();
+		assertThat(variableRead.getVariable().getType().getDeclaringType().getSimpleName()).isEqualTo("lower");
+	}
+
+	@Test
+	void anonymousResourceCanBeUsedAsAConstructorArgument() {
+		// contract: inferred anonymous resource bindings remain legal when reused as argument types
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(model.getElements(new TypeFilter<CtConstructorCall<?>>(CtConstructorCall.class)))
+				.filteredOn(call -> call.getType().getSimpleName().equals("MissingWrapper"))
+				.hasSize(2)
+				.allSatisfy(call -> assertThat(call.getExecutable().getParameters())
+						.singleElement()
+						.extracting(CtTypeReference::getSimpleName)
+						.isEqualTo("MissingResource"));
+	}
+
+	@Test
+	void anonymousResourceCanDeclareReferencedFields() {
+		// contract: inferred anonymous resource bindings remain legal as field declaring types
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(model.getElements(new TypeFilter<CtFieldRead<?>>(CtFieldRead.class)))
+				.filteredOn(read -> read.getVariable().getSimpleName().equals("missingField"))
+				.isNotEmpty()
+				.allSatisfy(read -> assertThat(read.getVariable().getDeclaringType().getSimpleName()).isEqualTo("MissingNode"));
+	}
+
+	@ParameterizedTest(name = "{0}")
+	@CsvSource({
+		"nested generic resource, MissingNestedWrapper, Outer",
+		"lowercase enclosing resource, MissingLowercaseWrapper, lower"
+	})
+	void nestedConstructorArgumentRetainsEveryTypeSegment(
+			String scenario, String constructedType, String expectedDeclaringType) {
+		// contract: argument recovery preserves nested names and source-declared enclosing types
+		// (#6800)
+		// given
+		Launcher launcher = launcherForAnonymousResourceProblemBinding();
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		var parameter = constructorParameter(model, constructedType);
+		assertThat(parameter)
+				.as("%s [simple name, declaring type]", scenario)
+				.extracting(
+						CtTypeReference::getSimpleName,
+						type -> type.getDeclaringType().getSimpleName())
+				.containsExactly("Resource", expectedDeclaringType);
+	}
+
+	@Test
+	void preJavaTenTypeNamedVarRetainsItsDeclaredType() {
+		// contract: `var` recovery is disabled while `var` remains an ordinary type name
+		// (#6800)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/PreJavaTenVarType.java");
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		CtVariableRead<?> variableRead = (CtVariableRead<?>) invocationNamed(model, "varTypeCall").getTarget();
+		assertThat(variableRead.getVariable().getType().getSimpleName()).isEqualTo("var");
+	}
+
+	private static Launcher launcherForProblemReferenceBinding() {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/ProblemReferenceBinding.java");
+		launcher.addInputResource("src/test/resources/spoon/test/reference/issue01");
+		return launcher;
+	}
+
+	private static Launcher launcherForAnonymousResourceProblemBinding() {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/AnonymousResourceProblemBinding.java");
+		launcher.addInputResource("src/test/resources/spoon/test/reference/issue01");
+		return launcher;
+	}
+
+	private static spoon.reflect.reference.CtTypeReference<?> constructorParameter(
+			spoon.reflect.CtModel model, String constructedType) {
+		CtConstructorCall<?> constructorCall = model
+				.filterChildren(new TypeFilter<>(CtConstructorCall.class))
+				.select((CtConstructorCall<?> candidate) -> candidate.getType().getSimpleName().equals(constructedType))
+				.first(CtConstructorCall.class);
+		assertThat(constructorCall).as("constructor call creating <%s>", constructedType).isNotNull();
+		return constructorCall
+				.getExecutable()
+				.getParameters()
+				.get(0);
+	}
+
+	private static CtInvocation<?> invocationNamed(CtQueryable root, String name) {
+		return findInvocation(
+				root,
+				candidate -> candidate.getExecutable().getSimpleName().equals(name),
+				"invocation named <%s>".formatted(name));
+	}
+
+	private static CtInvocation<?> invocationNamed(CtQueryable root, String name, int argumentCount) {
+		return findInvocation(
+				root,
+				candidate -> candidate.getExecutable().getSimpleName().equals(name)
+						&& candidate.getArguments().size() == argumentCount,
+				"invocation named <%s> with %d argument(s)".formatted(name, argumentCount));
+	}
+
+	private static CtInvocation<?> findInvocation(
+			CtQueryable root, Filter<CtInvocation<?>> filter, String description) {
+		CtInvocation<?> invocation = root
+				.filterChildren(new TypeFilter<>(CtInvocation.class))
+				.select(filter)
+				.first(CtInvocation.class);
+		assertThat(invocation).as(description).isNotNull();
+		return invocation;
+	}
+}

--- a/src/test/resources/spoon/test/reference/AnonymousResourceProblemBinding.java
+++ b/src/test/resources/spoon/test/reference/AnonymousResourceProblemBinding.java
@@ -1,0 +1,177 @@
+package spoon.test.reference;
+
+import ext.ImportedResource;
+import ext.QualifiedOuter.Resource;
+
+class AnonymousResourceProblemBinding {
+	boolean selectFirst;
+
+	void useConditionalAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new MissingResource() {
+			};
+			var wrapper = new MissingConditionalWrapper(selectFirst ? resource : resource)
+		) {
+			wrapper.consume();
+		}
+	}
+
+	void useConditionalAnonymousResourceAsMessageArgument() {
+		try (var resource = new MissingResource() {
+		}) {
+			consumeConditional(selectFirst ? resource : resource);
+		}
+	}
+
+	void useConditionalAnonymousResourceWithResolvedObjectParameter() {
+		try (var resource = new MissingResource() {
+		}) {
+			acceptObject(selectFirst ? resource : resource);
+		}
+	}
+
+	void useConditionalAnonymousResourceWithInapplicableMethod() {
+		try (var resource = new MissingResource() {
+		}) {
+			acceptString(selectFirst ? resource : resource);
+		}
+	}
+
+	void useConditionalAnonymousResourceWithInapplicableConstructor() {
+		try (var resource = new MissingResource() {
+		}) {
+			new KnownStringWrapper(selectFirst ? resource : resource);
+		}
+	}
+
+	void useDifferentConditionalAnonymousResourcesAsConstructorArgument() {
+		try (
+			var first = new MissingFirstResource() {
+			};
+			var second = new MissingSecondResource() {
+			};
+			var wrapper = new MissingMixedWrapper(selectFirst ? first : second)
+		) {
+			wrapper.consume();
+		}
+	}
+
+	void useDifferentlyParameterizedConditionalAnonymousResourcesAsConstructorArgument() {
+		try (
+			var first = new MissingResource<String>() {
+			};
+			var second = new MissingResource<Integer>() {
+			};
+			var wrapper = new MissingGenericMixedWrapper(selectFirst ? first : second)
+		) {
+			wrapper.consume();
+		}
+	}
+
+	void useNullableConditionalAnonymousResourcesAsConstructorArguments() {
+		try (var resource = new MissingResource() {
+		}) {
+			new MissingNullableWrapper(selectFirst ? resource : null);
+			new MissingNullFirstWrapper(selectFirst ? null : resource);
+		}
+	}
+
+	void acceptObject(Object value) {
+	}
+
+	void acceptString(String value) {
+	}
+
+	void useAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new MissingResource() {
+			};
+			var wrapper = new MissingWrapper(resource)
+		) {
+			wrapper.consume();
+		}
+	}
+
+	void useAnonymousResourceAsMessageArgument() {
+		try (var resource = new MissingResource() {
+		}) {
+			consume(resource);
+		}
+	}
+
+	void useParameterizedAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new MissingResource<String>() {
+			};
+			var wrapper = new MissingWrapper(resource);
+			var parameterizedWrapper = new MissingParameterizedWrapper(resource)
+		) {
+			wrapper.consumeParameterized();
+			parameterizedWrapper.consumeParameterized();
+		}
+	}
+
+	void useMembersOfAnonymousResource() {
+		try (var resource = new MissingNode() {
+		}) {
+			var field = resource.missingField;
+			resource.missingField.consume();
+			var callback = resource.missingField::consume;
+		}
+	}
+
+	void useImportedAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new ImportedResource() {
+			};
+			var wrapper = new MissingImportedWrapper(resource)
+		) {
+			wrapper.consumeImported();
+		}
+	}
+
+	void useNestedAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new Outer<String>().new Resource<Integer>() {
+			};
+			var wrapper = new MissingNestedWrapper(resource)
+		) {
+			wrapper.consumeNested();
+		}
+	}
+
+	void useDirectlyImportedNestedAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new Resource() {
+			};
+			var wrapper = new MissingDirectNestedWrapper(resource)
+		) {
+			wrapper.consumeDirectNested();
+		}
+	}
+
+	void useLowercaseEnclosingAnonymousResourceAsConstructorArgument() {
+		try (
+			var resource = new lower.Resource() {
+			};
+			var wrapper = new MissingLowercaseWrapper(resource)
+		) {
+			wrapper.consumeLowercase();
+		}
+	}
+
+	class Outer<T> {
+		class Resource<U> {
+		}
+	}
+
+	class lower {
+		class Resource {
+		}
+	}
+
+	class KnownStringWrapper {
+		KnownStringWrapper(String value) {
+		}
+	}
+}

--- a/src/test/resources/spoon/test/reference/PreJavaTenVarType.java
+++ b/src/test/resources/spoon/test/reference/PreJavaTenVarType.java
@@ -1,0 +1,18 @@
+package spoon.test.reference;
+
+class PreJavaTenVarType {
+	void useExplicitVarType() {
+		try (var resource = new VarSubtype() {
+		}) {
+			resource.varTypeCall();
+		}
+	}
+}
+
+class var {
+	void varTypeCall() {
+	}
+}
+
+class VarSubtype extends var {
+}

--- a/src/test/resources/spoon/test/reference/ProblemReferenceBinding.java
+++ b/src/test/resources/spoon/test/reference/ProblemReferenceBinding.java
@@ -1,0 +1,123 @@
+package spoon.test.reference;
+
+import ext.ImportedResource;
+
+class ProblemReferenceBinding {
+	void useResource() {
+		try (var resource = new MissingResource() {
+			void call() {
+			}
+		}) {
+			resource.call();
+		}
+	}
+
+	void useParameterizedResource() {
+		try (var resource = new MissingResource<String>() {
+			void parameterizedCall() {
+			}
+		}) {
+			resource.parameterizedCall();
+		}
+	}
+
+	void useMultipleUnresolvedResources() {
+		try (
+			var resource = new MissingService(missingArgument()) {
+				@Override
+				protected MissingExecutor createExecutor() {
+					return missingQueue.executor();
+				}
+			};
+			var log = MissingLog.capture(MissingService.class)
+		) {
+			resource.configure(missingDependency(MissingDependency.class));
+			resource.start();
+		}
+	}
+
+	void useNestedResource() {
+		try (var resource = new Outer.Resource() {
+		}) {
+			resource.nestedCall();
+		}
+	}
+
+	void useNestedGenericResource() {
+		try (var resource = new GenericOuter<String>().new Resource<Integer>() {
+		}) {
+			resource.nestedGenericCall();
+		}
+	}
+
+	void useGenericEnclosingResource() {
+		try (var resource = new GenericOuter<String>().new PlainResource() {
+		}) {
+			resource.genericEnclosingCall();
+		}
+	}
+
+	void useImportedResource() {
+		try (var resource = new ImportedResource() {
+			void importedCall() {
+			}
+		}) {
+			resource.importedCall();
+		}
+	}
+
+	void useQualifiedNestedResource() {
+		try (var resource = new ext.QualifiedOuter.Resource() {
+		}) {
+			resource.qualifiedNestedCall();
+		}
+	}
+
+	void useLowercaseNestedResource() {
+		try (var resource = new lower.Resource() {
+		}) {
+			resource.lowercaseNestedCall();
+		}
+	}
+
+	void useExplicitResourceType() {
+		try (BaseResource resource = new SubResource() {
+		}) {
+			resource.baseCall();
+		}
+	}
+}
+
+class Outer {
+	static class Resource {
+		void nestedCall() {
+		}
+	}
+}
+
+class GenericOuter<T> {
+	class Resource<U> {
+		void nestedGenericCall() {
+		}
+	}
+
+	class PlainResource {
+		void genericEnclosingCall() {
+		}
+	}
+}
+
+class lower {
+	static class Resource {
+		void lowercaseNestedCall() {
+		}
+	}
+}
+
+class BaseResource {
+	void baseCall() {
+	}
+}
+
+class SubResource extends BaseResource {
+}

--- a/src/test/resources/spoon/test/reference/issue01/ext/ImportedResource.java
+++ b/src/test/resources/spoon/test/reference/issue01/ext/ImportedResource.java
@@ -1,0 +1,4 @@
+package ext;
+
+public class ImportedResource {
+}

--- a/src/test/resources/spoon/test/reference/issue01/ext/QualifiedOuter.java
+++ b/src/test/resources/spoon/test/reference/issue01/ext/QualifiedOuter.java
@@ -1,0 +1,8 @@
+package ext;
+
+public class QualifiedOuter {
+	public static class Resource {
+		public void qualifiedNestedCall() {
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix type recovery for Java 10+ `var` resources when an anonymous object does not implement `AutoCloseable`.

Fixes #6800.

## Problem

Consider a Java 10+ `var` resource whose initializer is an anonymous object:

```java
try (var resource = new MissingResource() {
    void call() {}
}) {
    resource.call();
}
```

In no-classpath mode, the allocated class is unresolved and [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) cannot prove that the object implements `AutoCloseable`. ECJ returns an `InvalidTypeForAutoManagedResource` problem binding: a placeholder for a type that it could not resolve normally. For this binding, the readable name is the complete allocation expression rather than a valid Java type name. Spoon used that expression as an identifier while creating variable and executable references, which caused `CtReferenceImpl.setSimpleName` to throw `JLSViolation`.

This caused [StoneDetector](https://github.com/StoneDetector/StoneDetector) to fail on the twelve [Elasticsearch](https://github.com/elastic/elasticsearch) files listed below. Each failure has the same malformed allocation-name root cause.

The validated Elasticsearch files are:

- [ClusterApplierServiceWatchdogTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/server/src/test/java/org/elasticsearch/cluster/service/ClusterApplierServiceWatchdogTests.java)
- [TranslogTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java)
- [SecureBytesRefRecyclerTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/support/SecureBytesRefRecyclerTests.java)
- [SharedBlobCacheWarmingServiceTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/SharedBlobCacheWarmingServiceTests.java)
- [CacheBlobReaderTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cache/reader/CacheBlobReaderTests.java)
- [BlobStoreSyncDirectoryTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/BlobStoreSyncDirectoryTests.java)
- [StatelessElectionStrategyTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/StatelessElectionStrategyTests.java)
- [StatelessHeartbeatStoreTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/cluster/coordination/StatelessHeartbeatStoreTests.java)
- [StatelessCommitServiceTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/commits/StatelessCommitServiceTests.java)
- [IndexEngineTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/IndexEngineTests.java)
- [SearchDirectoryTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/lucene/SearchDirectoryTests.java)
- [ObjectStoreServiceTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/objectstore/ObjectStoreServiceTests.java)

## Change

- Recognize this specific [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) problem binding for Java 10+ `var` resources with anonymous initializers.
- Recover the declared allocation type from [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core)'s resolved allocation binding.
- Cache that semantic type by binding identity and reuse it for local-variable, receiver, method-argument, constructor-argument, and unresolved-executable references.
- Recover result-preserving conditional arguments before executable parameters are converted, including same-resource and resource-versus-`null` branches.
- Preserve known resolved signatures and a `ProblemMethodBinding`'s closest match; only genuinely unresolved executable parameters use the recovered argument type.
- Inspect only result-relevant direct and conditional expressions, avoiding repeated recursive scans of nested executable subtrees.
- Keep existing behavior for explicit resource types, Java 9 types named `var`, and other problem bindings.

## Tests

- Added cases for simple, parameterized, nested, imported, and package-qualified types.
- Added cases for unresolved executable references, referenced fields, and direct or conditional first-use method and constructor arguments.
- Added conditional cases for same resource types, either-side `null`, different resource types, resolved `Object` parameters, and inapplicable known method and constructor signatures.
- Added preservation tests for explicit resource types, generic type arguments, and a Java 9 class named `var`.
- `mvn -q -Dtest=spoon.test.reference.ProblemReferenceBindingTest,spoon.test.trycatch.TryCatchTest#testNonCloseableGenericTypeInTryWithResources test` passes all 28 tests.
- `mvn -q -DskipTests install` passes.
- [StoneDetector](https://github.com/StoneDetector/StoneDetector) successfully processes all twelve linked [Elasticsearch](https://github.com/elastic/elasticsearch) files, including [IndexEngineTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/stateless/src/test/java/org/elasticsearch/xpack/stateless/engine/IndexEngineTests.java): AST 12/12 and CFG, dominator tree, and path encoding 596/596, with an empty error file.

## Full test suite

`mvn -q verify` passes 4,485 tests with 0 failures, 0 errors, and 16 skipped on [OpenJDK](https://github.com/openjdk/jdk) 25.0.3.




