### PR TITLE
fix: treat upper and lower wildcard bounds as unequal

### DIFF
--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -27,6 +27,7 @@ import spoon.reflect.reference.CtArrayTypeReference;
 import spoon.reflect.reference.CtExecutableReference;
 import spoon.reflect.declaration.CtImport;
 import spoon.reflect.reference.CtReference;
+import spoon.reflect.reference.CtWildcardReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
 
 public class EqualsChecker extends CtInheritanceScanner {
@@ -179,6 +180,15 @@ public class EqualsChecker extends CtInheritanceScanner {
 			setNotEqual(CtRole.TYPE);
 		}
 		super.visitCtArrayTypeReference(e);
+	}
+
+	@Override
+	public void visitCtWildcardReference(CtWildcardReference e) {
+		final CtWildcardReference peek = (CtWildcardReference) this.other;
+		if (e.isUpper() != peek.isUpper()) {
+			setNotEqual(CtRole.IS_UPPER);
+		}
+		super.visitCtWildcardReference(e);
 	}
 
 	@Override

--- a/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
+++ b/src/main/java/spoon/support/visitor/equals/EqualsChecker.java
@@ -182,6 +182,9 @@ public class EqualsChecker extends CtInheritanceScanner {
 		super.visitCtArrayTypeReference(e);
 	}
 
+	/**
+	 * @param e the wildcard reference
+	 */
 	@Override
 	public void visitCtWildcardReference(CtWildcardReference e) {
 		final CtWildcardReference peek = (CtWildcardReference) this.other;

--- a/src/test/java/spoon/test/comparison/EqualTest.java
+++ b/src/test/java/spoon/test/comparison/EqualTest.java
@@ -29,6 +29,7 @@ import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.factory.Factory;
 import spoon.reflect.path.CtRole;
+import spoon.reflect.reference.CtWildcardReference;
 import spoon.support.compiler.jdt.JDTSnippetCompiler;
 import spoon.support.visitor.equals.EqualsVisitor;
 
@@ -127,5 +128,28 @@ public class EqualTest {
 		assertSame(var2.getCatchers().get(0).getParameter().getMultiTypes(), ev.getNotEqualElement());
 		assertSame(var.getCatchers().get(0).getParameter().getMultiTypes(), ev.getNotEqualOther());
 		assertSame(CtRole.MULTI_TYPE, ev.getNotEqualRole());
+	}
+
+	@Test
+	public void testEqualsWildcardRespectsUpperBound() {
+		// contract: ? super T and ? extends T are not equal
+		Factory factory = new Launcher().createFactory();
+		CtWildcardReference lower = factory.createWildcardReference()
+				.setBoundingType(factory.Type().objectType())
+				.setUpper(false);
+		CtWildcardReference upper = factory.createWildcardReference()
+				.setBoundingType(factory.Type().objectType())
+				.setUpper(true);
+
+		assertEquals("? super java.lang.Object", lower.toString());
+		assertEquals("? extends java.lang.Object", upper.toString());
+		assertNotEquals(lower, upper);
+		assertNotEquals(upper, lower);
+		assertEquals(lower, lower.clone());
+		assertEquals(upper, upper.clone());
+
+		EqualsVisitor ev = new EqualsVisitor();
+		assertFalse(ev.checkEquals(lower, upper));
+		assertSame(CtRole.IS_UPPER, ev.getNotEqualRole());
 	}
 }


### PR DESCRIPTION
## Summary
`CtWildcardReference.equals` ignored `isUpper`, so `? super T` and `? extends T` compared equal when they shared a bounding type.

`EqualsChecker` now compares `isUpper` like other boolean metamodel fields.

fix #6883

## Test plan
- `mvn -Dtest=EqualTest#testEqualsWildcardRespectsUpperBound test` (RED before the checker change, GREEN after)
- `mvn -Dtest=EqualTest,AssignmentsEqualsTest,GenericsTest#testWildcard,TypeReferenceTest#testClearBoundsForWildcardReference test`
- `mvn spotless:check checkstyle:check`