### PR TITLE
fix: use expression lambdas for single-statement block lambdas

### DIFF
--- a/src/main/java/spoon/reflect/visitor/CommentHelper.java
+++ b/src/main/java/spoon/reflect/visitor/CommentHelper.java
@@ -30,7 +30,7 @@ public class CommentHelper {
 	public static String printComment(CtComment comment) {
 		PrinterHelper ph = new PrinterHelper(comment.getFactory().getEnvironment());
 		// now we only use one single method to print all tags
-		printCommentContent(ph, comment, s -> { return  s; });
+		printCommentContent(ph, comment, s -> s);
 		return ph.toString();
 	}
 

--- a/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
+++ b/src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java
@@ -1054,7 +1054,7 @@ public class DefaultJavaPrettyPrinter implements CtVisitor, PrettyPrinter {
 		 * E.g. from CtJavaDocTag#toString
 		 * Write directly to PrinterHelper, because java doc tag is not a java token. Normally it is part of COMMENT token.
 		 */
-		CommentHelper.printJavaDocTag(printer.getPrinterHelper(), docTag, x -> { return x; });
+		CommentHelper.printJavaDocTag(printer.getPrinterHelper(), docTag, x -> x);
 	}
 
 	@Override


### PR DESCRIPTION
In the scope of checkstyle/checkstyle#20692

Expression lambdas are preferred over single-line block lambdas for
readability and conciseness (as recommended by the OpenJDK Java Style
Guidelines).

Changes 2 single-statement block lambdas like:
`  s -> { return s; }`
to:
`  s -> s`

Files changed:
`src/main/java/spoon/reflect/visitor/CommentHelper.java`
` src/main/java/spoon/reflect/visitor/DefaultJavaPrettyPrinter.java`