### PR TITLE
test: cover CtPackage.setShadow #1818

### DIFF
--- a/src/test/java/spoon/test/pkg/PackageTest.java
+++ b/src/test/java/spoon/test/pkg/PackageTest.java
@@ -471,6 +471,18 @@ public class PackageTest {
 	}
 
 
+	@Test
+	public void testPackageSetShadow() {
+		// contract: CtPackage.setShadow stores the flag so isShadow reflects it
+		Factory factory = createFactory();
+		CtPackage pkg = factory.Package().getOrCreate("spoon.test.pkg.shadow");
+		assertFalse(pkg.isShadow());
+		assertSame(pkg, pkg.setShadow(true));
+		assertTrue(pkg.isShadow());
+		assertSame(pkg, pkg.setShadow(false));
+		assertFalse(pkg.isShadow());
+	}
+
 	@ModelTest("./src/test/resources/noclasspath/MultipleClasses.java")
 	public void testGetTypesReturnsTypesInDeclarationOrder(CtModel model) {
 		// contract: Types should be stored in declaration order. This is important for the


### PR DESCRIPTION
CtPackage.setShadow was on the Descartes pseudo-tested list. I added a test that stores the shadow flag and checks isShadow, so emptying the method body fails.

#1818
