### PR TITLE
fix: preserve guarded multi-pattern hierarchy

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
+++ b/src/main/java/spoon/support/compiler/jdt/ParentExiter.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.compiler.ast.EitherOrMultiPattern;
 import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.ForStatement;
+import org.eclipse.jdt.internal.compiler.ast.GuardedPattern;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
@@ -533,9 +534,16 @@ public class ParentExiter extends CtInheritanceScanner {
 			&& caseStatement.getCaseExpressions().size() < cs.constantExpressions.length) {
 			return true;
 		}
-		// case A _, B _ -> {} is only one constantExpression in JDT, but an EitherOrMultiPattern
-		// so we need to unpack it and see how many case expressions it actually is
-		if (cs.constantExpressions.length == 1 && cs.constantExpressions[0] instanceof EitherOrMultiPattern eomp) {
+		// JDT represents case A _, B _ as one EitherOrMultiPattern, optionally wrapped by a guard,
+		// so we need to unpack it and see how many case expressions it actually is.
+		if (cs.constantExpressions.length != 1) {
+			return false;
+		}
+		Expression caseExpression = cs.constantExpressions[0];
+		if (caseExpression instanceof GuardedPattern guardedPattern) {
+			caseExpression = guardedPattern.primaryPattern;
+		}
+		if (caseExpression instanceof EitherOrMultiPattern eomp) {
 			// returns true if we still expect more case expressions to be added
 			return caseStatement.getCaseExpressions().size() < eomp.getAlternatives().length;
 		}

--- a/src/test/java/spoon/test/pattern/SwitchPatternTest.java
+++ b/src/test/java/spoon/test/pattern/SwitchPatternTest.java
@@ -77,6 +77,45 @@ class SwitchPatternTest {
 	}
 
 	@Test
+	void testMultipleTypePatternsWithGuardInSwitch() {
+		// contract: each alternative of a guarded multi-pattern case is represented as a case pattern
+		CtModel model = createModelFromString("""
+			sealed interface Base permits First, Second {}
+			final class First implements Base {}
+			final class Second implements Base {}
+			class Foo {
+				int select(Base value, boolean enabled) {
+					switch (value) {
+						case First _, Second _ when enabled: return 1;
+						default: return 0;
+					}
+				}
+			}
+			""");
+
+		assertThat(model.getElements(new TypeFilter<CtSwitch<?>>(CtSwitch.class)))
+			.singleElement()
+			.satisfies(ctSwitch -> assertThat(ctSwitch.getCases())
+				.first()
+				.satisfies(ctCase -> {
+					assertThat(ctCase.getCaseExpressions())
+						.hasSize(2)
+						.allSatisfy(expression -> assertThat(expression)
+							.isInstanceOfSatisfying(CtCasePattern.class, casePattern -> {
+								assertThat(casePattern.getParent()).isSameAs(ctCase);
+								assertThat(casePattern.getPattern())
+									.isInstanceOfSatisfying(
+										CtTypePattern.class,
+										pattern -> assertThat(pattern.getParent()).isSameAs(casePattern));
+							}));
+					assertThat(ctCase.getGuard())
+						.isNotNull()
+						.extracting(CtExpression::getParent)
+						.isSameAs(ctCase);
+				}));
+	}
+
+	@Test
 	void testCaseNull() {
 		// contract: "case null" is represented by a null literal
 		CtSwitch<?> sw = createFromSwitchStatement("case null");


### PR DESCRIPTION
## Summary

Preserve both patterns and the separate boolean guard in a switch label such as `case First _, Second _ when enabled`.

Fixes #6808.

## Problem

`First _` and `Second _` are two alternative patterns: the first matches a `First` value and the second matches a `Second` value. `enabled` is a separate boolean guard. Spoon must build one `CtCasePattern` for each alternative and attach `enabled` as the `CtCase` guard.

[ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) stores the two patterns inside one `EitherOrMultiPattern`, then wraps that node and the guard condition in a `GuardedPattern`. For this label, the correct alternative count is two. Spoon uses that count while it receives ECJ's child nodes: the first two pattern children belong to the comma-separated label, and the following expression is the guard.

Spoon counted alternatives only when `EitherOrMultiPattern` was the direct case expression. The wrapper therefore made Spoon expect one pattern instead of two. Spoon attached `First _` correctly, then treated the `CtTypePattern` for `Second _` as the guard. Model construction failed because a `CtTypePattern` belongs under a `CtCasePattern`, not directly under a `CtCase` guard.

## Change

- Unwrap the [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) `GuardedPattern` only while counting its alternatives.
- Create one `CtCasePattern` for each alternative.
- Keep each `CtTypePattern` below its `CtCasePattern`.
- Attach the real guard to the `CtCase`.

## Tests

- Added a regression that checks both alternatives, their node types, all parent links, and the guard parent.
- `mvn -q -Dtest=spoon.test.pattern.SwitchPatternTest#testMultipleTypePatternsWithGuardInSwitch test` passes.
- The complete switch and record-pattern suites pass: 17 tests.
- `mvn -q -DskipTests install` and `mvn -q spotless:check` pass.
- [StoneDetector](https://github.com/StoneDetector/StoneDetector) processes [OpenJDK](https://github.com/openjdk/jdk) [Unnamed.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/patterns/Unnamed.java): AST 1/1, CFG 4/4, dominators 4/4, paths 4/4, and no reported errors.
- Direct model inspection confirms that both guarded alternatives are retained.

## Full test suite

The complete Java 25 suite passes 4,461 tests with 0 failures, 0 errors, and 16 skipped.



