### PR TITLE
fix: retain comments without specialized placements

### DIFF
--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -7,6 +7,8 @@
  */
 package spoon.support.compiler.jdt;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.jspecify.annotations.Nullable;
@@ -64,6 +66,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -74,6 +77,8 @@ import java.util.stream.Collectors;
  * The comment builder that will insert all element of a CompilationUnitDeclaration into the Spoon AST
  */
 public class JDTCommentBuilder {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	private final CompilationUnitDeclaration declarationUnit;
 	private CompilationUnit spoonUnit;
@@ -530,7 +535,9 @@ public class JDTCommentBuilder {
 		if (!comment.isParentInitialized()) {
 			// A specialized visitor may not find a suitable child, for example when a
 			// comment is placed next to an operator or inside an empty module directive.
-			// Keep the comment on the enclosing element instead of dropping it.
+			LOGGER.error("\"" + comment + "\" cannot be added to a specialized AST child; attaching it to parent "
+					+ commentParent.getClass() + " at " + commentParent.getPosition().toString()
+					+ ", please report the bug by posting on https://github.com/INRIA/spoon/issues/2482");
 			commentParent.addComment(comment);
 		}
 	}

--- a/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
+++ b/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java
@@ -7,8 +7,6 @@
  */
 package spoon.support.compiler.jdt;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.jspecify.annotations.Nullable;
@@ -66,7 +64,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.annotation.Annotation;
-import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -77,8 +74,6 @@ import java.util.stream.Collectors;
  * The comment builder that will insert all element of a CompilationUnitDeclaration into the Spoon AST
  */
 public class JDTCommentBuilder {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	private final CompilationUnitDeclaration declarationUnit;
 	private CompilationUnit spoonUnit;
@@ -533,10 +528,10 @@ public class JDTCommentBuilder {
 		// now we make sure that there is a parent
 		// if there is no parent
 		if (!comment.isParentInitialized()) {
-			// that's a serious error, there is something to debug
-			LOGGER.error("\"" + comment + "\" cannot be added into the AST, with parent " + commentParent.getClass()
-					+ " at " + commentParent.getPosition().toString()
-					+ ", please report the bug by posting on https://github.com/INRIA/spoon/issues/2482");
+			// A specialized visitor may not find a suitable child, for example when a
+			// comment is placed next to an operator or inside an empty module directive.
+			// Keep the comment on the enclosing element instead of dropping it.
+			commentParent.addComment(comment);
 		}
 	}
 

--- a/src/test/java/spoon/test/comment/CommentTest.java
+++ b/src/test/java/spoon/test/comment/CommentTest.java
@@ -73,6 +73,7 @@ import spoon.reflect.visitor.filter.TypeFilter;
 import spoon.support.DefaultCoreFactory;
 import spoon.support.JavaOutputProcessor;
 import spoon.support.StandardEnvironment;
+import spoon.support.compiler.VirtualFile;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.support.reflect.code.CtCommentImpl;
 import spoon.test.comment.testclasses.BlockComment;
@@ -106,6 +107,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1277,34 +1279,71 @@ public class CommentTest {
 	}
 
 	@ModelTest("./src/test/java/spoon/test/comment/testclasses/ArrayAccessComments.java")
-	@GitHubIssue(issueNumber = 2482, fixed = false)
+	@GitHubIssue(issueNumber = 2482, fixed = true)
 	public void testArrayAccessComments(CtModel model) {
 		//contract: comments at array accesses should be properly added to the AST
 		List<CtComment> comments = model.getElements(new TypeFilter<>(CtComment.class));
 		List<CtArrayAccess<?, ?>> arrayAccesses = model.getElements(new TypeFilter<>(CtArrayAccess.class));
 
-		assertEquals(2,comments.size());
-		assertEquals("comment 1", comments.get(0).getContent());
-		assertEquals("comment 2", comments.get(1).getContent());
-
-		assertEquals(1, arrayAccesses.get(0).getComments().size());
-		assertEquals("comment 1", arrayAccesses.get(0).getComments().get(0).getContent());
-		assertEquals(1, arrayAccesses.get(1).getComments().size());
-		assertEquals("comment 2", arrayAccesses.get(1).getComments().get(0).getContent());
+		assertThat(comments)
+			.extracting(CtComment::getContent)
+			.containsExactly("comment 1", "comment 2");
+		assertThat(arrayAccesses)
+			.satisfiesExactly(
+				first -> assertThat(first.getComments())
+					.extracting(CtComment::getContent)
+					.containsExactly("comment 1"),
+				second -> assertThat(second.getComments())
+					.extracting(CtComment::getContent)
+					.containsExactly("comment 2"));
 	}
 
 	@ModelTest("./src/test/java/spoon/test/comment/testclasses/BinaryOperatorComments.java")
-	@GitHubIssue(issueNumber = 2482, fixed = false)
+	@GitHubIssue(issueNumber = 2482, fixed = true)
 	public void testBinaryOperatorComments(CtModel model) {
 		//contract: comments at binary operators should be properly added to the AST
 		List<CtComment> comments = model.getElements(new TypeFilter<>(CtComment.class));
 		List<CtBinaryOperator<?>> binaryOperators = model.getElements(new TypeFilter<>(CtBinaryOperator.class));
 
-		assertEquals(1, comments.size());
-		assertEquals("comment 1", comments.get(0).getContent());
+		assertThat(comments)
+			.extracting(CtComment::getContent)
+			.containsExactly("comment 1");
+		assertThat(binaryOperators)
+			.singleElement()
+			.satisfies(binaryOperator -> assertThat(binaryOperator.getComments())
+				.extracting(CtComment::getContent)
+				.containsExactly("comment 1"));
+	}
 
-		assertEquals(1, binaryOperators.get(0).getComments().size());
-		assertEquals("comment 1", binaryOperators.get(0).getComments().get(0).getContent());
+	@ModelTest(code = "@Deprecated(/* marker */) class CommentInEmptyAnnotation {}")
+	public void testCommentInEmptyAnnotationFallsBackToAnnotation(CtModel model) {
+		// contract: a comment is retained on its enclosing annotation when the annotation has no value expression
+		assertThat(model.getElements(new TypeFilter<CtAnnotation<?>>(CtAnnotation.class)))
+			.singleElement()
+			.satisfies(annotation -> assertThat(annotation.getComments())
+				.extracting(CtComment::getContent)
+				.containsExactly("marker"));
+	}
+
+	@Test
+	public void testCommentInModuleWithoutDirectivesFallsBackToModule() {
+		// contract: a comment is retained on its enclosing module when there is no directive to receive it
+		Launcher launcher = new Launcher();
+		launcher.getEnvironment().setComplianceLevel(9);
+		launcher.getEnvironment().setNoClasspath(true);
+		launcher.addInputResource(new VirtualFile("""
+			module comment.fallback {
+				// exports disabled
+			}
+			""", "module-info.java"));
+
+		CtModel model = launcher.buildModel();
+		assertThat(model.getAllModules())
+			.filteredOn(candidate -> candidate.getSimpleName().equals("comment.fallback"))
+			.singleElement()
+			.satisfies(module -> assertThat(module.getComments())
+				.extracting(CtComment::getContent)
+				.containsExactly("exports disabled"));
 	}
 
 	@ModelTest("./src/test/java/spoon/test/comment/testclasses/TypeParameterComments.java")


### PR DESCRIPTION
## Summary

Keep comments in the model when a specialized comment-placement visitor cannot attach them to a more specific child node.

Fixes #6812.

## Problem

Spoon first tries to attach each source comment to the most specific matching AST node. For some valid comment positions, the specialized placement visitor does not find a child that accepts the comment. Examples include a comment next to an array index or operator and a comment inside a module declaration with no directive. In those cases, [`JDTCommentBuilder.java`](https://github.com/martinfrancois/spoon/blob/92a7c1d52dc4b5df6468c73ca8c3ea02cf26acef/src/main/java/spoon/support/compiler/jdt/JDTCommentBuilder.java) logged an error and left the comment outside the model.

[Spoon issue #2482](https://github.com/INRIA/spoon/issues/2482) originally reported comments assigned to the wrong type and a missing end-of-type comment. [Spoon PR #2636](https://github.com/INRIA/spoon/pull/2636) fixed that original type-header reproduction by handling comments in declaration modifier ranges. Later comments on #2482 reported the array-access and binary-operator cases covered here. This pull request fixes the remaining path shared by those cases and the annotation and module examples: specialized placement runs, but no child accepts the comment.

This happened while [StoneDetector](https://github.com/StoneDetector/StoneDetector) used Spoon and the [Eclipse Java compiler (ECJ)](https://github.com/eclipse-jdt/eclipse.jdt.core) to analyze these [OpenJDK](https://github.com/openjdk/jdk) sources:

- [`WalkerFactory.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/src/java.xml/share/classes/com/sun/org/apache/xpath/internal/axes/WalkerFactory.java)
- [`com.foos/module-info.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/src/com.foos/module-info.java)
- [`NullPointerExceptionTest.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/hotspot/jtreg/runtime/exceptionMsgs/NullPointerException/NullPointerExceptionTest.java)
- [`FdlibmTranslit.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/jdk/java/lang/StrictMath/FdlibmTranslit.java)
- [`NumberTest.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/jdk/java/text/Format/NumberFormat/NumberTest.java)
- [`TestGetElementReferenceData.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/api/TestGetElementReferenceData.java)
- [`api/mod/module-info.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/api/mod/module-info.java)
- [`mVIII/module-info.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/jdeps/modules/src/mVIII/module-info.java)

The eight files produced 21 comment-placement errors.

## Change

- Keep the existing specialized placement logic.
- If that logic does not give the comment a parent, attach the comment to the enclosing AST element instead of dropping it.
- Keep the error log with accurate fallback wording and the issue-reporting link so users continue to report unsupported placements.

## Tests

- Enabled the existing array-access and binary-operator regressions in [`CommentTest.java`](https://github.com/martinfrancois/spoon/blob/92a7c1d52dc4b5df6468c73ca8c3ea02cf26acef/src/test/java/spoon/test/comment/CommentTest.java).
- Added cases for a comment in an empty annotation and a comment in a module with no directives.
- `mvn -q -Dtest=spoon.test.comment.CommentTest,spoon.test.compilation.CompilationTest test` passes: 58 tests, 0 failures, 0 errors.
- `mvn -q -DskipTests verify` passes after restoring the diagnostic.

## Integration validation

I built the fallback behavior with the combined local [ECJ](https://github.com/eclipse-jdt/eclipse.jdt.core) fixes and used the result in [StoneDetector](https://github.com/StoneDetector/StoneDetector).

All eight linked [OpenJDK](https://github.com/openjdk/jdk) files completed successfully: AST 8/8, CFG 159/159, dominator trees 159/159, and encoded paths 159/159. The run exited with code 0 and the functional result was complete. The current branch intentionally restores the Spoon error diagnostic when fallback placement is used, so equivalent runs retain comments while continuing to report unsupported placements.

## Full test suite

The complete Java 25 suite passes 4,462 tests with 0 failures, 0 errors, and 16 skipped.
