### PR TITLE
doc: document SpoonObjectTableModel#scanFields #1876

### DIFF
--- a/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
+++ b/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
@@ -81,6 +81,13 @@ public class SpoonObjectFieldsTable extends JFrame {
 			return null;
 		}
 
+		/**
+		 * Collects non-static declared fields of {@code c} and of every
+		 * superclass, adding them to this table model.
+		 *
+		 * @param c class whose instance fields should be listed; recursion
+		 *        stops when there is no superclass
+		 */
 		public void scanFields(Class<?> c) {
 			for (Field f : c.getDeclaredFields()) {
 				f.setAccessible(true);

--- a/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
+++ b/src/test/java/spoon/test/architecture/SpoonArchitectureEnforcerTest.java
@@ -190,7 +190,7 @@ public class SpoonArchitectureEnforcerTest {
 
 							// GOOD FIRST ISSUE
 							// ideally we want that **all** public methods are documented
-							// so far, we have this arbitrary limit in the condition below (32)
+							// so far, we have this arbitrary limit in the condition below (31)
 							// because it's a huge task to document everything at once
 							// so to contribute to Spoon, what you can do is
 							// 1) you lower the threshold (eg 30)
@@ -198,7 +198,7 @@ public class SpoonArchitectureEnforcerTest {
 							// 3) you document those methods
 							// 4) you run the test again to check that it passes
 							// 4) you commit your changes and create the corresponding pull requests
-							|| method.filterChildren(new TypeFilter<>(CtCodeElement.class)).list().size() > 32  // means that only large methods must be documented
+							|| method.filterChildren(new TypeFilter<>(CtCodeElement.class)).list().size() > 31  // means that only large methods must be documented
 			)) {
 
 				// OK it should be properly documented


### PR DESCRIPTION
Lowered the architecture-test Javadoc threshold from 32 to 31. That flagged one public method, SpoonObjectTableModel.scanFields, which I documented.

#1876
