### PR TITLE
fix: terminate wildcard erasure lookup

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/ReferenceBuilder.java
@@ -1086,6 +1086,10 @@ public class ReferenceBuilder {
 			return getTypeReferenceOfBoundingType(binding).clone();
 		} else {
 			CtTypeReference<?> ref = this.jdtTreeBuilder.getFactory().Core().createTypeParameterReference();
+			String declarationOwner = typeParameterDeclarationOwner(binding);
+			if (declarationOwner != null) {
+				ref.putMetadata("spoon.typeParameterDeclarationOwner", declarationOwner);
+			}
 			String name = new String(binding.sourceName());
 			if (binding.declaringElement instanceof SyntheticFactoryMethodBinding) {
 				// JDT uses these factory methods for type inference of diamond constructors. In no classpath mode they
@@ -1097,6 +1101,42 @@ public class ReferenceBuilder {
 			ref.setSimpleName(name);
 			return ref;
 		}
+	}
+
+	private static String typeParameterDeclarationOwner(TypeVariableBinding binding) {
+		if (binding.declaringElement instanceof MethodBinding method) {
+			var sourceMethod = method.sourceMethod();
+			if (sourceMethod != null && sourceMethod.compilationResult != null) {
+				return "M|" + normalizedSourceFile(sourceMethod.compilationResult.getFileName())
+						+ "|" + sourceMethod.declarationSourceStart
+						+ "|" + binding.rank;
+			}
+			return "M|" + normalizedTypeName(method.declaringClass)
+					+ "|" + new String(method.selector)
+					+ "|" + method.parameters.length
+					+ "|-1"
+					+ "|" + binding.rank;
+		}
+		if (binding.declaringElement instanceof ReferenceBinding type) {
+			if (type instanceof SourceTypeBinding sourceType
+					&& sourceType.scope != null
+					&& sourceType.scope.referenceContext != null
+					&& sourceType.scope.referenceContext.compilationResult != null) {
+				return "T|" + normalizedSourceFile(sourceType.scope.referenceContext.compilationResult.getFileName())
+						+ "|" + sourceType.scope.referenceContext.declarationSourceStart
+						+ "|" + binding.rank;
+			}
+			return "T|" + normalizedTypeName(type) + "|" + binding.rank;
+		}
+		return null;
+	}
+
+	private static String normalizedSourceFile(char[] fileName) {
+		return new String(fileName).replace('\\', '/');
+	}
+
+	private static String normalizedTypeName(ReferenceBinding type) {
+		return CharOperation.toString(type.compoundName).replace('$', '.');
 	}
 
 	private CtTypeReference<?> getTypeReferenceOfBoundingType(TypeVariableBinding binding) {

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -9,27 +9,64 @@ package spoon.support.reflect.reference;
 
 import spoon.SpoonException;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtExecutable;
 import spoon.reflect.declaration.CtFormalTypeDeclarer;
-import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeParameter;
 import spoon.reflect.reference.CtActualTypeContainer;
+import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.reference.CtTypeParameterReference;
 import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.CtVisitor;
 import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
+import java.io.File;
+import java.io.Serializable;
 import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> implements CtTypeParameterReference {
 	private static final long serialVersionUID = 1L;
+	// Executable matching erases its parameters and can re-enter declaration lookup through a sibling reference.
+	private static final ThreadLocal<Set<CtExecutableReference<?>>> RESOLVING_EXECUTABLE_DECLARATIONS =
+			ThreadLocal.withInitial(() -> Collections.newSetFromMap(new IdentityHashMap<>()));
+	private static final String DECLARATION_OWNER_METADATA = "spoon.typeParameterDeclarationOwner";
 
 
 	public CtTypeParameterReferenceImpl() {
+	}
+
+	@Override
+	public <E extends CtElement> E setParent(CtElement parent) {
+		if (isParentInitialized()
+				&& getParent() instanceof CtTypeParameter declaration
+				&& Objects.equals(getSimpleName(), declaration.getSimpleName())) {
+			rememberDeclarationOwner(declaration);
+		}
+		if (parent instanceof CtTypeParameter declaration
+				&& Objects.equals(getSimpleName(), declaration.getSimpleName())) {
+			rememberDeclarationOwner(declaration);
+		}
+		return super.setParent(parent);
+	}
+
+	private void rememberDeclarationOwner(CtTypeParameter declaration) {
+		Object declarationOwner = declaration.getMetadata(DECLARATION_OWNER_METADATA);
+		if (!(declarationOwner instanceof DeclarationOwnerIdentity)) {
+			declarationOwner = new DeclarationOwnerIdentity();
+			declaration.putMetadata(DECLARATION_OWNER_METADATA, declarationOwner);
+		}
+		putMetadata(DECLARATION_OWNER_METADATA, declarationOwner);
 	}
 
 	@Override
@@ -113,8 +150,8 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 			 */
 			return (CtTypeParameter) parent;
 		}
-
-		if (parent instanceof CtTypeReference) {
+		boolean nestedInTypeReference = parent instanceof CtTypeReference;
+		while (parent instanceof CtTypeReference) {
 			if (!parent.isParentInitialized()) {
 				// we might enter in that case because of a call
 				// of getSuperInterfaces() for example
@@ -123,19 +160,41 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 				if (typeDeclarer == null) {
 					return null;
 				}
+				break;
 			} else {
 				parent = parent.getParent();
 			}
 		}
-
+		CtTypeParameter lexicalDeclaration = nestedInTypeReference
+				? findTypeParamDeclarationInParents(this)
+				: null;
+		CtTypeParameter fallbackDeclaration = lexicalDeclaration;
+		if (lexicalDeclaration != null
+				&& getMetadata(DECLARATION_OWNER_METADATA) != null
+				&& hasMatchingDeclarationOwner(lexicalDeclaration)) {
+			return lexicalDeclaration;
+		}
 		if (parent instanceof CtExecutableReference) {
 			CtExecutableReference parentExec = (CtExecutableReference) parent;
-			if (Objects.nonNull(parentExec.getDeclaringType()) && !parentExec.getDeclaringType().equals(typeDeclarer)) {
-				CtElement parent2 = parentExec.getExecutableDeclaration();
-				if (parent2 instanceof CtMethod) {
+			if (Objects.nonNull(parentExec.getDeclaringType())
+					&& !parentExec.getDeclaringType().equals(typeDeclarer)) {
+				CtElement parent2 = getExecutableDeclaration(parentExec);
+				if (parent2 instanceof CtExecutable) {
+					CtTypeParameter executableDeclaration = findCorrespondingTypeParameter(
+							parentExec,
+							(CtExecutable<?>) parent2);
+					if (executableDeclaration != null && hasMatchingDeclarationOwner(executableDeclaration)) {
+						return executableDeclaration;
+					}
+					if (executableDeclaration != null) {
+						fallbackDeclaration = executableDeclaration;
+					}
 					typeDeclarer = parent2;
 				}
 			}
+		}
+		if (lexicalDeclaration != null && hasMatchingDeclarationOwner(lexicalDeclaration)) {
+			return lexicalDeclaration;
 		}
 
 		if (!(typeDeclarer instanceof CtFormalTypeDeclarer)) {
@@ -148,9 +207,187 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 		while (typeDeclarer != null) {
 			CtTypeParameter result = findTypeParamDeclaration((CtFormalTypeDeclarer) typeDeclarer, this.getSimpleName());
 			if (result != null) {
-				return result;
+				if (hasMatchingDeclarationOwner(result)) {
+					return result;
+				}
+				if (fallbackDeclaration == null) {
+					fallbackDeclaration = result;
+				}
 			}
 			typeDeclarer = typeDeclarer.getParent(CtFormalTypeDeclarer.class);
+		}
+		return fallbackDeclaration;
+	}
+
+	private boolean hasMatchingDeclarationOwner(CtTypeParameter declaration) {
+		Object expectedOwner = getMetadata(DECLARATION_OWNER_METADATA);
+		if (expectedOwner instanceof DeclarationOwnerIdentity) {
+			return expectedOwner == declaration.getMetadata(DECLARATION_OWNER_METADATA);
+		}
+		String actualOwner = declarationOwner(declaration);
+		return expectedOwner == null || expectedOwner.equals(actualOwner);
+	}
+
+	private String declarationOwner(CtTypeParameter declaration) {
+		if (!declaration.isParentInitialized()) {
+			return null;
+		}
+		CtElement owner = declaration.getParent();
+		if (!(owner instanceof CtFormalTypeDeclarer formalTypeDeclarer)) {
+			return null;
+		}
+		int rank = formalTypeDeclarer.getFormalCtTypeParameters().indexOf(declaration);
+		if (owner instanceof CtExecutable<?> executable) {
+			CtType<?> declaringType = executable.getParent(CtType.class);
+			if (declaringType == null) {
+				return null;
+			}
+			String sourceOwner = sourceDeclarationOwner("M", executable, rank);
+			if (sourceOwner != null) {
+				return sourceOwner;
+			}
+			return "M|" + normalizedTypeName(declaringType.getQualifiedName())
+					+ "|" + executable.getSimpleName()
+					+ "|" + executable.getParameters().size()
+					+ "|-1"
+					+ "|" + rank;
+		}
+		if (owner instanceof CtType<?> type) {
+			String sourceOwner = sourceDeclarationOwner("T", type, rank);
+			if (sourceOwner != null) {
+				return sourceOwner;
+			}
+			return "T|" + normalizedTypeName(type.getQualifiedName()) + "|" + rank;
+		}
+		return null;
+	}
+
+	private String sourceDeclarationOwner(String kind, CtElement declaration, int rank) {
+		if (!declaration.getPosition().isValidPosition()) {
+			return null;
+		}
+		File sourceFile = declaration.getPosition().getFile();
+		String sourcePath = sourceFile == null
+				? virtualSourcePath(declaration)
+				: sourceFile.getPath();
+		if (sourcePath == null) {
+			return null;
+		}
+		return kind + "|" + sourcePath.replace('\\', '/')
+				+ "|" + declaration.getPosition().getSourceStart()
+				+ "|" + rank;
+	}
+
+	private String virtualSourcePath(CtElement declaration) {
+		var compilationUnit = declaration.getPosition().getCompilationUnit();
+		for (var entry : declaration.getFactory().CompilationUnit().getMap().entrySet()) {
+			if (entry.getValue() == compilationUnit) {
+				return entry.getKey();
+			}
+		}
+		return null;
+	}
+
+	private String normalizedTypeName(String qualifiedName) {
+		return qualifiedName.replace('$', '.');
+	}
+
+	private static final class DeclarationOwnerIdentity implements Serializable {
+		private static final long serialVersionUID = 1L;
+	}
+
+	private CtElement getExecutableDeclaration(CtExecutableReference<?> executableReference) {
+		Set<CtExecutableReference<?>> resolving = RESOLVING_EXECUTABLE_DECLARATIONS.get();
+		if (!resolving.add(executableReference)) {
+			return null;
+		}
+		try {
+			return executableReference.getExecutableDeclaration();
+		} finally {
+			resolving.remove(executableReference);
+			if (resolving.isEmpty()) {
+				RESOLVING_EXECUTABLE_DECLARATIONS.remove();
+			}
+		}
+	}
+
+	private CtTypeParameter findCorrespondingTypeParameter(
+			CtExecutableReference<?> executableReference,
+			CtExecutable<?> executableDeclaration) {
+		Deque<Pair<CtTypeReference<?>, CtTypeReference<?>>> candidates = new ArrayDeque<>();
+		// Push siblings in reverse so the worklist preserves the previous depth-first search order.
+		List<CtTypeReference<?>> referenceParameters = executableReference.getParameters();
+		int parameterCount = Math.min(referenceParameters.size(), executableDeclaration.getParameters().size());
+		for (int index = parameterCount - 1; index >= 0; index--) {
+			candidates.push(Pair.of(
+					referenceParameters.get(index),
+					executableDeclaration.getParameters().get(index).getType()));
+		}
+		candidates.push(Pair.of(executableReference.getType(), executableDeclaration.getType()));
+
+		while (!candidates.isEmpty()) {
+			Pair<CtTypeReference<?>, CtTypeReference<?>> candidate = candidates.pop();
+			CtTypeReference<?> referenceType = candidate.getLeft();
+			CtTypeReference<?> declarationType = candidate.getRight();
+			if (referenceType == null || declarationType == null) {
+				continue;
+			}
+			if (referenceType == this) {
+				if (declarationType instanceof CtTypeParameterReference typeParameter
+						&& declarationType.getSimpleName().equals(getSimpleName())) {
+					CtTypeParameter declaration = findTypeParamDeclarationInParents(typeParameter);
+					return declaration != null ? declaration : typeParameter.getDeclaration();
+				}
+				continue;
+			}
+			if (referenceType instanceof CtWildcardReference referenceWildcard
+					&& declarationType instanceof CtWildcardReference declarationWildcard) {
+				if (referenceWildcard.isUpper() == declarationWildcard.isUpper()) {
+					candidates.push(Pair.of(
+							referenceWildcard.getBoundingType(), declarationWildcard.getBoundingType()));
+				}
+				continue;
+			}
+			if (referenceType instanceof CtArrayTypeReference<?> referenceArray
+					&& declarationType instanceof CtArrayTypeReference<?> declarationArray) {
+				candidates.push(Pair.of(
+						referenceArray.getComponentType(), declarationArray.getComponentType()));
+				continue;
+			}
+			if (referenceType instanceof CtWildcardReference
+					|| declarationType instanceof CtWildcardReference
+					|| referenceType instanceof CtArrayTypeReference
+					|| declarationType instanceof CtArrayTypeReference
+					|| !Objects.equals(referenceType.getQualifiedName(), declarationType.getQualifiedName())) {
+				continue;
+			}
+
+			List<CtTypeReference<?>> referenceArguments = referenceType.getActualTypeArguments();
+			List<CtTypeReference<?>> declarationArguments = declarationType.getActualTypeArguments();
+			int argumentCount = Math.min(referenceArguments.size(), declarationArguments.size());
+			for (int index = argumentCount - 1; index >= 0; index--) {
+				candidates.push(Pair.of(
+						referenceArguments.get(index),
+						declarationArguments.get(index)));
+			}
+			candidates.push(Pair.of(
+					referenceType.getDeclaringType(), declarationType.getDeclaringType()));
+		}
+		return null;
+	}
+
+	private CtTypeParameter findTypeParamDeclarationInParents(CtElement element) {
+		CtFormalTypeDeclarer typeDeclarer = element.getParent(CtFormalTypeDeclarer.class);
+		return findTypeParamDeclarationInHierarchy(typeDeclarer);
+	}
+
+	private CtTypeParameter findTypeParamDeclarationInHierarchy(CtFormalTypeDeclarer typeDeclarer) {
+		while (typeDeclarer != null) {
+			CtTypeParameter result = findTypeParamDeclaration(typeDeclarer, getSimpleName());
+			if (result != null) {
+				return result;
+			}
+			typeDeclarer = ((CtElement) typeDeclarer).getParent(CtFormalTypeDeclarer.class);
 		}
 		return null;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtTypeParameterReferenceImpl.java
@@ -24,6 +24,7 @@ import spoon.support.DerivedProperty;
 import spoon.support.UnsettableProperty;
 
 import java.io.File;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayDeque;
@@ -228,6 +229,7 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 		return expectedOwner == null || expectedOwner.equals(actualOwner);
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private String declarationOwner(CtTypeParameter declaration) {
 		if (!declaration.isParentInitialized()) {
 			return null;
@@ -262,6 +264,7 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 		return null;
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private String sourceDeclarationOwner(String kind, CtElement declaration, int rank) {
 		if (!declaration.getPosition().isValidPosition()) {
 			return null;
@@ -278,6 +281,7 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 				+ "|" + rank;
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private String virtualSourcePath(CtElement declaration) {
 		var compilationUnit = declaration.getPosition().getCompilationUnit();
 		for (var entry : declaration.getFactory().CompilationUnit().getMap().entrySet()) {
@@ -293,9 +297,11 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 	}
 
 	private static final class DeclarationOwnerIdentity implements Serializable {
+		@Serial
 		private static final long serialVersionUID = 1L;
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private CtElement getExecutableDeclaration(CtExecutableReference<?> executableReference) {
 		Set<CtExecutableReference<?>> resolving = RESOLVING_EXECUTABLE_DECLARATIONS.get();
 		if (!resolving.add(executableReference)) {
@@ -311,6 +317,7 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 		}
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private CtTypeParameter findCorrespondingTypeParameter(
 			CtExecutableReference<?> executableReference,
 			CtExecutable<?> executableDeclaration) {
@@ -381,13 +388,15 @@ public class CtTypeParameterReferenceImpl extends CtTypeReferenceImpl<Object> im
 		return findTypeParamDeclarationInHierarchy(typeDeclarer);
 	}
 
+	@SuppressWarnings("ReturnOfNull")
 	private CtTypeParameter findTypeParamDeclarationInHierarchy(CtFormalTypeDeclarer typeDeclarer) {
-		while (typeDeclarer != null) {
-			CtTypeParameter result = findTypeParamDeclaration(typeDeclarer, getSimpleName());
+		CtFormalTypeDeclarer currentTypeDeclarer = typeDeclarer;
+		while (currentTypeDeclarer != null) {
+			CtTypeParameter result = findTypeParamDeclaration(currentTypeDeclarer, getSimpleName());
 			if (result != null) {
 				return result;
 			}
-			typeDeclarer = ((CtElement) typeDeclarer).getParent(CtFormalTypeDeclarer.class);
+			currentTypeDeclarer = currentTypeDeclarer.getParent(CtFormalTypeDeclarer.class);
 		}
 		return null;
 	}

--- a/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtWildcardReferenceImpl.java
@@ -87,6 +87,11 @@ public class CtWildcardReferenceImpl extends CtTypeParameterReferenceImpl implem
 	}
 
 	@Override
+	public CtTypeReference<?> getTypeErasure() {
+		return isUpper() ? getBoundingType().getTypeErasure() : getFactory().Type().objectType();
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public Class<Object> getActualClass() {
 		if (isUpper()) {

--- a/src/test/java/spoon/test/reference/TypeParameterErasureRecursionTest.java
+++ b/src/test/java/spoon/test/reference/TypeParameterErasureRecursionTest.java
@@ -1,0 +1,716 @@
+package spoon.test.reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import spoon.Launcher;
+import spoon.reflect.code.CtConstructorCall;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtConstructor;
+import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.CtParameter;
+import spoon.reflect.declaration.CtType;
+import spoon.reflect.declaration.CtTypeParameter;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.reference.CtExecutableReference;
+import spoon.reflect.reference.CtTypeParameterReference;
+import spoon.reflect.reference.CtTypeReference;
+import spoon.reflect.reference.CtWildcardReference;
+import spoon.reflect.visitor.chain.CtQueryable;
+import spoon.reflect.visitor.filter.TypeFilter;
+import spoon.support.compiler.VirtualFile;
+import spoon.support.SerializationModelStreamer;
+
+class TypeParameterErasureRecursionTest {
+	@Test
+	void genericAnonymousIteratorTraversalTerminates() {
+		// contract: type-parameter erasure does not re-enter executable declaration lookup
+		// (#6802)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/TypeParameterErasureRecursion.java");
+
+		// when
+		var model = launcher.buildModel();
+
+		// then
+		assertThat(model.getElements(element -> true))
+				.allSatisfy(element -> assertThatCode(element::toString).doesNotThrowAnyException());
+	}
+
+	@Test
+	void wildcardErasureUsesItsJavaLanguageBound() {
+		// contract: wildcard erasure does not require a type-parameter declaration
+		// (#6802)
+		// given
+		Launcher launcher = new Launcher();
+		CtWildcardReference wildcard = launcher.getFactory().Core().createWildcardReference();
+		wildcard.setBoundingType(launcher.getFactory().Type().stringType());
+
+		// when / then
+		assertThat(wildcard.getTypeErasure().getQualifiedName()).isEqualTo("java.lang.String");
+		assertThat(wildcard.setUpper(false).getTypeErasure().getQualifiedName()).isEqualTo("java.lang.Object");
+	}
+
+	@Test
+	void adaptedExecutableTypeParameterResolvesToLexicalDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/TypeParameterErasureRecursion.java");
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "apply");
+		CtWildcardReference wildcard = (CtWildcardReference) invocation.getExecutable().getParameters().get(0);
+		CtTypeParameterReference adaptedTypeParameter = (CtTypeParameterReference) wildcard.getBoundingType();
+
+		// then
+		assertThat(adaptedTypeParameter.getDeclaration().getParent(CtMethod.class).getSimpleName())
+				.isEqualTo("mapAll");
+	}
+
+	@Test
+	void adaptedForEachTypeParameterRetainsItsDeclaringTypeParameter() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource("src/test/resources/spoon/test/reference/TypeParameterErasureRecursion.java");
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "forEach");
+		CtWildcardReference consumerArgument = (CtWildcardReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+		CtTypeParameterReference adaptedTypeParameter =
+				(CtTypeParameterReference) consumerArgument.getBoundingType();
+
+		// then
+		assertThat(adaptedTypeParameter)
+				.as("adapted for-each type parameter [declaration owner, erasure]")
+				.extracting(
+						type -> type.getDeclaration().getParent(CtType.class).getQualifiedName(),
+						type -> type.getTypeErasure().getQualifiedName())
+				.containsExactly("java.lang.Iterable", "java.lang.Object");
+	}
+
+	@Test
+	void nestedExecutableTypeParameterResolvesToCalleeDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends Number> void callee(java.util.List<T> value) {}
+				<T extends Number> void caller(java.util.List<T> value) { callee(value); }
+			}
+			""", "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getDeclaration().getParent(CtMethod.class).getSimpleName())
+				.isEqualTo("callee");
+	}
+
+	@Test
+	void nestedDeclaringTypeParameterDoesNotResolveToShadowingCallerDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe<T> {
+				void callee(java.util.List<T> value) {}
+				<T> void caller() { callee(null); }
+			}
+			""", "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getDeclaration())
+				.isSameAs(model.getAllTypes().iterator().next().getFormalCtTypeParameters().get(0));
+	}
+
+	@Test
+	void adaptedCallerTypeParameterDoesNotResolveToUnrelatedCalleeParameterWithSameName() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends CharSequence> void callee(java.util.List<T> value) {}
+				<T extends Number> void caller(java.util.List<T> value) { callee(value); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtMethod<?> caller = model.getAllTypes().iterator().next().getMethodsByName("caller").get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "callee");
+		CtTypeParameterReference adaptedTypeParameter = caller.getFormalCtTypeParameters().get(0).getReference();
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(adaptedTypeParameter));
+
+		// when
+		var declaration = adaptedTypeParameter.getDeclaration();
+
+		// then
+		assertThat(declaration).isSameAs(caller.getFormalCtTypeParameters().get(0));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void generatedExecutableReferenceRetainsCalleeTypeParameter() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends Number> void callee(java.util.List<T> value) {}
+				<T extends CharSequence> void caller() { callee(null); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtType<?> type = model.getAllTypes().iterator().next();
+		CtMethod<?> callee = type.getMethodsByName("callee").get(0);
+		CtMethod<?> caller = type.getMethodsByName("caller").get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "callee");
+		CtTypeParameterReference calleeTypeParameter = callee.getFormalCtTypeParameters().get(0).getReference();
+		callee.getParameters().get(0).getType().setActualTypeArguments(List.of(calleeTypeParameter));
+		CtExecutableReference<Object> executableReference =
+				(CtExecutableReference<Object>) callee.getReference();
+		((CtInvocation<Object>) invocation).setExecutable(executableReference);
+
+		// when
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) executableReference
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter)
+				.as("generated executable type parameter")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(callee.getFormalCtTypeParameters().get(0));
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void positionlessOverloadsRetainTheCalleeTypeParameter() {
+		// contract: declaration ownership distinguishes generated same-name, same-arity overloads
+		// (#6802)
+		// given
+		Factory factory = new Launcher().getFactory();
+		CtClass<?> type = factory.Class().create("GenericProbe");
+		CtMethod<Void> callee = createPositionlessGenericMethod(
+				factory, type, List.class, factory.Type().createReference(Number.class));
+		CtMethod<Void> caller = createPositionlessGenericMethod(
+				factory, type, Set.class, factory.Type().createReference(CharSequence.class));
+		CtInvocation<Void> invocation = factory.Code().createInvocation(null, callee.getReference());
+		caller.setBody(factory.Core().createBlock().addStatement(invocation));
+
+		// when
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getMetadata("spoon.typeParameterDeclarationOwner"))
+				.as("callee declaration-owner metadata")
+				.isNotNull()
+				.isNotEqualTo(caller.getFormalCtTypeParameters().get(0).getReference()
+						.getMetadata("spoon.typeParameterDeclarationOwner"));
+		assertThat(nestedTypeParameter)
+				.as("positionless overload type parameter")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(callee.getFormalCtTypeParameters().get(0));
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void positionlessTypeParameterOwnershipSurvivesExecutableRenaming() {
+		// contract: declaration ownership remains attached to the declaration across model mutations
+		// (#6802)
+		// given
+		Factory factory = new Launcher().getFactory();
+		CtClass<?> type = factory.Class().create("MutableGenericProbe");
+		CtMethod<Void> callee = createPositionlessGenericMethod(
+				factory, type, List.class, factory.Type().createReference(Number.class));
+		CtMethod<Void> caller = createPositionlessGenericMethod(
+				factory, type, Set.class, factory.Type().createReference(CharSequence.class));
+		CtInvocation<Void> invocation = factory.Code().createInvocation(null, callee.getReference());
+		caller.setBody(factory.Core().createBlock().addStatement(invocation));
+		CtTypeParameterReference callerTypeParameter = caller.getFormalCtTypeParameters().get(0).getReference();
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(callerTypeParameter));
+
+		// when
+		caller.setSimpleName("renamed");
+
+		// then
+		assertThat(callerTypeParameter)
+				.as("type parameter from the renamed caller")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(caller.getFormalCtTypeParameters().get(0));
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.CharSequence");
+				});
+	}
+
+	@Test
+	void parsedTypeParameterOwnershipSurvivesExecutableRenaming() {
+		// contract: source declaration ownership uses immutable source identity across model mutations
+		// (#6802)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+				class ParsedGenericProbe {
+					<T extends CharSequence> void method(java.util.List<T> value) {}
+					<T extends Number> void caller(java.util.Set<T> value) { method(null); }
+				}
+				""", "ParsedGenericProbe.java"));
+		CtType<?> type = launcher.buildModel().getAllTypes().iterator().next();
+		CtMethod<?> caller = type.getMethodsByName("caller").get(0);
+		CtTypeParameter callerTypeParameter = caller.getFormalCtTypeParameters().get(0);
+		CtTypeParameterReference callerReference = (CtTypeParameterReference) caller.getParameters().get(0)
+				.getType().getActualTypeArguments().get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "method");
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(callerReference));
+
+		// when
+		caller.setSimpleName("renamed");
+
+		// then
+		assertThat(callerReference)
+				.as("parsed type parameter from the renamed caller")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(callerTypeParameter);
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void parsedTypeParameterOwnershipSurvivesDeclaringTypeRenaming() {
+		// contract: source type-parameter ownership uses immutable source identity across model mutations
+		// (#6802)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+				class ParsedTypeProbe<T extends Number> {
+					<T extends CharSequence> void method(java.util.List<T> value) {}
+					void caller(java.util.Set<T> value) { method(null); }
+				}
+				""", "ParsedTypeProbe.java"));
+		CtType<?> type = launcher.buildModel().getAllTypes().iterator().next();
+		CtTypeParameter typeParameter = type.getFormalCtTypeParameters().get(0);
+		CtMethod<?> caller = type.getMethodsByName("caller").get(0);
+		CtTypeParameterReference callerReference = (CtTypeParameterReference) caller.getParameters().get(0)
+				.getType().getActualTypeArguments().get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "method");
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(callerReference));
+
+		// when
+		type.setSimpleName("RenamedTypeProbe");
+
+		// then
+		assertThat(callerReference)
+				.as("parsed type parameter from the renamed type")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(typeParameter);
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void unnamedVirtualFileDoesNotAuthenticateMissingDeclarationOwner() {
+		// contract: missing model-side source identity does not match a different shadowing declaration
+		// (#6802)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+				class VirtualGenericProbe<T extends Number> {
+					void method(java.util.List<T> value) {}
+					<T extends CharSequence> void caller() { method(null); }
+				}
+				"""));
+		CtType<?> type = launcher.buildModel().getAllTypes().iterator().next();
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) type.getMethodsByName("method")
+				.get(0).getParameters().get(0).getType().getActualTypeArguments().get(0);
+		CtInvocation<?> invocation = invocationNamed(type.getMethodsByName("caller").get(0), "method");
+
+		// when
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(nestedTypeParameter));
+
+		// then
+		assertThat(nestedTypeParameter)
+				.as("callee parameter from an unnamed virtual compilation unit")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(type.getFormalCtTypeParameters().get(0));
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void positionlessTypeParameterReferenceAllowsUntypedParameters() {
+		// contract: partially built generated methods do not require parameter types for declaration ownership
+		// (#6802)
+		// given
+		Factory factory = new Launcher().getFactory();
+		CtClass<?> type = factory.Class().create("PartialGenericProbe");
+		CtMethod<Void> method = factory.createMethod();
+		method.setSimpleName("method");
+		method.setType(factory.Type().voidPrimitiveType());
+		type.addMethod(method);
+		CtTypeParameter typeParameter = factory.createTypeParameter();
+		typeParameter.setSimpleName("T");
+		method.addFormalCtTypeParameter(typeParameter);
+		CtParameter<?> parameter = factory.createParameter();
+		parameter.setSimpleName("value");
+		method.addParameter(parameter);
+
+		// when
+		CtTypeParameterReference reference = typeParameter.getReference();
+
+		// then
+		assertThat(reference.getDeclaration()).isSameAs(typeParameter);
+	}
+
+	@Test
+	void directTypeParameterBoundRetainsItsDeclarationAfterReparenting() {
+		// contract: using T as another parameter's bound must not change T's declaration ownership
+		// (#6802)
+		// given
+		Factory factory = new Launcher().getFactory();
+		CtClass<?> type = factory.Class().create("BoundGenericProbe");
+		CtTypeParameter outerTypeParameter = factory.createTypeParameter();
+		outerTypeParameter.setSimpleName("T");
+		outerTypeParameter.setSuperclass(factory.Type().createReference(Number.class));
+		type.addFormalCtTypeParameter(outerTypeParameter);
+		CtMethod<Void> callee = createPositionlessGenericMethod(
+				factory, type, List.class, factory.Type().createReference(CharSequence.class));
+		CtMethod<Void> caller = factory.createMethod();
+		caller.setSimpleName("caller");
+		caller.setType(factory.Type().voidPrimitiveType());
+		type.addMethod(caller);
+		CtTypeParameter callerTypeParameter = factory.createTypeParameter();
+		callerTypeParameter.setSimpleName("U");
+		caller.addFormalCtTypeParameter(callerTypeParameter);
+		CtTypeParameterReference outerReference = outerTypeParameter.getReference();
+		callerTypeParameter.setSuperclass(outerReference);
+		CtInvocation<Void> invocation = factory.Code().createInvocation(null, callee.getReference());
+		caller.setBody(factory.Core().createBlock().addStatement(invocation));
+
+		// when
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(outerReference));
+
+		// then
+		assertThat(outerReference)
+				.as("reparented direct bound")
+				.satisfies(reference -> {
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(outerTypeParameter);
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void metadataFreeExecutableReferenceRetainsCalleeTypeParameter() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends Number> void callee(java.util.List<T> value) {}
+				<T extends CharSequence> void caller() { callee(null); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtType<?> type = model.getAllTypes().iterator().next();
+		CtMethod<?> callee = type.getMethodsByName("callee").get(0);
+		CtMethod<?> caller = type.getMethodsByName("caller").get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "callee");
+		CtTypeParameterReference metadataFreeTypeParameter = launcher.getFactory().Core()
+				.createTypeParameterReference();
+		metadataFreeTypeParameter.setSimpleName("T");
+		callee.getParameters().get(0).getType().setActualTypeArguments(List.of(metadataFreeTypeParameter));
+		CtExecutableReference<Object> executableReference =
+				(CtExecutableReference<Object>) callee.getReference();
+		((CtInvocation<Object>) invocation).setExecutable(executableReference);
+
+		// when
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) executableReference
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter)
+				.as("metadata-free type parameter")
+				.satisfies(reference -> {
+					assertThat(reference.getMetadata("spoon.typeParameterDeclarationOwner"))
+							.as("declaration-owner metadata")
+							.isNull();
+					assertThat(reference.getDeclaration())
+							.as("declaration")
+							.isSameAs(callee.getFormalCtTypeParameters().get(0));
+					assertThat(reference.getTypeErasure().getQualifiedName())
+							.as("erasure")
+							.isEqualTo("java.lang.Number");
+				});
+	}
+
+	@Test
+	void adaptedCallerTypeParameterOwnershipSurvivesCloneAndSerialization() throws Exception {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends CharSequence> void callee(java.util.List<T> value) {}
+				<T extends Number> void caller(java.util.List<T> value) { callee(value); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtMethod<?> caller = model.getAllTypes().iterator().next().getMethodsByName("caller").get(0);
+		CtInvocation<?> invocation = invocationNamed(caller, "callee");
+		CtTypeParameterReference adaptedTypeParameter = caller.getFormalCtTypeParameters().get(0).getReference();
+		invocation.getExecutable().getParameters().get(0).setActualTypeArguments(List.of(adaptedTypeParameter));
+
+		// when
+		CtMethod<?> clonedCaller = caller.clone();
+		CtInvocation<?> clonedInvocation = invocationNamed(clonedCaller, "callee");
+		CtTypeParameterReference clonedTypeParameter = (CtTypeParameterReference) clonedInvocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+		SerializationModelStreamer streamer = new SerializationModelStreamer();
+		streamer.save(launcher.getFactory(), serialized);
+		Factory loadedFactory = streamer.load(new ByteArrayInputStream(serialized.toByteArray()));
+		CtMethod<?> loadedCaller = loadedFactory.Type().get("GenericProbe").getMethodsByName("caller").get(0);
+		CtInvocation<?> loadedInvocation = invocationNamed(loadedCaller, "callee");
+		CtTypeParameterReference loadedTypeParameter = (CtTypeParameterReference) loadedInvocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(clonedTypeParameter.getDeclaration()).isSameAs(clonedCaller.getFormalCtTypeParameters().get(0));
+		assertThat(loadedTypeParameter.getDeclaration()).isSameAs(loadedCaller.getFormalCtTypeParameters().get(0));
+	}
+
+	@Test
+	void nestedConstructorTypeParameterResolvesToConstructorDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends Number> GenericProbe(java.util.List<T> value) {}
+				static <T extends Number> void caller(java.util.List<T> value) { new GenericProbe(value); }
+			}
+			""", "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtConstructorCall<?> constructorCall = model
+				.filterChildren(new TypeFilter<>(CtConstructorCall.class))
+				.first(CtConstructorCall.class);
+		assertThat(constructorCall).as("constructor call in generic probe").isNotNull();
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) constructorCall.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getDeclaration().getParent()).isInstanceOf(CtConstructor.class);
+	}
+
+	@Test
+	void deeplyNestedExecutableTypeParameterResolvesToCalleeDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T extends Number> void callee(java.util.List<java.util.List<T>> value) {}
+				<T extends Number> void caller(java.util.List<java.util.List<T>> value) { callee(value); }
+			}
+			""", "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getDeclaration().getParent(CtMethod.class).getSimpleName())
+				.isEqualTo("callee");
+	}
+
+	@ParameterizedTest(name = "receiver type {0}")
+	@ValueSource(strings = { "Box", "Box<T>" })
+	void receiverTypeParameterResolvesToDeclaringType(String receiverType) {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class Box<T> {
+				void callee(java.util.List<java.util.List<T>> value) {}
+			}
+			class Caller<T> {
+				void caller(%s box) { box.callee(null); }
+			}
+			""".formatted(receiverType), "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference nestedTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(nestedTypeParameter.getDeclaration().getParent(CtType.class).getSimpleName()).isEqualTo("Box");
+	}
+
+	@Test
+	void directGenericExecutableParameterResolvesToCalleeDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T> void callee(T value) {}
+				void caller() { callee(null); }
+			}
+			""", "GenericProbe.java"));
+
+		// when
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		// then
+		assertThat(invocation.getExecutable())
+				.as("direct generic invocation [parameter erasure, declaration]")
+				.extracting(
+						executable -> executable.getParameters().get(0).getQualifiedName(),
+						executable -> executable.getExecutableDeclaration().getSimpleName())
+				.containsExactly("java.lang.Object", "callee");
+	}
+
+	@Test
+	void siblingExecutableTypeParametersResolveRepeatedlyWithoutLeakingGuardState() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<A, B> void callee(java.util.Map<A, java.util.List<B>> value) {}
+				<A, B> void caller() { callee(null); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference first = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+		CtTypeParameterReference second = (CtTypeParameterReference) invocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(1).getActualTypeArguments().get(0);
+
+		// when / then
+		for (int iteration = 0; iteration < 3; iteration++) {
+			assertThat(List.of(first, second))
+					.as("sibling type-parameter declaration owners at iteration %d", iteration)
+					.extracting(type -> type.getDeclaration().getParent(CtMethod.class).getSimpleName())
+					.containsExactly("callee", "callee");
+		}
+
+		// and when
+		Launcher separateLauncher = new Launcher();
+		separateLauncher.addInputResource(new VirtualFile("""
+			class SeparateProbe {
+				<T> void callee(java.util.List<T> value) {}
+				<T> void caller() { callee(null); }
+			}
+			""", "SeparateProbe.java"));
+		var separateModel = separateLauncher.buildModel();
+		CtInvocation<?> separateInvocation = invocationNamed(separateModel, "callee");
+		CtTypeParameterReference separateTypeParameter = (CtTypeParameterReference) separateInvocation.getExecutable()
+				.getParameters().get(0).getActualTypeArguments().get(0);
+
+		// then
+		assertThat(separateTypeParameter.getDeclaration().getParent(CtMethod.class).getSimpleName())
+				.isEqualTo("callee");
+	}
+
+	@Test
+	void adaptedReturnTypeParameterResolvesToCallerDeclaration() {
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile("""
+			class GenericProbe {
+				<T> java.util.List<T> callee() { return null; }
+				<T> void caller() { java.util.List<T> value = callee(); }
+			}
+			""", "GenericProbe.java"));
+		var model = launcher.buildModel();
+		CtInvocation<?> invocation = invocationNamed(model, "callee");
+		CtTypeParameterReference returnTypeParameter = (CtTypeParameterReference) invocation.getExecutable()
+				.getType().getActualTypeArguments().get(0);
+
+		// when
+		var declaration = returnTypeParameter.getDeclaration();
+
+		// then
+		assertThat(declaration.getParent(CtMethod.class).getSimpleName()).isEqualTo("caller");
+	}
+
+	private static CtMethod<Void> createPositionlessGenericMethod(
+			Factory factory, CtClass<?> declaringType, Class<?> parameterType, CtTypeReference<?> bound) {
+		CtMethod<Void> method = factory.createMethod();
+		method.setSimpleName("method");
+		method.setType(factory.Type().voidPrimitiveType());
+		declaringType.addMethod(method);
+		CtTypeParameter typeParameter = factory.createTypeParameter();
+		typeParameter.setSimpleName("T");
+		typeParameter.setSuperclass(bound);
+		method.addFormalCtTypeParameter(typeParameter);
+		CtTypeReference<?> parameterReference = factory.Type().createReference(parameterType);
+		CtParameter<?> parameter = factory.createParameter();
+		parameter.setSimpleName("value");
+		parameter.setType(parameterReference);
+		method.addParameter(parameter);
+		parameterReference.addActualTypeArgument(typeParameter.getReference());
+		return method;
+	}
+
+	private static CtInvocation<?> invocationNamed(CtQueryable root, String name) {
+		CtInvocation<?> invocation = root
+				.filterChildren(new TypeFilter<>(CtInvocation.class))
+				.select((CtInvocation<?> candidate) -> candidate.getExecutable().getSimpleName().equals(name))
+				.first(CtInvocation.class);
+		assertThat(invocation).as("invocation named <%s>", name).isNotNull();
+		return invocation;
+	}
+}

--- a/src/test/resources/spoon/test/reference/TypeParameterErasureRecursion.java
+++ b/src/test/resources/spoon/test/reference/TypeParameterErasureRecursion.java
@@ -1,0 +1,67 @@
+package spoon.test.reference;
+
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+abstract class TypeParameterErasureRecursion<W, U> extends AbstractSet<U> {
+	private final Set<W> values;
+
+	TypeParameterErasureRecursion(Set<W> values) {
+		this.values = values;
+	}
+
+	@Override
+	public Iterator<U> iterator() {
+		return new Iterator<>() {
+			private final Iterator<W> iterator = values.iterator();
+
+			@Override
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+
+			@Override
+			public U next() {
+				return unwrap(iterator.next());
+			}
+		};
+	}
+
+	protected abstract U unwrap(W value);
+
+	@Override
+	@SuppressWarnings("unchecked")
+	public <A> A[] toArray(A[] array) {
+		Object[] result = array;
+		for (U value : this) {
+			result[0] = value;
+		}
+		return array;
+	}
+}
+
+abstract class GenericMap<E> {
+	private final Map<String, E> delegate = null;
+
+	Set<Map.Entry<String, E>> entrySet() {
+		return new TypeParameterErasureRecursion<>(delegate.entrySet()) {
+			@Override
+			protected Map.Entry<String, E> unwrap(Map.Entry<String, E> value) {
+				return value;
+			}
+		};
+	}
+}
+
+class GenericLambda {
+	static <T> void mapAll(Collection<? extends T> values, Function<T, MissingKey> mapper) {
+		values.forEach(value -> consume(mapper.apply(value), value));
+	}
+
+	static <T> void consume(MissingKey key, T value) {
+	}
+}


### PR DESCRIPTION
## Summary

Prevent recursive type erasure when Spoon resolves a bounded wildcard in no-classpath mode.

Fixes #6802.

## Problem

Type erasure is the simpler type Spoon uses when it compares generic method or constructor signatures. For a parameter such as `? extends E`, Spoon tried to compute that type by finding a declaration named `?`. Resolving the bound `E` then requested the containing method declaration. Matching that method erased the same wildcard parameter again, so the cycle repeated until a `StackOverflowError` occurred.

## Change

- Erase an upper-bounded wildcard to the erasure of its bound.
- Erase a lower-bounded wildcard to `Object`.
- Guard executable matching against re-entering the same executable reference through nested or sibling type parameters.
- Traverse paired return, parameter, declaring, wildcard, array, and generic-argument types with one ordered worklist, preserving the existing first-match order.
- After exact method or constructor lookup succeeds, follow the reference's array, wildcard, declaring-type, and generic-argument path to the corresponding nested declaration.
- Keep the surrounding lexical declaration for references created from a lexical type parameter, including after reparenting, cloning, and model serialization.
- Identify parsed declaration owners by source location rather than mutable method or type names, and retain the owner marker when the model is cloned or serialized.
- Resolve unnamed in-memory source files through Spoon's compilation-unit cache so the same declaration keeps one stable owner.
- Preserve intentional not-found results in declaration lookup helpers while satisfying the repository's Qodana requirements.

## Validation

- Added a reduced no-classpath regression that produces a `StackOverflowError` before the fix and terminates after the fix.
- `mvn -q -Dtest=spoon.test.reference.TypeParameterErasureRecursionTest test` passes all 24 focused tests, including positionless overloads, renamed parsed methods and types, direct-bound reparenting, cloning, serialization, and unnamed in-memory sources.
- `mvn -q -Dtest=spoon.test.generics.GenericsTest,spoon.test.reference.TypeReferenceTest test` passes all 96 tests.
- `mvn -q verify` passes with 16 skipped and no failures or errors.
- As a compatibility replay, [StoneDetector](https://github.com/StoneDetector/StoneDetector) processes the historical [Elasticsearch `AttributeMap.java`](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/x-pack/plugin/esql/src/main/java/org/elasticsearch/xpack/esql/core/expression/AttributeMap.java): AST 1/1, CFG 5/5, dominators 5/5, paths 5/5, and no reported errors. That full file also passes on the audited upstream base, so the reduced regression above is the discriminating evidence.
- All 14 GitHub checks pass, including the main Qodana check and the Java 17, 21, and 25 test matrix.



