### PR TITLE
fix: validate deep binary expressions iteratively

### DIFF
--- a/src/main/java/spoon/reflect/visitor/AstParentConsistencyChecker.java
+++ b/src/main/java/spoon/reflect/visitor/AstParentConsistencyChecker.java
@@ -7,12 +7,19 @@
  */
 package spoon.reflect.visitor;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
 
 public class AstParentConsistencyChecker extends CtScanner {
 
 	private CtElement parent;
+
 	@Override
 	public void scan(CtElement element) {
 		// We allow to share references across the AST
@@ -21,20 +28,101 @@ public class AstParentConsistencyChecker extends CtScanner {
 		if (element == null || element instanceof CtReference) {
 			return;
 		}
-		if (parent != null
-				&& element.isParentInitialized() // this is the fix of #1747
-				&& element.getParent() != parent) {
-			throw new IllegalStateException(toDebugString(element) // better debug
-					+ " is set as child of\n" + toDebugString(element.getParent())
-					+ "however it is visited as a child of\n" + toDebugString(parent));
-		}
+		checkParent(element, parent);
 		CtElement parent = this.parent;
 		this.parent = element;
-		super.scan(element);
-		this.parent = parent;
+		try {
+			super.scan(element);
+		} finally {
+			this.parent = parent;
+		}
+	}
+
+	/**
+	 * @param operator binary operator to visit
+	 * @param <T> type of the expression produced by the operator
+	 */
+	@Override
+	public <T> void visitCtBinaryOperator(CtBinaryOperator<T> operator) {
+		if (getClass() != AstParentConsistencyChecker.class) {
+			super.visitCtBinaryOperator(operator);
+			return;
+		}
+
+		CtElement initialParent = parent;
+		Deque<BinaryFrame> frames = new ArrayDeque<>();
+		frames.push(new BinaryFrame(operator));
+		try {
+			while (!frames.isEmpty()) {
+				BinaryFrame frame = frames.peek();
+				switch (frame.nextStage()) {
+				case 0 -> {
+					parent = frame.operator;
+					enter(frame.operator);
+					scan(CtRole.ANNOTATION, frame.operator.getAnnotations());
+					scan(CtRole.TYPE, frame.operator.getType());
+					scan(CtRole.CAST, frame.operator.getTypeCasts());
+				}
+				case 1 -> scanBinaryOperand(
+						frames, CtRole.LEFT_OPERAND, frame.operator.getLeftHandOperand(), frame.operator);
+				case 2 -> scanBinaryOperand(
+						frames, CtRole.RIGHT_OPERAND, frame.operator.getRightHandOperand(), frame.operator);
+				case 3 -> scan(CtRole.COMMENT, frame.operator.getComments());
+				default -> {
+					exit(frame.operator);
+					frames.pop();
+					parent = frames.isEmpty() ? operator : frames.peek().operator;
+				}
+				}
+			}
+		} finally {
+			parent = initialParent;
+		}
+	}
+
+	private void scanBinaryOperand(
+			Deque<BinaryFrame> frames, CtRole role, CtElement operand, CtBinaryOperator<?> parentOperator) {
+		if (operand instanceof CtBinaryOperator<?> binaryOperator) {
+			checkParent(binaryOperator, parentOperator);
+			frames.push(new BinaryFrame(binaryOperator));
+		} else {
+			parent = parentOperator;
+			scan(role, operand);
+		}
+	}
+
+	private static final class BinaryFrame {
+		private final CtBinaryOperator<?> operator;
+		private int stage;
+
+		private BinaryFrame(CtBinaryOperator<?> operator) {
+			this.operator = operator;
+		}
+
+		private int nextStage() {
+			int currentStage = stage;
+			stage = currentStage + 1;
+			return currentStage;
+		}
+	}
+
+	private static void checkParent(CtElement element, CtElement expectedParent) {
+		if (expectedParent != null
+				&& element.isParentInitialized() // this is the fix of #1747
+				&& element.getParent() != expectedParent) {
+			throw new IllegalStateException(toDebugString(element) // better debug
+					+ " is set as child of\n" + toDebugString(element.getParent())
+					+ "however it is visited as a child of\n" + toDebugString(expectedParent));
+		}
 	}
 
 	private static String toDebugString(CtElement e) {
-		return "Element: " + e + "\nSignature: " + e.getShortRepresentation() + "\nClass: " + e.getClass() + "\nposition: " + e.getPosition() + "\n";
+		String elementDescription = e.getClass().getSimpleName();
+		if (e instanceof CtBinaryOperator<?> binaryOperator) {
+			elementDescription = binaryOperator.getKind() + " binary operator";
+		} else if (e instanceof CtNamedElement namedElement) {
+			elementDescription += " " + namedElement.getSimpleName();
+		}
+		return "Element: " + elementDescription + "\nClass: " + e.getClass() + "\nposition: " + e.getPosition() + "\n";
 	}
 }

--- a/src/main/java/spoon/support/visitor/ProcessingVisitor.java
+++ b/src/main/java/spoon/support/visitor/ProcessingVisitor.java
@@ -7,10 +7,15 @@
  */
 package spoon.support.visitor;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 import spoon.processing.Processor;
 import spoon.processing.TraversalStrategy;
+import spoon.reflect.code.CtBinaryOperator;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.factory.Factory;
+import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.CtScanner;
 
 /**
@@ -53,24 +58,72 @@ public class ProcessingVisitor extends CtScanner {
 	 * {@link Processor#isToBeProcessed(CtElement)} returns true.
 	 */
 	@Override
-	@SuppressWarnings("unchecked")
 	public void scan(CtElement e) {
 		if (e == null) {
 			return;
 		}
+		if (getClass() == ProcessingVisitor.class && e instanceof CtBinaryOperator<?> binaryOperator) {
+			scanBinaryOperator(binaryOperator);
+			return;
+		}
+		processIfRequested(e, TraversalStrategy.PRE_ORDER);
+		super.scan(e);
+		processIfRequested(e, TraversalStrategy.POST_ORDER);
+	}
+
+	@SuppressWarnings("unchecked")
+	private void processIfRequested(CtElement element, TraversalStrategy strategy) {
 		Processor<CtElement> p = (Processor<CtElement>) processor;
-		if (p.getTraversalStrategy() == TraversalStrategy.PRE_ORDER
-				&& canBeProcessed(e)) {
-			if (p.isToBeProcessed(e)) {
-				p.process(e);
+		if (p.getTraversalStrategy() == strategy && canBeProcessed(element) && p.isToBeProcessed(element)) {
+			p.process(element);
+		}
+	}
+
+	private void scanBinaryOperator(CtBinaryOperator<?> root) {
+		Deque<BinaryFrame> frames = new ArrayDeque<>();
+		frames.push(new BinaryFrame(root));
+		while (!frames.isEmpty()) {
+			BinaryFrame frame = frames.peek();
+			switch (frame.nextStage()) {
+			case 0 -> {
+				processIfRequested(frame.operator, TraversalStrategy.PRE_ORDER);
+				enter(frame.operator);
+				scan(CtRole.ANNOTATION, frame.operator.getAnnotations());
+				scan(CtRole.TYPE, frame.operator.getType());
+				scan(CtRole.CAST, frame.operator.getTypeCasts());
+			}
+			case 1 -> scanBinaryOperand(frames, CtRole.LEFT_OPERAND, frame.operator.getLeftHandOperand());
+			case 2 -> scanBinaryOperand(frames, CtRole.RIGHT_OPERAND, frame.operator.getRightHandOperand());
+			case 3 -> scan(CtRole.COMMENT, frame.operator.getComments());
+			default -> {
+				exit(frame.operator);
+				processIfRequested(frame.operator, TraversalStrategy.POST_ORDER);
+				frames.pop();
+				}
 			}
 		}
-		super.scan(e);
-		if (p.getTraversalStrategy() == TraversalStrategy.POST_ORDER
-				&& canBeProcessed(e)) {
-			if (p.isToBeProcessed(e)) {
-				p.process(e);
-			}
+	}
+
+	private void scanBinaryOperand(Deque<BinaryFrame> frames, CtRole role, CtElement operand) {
+		if (operand instanceof CtBinaryOperator<?> binaryOperator) {
+			frames.push(new BinaryFrame(binaryOperator));
+		} else {
+			scan(role, operand);
+		}
+	}
+
+	private static final class BinaryFrame {
+		private final CtBinaryOperator<?> operator;
+		private int stage;
+
+		private BinaryFrame(CtBinaryOperator<?> operator) {
+			this.operator = operator;
+		}
+
+		private int nextStage() {
+			int currentStage = stage;
+			stage = currentStage + 1;
+			return currentStage;
 		}
 	}
 

--- a/src/test/java/spoon/reflect/visitor/AstParentConsistencyCheckerTest.java
+++ b/src/test/java/spoon/reflect/visitor/AstParentConsistencyCheckerTest.java
@@ -1,0 +1,150 @@
+package spoon.reflect.visitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import spoon.Launcher;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
+import spoon.support.compiler.VirtualFile;
+
+class AstParentConsistencyCheckerTest {
+	private static final int DEEP_BINARY_OPERATOR_COUNT = 32_000;
+
+	@Test
+	void deeplyNestedBinaryOperatorsDoNotConsumeOneStackFrameEach() {
+		// contract: parent validation supports legal, deeply nested binary-expression trees
+		// (#6804)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.addInputResource(new VirtualFile(deepBinarySource("DeepBinary"), "DeepBinary.java"));
+
+		// when / then
+		assertThatCode(launcher::buildModel).doesNotThrowAnyException();
+	}
+
+	@Test
+	void iterativeBinaryTraversalStillRejectsAnInconsistentParent() {
+		// contract: iterative traversal retains the parent-consistency invariant
+		// (#6804)
+		// given
+		CtClass<?> type = Launcher.parseClass("class BrokenBinary { int value = 1 + 2 + 3; }");
+		CtBinaryOperator<?> root = (CtBinaryOperator<?>) type.getField("value").getDefaultExpression();
+		root.getLeftHandOperand().setParent(root.getRightHandOperand());
+
+		// when / then
+		assertThatThrownBy(() -> new AstParentConsistencyChecker().scan(root))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("however it is visited as a child of");
+	}
+
+	@Test
+	void deeplyNestedInconsistentBinaryOperatorProducesTheParentDiagnostic() {
+		// contract: reporting an invalid deep tree is bounded as well as validating a valid one
+		// (#6804)
+		// given
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().disableConsistencyChecks();
+		launcher.addInputResource(new VirtualFile(
+				deepBinarySource("BrokenDeepBinary"), "BrokenDeepBinary.java"));
+		launcher.buildModel();
+		CtClass<?> type = launcher.getFactory().Class().get("BrokenDeepBinary");
+		CtBinaryOperator<?> root = (CtBinaryOperator<?>) type.getField("value").getDefaultExpression();
+		root.getLeftHandOperand().setParent(type.getField("value"));
+
+		// when / then
+		assertThatThrownBy(() -> new AstParentConsistencyChecker().scan(root))
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("PLUS binary operator")
+				.hasMessageContaining("however it is visited as a child of");
+	}
+
+	@Test
+	void subclassesRetainRecursiveScannerDispatchHooks() {
+		// contract: subclasses retain CtScanner's visit, role, enter, and exit ordering
+		// (#6804)
+		// given
+		CtClass<?> type = Launcher.parseClass("class BinaryHooks { int value = 1 + 2 + 3; }");
+		CtBinaryOperator<?> root = (CtBinaryOperator<?>) type.getField("value").getDefaultExpression();
+		DispatchCountingChecker checker = new DispatchCountingChecker();
+
+		// when
+		checker.scan(root);
+
+		// then
+		assertThat(checker.events).containsExactly(
+				"visit PLUS",
+				"enter PLUS",
+				"role leftOperand",
+				"visit PLUS",
+				"enter PLUS",
+				"exit PLUS",
+				"exit PLUS");
+	}
+
+	@Test
+	void directAcceptDoesNotLeakParentStateIntoTheNextScan() {
+		// contract: direct visitor dispatch leaves the reusable checker's root state unchanged
+		// (#6804)
+		// given
+		CtClass<?> firstType = Launcher.parseClass("class FirstBinary { int value = 1 + 2; }");
+		CtBinaryOperator<?> firstRoot =
+				(CtBinaryOperator<?>) firstType.getField("value").getDefaultExpression();
+		CtClass<?> secondType = Launcher.parseClass("class SecondBinary { int value = 3 + 4; }");
+		CtBinaryOperator<?> secondRoot =
+				(CtBinaryOperator<?>) secondType.getField("value").getDefaultExpression();
+		AstParentConsistencyChecker checker = new AstParentConsistencyChecker();
+
+		// when
+		firstRoot.accept(checker);
+
+		// then
+		assertThatCode(() -> checker.scan(secondRoot)).doesNotThrowAnyException();
+	}
+
+	private static String deepBinarySource(String typeName) {
+		StringBuilder source = new StringBuilder("class ")
+				.append(typeName)
+				.append(" { String value = \"a\"");
+		for (int index = 0; index < DEEP_BINARY_OPERATOR_COUNT; index++) {
+			source.append(" + \"a\"");
+		}
+		return source.append("; }").toString();
+	}
+
+	private static final class DispatchCountingChecker extends AstParentConsistencyChecker {
+		private final java.util.List<String> events = new java.util.ArrayList<>();
+
+		@Override
+		public <T> void visitCtBinaryOperator(CtBinaryOperator<T> operator) {
+			events.add("visit " + operator.getKind());
+			super.visitCtBinaryOperator(operator);
+		}
+
+		@Override
+		public void scan(CtRole role, CtElement element) {
+			if (role == CtRole.LEFT_OPERAND && element instanceof CtBinaryOperator<?>) {
+				events.add("role " + role);
+			}
+			super.scan(role, element);
+		}
+
+		@Override
+		protected void enter(CtElement element) {
+			if (element instanceof CtBinaryOperator<?> operator) {
+				events.add("enter " + operator.getKind());
+			}
+		}
+
+		@Override
+		protected void exit(CtElement element) {
+			if (element instanceof CtBinaryOperator<?> operator) {
+				events.add("exit " + operator.getKind());
+			}
+		}
+	}
+}

--- a/src/test/java/spoon/support/visitor/ProcessingVisitorTest.java
+++ b/src/test/java/spoon/support/visitor/ProcessingVisitorTest.java
@@ -1,0 +1,63 @@
+package spoon.support.visitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import spoon.Launcher;
+import spoon.processing.AbstractProcessor;
+import spoon.processing.TraversalStrategy;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.declaration.CtClass;
+import spoon.support.compiler.VirtualFile;
+
+class ProcessingVisitorTest {
+	private static final int DEEP_BINARY_OPERATOR_COUNT = 32_000;
+
+	@ParameterizedTest
+	@EnumSource(TraversalStrategy.class)
+	void deeplyNestedBinaryOperatorsAreProcessedWithoutRecursiveTraversal(TraversalStrategy traversalStrategy) {
+		// contract: both processor traversal strategies support legal, deeply nested binary trees
+		// (#6804)
+		// given
+		StringBuilder source = new StringBuilder("class DeepBinaryProcessing { String value = \"a\"");
+		for (int index = 0; index < DEEP_BINARY_OPERATOR_COUNT; index++) {
+			source.append(" + \"a\"");
+		}
+		source.append("; }");
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().disableConsistencyChecks();
+		launcher.addInputResource(new VirtualFile(source.toString(), "DeepBinaryProcessing.java"));
+		launcher.buildModel();
+		CtClass<?> type = launcher.getFactory().Class().get("DeepBinaryProcessing");
+		CtBinaryOperator<?> root = (CtBinaryOperator<?>) type.getField("value").getDefaultExpression();
+		CountingBinaryProcessor processor = new CountingBinaryProcessor(traversalStrategy);
+		processor.setFactory(launcher.getFactory());
+		ProcessingVisitor visitor = new ProcessingVisitor(launcher.getFactory());
+		visitor.setProcessor(processor);
+
+		// when / then
+		assertThatCode(() -> visitor.scan(root)).doesNotThrowAnyException();
+		assertThat(processor.processedOperators).isEqualTo(DEEP_BINARY_OPERATOR_COUNT);
+	}
+
+	private static final class CountingBinaryProcessor extends AbstractProcessor<CtBinaryOperator<?>> {
+		private final TraversalStrategy traversalStrategy;
+		private int processedOperators;
+
+		private CountingBinaryProcessor(TraversalStrategy traversalStrategy) {
+			this.traversalStrategy = traversalStrategy;
+		}
+
+		@Override
+		public TraversalStrategy getTraversalStrategy() {
+			return traversalStrategy;
+		}
+
+		@Override
+		public void process(CtBinaryOperator<?> operator) {
+			processedOperators++;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Process very deep binary-expression trees without overflowing the JVM stack.

Fixes #6804.

## Problem

[OpenJDK](https://github.com/openjdk/jdk)'s valid [`DeepStringConcat.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/DeepStringConcat.java) contains about 32,000 binary operators in one expression. Spoon recursively visited one operator per JVM frame. It first overflowed while checking parent links and then overflowed while running processors.

## Change

- Use an explicit stack when the concrete parent checker visits consecutive binary operands.
- Use the same approach in the concrete processing visitor.
- Preserve Spoon's existing child order and callbacks before and after each child.
- Preserve the normal recursive behavior for subclasses that override scanner hooks.
- Avoid recursive pretty-printing while reporting malformed parent links.
- Restore the parent checker's previous root state after a direct `accept` call.

## Validation

- Added deep-tree tests for parent checking and processor traversal.
- Added tests for child order, synchronous hooks, subclass overrides, malformed-tree diagnostics, and repeated checker use.
- `mvn -q -Dtest=spoon.reflect.visitor.AstParentConsistencyCheckerTest,spoon.support.visitor.ProcessingVisitorTest,spoon.FluentLauncherTest test` passes all 12 tests.
- `mvn -q -Dtest=spoon.test.architecture.SpoonArchitectureEnforcerTest test` passes all 9 tests. The two focused commands therefore run 21 tests in total.
- [StoneDetector](https://github.com/StoneDetector/StoneDetector) processes OpenJDK's [`DeepStringConcat.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/DeepStringConcat.java): exit 0, AST 1/1, and no reported errors.
- All 14 GitHub checks pass, including the Java 17, 21, and 25 test matrix, coverage, Javadoc quality, code generation, reproducibility, Qodana, and QDJVM.



