### PR TITLE
fix: preserve guarded switch case positions

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.compiler.ast.EitherOrMultiPattern;
 import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.ForStatement;
+import org.eclipse.jdt.internal.compiler.ast.GuardedPattern;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
@@ -513,13 +514,29 @@ public class ParentExiter extends CtInheritanceScanner {
 				caseStatement.addCaseExpression((CtExpression<E>) child);
 			}
 			return;
+		} else if (isGuardExpression(node)) {
+			caseStatement.setGuard((CtExpression<?>) child);
+			return;
 		} else if (child instanceof CtStatement) {
 			caseStatement.addStatement((CtStatement) child);
 			return;
-		} else if (child instanceof CtExpression<?> guard) {
-			caseStatement.setGuard(guard);
 		}
 		super.visitCtCase(caseStatement);
+	}
+
+	private boolean isGuardExpression(ASTNode node) {
+		if (!(node instanceof CaseStatement caseStatement)
+			|| caseStatement.constantExpressions == null
+			|| !(child instanceof CtExpression)) {
+			return false;
+		}
+		for (Expression expression : caseStatement.constantExpressions) {
+			if (expression instanceof GuardedPattern guardedPattern
+				&& getFinalExpressionFromCast(guardedPattern.condition) == childJDT) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private <E> boolean shouldAddAsCaseExpression(CtCase<E> caseStatement, ASTNode node) {

--- a/src/test/java/spoon/test/pattern/GuardedColonSwitchPositionTest.java
+++ b/src/test/java/spoon/test/pattern/GuardedColonSwitchPositionTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
+ *
+ * Copyright (C) 2006-2026 INRIA and contributors
+ *
+ * Spoon is available either under the terms of the MIT License (see LICENSE-MIT.txt) or the Cecill-C License (see LICENSE-CECILL-C.txt). You as the user are entitled to choose the terms under which to adopt Spoon.
+ */
+package spoon.test.pattern;
+
+import org.junit.jupiter.api.Test;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import spoon.Launcher;
+import spoon.reflect.CtModel;
+import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtSwitch;
+import spoon.reflect.code.CtSwitchExpression;
+import spoon.reflect.cu.SourcePosition;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GuardedColonSwitchPositionTest {
+	private static CtModel createModel() {
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(25);
+		launcher.addInputResource("src/test/resources/spoon/test/pattern/GuardedColonSwitch.java");
+		return launcher.buildModel();
+	}
+
+	@Test
+	void guardedFallThroughCaseHasOrderedContainedSourcePosition() {
+		// contract: #6806 consecutive guarded colon cases have ordered, contained positions
+		CtModel model = createModel();
+
+		assertThat(model.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class)))
+			.singleElement()
+			.satisfies(ctSwitch -> {
+				int switchStart = ctSwitch.getPosition().getSourceStart();
+				int switchEnd = ctSwitch.getPosition().getSourceEnd();
+				assertThat(ctSwitch.getCases())
+					.satisfiesExactly(
+						firstCase -> {
+							assertThat(firstCase.getGuard()).as("first case guard").isNotNull();
+							assertThat(firstCase.getStatements()).as("first case statements").isEmpty();
+						},
+						secondCase -> {
+							assertThat(secondCase.getGuard()).as("second case guard").isNotNull();
+							assertThat(secondCase.getCaseExpressions()).as("second case expressions").isNotEmpty();
+							assertThat(secondCase.getStatements()).as("second case statements").hasSize(2);
+						},
+						defaultCase -> assertThat(defaultCase.getGuard()).as("default case guard").isNull())
+					.allSatisfy(ctCase -> {
+						SourcePosition position = ctCase.getPosition();
+						assertThat(position.isValidPosition()).as("position of case <%s> is valid", ctCase).isTrue();
+						assertThat(position.getSourceStart())
+							.as("start of case <%s>", ctCase)
+							.isBetween(switchStart, position.getSourceEnd());
+						assertThat(position.getSourceEnd())
+							.as("end of case <%s>", ctCase)
+							.isLessThanOrEqualTo(switchEnd);
+					});
+			});
+	}
+
+	@Test
+	void castGuardIsAttachedToCase() {
+		// contract: guard identification follows JDT through casts that Spoon flattens into the expression
+		CtModel model = createModel();
+
+		assertThat(model.getElements(new TypeFilter<CtSwitchExpression<?, ?>>(CtSwitchExpression.class)))
+			.singleElement()
+			.satisfies(ctSwitch -> assertThat(ctSwitch.getCases())
+				.first()
+				.extracting(CtCase::getGuard)
+				.as("guard of the first switch-expression case")
+				.isNotNull()
+				.extracting(CtExpression::getTypeCasts)
+				.asInstanceOf(InstanceOfAssertFactories.LIST)
+				.hasSize(1));
+	}
+}

--- a/src/test/resources/spoon/test/pattern/GuardedColonSwitch.java
+++ b/src/test/resources/spoon/test/pattern/GuardedColonSwitch.java
@@ -1,0 +1,19 @@
+class GuardedColonSwitch {
+	int classify(Object value) {
+		switch (value) {
+			case String _ when !((String) value).isEmpty():
+			case Integer _, Byte _ when ((Number) value).intValue() > 0:
+				value.toString();
+				return 1;
+			default:
+				return -1;
+		}
+	}
+
+	int castGuard(Object value) {
+		return switch (value) {
+			case Boolean flag when (boolean) flag -> 1;
+			default -> 0;
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Keep a guarded switch case's condition separate from its body and preserve valid source positions.

Fixes #6806.

## Problem

In a label such as:

```java
case String _ when !((String) value).isEmpty():
```

the expression after `when` is the guard that decides whether the case matches. It belongs to the `CtCase` guard; it is not a statement in the case body.

A Spoon expression also implements `CtStatement`. `ParentExiter.visitCtCase` handled statement children before checking whether the child was the [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) `GuardedPattern.condition`. Every guard that reached this path was therefore added to the case body. Consecutive colon-style labels exposed the error: the misclassified guard appeared before the real body in source order, but Spoon stored both as body statements and rejected the resulting descending source coordinates.

For a cast-wrapped guard, ECJ's condition includes the top-level cast and Spoon flattens that cast while building the model. The ownership comparison therefore follows Spoon's final expression after cast unwrapping.

## Change

- Match the visited [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) child against `GuardedPattern.condition` before normal statement handling.
- Keep the guard attached to the `CtCase`, not its body.
- Use Spoon's existing cast-unwrapping helper when [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core)'s top-level cast is flattened.
- Keep normal statement handling unchanged for the real case body.

## Tests

`GuardedColonSwitchPositionTest` covers consecutive guarded colon cases, fall-through, empty and non-empty bodies, contained source positions, and cast guards.

Before the fix, the regression failed with:

```text
spoon.SpoonException: SourcePosition values must be ascending or equal [79, 79, 126, 125]
```

- The focused command below passes 18 tests:

  ```text
  mvn -q \
    -Dtest=spoon.test.pattern.GuardedColonSwitchPositionTest,spoon.test.pattern.RecordPatternTest,spoon.test.pattern.SwitchPatternTest \
    test
  ```

- `mvn -q -DskipTests verify` passes.
- [StoneDetector](https://github.com/StoneDetector/StoneDetector) processes [OpenJDK](https://github.com/openjdk/jdk) [T8314226.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/patterns/T8314226.java): AST 1/1, CFG 2/2, dominators 2/2, paths 2/2, and no reported errors.

## Full test suite

The complete Java 25 suite passes 4,462 tests with 0 failures, 0 errors, and 16 skipped.



