### PR TITLE
fix: validate supplementary identifiers by code point

### DIFF
--- a/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
+++ b/src/main/java/spoon/support/reflect/reference/CtReferenceImpl.java
@@ -122,22 +122,28 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 	private boolean checkAll(String name) {
 		int i = 0;
 		// leading digits come from anonymous/local classes. Skip them
-		while (i < name.length() && Character.isDigit(name.charAt(i))) {
-			i++;
+		while (i < name.length()) {
+			int codePoint = name.codePointAt(i);
+			if (!Character.isDigit(codePoint)) {
+				break;
+			}
+			i += Character.charCount(codePoint);
 		}
 		int start = i; // used to mark the beginning of a part
-		final char anything = 0;
-		char expectNext = anything;
-		for (; i < name.length(); i++) {
+		final int anything = 0;
+		int expectNext = anything;
+		while (i < name.length()) {
+			int codePoint = name.codePointAt(i);
 			if (expectNext != anything) {
-				if (name.charAt(i) != expectNext) {
+				if (codePoint != expectNext) {
 					return false;
-				} else if (name.charAt(i) == expectNext) {
+				} else {
 					expectNext = anything; // reset
+					i += Character.charCount(codePoint);
 					continue; // skip it, no further checks required
 				}
 			}
-			switch (name.charAt(i)) {
+			switch (codePoint) {
 				case '.':
 				case '<':
 				case '>':
@@ -153,12 +159,13 @@ public abstract class CtReferenceImpl extends CtElementImpl implements CtReferen
 					expectNext = ']'; // next char *must* close
 					break;
 				default: // if we come across an illegal java identifier char here, it's not valid at all
-					if (start == i && !Character.isJavaIdentifierStart(name.charAt(i))
-							|| !Character.isJavaIdentifierPart(name.charAt(i))) {
+					if (start == i && !Character.isJavaIdentifierStart(codePoint)
+							|| !Character.isJavaIdentifierPart(codePoint)) {
 						return false;
 					}
 					break;
 			}
+			i += Character.charCount(codePoint);
 		}
 		// make sure the end state is correct too
 		if (expectNext != anything) {

--- a/src/test/java/spoon/test/reference/SupplementaryIdentifierTest.java
+++ b/src/test/java/spoon/test/reference/SupplementaryIdentifierTest.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: (MIT OR CECILL-C)
+ *
+ * Copyright (C) 2006-2026 INRIA and contributors
+ */
+package spoon.test.reference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import spoon.JLSViolation;
+import spoon.Launcher;
+import spoon.reflect.code.CtFieldRead;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+class SupplementaryIdentifierTest {
+
+	private static final String SUPPLEMENTARY_IDENTIFIER = "\uD801\uDC00abc";
+
+	@ParameterizedTest(name = "source spelling {index}: {0}")
+	@ValueSource(strings = { SUPPLEMENTARY_IDENTIFIER, "\\uD801\\uDC00abc" })
+	void acceptsSupplementaryIdentifierReferences(String sourceIdentifier) {
+		// contract: raw and escaped supplementary Java identifiers are validated as one code point
+		// (#6810)
+		CtClass<?> type = Launcher.parseClass("""
+				class SupplementaryIdentifier {
+					int %s = 1;
+					boolean valid() { return %s == 1; }
+				}
+				""".formatted(sourceIdentifier, sourceIdentifier));
+
+		assertThat(type.getElements(new TypeFilter<CtFieldRead<?>>(CtFieldRead.class)))
+				.singleElement()
+				.extracting(fieldRead -> fieldRead.getVariable().getSimpleName())
+				.isEqualTo(SUPPLEMENTARY_IDENTIFIER);
+	}
+
+	@Test
+	void rejectsSupplementaryCodePointsThatAreNotJavaIdentifierParts() {
+		// contract: code-point validation does not make arbitrary supplementary characters legal identifiers
+		// (#6810)
+		var reference = new Launcher().getFactory().Core().createTypeReference();
+
+		assertThatThrownBy(() -> reference.setSimpleName("\uD83D\uDE00name"))
+				.isInstanceOf(JLSViolation.class);
+	}
+}


### PR DESCRIPTION
## Summary

Accept valid Java identifiers that contain supplementary Unicode characters.

Fixes #6810.

## Problem

Identifiers such as `François`, `Müller`, and `Ärger` already worked because `ç`, `ü`, and `Ä` each occupy one UTF-16 `char`. On a Swiss keyboard, using the diaeresis dead key and then Shift+A enters `Ä`; the keystrokes do not determine its UTF-16 length. A natural two-code-unit example is `𠮷` (U+20BB7), which is used in the Japanese surname `𠮷田`:

```java
int Ärger = 1; // accepted already
int 𠮷田 = 2;  // 𠮷 uses two code units and failed before the fix
```

`CtReferenceImpl.checkAll` validated one `char` at a time, so Spoon rejected each half of the U+20BB7 surrogate pair instead of validating the complete code point.

## Change

- Validate identifiers by Unicode code point.
- Advance by `Character.charCount(codePoint)` after each check.
- Keep UTF-16 indexes for Spoon's existing substring and delimiter handling.
- Continue rejecting supplementary characters that Java does not allow in identifiers.

## Tests

- Added a raw supplementary-plane identifier.
- Added the same identifier written as a Unicode surrogate-pair escape.
- Added an invalid supplementary character and verified that Spoon still rejects it.
- `mvn -q -Dtest=spoon.test.reference.SupplementaryIdentifierTest test` passes: 3 tests.
- `mvn -q -Dtest=spoon.test.reference.TypeReferenceTest test` passes.
- `mvn -q -DskipTests install` passes.
- [StoneDetector](https://github.com/StoneDetector/StoneDetector) processes [OpenJDK](https://github.com/openjdk/jdk) [SupplementaryJavaID1.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/unicode/SupplementaryJavaID1.java) and [SupplementaryJavaID6.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/unicode/SupplementaryJavaID6.java): AST 2/2, CFG 4/4, dominators 4/4, paths 4/4, and no reported errors.

## Full test suite

The complete Java 25 suite passes 4,463 tests with 0 failures, 0 errors, and 16 skipped.


## Compatibility

This restores support for identifiers accepted by the Java language. It does not change the public API or accept identifiers that Java rejects.


