### PR TITLE
fix: resolve variables declared by earlier try-with-resources resources

### DIFF
--- a/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
+++ b/src/main/java/spoon/reflect/visitor/filter/PotentialVariableDeclarationFunction.java
@@ -47,6 +47,7 @@ import spoon.reflect.declaration.CtParameter;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtVariable;
 import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.path.CtRole;
 import spoon.reflect.visitor.chain.CtConsumableFunction;
 import spoon.reflect.visitor.chain.CtConsumer;
 import spoon.reflect.visitor.chain.CtQuery;
@@ -432,14 +433,11 @@ public class PotentialVariableDeclarationFunction implements CtConsumableFunctio
 			return result;
 		}
 
-		if (parent instanceof CtTryWithResource ctTryWith) {
-			for (var resource : ctTryWith.getResources()) {
-				for (var scope : resource == child ? filteredChildScopes : exploreBranchForNewScopes(resource)) {
-					result.add(new VariableScope(scope.variable(), ctTryWith.getBody()));
-				}
+		if (parent instanceof CtTryWithResource) {
+			CtRole roleInTry = child.getRoleInParent();
+			if (roleInTry != CtRole.TRY_RESOURCE && roleInTry != CtRole.BODY) {
+				return result;
 			}
-
-			return result;
 		}
 
 		// For these elements the SiblingsFunction works fine to discover the variable declarations introduced by them like

--- a/src/test/java/spoon/test/query_function/VariableReferencesTest.java
+++ b/src/test/java/spoon/test/query_function/VariableReferencesTest.java
@@ -34,6 +34,7 @@ import spoon.reflect.code.CtLambda;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtLocalVariable;
 import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtTryWithResource;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtEnum;
@@ -459,6 +460,115 @@ public class VariableReferencesTest {
 		assertThat(references.get(7)).hasExactlyPotentialDeclarations(scannerField);
 		assertThat(references.get(8)).hasExactlyPotentialDeclarations(catchVariable, eField);
 		assertThat(references.get(10)).hasExactlyPotentialDeclarations(scannerField);
+	}
+
+	@ModelTest(code = ("""
+		class Test {
+			static class Res implements AutoCloseable {
+				Res(Object... args) {}
+				public void close() {}
+			}
+
+			static void use(Object value) {}
+
+			Res first;
+			Res later;
+
+			void method() {
+				try(
+					Res first = new Res(later);
+					Res second = new Res(first);
+					Res later = new Res(first, second)
+				) {
+					use(first);
+					use(second);
+					use(later);
+				}
+			}
+		}
+		"""))
+	public void testTryWithResourceReferencesEarlierResource(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a try-with-resource resource is in scope over the remainder of the resource specification, so the
+		// initializer of a resource can reference the resources declared before it, but not those declared after it
+		CtTryWithResource tryWithResource = assertThat(ctClass.getElements(new TypeFilter<CtTryWithResource>(CtTryWithResource.class)))
+			.singleElement()
+			.actual();
+
+		List<CtLocalVariable<?>> resources = ctClass.getElements(new TypeFilter<>(CtLocalVariable.class));
+		assertThat(resources).hasSize(3);
+		CtVariable<?> firstResource = resources.get(0);
+		CtVariable<?> secondResource = resources.get(1);
+		CtVariable<?> laterResource = resources.get(2);
+		assertThat(firstResource).getSimpleName().isEqualTo("first");
+		assertThat(secondResource).getSimpleName().isEqualTo("second");
+		assertThat(laterResource).getSimpleName().isEqualTo("later");
+
+		CtField<?> firstField = ctClass.getField("first");
+		assertNotNull(firstField);
+		CtField<?> laterField = ctClass.getField("later");
+		assertNotNull(laterField);
+
+		CtVariableReference<?> laterReference = assertThat(firstResource.getElements(new TypeFilter<CtVariableReference<?>>(CtVariableReference.class)))
+			.singleElement()
+			.actual();
+		assertThat(laterReference.map(new PotentialVariableDeclarationFunction("later")).list(CtVariable.class))
+			.singleElement()
+			.isSameAs(laterField);
+
+		CtVariableReference<?> firstReference = assertThat(secondResource.getElements(new TypeFilter<CtVariableReference<?>>(CtVariableReference.class)))
+			.singleElement()
+			.actual();
+		assertThat(firstReference)
+			.hasExactlyPotentialDeclarations(firstResource, firstField)
+			.getDeclaration()
+			.isSameAs(firstResource);
+
+		assertThat(laterResource.getElements(new TypeFilter<CtVariableReference<?>>(CtVariableReference.class))).satisfiesExactly(
+			reference -> assertThat(reference)
+				.hasExactlyPotentialDeclarations(firstResource, firstField)
+				.getDeclaration()
+				.isSameAs(firstResource),
+			reference -> assertThat(reference)
+				.hasExactlyPotentialDeclarations(secondResource)
+				.getDeclaration()
+				.isSameAs(secondResource));
+
+		assertThat(tryWithResource.getBody().getElements(new TypeFilter<CtVariableReference<?>>(CtVariableReference.class))).satisfiesExactly(
+			reference -> assertThat(reference).hasExactlyPotentialDeclarations(firstResource, firstField),
+			reference -> assertThat(reference).hasExactlyPotentialDeclarations(secondResource),
+			reference -> assertThat(reference).hasExactlyPotentialDeclarations(laterResource, laterField));
+	}
+
+	@ModelTest(code = ("""
+		class Test {
+			static class Res implements AutoCloseable {
+				Res(Object... args) {}
+				public void close() {}
+			}
+
+			void method(Res given) {
+				try(given; Res second = new Res(given)) {
+				}
+			}
+		}
+		"""))
+	public void testTryWithResourceExistingVariableResource(@BySimpleName("Test") CtClass<?> ctClass) {
+		// contract: a resource that is an existing variable rather than a declaration (Java 9) introduces no new
+		// variable, so references in the remainder of the specification still resolve to the original declaration
+		CtParameter<?> parameter = ctClass.getMethodsByName("method").get(0).getParameters().get(0);
+		assertThat(parameter).getSimpleName().isEqualTo("given");
+
+		CtLocalVariable<?> secondResource = assertThat(ctClass.getElements(new TypeFilter<CtLocalVariable<?>>(CtLocalVariable.class)))
+			.singleElement()
+			.actual();
+		assertThat(secondResource).getSimpleName().isEqualTo("second");
+
+		assertThat(ctClass.getElements(new TypeFilter<CtVariableReference<?>>(CtVariableReference.class))).satisfiesExactly(
+			reference -> assertThat(reference).hasExactlyPotentialDeclarations(parameter),
+			reference -> assertThat(reference)
+				.hasExactlyPotentialDeclarations(parameter)
+				.getDeclaration()
+				.isSameAs(parameter));
 	}
 
 	@ModelTest(code = """


### PR DESCRIPTION
`getDeclaration()` returns `null` for a reference to a resource made from the initializer
of a later resource:

```java
try (FileInputStream fis = new FileInputStream("input.txt");
     BufferedInputStream bis = new BufferedInputStream(fis)) {  // the read of `fis` resolves to null
}
```

According to [JLS 6.3](https://docs.oracle.com/javase/specs/jls/se26/html/jls-6.html#jls-6.3):

> The scope of a local variable declared in the resource specification of a try-with-resources statement (§14.20.3) is from the declaration rightward over the remainder of the resource specification and the entire try block associated with the try-with-resources statement.

Current implementation anchors the scope of every resource variable to the try body only. `SiblingsFuction`-based branch computes the JLS rule correctly. The only thing that has to be expressed is that the resources are not in the scope of catchers or finalizers.

Two tests are introduced. The first one fails before the change.